### PR TITLE
add instructions for moving central to ready only with API calls

### DIFF
--- a/dev/config/dataplane-cluster-configuration-infractl-osd.yaml
+++ b/dev/config/dataplane-cluster-configuration-infractl-osd.yaml
@@ -5,13 +5,13 @@
 #  'deprovisioning' and will later be deleted.
 #- This list is ordered, any new cluster should be appended at the end.
 clusters:
- - name: default/api-evan-acsms-fm-d-0a51-s2-devshift-org:6443/admin
-   cluster_id: 1sdu4lati28ifrnk73d3o4qa720rb5ek
-   cloud_provider: gcp
-   region: us-east1
+ - name: default/api-juan-fm-dev-94xt-s1-devshift-org:6443/admin
+   cluster_id: 1sh266ouf8lipuid2c0rna877eou6ecc
+   cloud_provider: aws
+   region: us-west-2
    schedulable: true
    status: ready
    dinosaur_instance_limit: 10
    provider_type: standalone
    supported_instance_type: "eval,standard"
-   cluster_dns: evan-acsms-fm-d.0a51.s2.devshift.org
+   cluster_dns: juan-fm-dev.94xt.s1.devshift.org


### PR DESCRIPTION
add instructions for moving central to ready only with API calls, and on an OSD cluster

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

See modified docs for instructions

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
