### PR TITLE
Add dbg-binary target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,10 @@ binary:
 	$(GO) build ./cmd/fleet-manager
 .PHONY: binary
 
+dbg-binary:
+	$(GO) build -gcflags=all="-N -l" ./cmd/fleet-manager
+.PHONY: dbg-binary
+
 # Install
 install: verify lint
 	$(GO) install ./cmd/fleet-manager


### PR DESCRIPTION
## Description

Adds Makefile target for building fleet-manager with debugging information.

## Checklist (Definition of Done)
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

n/a