### PR TITLE
Add e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,9 +270,11 @@ lint: golangci-lint specinstall
 
 fleet-manager:
 	GOOS="$(GOOS)" GOARCH="$(GOARCH)" $(GO) build $(GOARGS) ./cmd/fleet-manager
+.PHONY: fleet-manager
 
 fleetshard-sync:
 	GOOS="$(GOOS)" GOARCH="$(GOARCH)" $(GO) build $(GOARGS) -o fleetshard-sync ./fleetshard
+.PHONY: fleetshard-sync
 
 binary: fleet-manager fleetshard-sync
 .PHONY: binary

--- a/Makefile
+++ b/Makefile
@@ -329,6 +329,10 @@ test/cluster/cleanup:
 	./scripts/cleanup_test_cluster.sh
 .PHONY: test/cluster/cleanup
 
+test/e2e/cleanup:
+	./e2e/cleanup.sh
+.PHONY: test/e2e/cleanup
+
 # generate files
 generate: moq openapi/generate
 	$(GO) generate ./...

--- a/config/dataplane-cluster-configuration.yaml
+++ b/config/dataplane-cluster-configuration.yaml
@@ -12,24 +12,9 @@
 #    region: us-east-1
 #    multi_az: true
 #    schedulable: true
-#    central_instance_limit: 2
+#    dinosaur_instance_limit: 2
 #    status: "cluster_provisioning" #Valid values are `cluster_provisioning`, `cluster_provisioned` and `ready`. `cluster_provisioning` will be used if not specified.
 #    provider_type: "ocm" #Valid values are `ocm` and `standalone`. `ocm` will be used if not specified.
-#    cluster_dns: apps.example.com #Valid cluster DNS. This will be used to build central host url and to communicate with standalone clusters. Required when "provider_type" is "standalone" 
+#    cluster_dns: apps.example.com #Valid cluster DNS. This will be used to build dinosaur host url and to communicate with standalone clusters. Required when "provider_type" is "standalone" 
 #    supported_instance_type: "eval" # could be "eval", "standard" or both i.e "standard,eval" or "eval,standard". Defaults to "standard,eval" if not set 
-clusters:
- - name: minikube  # Uncomment if using minikube
-   cluster_id: 1234567890abcdef1234567890abcdef
-   cloud_provider: standalone
-   region: standalone
-   schedulable: true
-   status: ready
-   central_instance_limit: 5
-   provider_type: standalone
-   supported_instance_type: "eval,standard"
-   cluster_dns: cluster.local
-   available_central_operator_versions:
-    - version: "0.1.0"
-      ready: true
-      central_versions:
-       - version: "0.1.0"
+clusters: []  # For a list of development clusters see dev/config/dataplane-cluster-configuration.yaml

--- a/config/dataplane-cluster-configuration.yaml
+++ b/config/dataplane-cluster-configuration.yaml
@@ -12,9 +12,24 @@
 #    region: us-east-1
 #    multi_az: true
 #    schedulable: true
-#    dinosaur_instance_limit: 2
+#    central_instance_limit: 2
 #    status: "cluster_provisioning" #Valid values are `cluster_provisioning`, `cluster_provisioned` and `ready`. `cluster_provisioning` will be used if not specified.
 #    provider_type: "ocm" #Valid values are `ocm` and `standalone`. `ocm` will be used if not specified.
-#    cluster_dns: apps.example.com #Valid cluster DNS. This will be used to build dinosaur host url and to communicate with standalone clusters. Required when "provider_type" is "standalone" 
+#    cluster_dns: apps.example.com #Valid cluster DNS. This will be used to build central host url and to communicate with standalone clusters. Required when "provider_type" is "standalone" 
 #    supported_instance_type: "eval" # could be "eval", "standard" or both i.e "standard,eval" or "eval,standard". Defaults to "standard,eval" if not set 
