### PR TITLE
[fleetshard sync] Add reconcile function

### DIFF
--- a/fleetshard/main.go
+++ b/fleetshard/main.go
@@ -176,6 +176,7 @@ func (r ClusterReconciler) Reconcile(ctx context.Context, newCentral *v1alpha1.C
 		}
 	} else {
 		newCentral.ResourceVersion = central.ResourceVersion
+		// TODO(yury): implement update logic
 		if err := r.client.Update(ctx, newCentral); err != nil {
 			return errors.Wrapf(err, "updating central %q", newCentral.GetName())
 		}


### PR DESCRIPTION
## Description
First attempt to implement the central cluster reconciliation logic.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
