### PR TITLE
Drop quay creds overrides in build_deploy.sh

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,9 +117,9 @@ jobs:
       - name: Build and publish image to quay.io
         if: github.event_name == 'push'
         env:
-          QUAY_USER_NAME: ${{ secrets.QUAY_RHACS_ENG_FM_RW_USERNAME }}
-          QUAY_USER_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_FM_RW_PASSWORD }}
-          QUAY_ORG_NAME: rhacs-eng
+          QUAY_USER: ${{ secrets.QUAY_RHACS_ENG_FM_RW_USERNAME }}
+          QUAY_TOKEN: ${{ secrets.QUAY_RHACS_ENG_FM_RW_PASSWORD }}
+          QUAY_IMAGE_REPOSITORY: rhacs-eng/fleet-manager
         run: |
           chmod +x ./build_deploy.sh
           ./build_deploy.sh

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -29,7 +29,7 @@
 # the built images can be pushed to quay.io.
 
 # The version should be the short hash from git. This is what the deployment process expects.
-VERSION="$(git log --pretty=format:'%h' -n 1)"
+VERSION=`git rev-parse --short=7 HEAD`
 
 # Set the directory for docker configuration:
 DOCKER_CONFIG="${PWD}/.docker"

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -59,7 +59,7 @@ if [ -z "${QUAY_TOKEN}" ]; then
 fi
 if [ -z "${QUAY_IMAGE_REPOSITORY}" ]; then
   echo "The quay.io image repository hasn't been provided."
-  echo "Make sure to set the QUAY_IMAGE_REPOSITORY environment variable."
+  echo "Make sure to set the QUAY_IMAGE_REPOSITORY environment variable to '<org>/<repo>'."
   exit 1
 fi
 

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -31,11 +31,6 @@
 # The version should be the short hash from git. This is what the deployment process expects.
 VERSION="$(git log --pretty=format:'%h' -n 1)"
 
-# Set the variable required to login and push images to the registry
-QUAY_USER=${QUAY_USER_NAME:-$RHOAS_QUAY_USER}
-QUAY_TOKEN=${QUAY_USER_PASSWORD:-$RHOAS_QUAY_TOKEN}
-QUAY_ORG=${QUAY_ORG_NAME:-rhoas}
-
 # Set the directory for docker configuration:
 DOCKER_CONFIG="${PWD}/.docker"
 
@@ -78,7 +73,7 @@ else
 fi
 
 # Push the image:
-echo "Quay.io user and token is set, will push images to $QUAY_ORG org"
+echo "Quay.io user and token is set, will push images to $QUAY_IMAGE_REPOSITORY"
 make \
   DOCKER_CONFIG="${DOCKER_CONFIG}" \
   QUAY_USER="${QUAY_USER}" \
@@ -86,7 +81,7 @@ make \
   version="${VERSION}" \
   external_image_registry="quay.io" \
   internal_image_registry="quay.io" \
-  image_repository="$QUAY_ORG/fleet-manager" \
+  image_repository="${QUAY_IMAGE_REPOSITORY}" \
   docker/login \
   image/push
 
@@ -97,6 +92,6 @@ make \
   version="${BRANCH}" \
   external_image_registry="quay.io" \
   internal_image_registry="quay.io" \
-  image_repository="$QUAY_ORG/fleet-manager" \
+  image_repository="${QUAY_IMAGE_REPOSITORY}" \
   docker/login \
   image/push

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -49,12 +49,17 @@ cd "${LINK}"
 # Log in to the image registry:
 if [ -z "${QUAY_USER}" ]; then
   echo "The quay.io push user name hasn't been provided."
-  echo "Make sure to set the QUAY_USER_NAME environment variable."
+  echo "Make sure to set the QUAY_USER environment variable."
   exit 1
 fi
 if [ -z "${QUAY_TOKEN}" ]; then
   echo "The quay.io push token hasn't been provided."
-  echo "Make sure to set the QUAY_USER_PASSWORD environment variable."
+  echo "Make sure to set the QUAY_TOKEN environment variable."
+  exit 1
+fi
+if [ -z "${QUAY_IMAGE_REPOSITORY}" ]; then
+  echo "The quay.io image repository hasn't been provided."
+  echo "Make sure to set the QUAY_IMAGE_REPOSITORY environment variable."
   exit 1
 fi
 

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -28,7 +28,7 @@
 # The machines that run this script need to have access to internet, so that
 # the built images can be pushed to quay.io.
 
-# The version should be the short hash from git. This is what the deployment process expects.
+# The version should be a 7-char hash from git. This is what the deployment process in app-interface expects.
 VERSION=`git rev-parse --short=7 HEAD`
 
 # Set the directory for docker configuration:


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
`build_deploy.sh` should rely on `QUAY_USER` and `QUAY_TOKEN`.
Also, image tag should be 7 chars long.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

Not relevant
