### PR TITLE
Retrieve fleet-manager endpoint and cluster ID from environment

### DIFF
--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"time"
+
+	"github.com/caarlos0/env/v6"
+	"github.com/pkg/errors"
+)
+
+// Config contains this application's runtime configuration.
+type Config struct {
+	FleetManagerEndpoint string        `env:"FLEET_MANAGER_ENDPOINT" envDefault:"http://127.0.0.1:8000"`
+	ClusterID            string        `env:"CLUSTER_ID"`
+	RuntimePollPeriod    time.Duration `env:"RUNTIME_POLL_PERIOD" envDefault:"1s"`
+}
+
+// Load retrieves the current runtime configuration from the environment and returns it.
+func Load() (*Config, error) {
+	c := Config{}
+	if err := env.Parse(&c); err != nil {
+		return nil, errors.Wrapf(err, "Unable to parse runtime configuration from environment")
+	}
+	if c.ClusterID == "" {
+		return nil, errors.New("CLUSTER_ID unset in the environment")
+	}
+	if c.FleetManagerEndpoint == "" {
+		return nil, errors.New("FLEET_MANAGER_ENDPOINT unset in the environment")
+	}
+
+	return &c, nil
+}

--- a/fleetshard/main.go
+++ b/fleetshard/main.go
@@ -35,7 +35,10 @@ func main() {
 		glog.Fatalf("Failed to load configuration: %v", err)
 	}
 
-	glog.Infof("Starting application with configuration: %+v\n", *config)
+	glog.Info("Starting application")
+	glog.Infof("FleetManagerEndpoint: %s", config.FleetManagerEndpoint)
+	glog.Infof("ClusterID: %s", config.ClusterID)
+	glog.Infof("RuntimePollPeriod: %s", config.RuntimePollPeriod.String())
 
 	runtime, err := runtime.NewRuntime(config, k8s.CreateClientOrDie())
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/caarlos0/env/v6 v6.9.3 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -508,6 +508,8 @@ github.com/bytecodealliance/wasmtime-go v0.31.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOE
 github.com/bytecodealliance/wasmtime-go v0.33.1/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
 github.com/c2h5oh/datasize v0.0.0-20171227191756-4eba002a5eae/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
 github.com/caarlos0/ctrlc v1.0.0/go.mod h1:CdXpj4rmq0q/1Eb44M9zi2nKB0QraNKuRGYGrrHhcQw=
+github.com/caarlos0/env/v6 v6.9.3 h1:Tyg69hoVXDnpO5Qvpsu8EoquarbPyQb+YwExWHP8wWU=
+github.com/caarlos0/env/v6 v6.9.3/go.mod h1:hvp/ryKXKipEkcuYjs9mI4bBCg+UI0Yhgm5Zu0ddvwc=
 github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
 github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e/go.mod h1:9IOqJGCPMSc6E5ydlp5NIonxObaeu/Iub/X03EKPVYo=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=


### PR DESCRIPTION
## Description

Currently these values are hard-coded. Make them configurable using environment variables.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
