### PR TITLE
Makefile target for running local psql

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -405,6 +405,10 @@ db/login:
 	docker exec -u $(shell id -u) -it fleet-manager-db /bin/bash -c "PGPASSWORD=$(shell cat secrets/db.password) psql -d $(shell cat secrets/db.name) -U $(shell cat secrets/db.user)"
 .PHONY: db/login
 
+db/psql:
+	@PGPASSWORD=$(shell cat secrets/db.password) psql -h localhost -d $(shell cat secrets/db.name) -U $(shell cat secrets/db.user)
+.PHONY: db/psql
+
 db/generate/insert/cluster:
 	@read -r id external_id provider region multi_az<<<"$(shell ocm get /api/clusters_mgmt/v1/clusters/${CLUSTER_ID} | jq '.id, .external_id, .cloud_provider.id, .region.id, .multi_az' | tr -d \" | xargs -n2 echo)";\
 	echo -e "Run this command in your database:\n\nINSERT INTO clusters (id, created_at, updated_at, cloud_provider, cluster_id, external_id, multi_az, region, status, provider_type) VALUES ('"$$id"', current_timestamp, current_timestamp, '"$$provider"', '"$$id"', '"$$external_id"', "$$multi_az", '"$$region"', 'cluster_provisioned', 'ocm');";


### PR DESCRIPTION
## Description

I noticed that I did not have any psql history when using `db/login`. This is due to a dockerized psql being used.
When using a locally installed psql client a query history can be maintained between different DB sessions.

## Checklist (Definition of Done)

n/a

## Test manual

n/a