-clusters: []  # For a list of development clusters see dev/config/dataplane-cluster-configuration.yaml
+clusters:
+ - name: minikube  # Uncomment if using minikube
+   cluster_id: 1234567890abcdef1234567890abcdef
+   cloud_provider: standalone
+   region: standalone
+   schedulable: true
+   status: ready
+   central_instance_limit: 5
+   provider_type: standalone
+   supported_instance_type: "eval,standard"
+   cluster_dns: cluster.local
+   available_central_operator_versions:
+    - version: "0.1.0"
+      ready: true
+      central_versions:
+       - version: "0.1.0"

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,20 @@
+# e2e tests
+
+## Run it
+
+```
+# Setup a k8s cluster with the RHACS operator running
+
+# Run fleet-manager + database locally
+$ ./scripts/setup-dev-env.sh
+
+# Run fleetshard-sync locally
+$ make fleetshard/build
+$ OCM_TOKEN=$(ocm token) ./fleetshard-sync
+
+# Run e2e tests
+$ OCM_TOKEN=$(ocm token) go test ./e2e/...
+
+# To clean up the environment run
+$ ./e2e/cleanup.sh
+```

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -9,8 +9,8 @@
 $ ./scripts/setup-dev-env.sh
 
 # Run fleetshard-sync locally
-$ make fleetshard/build
-$ OCM_TOKEN=$(ocm token) ./fleetshard-sync
+$ make fleetshard-sync
+$ CLUSTER_ID=1234567890abcdef1234567890abcdef OCM_TOKEN=$(ocm token) ./fleetshard-sync
 
 # Run e2e tests
 $ OCM_TOKEN=$(ocm token) go test ./e2e/...

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -13,7 +13,7 @@ $ make fleetshard-sync
 $ CLUSTER_ID=1234567890abcdef1234567890abcdef OCM_TOKEN=$(ocm token) ./fleetshard-sync
 
 # Run e2e tests
-$ OCM_TOKEN=$(ocm token) go test ./e2e/...
+$ RUN_E2E=true OCM_TOKEN=$(ocm token) go test ./e2e/...
 
 # To clean up the environment run
 $ ./e2e/cleanup.sh

--- a/e2e/cleanup.sh
+++ b/e2e/cleanup.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-kubectl delete ns e2e-test-central
+namespaces=$(kubectl get ns | grep e2e-test-central | awk '{ print $1 }' | tr '\n' ' ')
+for namespace in $(echo "$namespaces");
+do
+  kubectl delete namespace "$namespace" &
+done
 docker stop fleet-manager-db && docker rm fleet-manager-db

--- a/e2e/cleanup.sh
+++ b/e2e/cleanup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+kubectl delete ns e2e-test-central
+docker stop fleet-manager-db && docker rm fleet-manager-db

--- a/e2e/cleanup.sh
+++ b/e2e/cleanup.sh
@@ -6,4 +6,4 @@ for namespace in $(echo "$namespaces");
 do
   kubectl delete namespace "$namespace" &
 done
-docker stop fleet-manager-db && docker rm fleet-manager-db
+make db/teardown

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -1,0 +1,26 @@
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+)
+
+var cfg *rest.Config
+var k8sClient client.Client
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "RHACS ManagedServices Suite")
+}
+
+//TODO: Deploy fleet-manager, fleetshard-sync and database into a cluster
+var _ = BeforeSuite(func() {
+	k8sClient = k8s.CreateClientOrDie()
+})
+
+var _ = AfterSuite(func() {
+})

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
 	"k8s.io/client-go/rest"
+	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
 )
@@ -13,6 +14,9 @@ var cfg *rest.Config
 var k8sClient client.Client
 
 func TestE2E(t *testing.T) {
+	if os.Getenv("RUN_E2E") != "true" {
+		t.Skip("Skip e2e tests. Set RUN_E2E=1 env variable to enable e2e tests.")
+	}
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "RHACS ManagedServices Suite")
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -60,5 +60,6 @@ var _ = Describe("Central", func() {
 		})
 
 		//TODO(create-ticket): Add test to eventually reach ready state
