### PR TITLE
add Ping Test after creating new db connection

### DIFF
--- a/pkg/db/connection.go
+++ b/pkg/db/connection.go
@@ -50,6 +50,9 @@ func NewConnectionFactory(config *DatabaseConfig) (*ConnectionFactory, func()) {
 	if sqlDBErr != nil {
 		panic(fmt.Errorf("Unexpected connection error: %s", sqlDBErr))
 	}
+	if err := sqlDB.Ping(); err != nil {
+		panic(fmt.Errorf("unexpected connection error: %s", err))
+	}
 
 	sqlDB.SetMaxOpenConns(config.MaxOpenConnections)
 	dbFactory := &ConnectionFactory{Config: config, DB: db}


### PR DESCRIPTION
## Description
When the db for fleet manager is not available there is a misleading panic due to a nil pointer dereference. In this PR I added a Ping Test when creating the DB connection to panic whenever the db is not reachable at creation of a connection.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~[ ] Unit and integration tests added~
- ~[ ] Documentation added if necessary~
- ~[ ] CI and all relevant tests are passing~

## Test manual

Tested through IDE debugging that if DB is not reachable, it will now panic on connection creation

