### PR TITLE
Add conversion function for data plane dinosaur status

### DIFF
--- a/internal/dinosaur/pkg/presenters/data_plane_dinosaur_status.go
+++ b/internal/dinosaur/pkg/presenters/data_plane_dinosaur_status.go
@@ -6,10 +6,10 @@ import (
 )
 
 func ConvertDataPlaneDinosaurStatus(status map[string]private.DataPlaneDinosaurStatus) []*dbapi.DataPlaneDinosaurStatus {
-	var res []*dbapi.DataPlaneDinosaurStatus
+	res := make([]*dbapi.DataPlaneDinosaurStatus, len(status))
 
 	for k, v := range status {
-		var c []dbapi.DataPlaneDinosaurStatusCondition
+		c := make([]dbapi.DataPlaneDinosaurStatusCondition, len(v.Conditions))
 		var routes []dbapi.DataPlaneDinosaurRouteRequest
 		for _, s := range v.Conditions {
 			c = append(c, dbapi.DataPlaneDinosaurStatusCondition{
@@ -20,6 +20,7 @@ func ConvertDataPlaneDinosaurStatus(status map[string]private.DataPlaneDinosaurS
 			})
 		}
 		if v.Routes != nil {
+			routes = make([]dbapi.DataPlaneDinosaurRouteRequest, len(*v.Routes))
 			for _, ro := range *v.Routes {
 				routes = append(routes, dbapi.DataPlaneDinosaurRouteRequest{
 					Name:   ro.Name,


### PR DESCRIPTION
## Description

Add conversion function for data plane dinosaur status. Taken and modified from kafka's fleet manager (https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/blob/main/internal/kafka/internal/presenters/data_plane_kafka_status.go#L8).

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