+		//TODO(yury): Add removal test
 	})
 })

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,0 +1,65 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/fleetmanager"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/public"
+	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+// TODO(create-ticket): Why is a central always created as a "eval" instance type?
+var centralName = fmt.Sprintf("%s-%d", "e2e-test-central", time.Now().UnixMilli())
+
+var _ = Describe("Central creation", func() {
+	var _ = Describe("new", func() {
+		Describe("should be created and deployed to k8s", func() {
+			client, err := fleetmanager.NewClient("http://localhost:8000", "cluster-id")
+			Expect(err).To(BeNil())
+
+			request := public.CentralRequestPayload{
+				Name:          centralName,
+				MultiAz:       true,
+				CloudProvider: "standalone",
+				Region:        "standalone",
+			}
+
+			var createdCentral *public.CentralRequest
+			It("created a central", func() {
+				createdCentral, err = client.CreateCentral(request)
+				Expect(err).To(BeNil())
+				Expect(constants.DinosaurRequestStatusAccepted.String()).To(Equal(createdCentral.Status))
+			})
+
+			It("should transition central's state to provisioning", func() {
+				Eventually(func() string {
+					provisioningCentral, err := client.GetCentral(createdCentral.Id)
+					Expect(err).To(BeNil())
+					return provisioningCentral.Status
+				}).WithTimeout(2 * time.Minute).Should(Equal(constants.DinosaurRequestStatusProvisioning.String()))
+			})
+
+			It("should create central namespace", func() {
+				Eventually(func() error {
+					ns := &v1.Namespace{}
+					return k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: centralName}, ns)
+				}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
+			})
+
+			It("should create central in managed cluster", func() {
+				Eventually(func() error {
+					central := &v1alpha1.Central{}
+					return k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: centralName, Namespace: centralName}, central)
+				}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
+			})
+
+			//TODO(create-ticket): Add test to eventually reach ready state
+		})
+	})
+})

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -17,49 +17,48 @@ import (
 // TODO(create-ticket): Why is a central always created as a "eval" instance type?
 var centralName = fmt.Sprintf("%s-%d", "e2e-test-central", time.Now().UnixMilli())
 
-var _ = Describe("Central creation", func() {
-	var _ = Describe("new", func() {
-		Describe("should be created and deployed to k8s", func() {
-			client, err := fleetmanager.NewClient("http://localhost:8000", "cluster-id")
+// TODO(create-ticket): Use correct OCM_TOKEN for different clients (console.redhat.com, fleetshard)
+var _ = Describe("Central", func() {
+	Describe("should be created and deployed to k8s", func() {
+		client, err := fleetmanager.NewClient("http://localhost:8000", "cluster-id")
+		Expect(err).To(BeNil())
+
+		request := public.CentralRequestPayload{
+			Name:          centralName,
+			MultiAz:       true,
+			CloudProvider: "standalone",
+			Region:        "standalone",
+		}
+
+		var createdCentral *public.CentralRequest
+		It("created a central", func() {
+			createdCentral, err = client.CreateCentral(request)
 			Expect(err).To(BeNil())
-
-			request := public.CentralRequestPayload{
-				Name:          centralName,
-				MultiAz:       true,
-				CloudProvider: "standalone",
-				Region:        "standalone",
-			}
-
-			var createdCentral *public.CentralRequest
-			It("created a central", func() {
-				createdCentral, err = client.CreateCentral(request)
-				Expect(err).To(BeNil())
-				Expect(constants.DinosaurRequestStatusAccepted.String()).To(Equal(createdCentral.Status))
-			})
-
-			It("should transition central's state to provisioning", func() {
-				Eventually(func() string {
-					provisioningCentral, err := client.GetCentral(createdCentral.Id)
-					Expect(err).To(BeNil())
-					return provisioningCentral.Status
-				}).WithTimeout(2 * time.Minute).Should(Equal(constants.DinosaurRequestStatusProvisioning.String()))
-			})
-
-			It("should create central namespace", func() {
-				Eventually(func() error {
-					ns := &v1.Namespace{}
-					return k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: centralName}, ns)
-				}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
-			})
-
-			It("should create central in managed cluster", func() {
-				Eventually(func() error {
-					central := &v1alpha1.Central{}
-					return k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: centralName, Namespace: centralName}, central)
-				}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
-			})
-
-			//TODO(create-ticket): Add test to eventually reach ready state
+			Expect(constants.DinosaurRequestStatusAccepted.String()).To(Equal(createdCentral.Status))
 		})
+
+		It("should transition central's state to provisioning", func() {
+			Eventually(func() string {
+				provisioningCentral, err := client.GetCentral(createdCentral.Id)
+				Expect(err).To(BeNil())
+				return provisioningCentral.Status
+			}).WithTimeout(2 * time.Minute).Should(Equal(constants.DinosaurRequestStatusProvisioning.String()))
+		})
+
+		It("should create central namespace", func() {
+			Eventually(func() error {
+				ns := &v1.Namespace{}
+				return k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: centralName}, ns)
+			}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
+		})
+
+		It("should create central in managed cluster", func() {
+			Eventually(func() error {
+				central := &v1alpha1.Central{}
+				return k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: centralName, Namespace: centralName}, central)
+			}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
+		})
+
+		//TODO(create-ticket): Add test to eventually reach ready state
 	})
 })

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Central", func() {
 			}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
 		})
 
