### PR TITLE
enabling cluster state transition provisioned, waiting, ready

### DIFF
--- a/dev/config/dataplane-cluster-configuration-minikube.yaml
+++ b/dev/config/dataplane-cluster-configuration-minikube.yaml
@@ -27,6 +27,7 @@ clusters:
 #    provider_type: standalone
 #    supported_instance_type: "eval,standard"
 #    cluster_dns: kubernetes.docker.internal
+#    dinosaur_instance_limit: 5
  - name: minikube  # Uncomment if using minikube
    cluster_id: 1234567890abcdef1234567890abcdef
    cloud_provider: standalone

--- a/internal/dinosaur/pkg/presenters/data_plane_cluster_status.go
+++ b/internal/dinosaur/pkg/presenters/data_plane_cluster_status.go
@@ -1,9 +1,9 @@
 package presenters
 
 import (
-	"github.com/stackrox/acs-fleet-manager/pkg/api"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
+	"github.com/stackrox/acs-fleet-manager/pkg/api"
 )
 
 func ConvertDataPlaneClusterStatus(status private.DataPlaneClusterUpdateStatusRequest) (*dbapi.DataPlaneClusterStatus, error) {
@@ -11,9 +11,9 @@ func ConvertDataPlaneClusterStatus(status private.DataPlaneClusterUpdateStatusRe
 	res.Conditions = make([]dbapi.DataPlaneClusterStatusCondition, len(status.Conditions))
 	for i, cond := range status.Conditions {
 		res.Conditions[i] = dbapi.DataPlaneClusterStatusCondition{
-			Type: cond.Type,
-			Reason: cond.Reason,
-			Status: cond.Status,
+			Type:    cond.Type,
+			Reason:  cond.Reason,
+			Status:  cond.Status,
 			Message: cond.Message,
 		}
 	}
@@ -21,7 +21,7 @@ func ConvertDataPlaneClusterStatus(status private.DataPlaneClusterUpdateStatusRe
 	for i, op := range status.DinosaurOperator {
 		res.AvailableDinosaurOperatorVersions[i] = api.DinosaurOperatorVersion{
 			Version: op.Version,
-			Ready: op.Ready,
+			Ready:   op.Ready,
 		}
 		res.AvailableDinosaurOperatorVersions[i].DinosaurVersions = make([]api.DinosaurVersion, len(op.DinosaurVersions))
 		for j, v := range op.DinosaurVersions {
@@ -32,7 +32,16 @@ func ConvertDataPlaneClusterStatus(status private.DataPlaneClusterUpdateStatusRe
 }
 
 func PresentDataPlaneClusterConfig(config *dbapi.DataPlaneClusterConfig) private.DataplaneClusterAgentConfig {
-	// TODO implement presenter
-	var res private.DataplaneClusterAgentConfig
+	res := private.DataplaneClusterAgentConfig{
+		Spec: private.DataplaneClusterAgentConfigSpec{
+			Observability: private.DataplaneClusterAgentConfigSpecObservability{
+				AccessToken: &config.Observability.AccessToken,
+				Channel:     config.Observability.Channel,
+				Repository:  config.Observability.Repository,
+				Tag:         config.Observability.Tag,
+			},
+		},
+	}
+
 	return res
 }

--- a/internal/dinosaur/pkg/workers/clusters_mgr.go
+++ b/internal/dinosaur/pkg/workers/clusters_mgr.go
@@ -570,7 +570,7 @@ func (c *ClusterManager) reconcileClusterStatus(cluster *api.Cluster) (*api.Clus
 }
 
 func (c *ClusterManager) reconcileAddonOperator(provisionedCluster api.Cluster) error {
-	// TODO: Activate dinosaur reconcilation and FleetshardOperatorAddon Provision
+	// TODO(create-ticket): Activate dinosaur reconcilation and FleetshardOperatorAddon.Provision
 	// as soon as this components are available
 	dinosaurOperatorIsReady := true
 	// dinosaurOperatorIsReady, err := c.reconcileDinosaurOperator(provisionedCluster)

--- a/internal/dinosaur/pkg/workers/clusters_mgr.go
+++ b/internal/dinosaur/pkg/workers/clusters_mgr.go
@@ -516,10 +516,10 @@ func (c *ClusterManager) reconcileProvisionedCluster(cluster api.Cluster) error 
 	// independently of the installation of the addon, and it should use the
 	// result of the addon/s reconciliation to set the status of the cluster
 	// TODO(create-ticket): Install the ACS Operator and Fleetshard Operator (Add-Ons)
-	//addOnErr := c.reconcileAddonOperator(cluster)
-	//if addOnErr != nil {
-	//	return errors.WithMessagef(addOnErr, "failed to reconcile cluster %s addon operator: %s", cluster.ClusterID, addOnErr.Error())
-	//}
+	addOnErr := c.reconcileAddonOperator(cluster)
+	if addOnErr != nil {
+		return errors.WithMessagef(addOnErr, "failed to reconcile cluster %s addon operator: %s", cluster.ClusterID, addOnErr.Error())
+	}
 
 	return nil
 }
@@ -570,16 +570,20 @@ func (c *ClusterManager) reconcileClusterStatus(cluster *api.Cluster) (*api.Clus
 }
 
 func (c *ClusterManager) reconcileAddonOperator(provisionedCluster api.Cluster) error {
-	dinosaurOperatorIsReady, err := c.reconcileDinosaurOperator(provisionedCluster)
-	if err != nil {
-		return err
-	}
+	// TODO: Activate dinosaur reconcilation and FleetshardOperatorAddon Provision
+	// as soon as this components are available
+	dinosaurOperatorIsReady := true
+	// dinosaurOperatorIsReady, err := c.reconcileDinosaurOperator(provisionedCluster)
+	// if err != nil {
+	// 	return err
+	// }
 
 	glog.Infof("Provisioning fleetshard-operator as it is enabled")
-	fleetshardOperatorIsReady, errs := c.FleetshardOperatorAddon.Provision(provisionedCluster)
-	if errs != nil {
-		return errs
-	}
+	fleetshardOperatorIsReady := true
+	// fleetshardOperatorIsReady, errs := c.FleetshardOperatorAddon.Provision(provisionedCluster)
+	// if errs != nil {
+	// 	return errs
+	// }
 
 	if dinosaurOperatorIsReady && fleetshardOperatorIsReady {
 		glog.V(5).Infof("Set cluster status to %s for cluster %s", api.ClusterWaitingForFleetShardOperator, provisionedCluster.ClusterID)


### PR DESCRIPTION
## Description

Testing state transition for clusters in fleet manager from `cluster_provisioned` to `waiting_for_fleetshard_operator` to `ready`. Cluster starts at `cluster_provisioned` state and should transition to `waiting_for_fleetshard_operator` with the reconcilation of the `cluster_provisioned` state. This step was commented out and reactivated in this PR. Skipping operator/addon installation for now. The transition from `waiting_for_fleetshard_operator` to `ready` was tested and works with a PUT request to `/api/rhacs/v1/agent-clusters/<id>/status`.

Also added a presenter implementation for the response for `GET /api/rhacs/v1/agent-cluster/<id>`.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~[ ] Unit and integration tests added~
- ~[ ] Documentation added if necessary~
- [x] CI and all relevant tests are passing

## Test manual

Manual Testing:

```yaml
# Configure `dataplane-cluster-configuration.yaml` with a cluster in `cluster_provisioned` state for example:
clusters:
 - name: docker-desktop
   cluster_id: 1234567890abcdef1234567890abcdef
   cloud_provider: standalone
   region: standalone
   schedulable: true
   status: cluster_provisioned
   provider_type: standalone
   supported_instance_type: "eval,standard"
   cluster_dns: kubernetes.docker.internal
```

```bash
# Run fleet-manager with clean DB
make db/teardown db/setup db/migrate
make run

# After leader election it should detect a cluster in provisioned state and bring it to waiting_for_fleetshard_operator state
# verify that by searching for log messages like this:
I0527 13:04:11.154602   95770 accepted_dinosaurs_mgr.go:65] accepted dinosaurs count = 0
I0527 13:04:11.155129   95770 clusters_mgr.go:281] provisioned clusters count = 1
I0527 13:04:11.155143   95770 clusters_mgr.go:286] provisioned cluster ClusterID = 1234567890abcdef1234567890abcdef
I0527 13:04:11.155162   95770 clusters_mgr.go:581] Provisioning fleetshard-operator as it is enabled
I0527 13:04:11.155167   95770 clusters_mgr.go:589] Set cluster status to waiting_for_fleetshard_operator for cluster 1234567890abcdef1234567890abcdef 

# also verify cluster is in waiting_for_fleetshard_operator state in DB
make db/login
select cluster_id, status from clusters;
            cluster_id            |             status              
----------------------------------+---------------------------------
 1234567890abcdef1234567890abcdef | waiting_for_fleetshard_operator
(1 row)

# Send PUT requests to set cluster to ready state
cluster_id=1234567890abcdef1234567890abcdef
curl -v -H "Authorization: Bearer $(ocm token)" http://localhost:8000/api/rhacs/v1/agent-clusters/$cluster_id/status\?async\=true -X PUT -d '
{
  "dinosaurOperator": [
    {
      "ready": true,
      "version": "0.1.0",
      "dinosaurVersions": ["0.1.0"]
    }
  ],
  "conditions": [
    {
      "type": "Ready",
      "status": "true",
      "message": "fully operational",
      "reason": "this is a test"
    }
  ]
}' | jq .
# should return 200 OK

# Verify that cluster is in ready state in DB
make db/login
select cluster_id, status from clusters;
            cluster_id            | status 
----------------------------------+--------
 1234567890abcdef1234567890abcdef | ready
(1 row)
```

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
