### PR TITLE
added minimal data to internal GET centrals API response

### DIFF
--- a/internal/dinosaur/pkg/presenters/manageddinosaur.go
+++ b/internal/dinosaur/pkg/presenters/manageddinosaur.go
@@ -6,7 +6,6 @@ import (
 )
 
 func PresentManagedDinosaur(from *v1.ManagedDinosaur) private.ManagedDinosaur {
-	// TODO implement presenter
 	res := private.ManagedDinosaur{
 		Id:   from.Annotations["mas/id"],
 		Kind: from.Kind,
@@ -19,7 +18,6 @@ func PresentManagedDinosaur(from *v1.ManagedDinosaur) private.ManagedDinosaur {
 			},
 		},
 		Spec: private.ManagedDinosaurAllOfSpec{
-			// TODO implement your spec fields here
 			Owners: from.Spec.Owners,
 			Endpoint: private.ManagedDinosaurAllOfSpecEndpoint{
 				Host: from.Spec.Endpoint.Host,


### PR DESCRIPTION
## Description
The previous response from the internal API with Method GET and path `/api/rhacs/v1/agent-clusters/{cluster_id}/dinosaurs`
returned a response were the spec field of the ManagedDinosours were missing:

```
{
  "kind": "ManagedDinosaurList",
  "items": [
    {
      "id": "ca5o5n5vqc7sltde4h10",
      "kind": "ManagedDinosaur",
      "metadata": {
        "name": "docker-desktop",
        "annotations": {
          "mas/id": "ca5o5n5vqc7sltde4h10",
          "mas/placementId": ""
        }
      },
      "spec": {
        "endpoint": {},
        "versions": {},
        "deleted": false
      }
    }
  ]
}
```

This PR fixes the type conversion between internal and presented struct to include the missing data. The response now look like this:

```
{
  "kind": "ManagedDinosaurList",
  "items": [
    {
      "id": "ca68cgtvqc7u0ehh9afg",
      "kind": "ManagedDinosaur",
      "metadata": {
        "name": "supercentral3000",
        "annotations": {
          "mas/id": "ca68cgtvqc7u0ehh9afg",
          "mas/placementId": ""
        }
      },
      "spec": {
        "owners": [
          "rh-ee-jmalsam"
        ],
        "endpoint": {
          "host": "superhost3000",
          "tls": {}
        },
        "versions": {},
        "deleted": false
      }
    }
  ]
}
```

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~[ ] Unit and integration tests added~
- ~[ ] Documentation added if necessary~
- [x] CI and all relevant tests are passing

## Test manual

At time of testing, state reconciliation for accepted and preparing state of centrals did not work, so you have to take following steps to get the API to return an object:

- create central through public API of fleet manager
- manually set the state of the db entry to `provisioning` or `ready`
- manually set the host field of the db entry to something else than empty string
- call the endpoint `/api/rhacs/v1/agent-clusters/{cluster_id}/dinosaurs`
