### PR TITLE
enable setting operator versions in dataplane config file

### DIFF
--- a/dev/config/dataplane-cluster-configuration-dockerdesktop.yaml
+++ b/dev/config/dataplane-cluster-configuration-dockerdesktop.yaml
@@ -17,27 +17,17 @@
 #    provider_type: "ocm" #Valid values are `ocm` and `standalone`. `ocm` will be used if not specified.
 #    cluster_dns: apps.example.com #Valid cluster DNS. This will be used to build dinosaur host url and to communicate with standalone clusters. Required when "provider_type" is "standalone" 
 #    supported_instance_type: "eval" # could be "eval", "standard" or both i.e "standard,eval" or "eval,standard". Defaults to "standard,eval" if not set 
-clusters:
-#  - name: docker-desktop  # Uncomment if using docker-desktop
-#    cluster_id: 1234567890abcdef1234567890abcdef
-#    cloud_provider: standalone
-#    region: standalone
-#    schedulable: true
-#    status: ready
-#    provider_type: standalone
-#    supported_instance_type: "eval,standard"
-#    cluster_dns: kubernetes.docker.internal
-#    dinosaur_instance_limit: 5
- - name: minikube  # Uncomment if using minikube
+clusters:   # For a list of development clusters see dev/config/dataplane-cluster-configuration.yaml
+ - name: docker-desktop  # Uncomment if using docker-desktop
    cluster_id: 1234567890abcdef1234567890abcdef
    cloud_provider: standalone
    region: standalone
    schedulable: true
    status: ready
-   dinosaur_instance_limit: 5
    provider_type: standalone
    supported_instance_type: "eval,standard"
-   cluster_dns: cluster.local
+   cluster_dns: kubernetes.docker.internal
+   dinosaur_instance_limit: 5
    available_dinosaur_operator_versions:
     - version: "0.1.0"
       ready: true

--- a/dev/config/dataplane-cluster-configuration-dockerdesktop.yaml
+++ b/dev/config/dataplane-cluster-configuration-dockerdesktop.yaml
@@ -1,24 +1,11 @@
 ---
 #- A list of clusters for fleet manager
 #- The `cluster_id` field can not be empty
-#- All clusters in fleet manager DB already but are missing in the list will be marked as
+#- All clusters which are already stored in fleet-manager's DB but are missing in the list will be marked as
 #  'deprovisioning' and will later be deleted.
 #- This list is ordered, any new cluster should be appended at the end.
-#e.g.:
-#clusters:
-#  - name: anyname # This field is required for a standalone cluster i.e when the provider_type is "standalone". The value has to match the cluster / context name in the given kubeconfig file via the `--kubeconfig` flag.
-#    cluster_id: 1jp6kdr7k0sjbe5adck2prjur8f39378  #This field is required
-#    cloud_provider: aws
-#    region: us-east-1
-#    multi_az: true
-#    schedulable: true
-#    dinosaur_instance_limit: 2
-#    status: "cluster_provisioning" #Valid values are `cluster_provisioning`, `cluster_provisioned` and `ready`. `cluster_provisioning` will be used if not specified.
-#    provider_type: "ocm" #Valid values are `ocm` and `standalone`. `ocm` will be used if not specified.
-#    cluster_dns: apps.example.com #Valid cluster DNS. This will be used to build dinosaur host url and to communicate with standalone clusters. Required when "provider_type" is "standalone" 
-#    supported_instance_type: "eval" # could be "eval", "standard" or both i.e "standard,eval" or "eval,standard". Defaults to "standard,eval" if not set 
-clusters:   # For a list of development clusters see dev/config/dataplane-cluster-configuration.yaml
- - name: docker-desktop  # Uncomment if using docker-desktop
+clusters:
+ - name: docker-desktop
    cluster_id: 1234567890abcdef1234567890abcdef
    cloud_provider: standalone
    region: standalone
@@ -27,9 +14,9 @@ clusters:   # For a list of development clusters see dev/config/dataplane-cluste
    provider_type: standalone
    supported_instance_type: "eval,standard"
    cluster_dns: kubernetes.docker.internal
-   dinosaur_instance_limit: 5
-   available_dinosaur_operator_versions:
+   central_instance_limit: 5
+   available_central_operator_versions:
     - version: "0.1.0"
       ready: true
-      dinosaur_versions:
+      central_versions:
        - version: "0.1.0"

--- a/dev/config/dataplane-cluster-configuration-infractl-osd.yaml
+++ b/dev/config/dataplane-cluster-configuration-infractl-osd.yaml
@@ -11,7 +11,7 @@ clusters:
    region: us-east1
    schedulable: true
    status: ready
-   dinosaur_instance_limit: 10
+   central_instance_limit: 10
    provider_type: standalone
    supported_instance_type: "eval,standard"
    cluster_dns: evan-acsms-fm-d.0a51.s2.devshift.org

--- a/dev/config/dataplane-cluster-configuration-minikube.yaml
+++ b/dev/config/dataplane-cluster-configuration-minikube.yaml
@@ -12,34 +12,24 @@
 #    region: us-east-1
 #    multi_az: true
 #    schedulable: true
-#    dinosaur_instance_limit: 2
+#    central_instance_limit: 2
 #    status: "cluster_provisioning" #Valid values are `cluster_provisioning`, `cluster_provisioned` and `ready`. `cluster_provisioning` will be used if not specified.
 #    provider_type: "ocm" #Valid values are `ocm` and `standalone`. `ocm` will be used if not specified.
-#    cluster_dns: apps.example.com #Valid cluster DNS. This will be used to build dinosaur host url and to communicate with standalone clusters. Required when "provider_type" is "standalone" 
+#    cluster_dns: apps.example.com #Valid cluster DNS. This will be used to build central host url and to communicate with standalone clusters. Required when "provider_type" is "standalone" 
 #    supported_instance_type: "eval" # could be "eval", "standard" or both i.e "standard,eval" or "eval,standard". Defaults to "standard,eval" if not set 
 clusters:
-#  - name: docker-desktop  # Uncomment if using docker-desktop
-#    cluster_id: 1234567890abcdef1234567890abcdef
-#    cloud_provider: standalone
-#    region: standalone
-#    schedulable: true
-#    status: ready
-#    provider_type: standalone
-#    supported_instance_type: "eval,standard"
-#    cluster_dns: kubernetes.docker.internal
-#    dinosaur_instance_limit: 5
  - name: minikube  # Uncomment if using minikube
    cluster_id: 1234567890abcdef1234567890abcdef
    cloud_provider: standalone
    region: standalone
    schedulable: true
    status: ready
-   dinosaur_instance_limit: 5
+   central_instance_limit: 5
    provider_type: standalone
    supported_instance_type: "eval,standard"
    cluster_dns: cluster.local
-   available_dinosaur_operator_versions:
+   available_central_operator_versions:
     - version: "0.1.0"
       ready: true
-      dinosaur_versions:
+      central_versions:
        - version: "0.1.0"

