### PR TITLE
Return 200 on successful PUT to update an agent status

### DIFF
--- a/internal/dinosaur/pkg/handlers/data_plane_cluster.go
+++ b/internal/dinosaur/pkg/handlers/data_plane_cluster.go
@@ -43,8 +43,7 @@ func (h *dataPlaneClusterHandler) UpdateDataPlaneClusterStatus(w http.ResponseWr
 		},
 	}
 
-	// TODO do we always to return HTTP 204 No Content?
-	handlers.Handle(w, r, cfg, http.StatusNoContent)
+	handlers.Handle(w, r, cfg, http.StatusOK)
 }
 
 func (h *dataPlaneClusterHandler) GetDataPlaneClusterConfig(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Before this change for a successful request the response returned 204. The openAPI spec indicates a 200 should be returned on success, which is consistent with the implementation that performs a synchronous update in the database. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Testing

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```

also manual testing

```bash
make db/teardown db/setup db/migrate
cp dev/config/dataplane-cluster-configuration-minikube.yaml config/dataplane-cluster-configuration.yaml
make binary && ./fleet-manager serve 2>&1 | tee fleet-manager-serve.log

# wait until leader election is solved in the server
cluster_id='1234567890abcdef1234567890abcdef'
curl -v -H "Authorization: Bearer $(ocm token)" http://localhost:8000/api/rhacs/v1/agent-clusters/${cluster_id}/status?async=true -X PUT -d '
{
  "dinosaurOperator": [
    {
      "ready": true,
      "version": "0.1.0",
      "dinosaurVersions": ["0.1.0"]
    } 
  ],
  "conditions": [
    {
      "type": "Ready",
      "status": "true",
      "message": "fully operational",
      "reason": "this is a test"
    }
  ]
}' | jq .
...
< HTTP/1.1 200 OK
...
```