### PR TITLE
Add full permissions for fleet shard synchronizer

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-rbac.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-rbac.yaml
@@ -21,6 +21,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: fleetshard-sync-role
+# // TODO(create-ticket): Replace with least privileges permissions
 rules:
 - apiGroups:
   - '*'

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-rbac.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fleetshard-sync
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fleetshard-sync-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fleetshard-sync-role
+subjects:
+- kind: ServiceAccount
+  name: fleetshard-sync
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fleetshard-sync-role
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fleetshard-sync
+  namespace: {{ .Release.Namespace }}
   labels:
     app: fleetshard-sync
 spec:
@@ -16,6 +17,7 @@ spec:
       labels:
         app: fleetshard-sync
     spec:
+      serviceAccountName: fleetshard-sync
       containers:
       - name: fleetshard-sync
         image: quay.io/app-sre/acs-fleet-manager:main


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Add full permissions for fleet shard synchronizer. Also added a TODO to only give minimal permissions when it is clear which API operations we want to do.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

Manual testing against staging dataplane cluster "acs-dp-1":

```bash
helm -n rhacs delete rhacs-terraform
helm -n rhacs install rhacs-terraform dp-terraform/helm/rhacs-terraform/ \
      --set fleetshardSync.ocmToken=$(ocm token) \
      --set fleetshardSync.fleetManagerEndpoint=${NGROK_PREFIX} \
      --set fleetshardSync.clusterId=${cluster_id}

jrodrig-mac:acs-fleet-manager jrodrig$ helm -n rhacs list
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
rhacs-terraform rhacs           1               2022-06-06 12:17:09.670204 +0200 CEST   deployed        rhacs-terraform-0.1.0   0.1.0      
jrodrig-mac:acs-fleet-manager jrodrig$ oc -n rhacs get deployments
NAME              READY   UP-TO-DATE   AVAILABLE   AGE
fleetshard-sync   1/1     1            1           31s
```