### PR TITLE
Bump gotestsum so that integration tests can be run with latest Golang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ ifeq (, $(shell which $(LOCAL_BIN_PATH)/gotestsum 2> /dev/null))
 	GOTESTSUM_TMP_DIR=$$(mktemp -d) ;\
 	cd $$GOTESTSUM_TMP_DIR ;\
 	$(GO) mod init tmp ;\
-	$(GO) get -d gotest.tools/gotestsum@v0.6.0 ;\
+	$(GO) get -d gotest.tools/gotestsum@v1.8.1 ;\
 	mkdir -p ${LOCAL_BIN_PATH} ;\
 	$(GO) build -o ${LOCAL_BIN_PATH}/gotestsum gotest.tools/gotestsum ;\
 	rm -rf $$GOTESTSUM_TMP_DIR ;\


### PR DESCRIPTION
## Description

With Golang 1.18.2 I am seeing this when attempting to run integration tests:

```
➜  acs-fleet-manager git:(main) OCM_ENV=integration make test/integration     

go test -i ./internal/dinosaur/test/integration/...
go: -i flag is deprecated
go: creating new go.mod: module tmp
go: added github.com/fatih/color v1.9.0
go: added github.com/fsnotify/fsnotify v1.4.9
go: added github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
go: added github.com/jonboulle/clockwork v0.1.0
go: added github.com/mattn/go-colorable v0.1.6
go: added github.com/mattn/go-isatty v0.0.12
go: added github.com/pkg/errors v0.9.1
go: added github.com/spf13/pflag v1.0.3
go: added golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
go: added golang.org/x/sync v0.0.0-20190423024810-112230192c58
go: added golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634
go: added golang.org/x/tools v0.0.0-20190624222133-a101b041ded4
go: added gotest.tools/gotestsum v0.6.0
# golang.org/x/sys/unix
/Users/moritz/go/pkg/mod/golang.org/x/sys@v0.0.0-20201009025420-dfb3f7c4e634/unix/syscall_darwin.1_13.go:29:3: //go:linkname must refer to declared function or variable
/Users/moritz/go/pkg/mod/golang.org/x/sys@v0.0.0-20201009025420-dfb3f7c4e634/unix/zsyscall_darwin_amd64.1_13.go:27:3: //go:linkname must refer to declared function or variable
/Users/moritz/go/pkg/mod/golang.org/x/sys@v0.0.0-20201009025420-dfb3f7c4e634/unix/zsyscall_darwin_amd64.1_13.go:40:3: //go:linkname must refer to declared function or variable
/Users/moritz/go/pkg/mod/golang.org/x/sys@v0.0.0-20201009025420-dfb3f7c4e634/unix/zsyscall_darwin_amd64.go:28:3: //go:linkname must refer to declared function or variable
/Users/moritz/go/pkg/mod/golang.org/x/sys@v0.0.0-20201009025420-dfb3f7c4e634/unix/zsyscall_darwin_amd64.go:43:3: //go:linkname must refer to declared function or variable
/Users/moritz/go/pkg/mod/golang.org/x/sys@v0.0.0-20201009025420-dfb3f7c4e634/unix/zsyscall_darwin_amd64.go:59:3: //go:linkname must refer to declared function or variable
/Users/moritz/go/pkg/mod/golang.org/x/sys@v0.0.0-20201009025420-dfb3f7c4e634/unix/zsyscall_darwin_amd64.go:75:3: //go:linkname must refer to declared function or variable
/Users/moritz/go/pkg/mod/golang.org/x/sys@v0.0.0-20201009025420-dfb3f7c4e634/unix/zsyscall_darwin_amd64.go:90:3: //go:linkname must refer to declared function or variable
/Users/moritz/go/pkg/mod/golang.org/x/sys@v0.0.0-20201009025420-dfb3f7c4e634/unix/zsyscall_darwin_amd64.go:105:3: //go:linkname must refer to declared function or variable
/Users/moritz/go/pkg/mod/golang.org/x/sys@v0.0.0-20201009025420-dfb3f7c4e634/unix/zsyscall_darwin_amd64.go:121:3: //go:linkname must refer to declared function or variable
/Users/moritz/go/pkg/mod/golang.org/x/sys@v0.0.0-20201009025420-dfb3f7c4e634/unix/zsyscall_darwin_amd64.go:121:3: too many errors
make: *** [gotestsum] Error 2
➜  acs-fleet-manager git:(main)
```

