### PR TITLE
Add fleetshard-sync to images, support building images in containers

### DIFF
--- a/BUILD_IMAGE_VERSION
+++ b/BUILD_IMAGE_VERSION
@@ -1,1 +1,0 @@
-stackrox-build-0.3.35

--- a/BUILD_IMAGE_VERSION
+++ b/BUILD_IMAGE_VERSION
@@ -1,0 +1,1 @@
+stackrox-build-0.3.35

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
 COPY \
     fleet-manager \
+    fleetshard-sync \
     /usr/local/bin/
 
 EXPOSE 8000

--- a/Makefile
+++ b/Makefile
@@ -269,10 +269,10 @@ lint: golangci-lint specinstall
 # NOTE it may be necessary to use CGO_ENABLED=0 for backwards compatibility with centos7 if not using centos7
 
 fleet-manager:
-	$(GO) build $(GOARGS) ./cmd/fleet-manager
+	GOOS="$(GOOS)" GOARCH="$(GOARCH)" $(GO) build $(GOARGS) ./cmd/fleet-manager
 
 fleetshard-sync:
-	$(GO) build $(GOARGS) -o fleetshard-sync ./fleetshard
+	GOOS="$(GOOS)" GOARCH="$(GOARCH)" $(GO) build $(GOARGS) -o fleetshard-sync ./fleetshard
 
 binary: fleet-manager fleetshard-sync
 .PHONY: binary
@@ -436,9 +436,9 @@ docker/login/internal:
 
 # Build the binary and image
 # TODO(create-ticket): Revisit decision to use a combined-image-approach, where the image contains both the fleet-manager and the fleetshard-sync.
-image/build:
-	GOOS=linux GOARCH=amd64 $(GO) build $(GOARGS) ./cmd/fleet-manager
-	GOOS=linux GOARCH=amd64 $(GO) build $(GOARGS) -o fleetshard-sync ./fleetshard
+image/build: GOOS=linux
+image/build: GOARCH=amd64
+image/build: fleet-manager fleetshard-sync
 	docker --config="${DOCKER_CONFIG}" build -t "$(external_image_registry)/$(image_repository):$(image_tag)" .
 .PHONY: image/build
 

--- a/Makefile
+++ b/Makefile
@@ -284,6 +284,7 @@ install: verify lint
 
 clean:
 	rm -f fleet-manager fleetshard-sync
+.PHONY: clean
 
 # Runs the unit tests.
 #

--- a/Makefile
+++ b/Makefile
@@ -1,39 +1,9 @@
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 DOCS_DIR := $(PROJECT_PATH)/docs
-BUILD_IMAGE := quay.io/stackrox-io/apollo-ci:$(shell sed 's/\s*\#.*//' BUILD_IMAGE_VERSION)
 
 .DEFAULT_GOAL := help
 SHELL = bash
-
-# Figure out whether to use standalone Docker volume for GOPATH/Go build cache, or bind
-# mount one from the host filesystem.
-# The latter is painfully slow on Mac OS X with Docker Desktop, so we default to using a
-# standalone volume in that case, and to bind mounting otherwise.
-UNAME_S := $(shell uname -s)
-
-ifeq ($(UNAME_S),Darwin)
-BIND_GOCACHE ?= 0
-BIND_GOPATH ?= 0
-else
-BIND_GOCACHE ?= 1
-BIND_GOPATH ?= 1
-endif
-
-ifeq ($(BIND_GOCACHE),1)
-GOCACHE_VOLUME_SRC := $(CURDIR)/linux-gocache
-else
-GOCACHE_VOLUME_SRC := $(GOCACHE_VOLUME_NAME)
-endif
-
-ifeq ($(BIND_GOPATH),1)
-GOPATH_VOLUME_SRC := $(GOPATH)
-else
-GOPATH_VOLUME_SRC := $(GOPATH_VOLUME_NAME)
-endif
-
-LOCAL_VOLUME_ARGS := -v$(CURDIR):/src:delegated -v $(GOCACHE_VOLUME_SRC):/linux-gocache:delegated -v $(GOPATH_VOLUME_SRC):/go:delegated
-GOPATH_WD_OVERRIDES := -w /src -e GOPATH=/go -e GOCACHE=/linux-gocache
 
 # The details of the application:
 binary:=fleet-manager
@@ -457,14 +427,11 @@ docker/login/internal:
 .PHONY: docker/login/internal
 
 # Build the binary and image
-image/build: build-dockerized
+image/build:
+	GOOS=linux GOARCH=amd64 $(GO) build ./cmd/fleet-manager
+	GOOS=linux GOARCH=amd64 $(GO) build -o fleetshard-sync ./fleetshard
 	docker --config="${DOCKER_CONFIG}" build -t "$(external_image_registry)/$(image_repository):$(image_tag)" .
 .PHONY: image/build
-
-build-dockerized:
-	@echo "+ $@"
-	docker run -i -e RACE -e CI -e CIRCLE_TAG -e GOTAGS -e DEBUG_BUILD -e CGO_ENABLED=0 --rm $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make binary
-.PHONY: build-dockerized
 
 # Build and push the image
 image/push: image/build

--- a/secrets/db.host.internal-docker
+++ b/secrets/db.host.internal-docker
@@ -1,0 +1,1 @@
+kubernetes.docker.internal


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