-		It("should create central in managed cluster", func() {
+		It("should create central in its namespace on a managed cluster", func() {
 			Eventually(func() error {
 				central := &v1alpha1.Central{}
 				return k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: centralName, Namespace: centralName}, central)

--- a/fleetshard/README.md
+++ b/fleetshard/README.md
@@ -10,7 +10,7 @@ $ ./scripts/setup-dev-env.sh
 
 # Build and run fleetshard-sync
 $ make fleetshard/build
-$ ./fleetshard-sync
+$ OCM_TOKEN=$(ocm token) ./fleetshard-sync
 
 # Create a central instace
 $ ./scripts/create-central.sh

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -11,7 +11,7 @@ import (
 type Config struct {
 	FleetManagerEndpoint string        `env:"FLEET_MANAGER_ENDPOINT" envDefault:"http://127.0.0.1:8000"`
 	ClusterID            string        `env:"CLUSTER_ID"`
-	RuntimePollPeriod    time.Duration `env:"RUNTIME_POLL_PERIOD" envDefault:"1s"`
+	RuntimePollPeriod    time.Duration `env:"RUNTIME_POLL_PERIOD" envDefault:"5s"`
 }
 
 // Load retrieves the current runtime configuration from the environment and returns it.

--- a/fleetshard/pkg/fleetmanager/client.go
+++ b/fleetshard/pkg/fleetmanager/client.go
@@ -21,7 +21,7 @@ const (
 	publicCentralURI = "api/rhacs/v1/centrals"
 )
 
-// Client represents the client to REST client to connect to fleet-manager
+// Client represents the REST client for connecting to fleet-manager
 type Client struct {
 	client             http.Client
 	ocmToken           string
@@ -96,6 +96,7 @@ func (c *Client) UpdateStatus(statuses map[string]private.DataPlaneCentralStatus
 	return nil
 }
 
+// CreateCentral creates a central from the public fleet-manager API
 func (c *Client) CreateCentral(request public.CentralRequestPayload) (*public.CentralRequest, error) {
 	reqBody, err := json.Marshal(request)
 	if err != nil {
@@ -115,6 +116,7 @@ func (c *Client) CreateCentral(request public.CentralRequestPayload) (*public.Ce
 	return result, nil
 }
 
+// GetCentral returns a Central from the public fleet-manager API
 func (c *Client) GetCentral(id string) (*public.CentralRequest, error) {
 	resp, err := c.newRequest(http.MethodGet, fmt.Sprintf("%s/%s", c.publicAPIEndpoint, id), nil)
 	if err != nil {

--- a/fleetshard/pkg/fleetmanager/client.go
+++ b/fleetshard/pkg/fleetmanager/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/compat"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/public"
 	"io"
 	"net/http"
 	"os"
@@ -16,14 +17,17 @@ import (
 const (
 	uri         = "api/rhacs/v1/agent-clusters"
 	statusRoute = "status"
+
+	publicCentralURI = "api/rhacs/v1/centrals"
 )
 
 // Client represents the client to REST client to connect to fleet-manager
 type Client struct {
-	client    http.Client
-	ocmToken  string
-	clusterID string
-	endpoint  string
+	client             http.Client
+	ocmToken           string
+	clusterID          string
+	privateAPIEndpoint string
+	publicAPIEndpoint  string
 }
 
 // NewClient creates a new client
@@ -39,20 +43,21 @@ func NewClient(endpoint string, clusterID string) (*Client, error) {
 	}
 
 	if endpoint == "" {
-		return nil, errors.New("endpoint is empty")
+		return nil, errors.New("privateAPIEndpoint is empty")
 	}
 
 	return &Client{
-		client:    http.Client{},
-		clusterID: clusterID,
-		ocmToken:  ocmToken,
-		endpoint:  fmt.Sprintf("%s/%s/%s/%s", endpoint, uri, clusterID, "centrals"),
+		client:             http.Client{},
+		clusterID:          clusterID,
+		ocmToken:           ocmToken,
+		privateAPIEndpoint: fmt.Sprintf("%s/%s/%s/%s", endpoint, uri, clusterID, "centrals"),
+		publicAPIEndpoint:  fmt.Sprintf("%s/%s", endpoint, publicCentralURI),
 	}, nil
 }
 
 // GetManagedCentralList returns a list of centrals from fleet-manager which should be managed by this fleetshard.
 func (c *Client) GetManagedCentralList() (*private.ManagedCentralList, error) {
-	resp, err := c.newRequest(http.MethodGet, c.endpoint, &bytes.Buffer{})
+	resp, err := c.newRequest(http.MethodGet, c.privateAPIEndpoint, &bytes.Buffer{})
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +85,7 @@ func (c *Client) UpdateStatus(statuses map[string]private.DataPlaneCentralStatus
 		return err
 	}
 
-	resp, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/%s", c.endpoint, statusRoute), bufUpdateBody)
+	resp, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/%s", c.privateAPIEndpoint, statusRoute), bufUpdateBody)
 	if err != nil {
 		return err
 	}
@@ -89,6 +94,51 @@ func (c *Client) UpdateStatus(statuses map[string]private.DataPlaneCentralStatus
 		return errors.Wrapf(err, "updating status")
 	}
 	return nil
+}
+
+func (c *Client) CreateCentral(request public.CentralRequestPayload) (*public.CentralRequest, error) {
+	reqBody, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.newRequest(http.MethodPost, fmt.Sprintf("%s?async=true", c.publicAPIEndpoint), bytes.NewBuffer(reqBody))
+	if err != nil {
+		return nil, err
+	}
+
+	all, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Println(string(all))
+	result := public.CentralRequest{}
+	err = json.Unmarshal(all, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *Client) GetCentral(id string) (*public.CentralRequest, error) {
+	resp, err := c.newRequest(http.MethodGet, fmt.Sprintf("%s/%s", c.publicAPIEndpoint, id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	central := public.CentralRequest{}
+	err = json.Unmarshal(respBody, &central)
+	if err != nil {
+		return nil, err
+	}
+
+	return &central, nil
 }
 
 func (c *Client) newRequest(method string, url string, body io.Reader) (*http.Response, error) {

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -76,6 +76,7 @@ func (r *Runtime) Start() error {
 
 			reconciler := r.reconcilers[central.Metadata.Name]
 			go func(reconciler *centralreconciler.CentralReconciler, central private.ManagedCentral) {
+				glog.Infof("Start reconcile central %s", central.Metadata.Name)
 				status, err := reconciler.Reconcile(context.Background(), central)
 				r.handleReconcileResult(central, status, err)
 			}(reconciler, central)

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,6 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/caarlos0/env/v6 v6.9.3 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/lib/pq v1.10.6
 	github.com/mendsley/gojwk v0.0.0-20141217222730-4d5ec6e58103
 	github.com/olekukonko/tablewriter v0.0.5
+	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0
 	github.com/openshift-online/ocm-sdk-go v0.1.270
 	github.com/openshift/api v3.9.1-0.20191201231411-9f834e337466+incompatible

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -o pipefail
 
 SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 DIRNAME=$(dirname "$SCRIPT")
 
-if docker ps | grep -vq fleet-manager-db; then
+$(docker ps | grep -q fleet-manager-db)
+setup_db_container=$?
+if [[ "$setup_db_container" -ne "0" ]]; then
   echo "Setting up fleet-manager database"
   make db/setup
 else


### PR DESCRIPTION
## Description

Add a simple e2e testing suite to run locally. See `e2e/README.md` for instructions.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