The problem seems to be an old version of the package `golang.org/x/sys` which is brought in as a transitive dependency by an old version of `gogetsum`. Bumping the latter to its latest version seems to fix the problem for me:

```
➜  acs-fleet-manager git:(main) ✗ OCM_ENV=integration make test/integration

go test -i ./internal/dinosaur/test/integration/...
go: -i flag is deprecated
/Users/moritz/go/src/github.com/stackrox/acs-fleet-manager/bin/gotestsum --junitfile data/results/fleet-manager-integration-tests.xml --format short-verbose -- -p 1 -ldflags -s -v -timeout 15m -count=1  \
                                ./internal/dinosaur/test/integration/...
PASS internal/dinosaur/test/integration.TestAuth_success (0.82s)
PASS internal/dinosaur/test/integration.TestAuthSucess_publicUrls (0.32s)
PASS internal/dinosaur/test/integration.TestAuthSuccess_usingSSORHToken (0.89s)
PASS internal/dinosaur/test/integration.TestAuthFailure_withoutToken (0.32s)
PASS internal/dinosaur/test/integration.TestAuthFailure_invalidTokenWithInvalidTyp (0.76s)
PASS internal/dinosaur/test/integration.TestAuthFailure_ExpiredToken (1.50s)
PASS internal/dinosaur/test/integration.TestAuthFailure_invalidTokenMissingIat (0.77s)
PASS internal/dinosaur/test/integration.TestAuthFailure_invalidTokenMissingAlgHeader (0.33s)
PASS internal/dinosaur/test/integration.TestAuthFailure_invalidTokenUnsigned (0.35s)
PASS internal/dinosaur/test/integration.TestCloudProviderRegions (0.66s)
PASS internal/dinosaur/test/integration.TestCachedCloudProviderRegions (0.58s)
git difPASS internal/dinosaur/test/integration.TestListCloudProviders (1.47s)
fPASS internal/dinosaur/test/integration.TestListCloudProviderRegions (1.02s)
PASS internal/dinosaur/test/integration.TestListCloudProviderRegionsWithInstanceType (1.04s)
PASS internal/dinosaur/test/integration.TestDinosaurCreate_TooManyDinosaurs (0.82s)
PASS internal/dinosaur/test/integration.TestDinosaur_Delete/should_fail_when_deleting_dinosaur_without_async_set_to_true (0.47s)
PASS internal/dinosaur/test/integration.TestDinosaur_Delete/should_fail_when_deleting_dinosaur_with_empty_id (0.00s)
PASS internal/dinosaur/test/integration.TestDinosaur_Delete/should_succeed_when_deleting_dinosaur_with_valid_id_and_context (0.02s)
PASS internal/dinosaur/test/integration.TestDinosaur_Delete (0.81s)
PASS internal/dinosaur/test/integration.TestTermsRequired_CreateDinosaurTermsRequired (0.99s)
PASS internal/dinosaur/test/integration.TestTermsRequired_CreateDinosaur_TermsNotRequired (1.02s)
PASS internal/dinosaur/test/integration

=== Skipped
=== SKIP: internal/dinosaur/test/integration TestAdminDinosaur_Get (0.00s)
    main_test.go:21: Not fully implemented yet

=== SKIP: internal/dinosaur/test/integration TestDinosaurCreate_Success (0.00s)
    main_test.go:21: Not fully implemented yet

DONE 23 tests, 2 skipped in 18.464s
➜  acs-fleet-manager git:(main) ✗
```

