### PR TITLE
Handle fleet manager REST api errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ cmd/fleet-manager/fleet-manager
 # cluster details (used for testing)
 /internal/dinosaur/test/integration/test_cluster.json
 
+# cluster configuration, overwritten locally to custom clusters
+config/dataplane-cluster-configuration.yaml
+
 # integration test's results
 /data/results/*
 !/data/results/.keep

--- a/fleetshard/pkg/centralreconciler/reconciler.go
+++ b/fleetshard/pkg/centralreconciler/reconciler.go
@@ -74,10 +74,10 @@ func (r CentralReconciler) Reconcile(ctx context.Context, remoteCentral private.
 		if err := r.client.Create(ctx, central); err != nil {
 			return nil, errors.Wrapf(err, "creating new central %q", remoteCentral.Metadata.Name)
 		}
+		glog.Infof("Central %s created", central.GetName())
 	} else {
 		// TODO(yury): implement update logic
 		glog.Infof("Update central tenant %s", central.GetName())
-		glog.Info("Implement update logic for Centrals")
 
 		err = r.incrementCentralRevision(central)
 		if err != nil {

--- a/fleetshard/pkg/fleetmanager/client.go
+++ b/fleetshard/pkg/fleetmanager/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/compat"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
 	"io"
 	"io/ioutil"
@@ -57,39 +58,39 @@ func (c *Client) GetManagedCentralList() (*private.ManagedCentralList, error) {
 		return nil, err
 	}
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	list := &private.ManagedCentralList{}
+	err = c.unmarshalResponse(resp.Body, &list)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "error calling %s", c.endpoint)
 	}
 
-	list := &private.ManagedCentralList{}
-	err = json.Unmarshal(respBody, &list)
-	if err != nil {
-		return nil, err
-	}
 	return list, nil
 }
 
 // UpdateStatus batch updates the status of managed centrals. The status param takes a map of DataPlaneCentralStatus indexed by
 // the Centrals ID.
-func (c *Client) UpdateStatus(statuses map[string]private.DataPlaneCentralStatus) ([]byte, error) {
+func (c *Client) UpdateStatus(statuses map[string]private.DataPlaneCentralStatus) error {
 	updateBody, err := json.Marshal(statuses)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	bufUpdateBody := &bytes.Buffer{}
 	_, err = bufUpdateBody.Write(updateBody)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	resp, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/%s", c.endpoint, statusRoute), bufUpdateBody)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return ioutil.ReadAll(resp.Body)
+	into := make(map[string]interface{})
+	if err := c.unmarshalResponse(resp.Body, &into); err != nil {
+		return errors.Wrapf(err, "failed to updates status")
+	}
+	return nil
 }
 
 func (c *Client) newRequest(method string, url string, body io.Reader) (*http.Response, error) {
@@ -105,4 +106,29 @@ func (c *Client) newRequest(method string, url string, body io.Reader) (*http.Re
 		return nil, err
 	}
 	return resp, nil
+}
+
+func (c *Client) unmarshalResponse(body io.Reader, v interface{}) error {
+	data, err := ioutil.ReadAll(body)
+	if err != nil {
+		return err
+	}
+
+	into := make(map[string]interface{})
+	err = json.Unmarshal(data, &into)
+	if err != nil {
+		return err
+	}
+
+	// Unmarshal error
+	if into["kind"] == "Error" {
+		apiError := compat.Error{}
+		err = json.Unmarshal(data, &apiError)
+		if err != nil {
+			return err
+		}
+		return errors.Errorf("API error occured %s: %s", apiError.Code, apiError.Reason)
+	}
+
+	return json.Unmarshal(data, v)
 }

--- a/fleetshard/pkg/fleetmanager/client_test.go
+++ b/fleetshard/pkg/fleetmanager/client_test.go
@@ -2,6 +2,7 @@ package fleetmanager
 
 import (
 	"encoding/json"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/compat"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,6 +31,30 @@ func TestClientGetManagedCentralList(t *testing.T) {
 	result, err := client.GetManagedCentralList()
 	require.NoError(t, err)
 	assert.Equal(t, &private.ManagedCentralList{}, result)
+}
+
+func TestClientReturnsError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		assert.Contains(t, request.RequestURI, "/api/rhacs/v1/agent-clusters/cluster-id/centrals")
+		bytes, err := json.Marshal(compat.Error{
+			Kind:   "error",
+			Reason: "some reason",
+		})
+		require.NoError(t, err)
+		_, err = writer.Write(bytes)
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	err := os.Setenv("OCM_TOKEN", "token")
+	require.NoError(t, err)
+
+	client, err := NewClient(ts.URL, "cluster-id")
+	require.NoError(t, err)
+
+	_, err = client.GetManagedCentralList()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "some reason")
 }
 
 func TestClientUpdateStatus(t *testing.T) {

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -63,7 +63,7 @@ func (r *Runtime) Start() error {
 	ticker := concurrency.NewRetryTicker(func(ctx context.Context) (timeToNextTick time.Duration, err error) {
 		list, err := r.client.GetManagedCentralList()
 		if err != nil {
-			err = errors.Wrapf(err, "failed to list centrals")
+			err = errors.Wrapf(err, "retrieving list of managed centrals")
 			glog.Error(err)
 			return 0, err
 		}
@@ -97,7 +97,7 @@ func (r *Runtime) handleReconcileResult(central private.ManagedCentral, status *
 		central.Id: *status,
 	})
 	if err != nil {
-		err = errors.Wrapf(err, "updating central status %s", central.Metadata.Name)
+		err = errors.Wrapf(err, "updating status for Central %s", central.Metadata.Name)
 		glog.Error(err)
 	}
 }

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -21,10 +21,10 @@ import (
 type reconcilerRegistry map[string]*centralreconciler.CentralReconciler
 
 var backoff = wait.Backoff{
-	Duration: 5 * time.Second,
-	Factor:   3.0,
+	Duration: 1 * time.Second,
+	Factor:   1.5,
 	Jitter:   0.1,
-	Steps:    5,
+	Steps:    15,
 	Cap:      10 * time.Minute,
 }
 
@@ -63,7 +63,8 @@ func (r *Runtime) Start() error {
 	ticker := concurrency.NewRetryTicker(func(ctx context.Context) (timeToNextTick time.Duration, err error) {
 		list, err := r.client.GetManagedCentralList()
 		if err != nil {
-			glog.Error("failed to list central", err)
+			err = errors.Wrapf(err, "failed to list centrals")
+			glog.Error(err)
 			return 0, err
 		}
 
@@ -92,12 +93,11 @@ func (r *Runtime) handleReconcileResult(central private.ManagedCentral, status *
 		return
 	}
 
-	resp, err := r.client.UpdateStatus(map[string]private.DataPlaneCentralStatus{
+	err = r.client.UpdateStatus(map[string]private.DataPlaneCentralStatus{
 		central.Id: *status,
 	})
 	if err != nil {
-		glog.Errorf("error occurred %s: %s", central.Metadata.Name, err.Error())
+		err = errors.Wrapf(err, "updating central status %s", central.Metadata.Name)
+		glog.Error(err)
 	}
-	//TODO: handle response correctly
-	glog.Infof(string(resp))
 }

--- a/internal/dinosaur/pkg/handlers/data_plane_cluster.go
+++ b/internal/dinosaur/pkg/handlers/data_plane_cluster.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/services"
 	"github.com/stackrox/acs-fleet-manager/pkg/handlers"
 
-	"github.com/stackrox/acs-fleet-manager/pkg/errors"
 	"github.com/gorilla/mux"
+	"github.com/stackrox/acs-fleet-manager/pkg/errors"
 )
 
 type dataPlaneClusterHandler struct {


### PR DESCRIPTION
## Description
Handle fleet manager API errors correctly. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~Unit and integration tests added~~
- [ ] ~~Documentation added if necessary~~
- [ ] CI and all relevant tests are passing

## Test manual

 - Run Fleet-Manager + Fleetshard-sync with an invalid OCM token, should write errors into the log