--- a/internal/dinosaur/pkg/api/dbapi/data_plane_cluster_status.go
+++ b/internal/dinosaur/pkg/api/dbapi/data_plane_cluster_status.go
@@ -4,7 +4,7 @@ import "github.com/stackrox/acs-fleet-manager/pkg/api"
 
 type DataPlaneClusterStatus struct {
 	Conditions                        []DataPlaneClusterStatusCondition
-	AvailableDinosaurOperatorVersions []api.DinosaurOperatorVersion
+	AvailableDinosaurOperatorVersions []api.CentralOperatorVersion
 }
 
 type DataPlaneClusterStatusCondition struct {

--- a/internal/dinosaur/pkg/config/dataplane_cluster_config.go
+++ b/internal/dinosaur/pkg/config/dataplane_cluster_config.go
@@ -97,17 +97,18 @@ func NewDataplaneClusterConfig() *DataplaneClusterConfig {
 
 //manual cluster configuration
 type ManualCluster struct {
-	Name                  string                  `yaml:"name"`
-	ClusterId             string                  `yaml:"cluster_id"`
-	CloudProvider         string                  `yaml:"cloud_provider"`
-	Region                string                  `yaml:"region"`
-	MultiAZ               bool                    `yaml:"multi_az"`
-	Schedulable           bool                    `yaml:"schedulable"`
-	DinosaurInstanceLimit int                     `yaml:"dinosaur_instance_limit"`
-	Status                api.ClusterStatus       `yaml:"status"`
-	ProviderType          api.ClusterProviderType `yaml:"provider_type"`
-	ClusterDNS            string                  `yaml:"cluster_dns"`
-	SupportedInstanceType string                  `yaml:"supported_instance_type"`
+	Name                              string                        `yaml:"name"`
+	ClusterId                         string                        `yaml:"cluster_id"`
+	CloudProvider                     string                        `yaml:"cloud_provider"`
+	Region                            string                        `yaml:"region"`
+	MultiAZ                           bool                          `yaml:"multi_az"`
+	Schedulable                       bool                          `yaml:"schedulable"`
+	DinosaurInstanceLimit             int                           `yaml:"dinosaur_instance_limit"`
+	Status                            api.ClusterStatus             `yaml:"status"`
+	ProviderType                      api.ClusterProviderType       `yaml:"provider_type"`
+	ClusterDNS                        string                        `yaml:"cluster_dns"`
+	SupportedInstanceType             string                        `yaml:"supported_instance_type"`
+	AvailableDinosaurOperatorVersions []api.DinosaurOperatorVersion `yaml:"available_dinosaur_operator_versions"`
 }
 
 func (c *ManualCluster) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/internal/dinosaur/pkg/config/dataplane_cluster_config.go
+++ b/internal/dinosaur/pkg/config/dataplane_cluster_config.go
@@ -97,18 +97,18 @@ func NewDataplaneClusterConfig() *DataplaneClusterConfig {
 
 //manual cluster configuration
 type ManualCluster struct {
-	Name                              string                        `yaml:"name"`
-	ClusterId                         string                        `yaml:"cluster_id"`
-	CloudProvider                     string                        `yaml:"cloud_provider"`
-	Region                            string                        `yaml:"region"`
-	MultiAZ                           bool                          `yaml:"multi_az"`
-	Schedulable                       bool                          `yaml:"schedulable"`
-	DinosaurInstanceLimit             int                           `yaml:"dinosaur_instance_limit"`
-	Status                            api.ClusterStatus             `yaml:"status"`
-	ProviderType                      api.ClusterProviderType       `yaml:"provider_type"`
-	ClusterDNS                        string                        `yaml:"cluster_dns"`
-	SupportedInstanceType             string                        `yaml:"supported_instance_type"`
-	AvailableDinosaurOperatorVersions []api.DinosaurOperatorVersion `yaml:"available_dinosaur_operator_versions"`
+	Name                             string                       `yaml:"name"`
+	ClusterId                        string                       `yaml:"cluster_id"`
+	CloudProvider                    string                       `yaml:"cloud_provider"`
+	Region                           string                       `yaml:"region"`
+	MultiAZ                          bool                         `yaml:"multi_az"`
+	Schedulable                      bool                         `yaml:"schedulable"`
+	CentralInstanceLimit             int                          `yaml:"central_instance_limit"`
+	Status                           api.ClusterStatus            `yaml:"status"`
+	ProviderType                     api.ClusterProviderType      `yaml:"provider_type"`
+	ClusterDNS                       string                       `yaml:"cluster_dns"`
+	SupportedInstanceType            string                       `yaml:"supported_instance_type"`
+	AvailableCentralOperatorVersions []api.CentralOperatorVersion `yaml:"available_central_operator_versions"`
 }
 
 func (c *ManualCluster) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -171,7 +171,7 @@ func (conf *ClusterConfig) GetCapacityForRegion(region string) int {
 	var capacity = 0
 	for _, cluster := range conf.clusterList {
 		if cluster.Region == region {
-			capacity += cluster.DinosaurInstanceLimit
+			capacity += cluster.CentralInstanceLimit
 		}
 	}
 	return capacity
@@ -179,7 +179,7 @@ func (conf *ClusterConfig) GetCapacityForRegion(region string) int {
 
 func (conf *ClusterConfig) IsNumberOfDinosaurWithinClusterLimit(clusterId string, count int) bool {
 	if _, exist := conf.clusterConfigMap[clusterId]; exist {
-		limit := conf.clusterConfigMap[clusterId].DinosaurInstanceLimit
+		limit := conf.clusterConfigMap[clusterId].CentralInstanceLimit
 		return limit == -1 || count <= limit
 	}
 	return true

--- a/internal/dinosaur/pkg/config/dataplane_cluster_config_test.go
+++ b/internal/dinosaur/pkg/config/dataplane_cluster_config_test.go
@@ -1,9 +1,10 @@
 package config
 
 import (
+	"testing"
+
 	"github.com/stackrox/acs-fleet-manager/pkg/api"
 	"gopkg.in/yaml.v2"
-	"testing"
 )
 
 // TODO(create-ticket): Add testing for config file marshaling or switch to a simpler format / parsing logic.
@@ -19,6 +20,11 @@ dinosaur_instance_limit: 5
 provider_type: standalone
 supported_instance_type: "eval,standard"
 cluster_dns: cluster.local
+available_dinosaur_operator_versions:
+  - version: "0.1.0"
+    ready: true
+    dinosaur_versions:
+      - version: "0.1.0"
 `)
 
 	c := ManualCluster{}

--- a/internal/dinosaur/pkg/config/dataplane_cluster_config_test.go
+++ b/internal/dinosaur/pkg/config/dataplane_cluster_config_test.go
@@ -16,14 +16,14 @@ cloud_provider: standalone
 region: standalone
 schedulable: true
 status: ready
-dinosaur_instance_limit: 5
+central_instance_limit: 5
 provider_type: standalone
 supported_instance_type: "eval,standard"
 cluster_dns: cluster.local
-available_dinosaur_operator_versions:
+available_central_operator_versions:
   - version: "0.1.0"
     ready: true
-    dinosaur_versions:
+    central_versions:
       - version: "0.1.0"
 `)
 
@@ -31,7 +31,27 @@ available_dinosaur_operator_versions:
 	if err := yaml.Unmarshal(configFile, &c); err != nil {
 		t.Fail()
 	}
+
 	if c.Status != api.ClusterReady {
 		t.Fail()
+	}
+
+	if len(c.AvailableCentralOperatorVersions) < 1 {
+		t.Fatal("Expected operator versions to not be empty")
+	}
+
+	want := "0.1.0"
+	got := c.AvailableCentralOperatorVersions[0].Version
+	if got != want {
+		t.Fatalf("Expected first central operator version to be: %s, got: %s\n", want, got)
+	}
+
+	if len(c.AvailableCentralOperatorVersions[0].CentralVersions) < 1 {
+		t.Fatal("Expected central versions to not be empty")
+	}
+
+	got = c.AvailableCentralOperatorVersions[0].CentralVersions[0].Version
+	if got != want {
+		t.Fatalf("Expected first central version to be: %s, got: %s\n", want, got)
 	}
 }

--- a/internal/dinosaur/pkg/presenters/data_plane_cluster_status.go
+++ b/internal/dinosaur/pkg/presenters/data_plane_cluster_status.go
@@ -17,15 +17,15 @@ func ConvertDataPlaneClusterStatus(status private.DataPlaneClusterUpdateStatusRe
 			Message: cond.Message,
 		}
 	}
-	res.AvailableDinosaurOperatorVersions = make([]api.DinosaurOperatorVersion, len(status.CentralOperator))
+	res.AvailableDinosaurOperatorVersions = make([]api.CentralOperatorVersion, len(status.CentralOperator))
 	for i, op := range status.CentralOperator {
-		res.AvailableDinosaurOperatorVersions[i] = api.DinosaurOperatorVersion{
+		res.AvailableDinosaurOperatorVersions[i] = api.CentralOperatorVersion{
 			Version: op.Version,
 			Ready:   op.Ready,
 		}
-		res.AvailableDinosaurOperatorVersions[i].DinosaurVersions = make([]api.DinosaurVersion, len(op.CentralVersions))
+		res.AvailableDinosaurOperatorVersions[i].CentralVersions = make([]api.CentralVersion, len(op.CentralVersions))
 		for j, v := range op.CentralVersions {
-			res.AvailableDinosaurOperatorVersions[i].DinosaurVersions[j] = api.DinosaurVersion{Version: v}
+			res.AvailableDinosaurOperatorVersions[i].CentralVersions[j] = api.CentralVersion{Version: v}
 		}
 	}
 	return &res, nil

--- a/internal/dinosaur/pkg/services/clusters.go
+++ b/internal/dinosaur/pkg/services/clusters.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/clusters"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/clusters/types"
 
-	"github.com/stackrox/acs-fleet-manager/pkg/metrics"
 	"github.com/golang/glog"
+	"github.com/stackrox/acs-fleet-manager/pkg/metrics"
 
 	"gorm.io/gorm"
 
@@ -711,7 +711,7 @@ func (c clusterService) IsDinosaurVersionAvailableInCluster(cluster *api.Cluster
 	for _, version := range readyDinosaurOperatorVersions {
 		if version.Version == dinosaurOperatorVersion {
 			kVvalid := false
-			for _, kversion := range version.DinosaurVersions {
+			for _, kversion := range version.CentralVersions {
 				if kversion.Version == dinosaurVersion {
 					kVvalid = true
 					break

--- a/internal/dinosaur/pkg/workers/clusters_mgr.go
+++ b/internal/dinosaur/pkg/workers/clusters_mgr.go
@@ -638,8 +638,8 @@ func (c *ClusterManager) reconcileClusterWithManualConfig() []error {
 			SupportedInstanceType: p.SupportedInstanceType,
 		}
 
-		if len(p.AvailableDinosaurOperatorVersions) > 0 {
-			if err := clusterRequest.SetAvailableDinosaurOperatorVersions(p.AvailableDinosaurOperatorVersions); err != nil {
+		if len(p.AvailableCentralOperatorVersions) > 0 {
+			if err := clusterRequest.SetAvailableDinosaurOperatorVersions(p.AvailableCentralOperatorVersions); err != nil {
 				return []error{errors.Wrapf(err, "Failed to set operator versions for manual cluster %s with config file", p.ClusterId)}
 			}
 		}
@@ -1007,7 +1007,7 @@ func (c *ClusterManager) setClusterStatusMaxCapacityMetrics() {
 		supportedInstanceTypes := strings.Split(cluster.SupportedInstanceType, ",")
 		for _, instanceType := range supportedInstanceTypes {
 			if instanceType != "" {
-				capacity := float64(cluster.DinosaurInstanceLimit)
+				capacity := float64(cluster.CentralInstanceLimit)
 				metrics.UpdateClusterStatusCapacityMaxCount(cluster.Region, instanceType, cluster.ClusterId, capacity)
 			}
 		}

--- a/internal/dinosaur/pkg/workers/clusters_mgr.go
+++ b/internal/dinosaur/pkg/workers/clusters_mgr.go
@@ -637,6 +637,13 @@ func (c *ClusterManager) reconcileClusterWithManualConfig() []error {
 			ClusterDNS:            p.ClusterDNS,
 			SupportedInstanceType: p.SupportedInstanceType,
 		}
+
+		if len(p.AvailableDinosaurOperatorVersions) > 0 {
+			if err := clusterRequest.SetAvailableDinosaurOperatorVersions(p.AvailableDinosaurOperatorVersions); err != nil {
+				return []error{errors.Wrapf(err, "Failed to set operator versions for manual cluster %s with config file", p.ClusterId)}
+			}
+		}
+
 		if err := c.ClusterService.RegisterClusterJob(&clusterRequest); err != nil {
 			return []error{errors.Wrapf(err, "Failed to register new cluster %s with config file", p.ClusterId)}
 		} else {

--- a/internal/dinosaur/pkg/workers/dinosaur_mgrs/accepted_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaur_mgrs/accepted_dinosaurs_mgr.go
@@ -4,17 +4,17 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	constants2 "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/config"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/services"
 	"github.com/stackrox/acs-fleet-manager/pkg/api"
-	"github.com/google/uuid"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/acs-fleet-manager/pkg/logger"
 	"github.com/stackrox/acs-fleet-manager/pkg/metrics"
 	"github.com/stackrox/acs-fleet-manager/pkg/workers"
-	"github.com/pkg/errors"
 
 	"github.com/golang/glog"
 )
@@ -91,7 +91,7 @@ func (k *AcceptedDinosaurManager) reconcileAcceptedDinosaur(dinosaur *dbapi.Dino
 	dinosaur.ClusterID = cluster.ClusterID
 
 	// Set desired dinosaur operator version
-	var selectedDinosaurOperatorVersion *api.DinosaurOperatorVersion
+	var selectedDinosaurOperatorVersion *api.CentralOperatorVersion
 
 	readyDinosaurOperatorVersions, err := cluster.GetAvailableAndReadyDinosaurOperatorVersions()
 	if err != nil || len(readyDinosaurOperatorVersions) == 0 {
@@ -120,10 +120,10 @@ func (k *AcceptedDinosaurManager) reconcileAcceptedDinosaur(dinosaur *dbapi.Dino
 	dinosaur.DesiredDinosaurOperatorVersion = selectedDinosaurOperatorVersion.Version
 
 	// Set desired Dinosaur version
-	if len(selectedDinosaurOperatorVersion.DinosaurVersions) == 0 {
+	if len(selectedDinosaurOperatorVersion.CentralVersions) == 0 {
 		return errors.New(fmt.Sprintf("failed to get Dinosaur version %s", dinosaur.ID))
 	}
-	dinosaur.DesiredDinosaurVersion = selectedDinosaurOperatorVersion.DinosaurVersions[len(selectedDinosaurOperatorVersion.DinosaurVersions)-1].Version
+	dinosaur.DesiredDinosaurVersion = selectedDinosaurOperatorVersion.CentralVersions[len(selectedDinosaurOperatorVersion.CentralVersions)-1].Version
 
 	glog.Infof("Dinosaur instance with id %s is assigned to cluster with id %s", dinosaur.ID, dinosaur.ClusterID)
 	dinosaur.Status = constants2.DinosaurRequestStatusPreparing.String()

--- a/internal/dinosaur/test/helper.go
+++ b/internal/dinosaur/test/helper.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stackrox/acs-fleet-manager/pkg/api"
 	"github.com/stackrox/acs-fleet-manager/test/mocks"
 
+	"github.com/goava/di"
+	"github.com/golang/glog"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur"
 	adminprivate "github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/admin/private"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
@@ -23,8 +25,6 @@ import (
 	"github.com/stackrox/acs-fleet-manager/pkg/server"
 	coreWorkers "github.com/stackrox/acs-fleet-manager/pkg/workers"
 	"github.com/stackrox/acs-fleet-manager/test"
-	"github.com/goava/di"
-	"github.com/golang/glog"
 )
 
 type Services struct {
@@ -108,7 +108,7 @@ func NewMockDataplaneCluster(name string, capacity int) config.ManualCluster {
 		Region:                mocks.MockCluster.Region().ID(),
 		MultiAZ:               true,
 		Schedulable:           true,
-		DinosaurInstanceLimit: capacity,
+		CentralInstanceLimit:  capacity,
 		Status:                api.ClusterReady,
 		SupportedInstanceType: "eval,standard",
 	}

--- a/pkg/api/cluster_types.go
+++ b/pkg/api/cluster_types.go
@@ -6,8 +6,8 @@ import (
 	"regexp"
 	"sort"
 
-	fleetmanagererrors "github.com/stackrox/acs-fleet-manager/pkg/errors"
 	"github.com/pkg/errors"
+	fleetmanagererrors "github.com/stackrox/acs-fleet-manager/pkg/errors"
 	"gorm.io/gorm"
 )
 
@@ -190,7 +190,7 @@ func (cluster *Cluster) BeforeCreate(tx *gorm.DB) error {
 type DinosaurOperatorVersion struct {
 	Version          string            `json:"version"`
 	Ready            bool              `json:"ready"`
-	DinosaurVersions []DinosaurVersion `json:"dinosaurVersions"`
+	DinosaurVersions []DinosaurVersion `json:"dinosaurVersions" yaml:"dinosaur_versions"`
 }
 
 type DinosaurVersion struct {

--- a/pkg/api/cluster_types.go
+++ b/pkg/api/cluster_types.go
@@ -187,17 +187,17 @@ func (cluster *Cluster) BeforeCreate(tx *gorm.DB) error {
 	return nil
 }
 
-type DinosaurOperatorVersion struct {
-	Version          string            `json:"version"`
-	Ready            bool              `json:"ready"`
-	DinosaurVersions []DinosaurVersion `json:"dinosaurVersions" yaml:"dinosaur_versions"`
+type CentralOperatorVersion struct {
+	Version         string           `json:"version"`
+	Ready           bool             `json:"ready"`
+	CentralVersions []CentralVersion `json:"centralVersions" yaml:"central_versions"`
 }
 
-type DinosaurVersion struct {
+type CentralVersion struct {
 	Version string `json:"version"`
 }
 
-func (s *DinosaurVersion) Compare(other DinosaurVersion) (int, error) {
+func (s *CentralVersion) Compare(other CentralVersion) (int, error) {
 	return buildAwareSemanticVersioningCompare(s.Version, other.Version)
 }
 
@@ -212,7 +212,7 @@ var DinosaurOperatorVersionNumberPartRegex = regexp.MustCompile(`\d+\.\d+\.\d+-\
 // If s.Version is equal than other.Version 0 is returned. If s.Version is greater
 // than other.Version 1 is returned. If there is an error during the comparison
 // an error is returned
-func (s *DinosaurOperatorVersion) Compare(other DinosaurOperatorVersion) (int, error) {
+func (s *CentralOperatorVersion) Compare(other CentralOperatorVersion) (int, error) {
 	v1VersionNumber := DinosaurOperatorVersionNumberPartRegex.FindString(s.Version)
 	if v1VersionNumber == "" {
 		return 0, fmt.Errorf("'%s' does not follow expected Dinosaur Operator Version format", s.Version)
@@ -234,14 +234,14 @@ func CompareSemanticVersionsMajorAndMinor(current, desired string) (int, error) 
 	return checkIfMinorDowngrade(current, desired)
 }
 
-func (s *DinosaurOperatorVersion) DeepCopy() *DinosaurOperatorVersion {
-	var res DinosaurOperatorVersion = *s
-	res.DinosaurVersions = nil
+func (s *CentralOperatorVersion) DeepCopy() *CentralOperatorVersion {
+	var res CentralOperatorVersion = *s
+	res.CentralVersions = nil
 
-	if s.DinosaurVersions != nil {
-		dinosaurVersionsCopy := make([]DinosaurVersion, len(s.DinosaurVersions))
-		copy(dinosaurVersionsCopy, s.DinosaurVersions)
-		res.DinosaurVersions = dinosaurVersionsCopy
+	if s.CentralVersions != nil {
+		dinosaurVersionsCopy := make([]CentralVersion, len(s.CentralVersions))
+		copy(dinosaurVersionsCopy, s.CentralVersions)
+		res.CentralVersions = dinosaurVersionsCopy
 	}
 
 	return &res
@@ -250,13 +250,13 @@ func (s *DinosaurOperatorVersion) DeepCopy() *DinosaurOperatorVersion {
 // GetAvailableAndReadyDinosaurOperatorVersions returns the cluster's list of available
 // and ready versions or an error. An empty list is returned if there are no
 // available and ready versions
-func (cluster *Cluster) GetAvailableAndReadyDinosaurOperatorVersions() ([]DinosaurOperatorVersion, error) {
+func (cluster *Cluster) GetAvailableAndReadyDinosaurOperatorVersions() ([]CentralOperatorVersion, error) {
 	dinosaurOperatorVersions, err := cluster.GetAvailableDinosaurOperatorVersions()
 	if err != nil {
 		return nil, err
 	}
 
-	res := []DinosaurOperatorVersion{}
+	res := []CentralOperatorVersion{}
 	for _, val := range dinosaurOperatorVersions {
 		if val.Ready {
 			res = append(res, val)
@@ -270,8 +270,8 @@ func (cluster *Cluster) GetAvailableAndReadyDinosaurOperatorVersions() ([]Dinosa
 // This returns the available versions in the cluster independently on whether
 // they are ready or not. If you want to only get the available and ready
 // versions use the GetAvailableAndReadyDinosaurOperatorVersions method
-func (cluster *Cluster) GetAvailableDinosaurOperatorVersions() ([]DinosaurOperatorVersion, error) {
-	versions := []DinosaurOperatorVersion{}
+func (cluster *Cluster) GetAvailableDinosaurOperatorVersions() ([]CentralOperatorVersion, error) {
+	versions := []CentralOperatorVersion{}
 	if cluster.AvailableDinosaurOperatorVersions == nil {
 		return versions, nil
 	}
@@ -288,15 +288,15 @@ func (cluster *Cluster) GetAvailableDinosaurOperatorVersions() ([]DinosaurOperat
 // in the versions slice. The following elements are sorted in ascending order:
 // - The dinosaur operator versions
 // - For each dinosaur operator version, their Dinosaur Versions
-func DinosaurOperatorVersionsDeepSort(versions []DinosaurOperatorVersion) ([]DinosaurOperatorVersion, error) {
+func DinosaurOperatorVersionsDeepSort(versions []CentralOperatorVersion) ([]CentralOperatorVersion, error) {
 	if versions == nil {
 		return versions, nil
 	}
 	if len(versions) == 0 {
-		return []DinosaurOperatorVersion{}, nil
+		return []CentralOperatorVersion{}, nil
 	}
 
-	var versionsToSet []DinosaurOperatorVersion
+	var versionsToSet []CentralOperatorVersion
 	for idx := range versions {
 		version := &versions[idx]
 		copiedDinosaurOperatorVersion := version.DeepCopy()
@@ -320,8 +320,8 @@ func DinosaurOperatorVersionsDeepSort(versions []DinosaurOperatorVersion) ([]Din
 	for idx := range versionsToSet {
 
 		// Sort DinosaurVersions
-		sort.Slice(versionsToSet[idx].DinosaurVersions, func(i, j int) bool {
-			res, err := versionsToSet[idx].DinosaurVersions[i].Compare(versionsToSet[idx].DinosaurVersions[j])
+		sort.Slice(versionsToSet[idx].CentralVersions, func(i, j int) bool {
+			res, err := versionsToSet[idx].CentralVersions[i].Compare(versionsToSet[idx].CentralVersions[j])
 			if err != nil {
 				errors = append(errors, err)
 			}
@@ -346,13 +346,13 @@ func DinosaurOperatorVersionsDeepSort(versions []DinosaurOperatorVersion) ([]Din
 // If availableDinosaurOperatorVersions is nil an empty list is set. See
 // DinosaurOperatorVersionNumberPartRegex for details on the expected dinosaur operator version
 // format
-func (cluster *Cluster) SetAvailableDinosaurOperatorVersions(availableDinosaurOperatorVersions []DinosaurOperatorVersion) error {
+func (cluster *Cluster) SetAvailableDinosaurOperatorVersions(availableDinosaurOperatorVersions []CentralOperatorVersion) error {
 	sortedVersions, err := DinosaurOperatorVersionsDeepSort(availableDinosaurOperatorVersions)
 	if err != nil {
 		return err
 	}
 	if sortedVersions == nil {
-		sortedVersions = []DinosaurOperatorVersion{}
+		sortedVersions = []CentralOperatorVersion{}
 	}
 
 	if v, err := json.Marshal(sortedVersions); err != nil {

--- a/pkg/api/cluster_types_test.go
+++ b/pkg/api/cluster_types_test.go
@@ -10,16 +10,16 @@ func TestGetAvailableDinosaurOperatorVersions(t *testing.T) {
 	tests := []struct {
 		name    string
 		cluster func() *Cluster
-		want    []DinosaurOperatorVersion
+		want    []CentralOperatorVersion
 		wantErr bool
 	}{
 		{
 			name: "When cluster has a non empty list of available dinosaur operator versions those are returned",
 			cluster: func() *Cluster {
-				inputDinosaurOperatorVersions := []DinosaurOperatorVersion{
-					DinosaurOperatorVersion{Version: "v3", Ready: true},
-					DinosaurOperatorVersion{Version: "v6", Ready: false},
-					DinosaurOperatorVersion{Version: "v7", Ready: true},
+				inputDinosaurOperatorVersions := []CentralOperatorVersion{
+					CentralOperatorVersion{Version: "v3", Ready: true},
+					CentralOperatorVersion{Version: "v6", Ready: false},
+					CentralOperatorVersion{Version: "v7", Ready: true},
 				}
 				inputDinosaurOperatorVersionsJSON, err := json.Marshal(inputDinosaurOperatorVersions)
 				if err != nil {
@@ -28,17 +28,17 @@ func TestGetAvailableDinosaurOperatorVersions(t *testing.T) {
 				res := Cluster{AvailableDinosaurOperatorVersions: inputDinosaurOperatorVersionsJSON}
 				return &res
 			},
-			want: []DinosaurOperatorVersion{
-				DinosaurOperatorVersion{Version: "v3", Ready: true},
-				DinosaurOperatorVersion{Version: "v6", Ready: false},
-				DinosaurOperatorVersion{Version: "v7", Ready: true},
+			want: []CentralOperatorVersion{
+				CentralOperatorVersion{Version: "v3", Ready: true},
+				CentralOperatorVersion{Version: "v6", Ready: false},
+				CentralOperatorVersion{Version: "v7", Ready: true},
 			},
 			wantErr: false,
 		},
 		{
 			name: "When cluster has an empty list of available dinosaur operator the empty list is returned",
 			cluster: func() *Cluster {
-				inputDinosaurOperatorVersions := []DinosaurOperatorVersion{}
+				inputDinosaurOperatorVersions := []CentralOperatorVersion{}
 				inputDinosaurOperatorVersionsJSON, err := json.Marshal(inputDinosaurOperatorVersions)
 				if err != nil {
 					panic(err)
@@ -46,7 +46,7 @@ func TestGetAvailableDinosaurOperatorVersions(t *testing.T) {
 				res := Cluster{AvailableDinosaurOperatorVersions: inputDinosaurOperatorVersionsJSON}
 				return &res
 			},
-			want:    []DinosaurOperatorVersion{},
+			want:    []CentralOperatorVersion{},
 			wantErr: false,
 		},
 		{
@@ -55,7 +55,7 @@ func TestGetAvailableDinosaurOperatorVersions(t *testing.T) {
 				res := Cluster{AvailableDinosaurOperatorVersions: nil}
 				return &res
 			},
-			want:    []DinosaurOperatorVersion{},
+			want:    []CentralOperatorVersion{},
 			wantErr: false,
 		},
 		{
@@ -86,16 +86,16 @@ func TestGetAvailableAndReadyDinosaurOperatorVersions(t *testing.T) {
 	tests := []struct {
 		name    string
 		cluster func() *Cluster
-		want    []DinosaurOperatorVersion
+		want    []CentralOperatorVersion
 		wantErr bool
 	}{
 		{
 			name: "When cluster has a non empty list of available dinosaur operator versions those ready returned",
 			cluster: func() *Cluster {
-				inputDinosaurOperatorVersions := []DinosaurOperatorVersion{
-					DinosaurOperatorVersion{Version: "v3", Ready: true},
-					DinosaurOperatorVersion{Version: "v6", Ready: false},
-					DinosaurOperatorVersion{Version: "v7", Ready: true},
+				inputDinosaurOperatorVersions := []CentralOperatorVersion{
+					CentralOperatorVersion{Version: "v3", Ready: true},
+					CentralOperatorVersion{Version: "v6", Ready: false},
+					CentralOperatorVersion{Version: "v7", Ready: true},
 				}
 				inputDinosaurOperatorVersionsJSON, err := json.Marshal(inputDinosaurOperatorVersions)
 				if err != nil {
@@ -104,16 +104,16 @@ func TestGetAvailableAndReadyDinosaurOperatorVersions(t *testing.T) {
 				res := Cluster{AvailableDinosaurOperatorVersions: inputDinosaurOperatorVersionsJSON}
 				return &res
 			},
-			want: []DinosaurOperatorVersion{
-				DinosaurOperatorVersion{Version: "v3", Ready: true},
-				DinosaurOperatorVersion{Version: "v7", Ready: true},
+			want: []CentralOperatorVersion{
+				CentralOperatorVersion{Version: "v3", Ready: true},
+				CentralOperatorVersion{Version: "v7", Ready: true},
 			},
 			wantErr: false,
 		},
 		{
 			name: "When cluster has an empty list of available dinosaur operator the empty list is returned",
 			cluster: func() *Cluster {
-				inputDinosaurOperatorVersions := []DinosaurOperatorVersion{}
+				inputDinosaurOperatorVersions := []CentralOperatorVersion{}
 				inputDinosaurOperatorVersionsJSON, err := json.Marshal(inputDinosaurOperatorVersions)
 				if err != nil {
 					panic(err)
@@ -121,7 +121,7 @@ func TestGetAvailableAndReadyDinosaurOperatorVersions(t *testing.T) {
 				res := Cluster{AvailableDinosaurOperatorVersions: inputDinosaurOperatorVersionsJSON}
 				return &res
 			},
-			want:    []DinosaurOperatorVersion{},
+			want:    []CentralOperatorVersion{},
 			wantErr: false,
 		},
 		{
@@ -130,7 +130,7 @@ func TestGetAvailableAndReadyDinosaurOperatorVersions(t *testing.T) {
 				res := Cluster{AvailableDinosaurOperatorVersions: nil}
 				return &res
 			},
-			want:    []DinosaurOperatorVersion{},
+			want:    []CentralOperatorVersion{},
 			wantErr: false,
 		},
 		{
@@ -160,115 +160,115 @@ func TestGetAvailableAndReadyDinosaurOperatorVersions(t *testing.T) {
 func TestSetAvailableDinosaurOperatorVersions(t *testing.T) {
 	tests := []struct {
 		name                          string
-		inputDinosaurOperatorVersions []DinosaurOperatorVersion
-		want                          []DinosaurOperatorVersion
+		inputDinosaurOperatorVersions []CentralOperatorVersion
+		want                          []CentralOperatorVersion
 		wantErr                       bool
 	}{
 		{
 			name: "When setting a non empty ordered list of dinosaur operator versions that list is stored as is",
-			inputDinosaurOperatorVersions: []DinosaurOperatorVersion{
-				DinosaurOperatorVersion{Version: "dinosaur-operator-v.3.0.0-0", Ready: true},
-				DinosaurOperatorVersion{Version: "dinosaur-operator-v.6.0.0-0", Ready: false},
-				DinosaurOperatorVersion{Version: "dinosaur-operator-v.7.0.0-0", Ready: true},
+			inputDinosaurOperatorVersions: []CentralOperatorVersion{
+				CentralOperatorVersion{Version: "dinosaur-operator-v.3.0.0-0", Ready: true},
+				CentralOperatorVersion{Version: "dinosaur-operator-v.6.0.0-0", Ready: false},
+				CentralOperatorVersion{Version: "dinosaur-operator-v.7.0.0-0", Ready: true},
 			},
-			want: []DinosaurOperatorVersion{
-				DinosaurOperatorVersion{Version: "dinosaur-operator-v.3.0.0-0", Ready: true},
-				DinosaurOperatorVersion{Version: "dinosaur-operator-v.6.0.0-0", Ready: false},
-				DinosaurOperatorVersion{Version: "dinosaur-operator-v.7.0.0-0", Ready: true},
+			want: []CentralOperatorVersion{
+				CentralOperatorVersion{Version: "dinosaur-operator-v.3.0.0-0", Ready: true},
+				CentralOperatorVersion{Version: "dinosaur-operator-v.6.0.0-0", Ready: false},
+				CentralOperatorVersion{Version: "dinosaur-operator-v.7.0.0-0", Ready: true},
 			},
 			wantErr: false,
 		},
 		{
 			name: "When setting a non empty unordered list of dinosaur operator versions that list is stored in semver ascending order",
-			inputDinosaurOperatorVersions: []DinosaurOperatorVersion{
-				DinosaurOperatorVersion{Version: "dinosaur-operator-v.5.0.0-0", Ready: true},
-				DinosaurOperatorVersion{Version: "dinosaur-operator-v.3.0.0-0", Ready: false},
-				DinosaurOperatorVersion{Version: "dinosaur-operator-v.2.0.0-0", Ready: true},
+			inputDinosaurOperatorVersions: []CentralOperatorVersion{
+				CentralOperatorVersion{Version: "dinosaur-operator-v.5.0.0-0", Ready: true},
+				CentralOperatorVersion{Version: "dinosaur-operator-v.3.0.0-0", Ready: false},
+				CentralOperatorVersion{Version: "dinosaur-operator-v.2.0.0-0", Ready: true},
 			},
-			want: []DinosaurOperatorVersion{
-				DinosaurOperatorVersion{Version: "dinosaur-operator-v.2.0.0-0", Ready: true},
-				DinosaurOperatorVersion{Version: "dinosaur-operator-v.3.0.0-0", Ready: false},
-				DinosaurOperatorVersion{Version: "dinosaur-operator-v.5.0.0-0", Ready: true},
+			want: []CentralOperatorVersion{
+				CentralOperatorVersion{Version: "dinosaur-operator-v.2.0.0-0", Ready: true},
+				CentralOperatorVersion{Version: "dinosaur-operator-v.3.0.0-0", Ready: false},
+				CentralOperatorVersion{Version: "dinosaur-operator-v.5.0.0-0", Ready: true},
 			},
 			wantErr: false,
 		},
 		{
 			name: "When setting a non empty unordered list of dinosaur operator versions that list is stored in semver ascending order (case 2)",
-			inputDinosaurOperatorVersions: []DinosaurOperatorVersion{
-				DinosaurOperatorVersion{Version: "dinosaur-operator-v.5.10.0-3", Ready: true},
-				DinosaurOperatorVersion{Version: "dinosaur-operator-v.5.8.0-9", Ready: false},
-				DinosaurOperatorVersion{Version: "dinosaur-operator-v.2.0.0-0", Ready: true},
+			inputDinosaurOperatorVersions: []CentralOperatorVersion{
+				CentralOperatorVersion{Version: "dinosaur-operator-v.5.10.0-3", Ready: true},
+				CentralOperatorVersion{Version: "dinosaur-operator-v.5.8.0-9", Ready: false},
+				CentralOperatorVersion{Version: "dinosaur-operator-v.2.0.0-0", Ready: true},
 			},
-			want: []DinosaurOperatorVersion{
-				DinosaurOperatorVersion{Version: "dinosaur-operator-v.2.0.0-0", Ready: true},
-				DinosaurOperatorVersion{Version: "dinosaur-operator-v.5.8.0-9", Ready: false},
-				DinosaurOperatorVersion{Version: "dinosaur-operator-v.5.10.0-3", Ready: true},
+			want: []CentralOperatorVersion{
+				CentralOperatorVersion{Version: "dinosaur-operator-v.2.0.0-0", Ready: true},
+				CentralOperatorVersion{Version: "dinosaur-operator-v.5.8.0-9", Ready: false},
+				CentralOperatorVersion{Version: "dinosaur-operator-v.5.10.0-3", Ready: true},
 			},
 			wantErr: false,
 		},
 		{
 			name:                          "When setting an empty list of dinosaur operator versions that list is stored as the empty list",
-			inputDinosaurOperatorVersions: []DinosaurOperatorVersion{},
-			want:                          []DinosaurOperatorVersion{},
+			inputDinosaurOperatorVersions: []CentralOperatorVersion{},
+			want:                          []CentralOperatorVersion{},
 			wantErr:                       false,
 		},
 		{
 			name:                          "When setting a nil list of dinosaur operator versions that list is stored as the empty list",
 			inputDinosaurOperatorVersions: nil,
-			want:                          []DinosaurOperatorVersion{},
+			want:                          []CentralOperatorVersion{},
 			wantErr:                       false,
 		},
 		{
 			name: "Dinosaur versions are stored and in sorted order",
-			inputDinosaurOperatorVersions: []DinosaurOperatorVersion{
-				DinosaurOperatorVersion{
+			inputDinosaurOperatorVersions: []CentralOperatorVersion{
+				CentralOperatorVersion{
 					Version: "dinosaur-operator-v.5.10.0-3",
 					Ready:   true,
-					DinosaurVersions: []DinosaurVersion{
-						DinosaurVersion{Version: "2.7.5"},
-						DinosaurVersion{Version: "2.7.3"},
+					CentralVersions: []CentralVersion{
+						CentralVersion{Version: "2.7.5"},
+						CentralVersion{Version: "2.7.3"},
 					},
 				},
-				DinosaurOperatorVersion{
+				CentralOperatorVersion{
 					Version: "dinosaur-operator-v.5.8.0-9",
 					Ready:   false,
-					DinosaurVersions: []DinosaurVersion{
-						DinosaurVersion{Version: "2.9.4"},
-						DinosaurVersion{Version: "2.2.1"},
+					CentralVersions: []CentralVersion{
+						CentralVersion{Version: "2.9.4"},
+						CentralVersion{Version: "2.2.1"},
 					},
 				},
-				DinosaurOperatorVersion{
+				CentralOperatorVersion{
 					Version: "dinosaur-operator-v.2.0.0-0",
 					Ready:   true,
-					DinosaurVersions: []DinosaurVersion{
-						DinosaurVersion{Version: "4.5.6"},
-						DinosaurVersion{Version: "1.2.3"},
+					CentralVersions: []CentralVersion{
+						CentralVersion{Version: "4.5.6"},
+						CentralVersion{Version: "1.2.3"},
 					},
 				},
 			},
-			want: []DinosaurOperatorVersion{
-				DinosaurOperatorVersion{
+			want: []CentralOperatorVersion{
+				CentralOperatorVersion{
 					Version: "dinosaur-operator-v.2.0.0-0",
 					Ready:   true,
-					DinosaurVersions: []DinosaurVersion{
-						DinosaurVersion{Version: "1.2.3"},
-						DinosaurVersion{Version: "4.5.6"},
+					CentralVersions: []CentralVersion{
+						CentralVersion{Version: "1.2.3"},
+						CentralVersion{Version: "4.5.6"},
 					},
 				},
-				DinosaurOperatorVersion{
+				CentralOperatorVersion{
 					Version: "dinosaur-operator-v.5.8.0-9",
 					Ready:   false,
-					DinosaurVersions: []DinosaurVersion{
-						DinosaurVersion{Version: "2.2.1"},
-						DinosaurVersion{Version: "2.9.4"},
+					CentralVersions: []CentralVersion{
+						CentralVersion{Version: "2.2.1"},
+						CentralVersion{Version: "2.9.4"},
 					},
 				},
-				DinosaurOperatorVersion{
+				CentralOperatorVersion{
 					Version: "dinosaur-operator-v.5.10.0-3",
 					Ready:   true,
-					DinosaurVersions: []DinosaurVersion{
-						DinosaurVersion{Version: "2.7.3"},
-						DinosaurVersion{Version: "2.7.5"},
+					CentralVersions: []CentralVersion{
+						CentralVersion{Version: "2.7.3"},
+						CentralVersion{Version: "2.7.5"},
 					},
 				},
 			},
@@ -288,7 +288,7 @@ func TestSetAvailableDinosaurOperatorVersions(t *testing.T) {
 			}
 
 			if !errResultTestFailed {
-				var got []DinosaurOperatorVersion
+				var got []CentralOperatorVersion
 				err := json.Unmarshal(cluster.AvailableDinosaurOperatorVersions, &got)
 				if err != nil {
 					panic(err)
@@ -305,73 +305,73 @@ func TestSetAvailableDinosaurOperatorVersions(t *testing.T) {
 func TestCompare(t *testing.T) {
 	tests := []struct {
 		name                          string
-		inputDinosaurOperatorVersion1 DinosaurOperatorVersion
-		inputDinosaurOperatorVersion2 DinosaurOperatorVersion
+		inputDinosaurOperatorVersion1 CentralOperatorVersion
+		inputDinosaurOperatorVersion2 CentralOperatorVersion
 		want                          int
 		wantErr                       bool
 	}{
 		{
 			name:                          "When inputDinosaurOperatorVersion1 is smaller than inputDinosaurOperatorVersion2 -1 is returned",
-			inputDinosaurOperatorVersion1: DinosaurOperatorVersion{Version: "dinosaur-operator-v.3.0.0-0", Ready: true},
-			inputDinosaurOperatorVersion2: DinosaurOperatorVersion{Version: "dinosaur-operator-v.6.0.0-0", Ready: false},
+			inputDinosaurOperatorVersion1: CentralOperatorVersion{Version: "dinosaur-operator-v.3.0.0-0", Ready: true},
+			inputDinosaurOperatorVersion2: CentralOperatorVersion{Version: "dinosaur-operator-v.6.0.0-0", Ready: false},
 			want:                          -1,
 			wantErr:                       false,
 		},
 		{
 			name:                          "When inputDinosaurOperatorVersion1 is equal than inputDinosaurOperatorVersion2 0 is returned",
-			inputDinosaurOperatorVersion1: DinosaurOperatorVersion{Version: "dinosaur-operator-v.3.0.0-0", Ready: true},
-			inputDinosaurOperatorVersion2: DinosaurOperatorVersion{Version: "dinosaur-operator-v.3.0.0-0", Ready: false},
+			inputDinosaurOperatorVersion1: CentralOperatorVersion{Version: "dinosaur-operator-v.3.0.0-0", Ready: true},
+			inputDinosaurOperatorVersion2: CentralOperatorVersion{Version: "dinosaur-operator-v.3.0.0-0", Ready: false},
 			want:                          0,
 			wantErr:                       false,
 		},
 		{
 			name:                          "When inputDinosaurOperatorVersion1 is bigger than inputDinosaurOperatorVersion2 1 is returned",
-			inputDinosaurOperatorVersion1: DinosaurOperatorVersion{Version: "dinosaur-operator-v.6.0.0-0", Ready: true},
-			inputDinosaurOperatorVersion2: DinosaurOperatorVersion{Version: "dinosaur-operator-v.3.0.0-0", Ready: false},
+			inputDinosaurOperatorVersion1: CentralOperatorVersion{Version: "dinosaur-operator-v.6.0.0-0", Ready: true},
+			inputDinosaurOperatorVersion2: CentralOperatorVersion{Version: "dinosaur-operator-v.3.0.0-0", Ready: false},
 			want:                          1,
 			wantErr:                       false,
 		},
 		{
 			name:                          "Check that semver-level comparison is performed",
-			inputDinosaurOperatorVersion1: DinosaurOperatorVersion{Version: "dinosaur-operator-v.6.3.10-6", Ready: true},
-			inputDinosaurOperatorVersion2: DinosaurOperatorVersion{Version: "dinosaur-operator-v.6.3.8-9", Ready: false},
+			inputDinosaurOperatorVersion1: CentralOperatorVersion{Version: "dinosaur-operator-v.6.3.10-6", Ready: true},
+			inputDinosaurOperatorVersion2: CentralOperatorVersion{Version: "dinosaur-operator-v.6.3.8-9", Ready: false},
 			want:                          1,
 			wantErr:                       false,
 		},
 		{
 			name:                          "When inputDinosaurOperatorVersion1 is empty an error is returned",
-			inputDinosaurOperatorVersion1: DinosaurOperatorVersion{Version: "", Ready: true},
-			inputDinosaurOperatorVersion2: DinosaurOperatorVersion{Version: "dinosaur-operator-v.3.0.0-0", Ready: false},
+			inputDinosaurOperatorVersion1: CentralOperatorVersion{Version: "", Ready: true},
+			inputDinosaurOperatorVersion2: CentralOperatorVersion{Version: "dinosaur-operator-v.3.0.0-0", Ready: false},
 			wantErr:                       true,
 		},
 		{
 			name:                          "When inputDinosaurOperatorVersion2 is empty an error is returned",
-			inputDinosaurOperatorVersion1: DinosaurOperatorVersion{Version: "dinosaur-operator-v.6.0.0-0", Ready: true},
-			inputDinosaurOperatorVersion2: DinosaurOperatorVersion{Version: "", Ready: false},
+			inputDinosaurOperatorVersion1: CentralOperatorVersion{Version: "dinosaur-operator-v.6.0.0-0", Ready: true},
+			inputDinosaurOperatorVersion2: CentralOperatorVersion{Version: "", Ready: false},
 			wantErr:                       true,
 		},
 		{
 			name:                          "When inputDinosaurOperatorVersion1 has an invalid semver version format an error is returned",
-			inputDinosaurOperatorVersion1: DinosaurOperatorVersion{Version: "dinosaur-operator-v.6invalid.0.0-0", Ready: true},
-			inputDinosaurOperatorVersion2: DinosaurOperatorVersion{Version: "dinosaur-operator-v.7.0.0-0", Ready: false},
+			inputDinosaurOperatorVersion1: CentralOperatorVersion{Version: "dinosaur-operator-v.6invalid.0.0-0", Ready: true},
+			inputDinosaurOperatorVersion2: CentralOperatorVersion{Version: "dinosaur-operator-v.7.0.0-0", Ready: false},
 			wantErr:                       true,
 		},
 		{
 			name:                          "When inputDinosaurOperatorVersion1 has an invalid expected format an error is returned",
-			inputDinosaurOperatorVersion1: DinosaurOperatorVersion{Version: "dinosaur-operator-v.6.0.0", Ready: true},
-			inputDinosaurOperatorVersion2: DinosaurOperatorVersion{Version: "dinosaur-operator-v.7.0.0-0", Ready: false},
+			inputDinosaurOperatorVersion1: CentralOperatorVersion{Version: "dinosaur-operator-v.6.0.0", Ready: true},
+			inputDinosaurOperatorVersion2: CentralOperatorVersion{Version: "dinosaur-operator-v.7.0.0-0", Ready: false},
 			wantErr:                       true,
 		},
 		{
 			name:                          "When inputDinosaurOperatorVersion2 has an invalid semver version format an error is returned",
-			inputDinosaurOperatorVersion1: DinosaurOperatorVersion{Version: "dinosaur-operator-v.6.0.0-0", Ready: true},
-			inputDinosaurOperatorVersion2: DinosaurOperatorVersion{Version: "dinosaur-operator-v.6invalid.0.0-0", Ready: false},
+			inputDinosaurOperatorVersion1: CentralOperatorVersion{Version: "dinosaur-operator-v.6.0.0-0", Ready: true},
+			inputDinosaurOperatorVersion2: CentralOperatorVersion{Version: "dinosaur-operator-v.6invalid.0.0-0", Ready: false},
 			wantErr:                       true,
 		},
 		{
 			name:                          "When inputDinosaurOperatorVersion2 has an invalid expected format an error is returned",
-			inputDinosaurOperatorVersion1: DinosaurOperatorVersion{Version: "dinosaur-operator-v.7.0.0-0", Ready: true},
-			inputDinosaurOperatorVersion2: DinosaurOperatorVersion{Version: "dinosaur-operator-v.6.0.0", Ready: true},
+			inputDinosaurOperatorVersion1: CentralOperatorVersion{Version: "dinosaur-operator-v.7.0.0-0", Ready: true},
+			inputDinosaurOperatorVersion2: CentralOperatorVersion{Version: "dinosaur-operator-v.6.0.0", Ready: true},
 			wantErr:                       true,
 		},
 	}
@@ -397,22 +397,22 @@ func TestCompare(t *testing.T) {
 
 func Test_DinosaurOperatorVersionsDeepSort(t *testing.T) {
 	type args struct {
-		versions []DinosaurOperatorVersion
+		versions []CentralOperatorVersion
 	}
 
 	tests := []struct {
 		name    string
 		args    args
 		cluster func() *Cluster
-		want    []DinosaurOperatorVersion
+		want    []CentralOperatorVersion
 		wantErr bool
 	}{
 		{
 			name: "When versions to sort is empty result is empty",
 			args: args{
-				versions: []DinosaurOperatorVersion{},
+				versions: []CentralOperatorVersion{},
 			},
-			want: []DinosaurOperatorVersion{},
+			want: []CentralOperatorVersion{},
 		},
 		{
 			name: "When versions to sort is nil result is nil",
@@ -424,63 +424,63 @@ func Test_DinosaurOperatorVersionsDeepSort(t *testing.T) {
 		{
 			name: "When one of the dinosaur operator versions does not follow semver an error is returned",
 			args: args{
-				[]DinosaurOperatorVersion{DinosaurOperatorVersion{Version: "dinosaur-operator-v.nonsemver243-0"}, DinosaurOperatorVersion{Version: "dinosaur-operator-v.2.5.6-0"}},
+				[]CentralOperatorVersion{CentralOperatorVersion{Version: "dinosaur-operator-v.nonsemver243-0"}, CentralOperatorVersion{Version: "dinosaur-operator-v.2.5.6-0"}},
 			},
 			wantErr: true,
 		},
 		{
 			name: "All different versions are deeply sorted",
 			args: args{
-				versions: []DinosaurOperatorVersion{
-					DinosaurOperatorVersion{
+				versions: []CentralOperatorVersion{
+					CentralOperatorVersion{
 						Version: "dinosaur-operator-v.2.7.5-0",
-						DinosaurVersions: []DinosaurVersion{
-							DinosaurVersion{Version: "1.5.8"},
-							DinosaurVersion{Version: "0.7.1"},
-							DinosaurVersion{Version: "1.5.1"},
+						CentralVersions: []CentralVersion{
+							CentralVersion{Version: "1.5.8"},
+							CentralVersion{Version: "0.7.1"},
+							CentralVersion{Version: "1.5.1"},
 						},
 					},
-					DinosaurOperatorVersion{
+					CentralOperatorVersion{
 						Version: "dinosaur-operator-v.2.7.3-0",
-						DinosaurVersions: []DinosaurVersion{
-							DinosaurVersion{Version: "1.0.0"},
-							DinosaurVersion{Version: "2.0.0"},
-							DinosaurVersion{Version: "5.0.0"},
+						CentralVersions: []CentralVersion{
+							CentralVersion{Version: "1.0.0"},
+							CentralVersion{Version: "2.0.0"},
+							CentralVersion{Version: "5.0.0"},
 						},
 					},
-					DinosaurOperatorVersion{
+					CentralOperatorVersion{
 						Version: "dinosaur-operator-v.2.5.2-0",
-						DinosaurVersions: []DinosaurVersion{
-							DinosaurVersion{Version: "2.6.1"},
-							DinosaurVersion{Version: "5.7.2"},
-							DinosaurVersion{Version: "2.3.5"},
+						CentralVersions: []CentralVersion{
+							CentralVersion{Version: "2.6.1"},
+							CentralVersion{Version: "5.7.2"},
+							CentralVersion{Version: "2.3.5"},
 						},
 					},
 				},
 			},
-			want: []DinosaurOperatorVersion{
-				DinosaurOperatorVersion{
+			want: []CentralOperatorVersion{
+				CentralOperatorVersion{
 					Version: "dinosaur-operator-v.2.5.2-0",
-					DinosaurVersions: []DinosaurVersion{
-						DinosaurVersion{Version: "2.3.5"},
-						DinosaurVersion{Version: "2.6.1"},
-						DinosaurVersion{Version: "5.7.2"},
+					CentralVersions: []CentralVersion{
+						CentralVersion{Version: "2.3.5"},
+						CentralVersion{Version: "2.6.1"},
+						CentralVersion{Version: "5.7.2"},
 					},
 				},
-				DinosaurOperatorVersion{
+				CentralOperatorVersion{
 					Version: "dinosaur-operator-v.2.7.3-0",
-					DinosaurVersions: []DinosaurVersion{
-						DinosaurVersion{Version: "1.0.0"},
-						DinosaurVersion{Version: "2.0.0"},
-						DinosaurVersion{Version: "5.0.0"},
+					CentralVersions: []CentralVersion{
+						CentralVersion{Version: "1.0.0"},
+						CentralVersion{Version: "2.0.0"},
+						CentralVersion{Version: "5.0.0"},
 					},
 				},
-				DinosaurOperatorVersion{
+				CentralOperatorVersion{
 					Version: "dinosaur-operator-v.2.7.5-0",
-					DinosaurVersions: []DinosaurVersion{
-						DinosaurVersion{Version: "0.7.1"},
-						DinosaurVersion{Version: "1.5.1"},
-						DinosaurVersion{Version: "1.5.8"},
+					CentralVersions: []CentralVersion{
+						CentralVersion{Version: "0.7.1"},
+						CentralVersion{Version: "1.5.1"},
+						CentralVersion{Version: "1.5.8"},
 					},
 				},
 			},


### PR DESCRIPTION
## Description
In order to get a central resource in fleet manager to transition from `accepted` to `provisioning` you have to set available operator version for a cluster. Until now it was expected that this would be done by fleet shard components with a PUT request to `/api/rhacs/v1/<cluster-id>/status` when they are deployed and ready on the data plane cluster. Since we're bringing the clusters in manually, it makes sense to also allow setting this configuration with the `dataplane-cluster-configuration.yaml` file. When using the new introduced configuration:
```
...
   available_central_operator_versions:
    - version: "0.1.0"
      ready: true
      central_versions:
       - version: "0.1.0"
```
The cluster will be in `ready` state and have an operator version available, thus there is no further preparation necessary to start with proper central reconciliation.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Documentation added if necessary
- [x] CI and all relevant tests are passing

## Test manual

Manual testing:

```bash
make db/teardown db/setup db/migrate

# do this for the config file for the cluster you want to test it with
cp dev/config/dataplane-cluster-configuration-dockerdesktop.yaml ./config/dataplane-cluster-configuration.yaml
make run

# after leader election cluster should be in database looking like this:
make db/login
select * from clusters;

-[ RECORD 1 ]------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------
id                                   | caaspvq87d5jrvreqb60
created_at                           | 2022-05-31 08:08:31.23905+00
updated_at                           | 2022-05-31 08:08:31.23905+00
deleted_at                           | 
cloud_provider                       | standalone
cluster_id                           | 1234567890abcdef1234567890abcdef
external_id                          | 
multi_az                             | f
region                               | standalone
status                               | ready
identity_provider_id                 | 
cluster_dns                          | kubernetes.docker.internal
provider_type                        | standalone
provider_spec                        | 
cluster_spec                         | 
available_dinosaur_operator_versions | \x5b7b2276657273696f6e223a22302e312e30222c227265616479223a747275652c2263656e7472616c56657273696f6e73223a5b7b2276657273696f6e223a22302e312e30227d5d7d5d
supported_instance_type              | eval,standard
```

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
