### PR TITLE
Optionally install ACS operator on terraform

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/acs-operator.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/acs-operator.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.acsOperator.enabled }}
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: rhacs-operator
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhacs-operator
+  namespace: {{ .Release.Namespace }}
+spec:
+  channel: latest
+  installPlanApproval: Automatic
+  name: rhacs-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: {{ .Values.acsOperator.startingCSV }}
+{{ end }}

--- a/dp-terraform/helm/rhacs-terraform/templates/acs-operator.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/acs-operator.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.acsOperator.enabled }}
+{{- if .Values.acsOperator.enabled }}
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -17,4 +17,4 @@ spec:
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   startingCSV: {{ .Values.acsOperator.startingCSV }}
-{{ end }}
+{{- end }}

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -6,3 +6,6 @@ fleetshardSync:
   ocmToken: ""
   fleetManagerEndpoint: ""
   clusterId: ""
+acsOperator:
+  enabled: false
+  startingCSV: rhacs-operator.v3.70.0


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Optionally install ACS operator on terraform. This is mostly useful as a temporary dev tool, until the fleetshard sync installs the ACS operator.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

NOTE: deleting the subscrition does not delete the ClusterServiceVersion properly. This seems to be a problem of OLM. The definitive implementation of fleet shard synchronizer should do something about it.

### Test Helm install and upgrade

```bash
FM_ENDPOINT=... https://bfdc-83-33-206-69.eu.ngrok.io
oc delete namespace rhacs
oc create namespace rhacs
helm -n rhacs install rhacs-terraform dp-terraform/helm/rhacs-terraform/ \
      --set fleetshardSync.ocmToken=$(ocm token) \
      --set fleetshardSync.fleetManagerEndpoint=${FM_ENDPOINT} \
      --set fleetshardSync.clusterId=${cluster_id}
helm -n rhacs list
oc -n rhacs get deployment
# expected: no object
oc get OperatorGroup -A | grep rhacs
# expected: no object
oc get subscriptions -A | grep rhacs

helm -n rhacs upgrade rhacs-terraform dp-terraform/helm/rhacs-terraform/ \
      --set fleetshardSync.ocmToken=$(ocm token) \
      --set fleetshardSync.fleetManagerEndpoint=${FM_ENDPOINT} \
      --set fleetshardSync.clusterId=${cluster_id} \
      --set acsOperator.enabled=true \
      --set acsOperator.startingCSV=rhacs-operator.v3.70.0
# expected: one object 
oc get OperatorGroup -A | grep rhacs
# expected: one object. It also appears in "Installed operators"  in openshift UI
oc get subscriptions -A | grep rhacs

# This doesn't delete the operator properly: deleting the subscrition does not delete 
# the ClusterServiceVersion properly
helm -n rhacs upgrade rhacs-terraform dp-terraform/helm/rhacs-terraform/ \
      --set fleetshardSync.ocmToken=$(ocm token) \
      --set fleetshardSync.fleetManagerEndpoint=${FM_ENDPOINT} \
      --set fleetshardSync.clusterId=${cluster_id}
# expected: no object
oc get OperatorGroup -A | grep rhacs
# expected: no object
oc get subscriptions -A | grep rhacs      

helm -n rhacs delete rhacs-terraform 
```

### Test end to end flow of creating a central

```bash
# assuming this has credentials for staging OCM cluster
KUBECONFIG=${HOME}/.kube/config
DATAPLANE_CLUSTER_CONF="$(pwd)/dev/config/dataplane-cluster-configuration-staging.yaml"

make db/teardown db/setup db/migrate
rm fleet-manager && make binary && ./fleet-manager serve \
   --dataplane-cluster-config-file=${DATAPLANE_CLUSTER_CONF} \
   --providers-config-file=$(pwd)/dev/config/provider-configuration-infractl-osd.yaml \
   --kubeconfig=${KUBECONFIG} \
   2>&1 | tee fleet-manager-serve.log

ngrok http 8000 # write down endpoint in FM_ENDPOINT env var

# launch fleetshard sync connected to local fleet manager, and installing ACS operator
oc delete namespace rhacs
oc create namespace rhacs
cluster_id=$(grep cluster_id ${DATAPLANE_CLUSTER_CONF}  | tail -n1 | tr -s ' '  | cut -d ' ' -f 3)
helm -n rhacs install rhacs-terraform dp-terraform/helm/rhacs-terraform/ \
      --set fleetshardSync.ocmToken=$(ocm token) \
      --set fleetshardSync.fleetManagerEndpoint=${FM_ENDPOINT} \
      --set fleetshardSync.clusterId=${cluster_id} \
      --set acsOperator.enabled=true \
      --set acsOperator.startingCSV=rhacs-operator.v3.70.0

# 200 and no central
curl -v -H "Authorization: Bearer $(ocm token)" http://localhost:8000/api/rhacs/v1/centrals | jq .
# 200: cluster is there
curl -v -H "Authorization: Bearer $(ocm token)" http://localhost:8000/api/rhacs/v1/agent-clusters/${cluster_id} | jq .

# create a central for the same cloud provider and region as the cluster
## Note currently fleetshard sync uses the name of the central as namespace
oc create namespace rhacs-centrals
curl -v -H "Authorization: Bearer $(ocm token)" http://localhost:8000/api/rhacs/v1/centrals?async=true -X POST -d '{"name": "rhacs-centrals", "multi_az": true, "cloud_provider": "aws", "region": "us-east-1"}' | jq .
# 200 and the new central is accepted
curl -v -H "Authorization: Bearer $(ocm token)" http://localhost:8000/api/rhacs/v1/centrals | jq .

# register operator version for cluster : without this it never transitions to accepted, and the fleetshard sync
# doesn't install it
curl -v -H "Authorization: Bearer $(ocm token)" http://localhost:8000/api/rhacs/v1/agent-clusters/${cluster_id}/status?async=true -X PUT -d '
{
  "centralOperator": [
    {
      "ready": true,
      "version": "3.70.0",
      "centralVersions": ["3.70.0"]
    } 
  ],
  "conditions": [
    {
      "type": "Ready",
      "status": "true",
      "message": "fully operational",
      "reason": "this is a test"
    }
  ]
}' | jq .

# 200 and the new central is provisioning: it never gets to ready, call from fleetshard sync is missing
curl -v -H "Authorization: Bearer $(ocm token)" http://localhost:8000/api/rhacs/v1/centrals | jq .
# also in fleet shard sync logs
I0606 12:49:29.814243 1 reconciler.go:73] Creating central tenant rhacs-centrals
I0606 12:49:29.826394 1 runtime.go:102] {"caevehjhkdfojdp9i490":{"conditions":[{"type":"Ready","status":"True"}],"versions":{}}}
...
I0606 12:50:25.962234 1 client.go:96] Send request to https://388b-83-33-206-69.eu.ngrok.io/api/rhacs/v1/agent-clusters/1sii8ba1joon73n3d9n938sjf2e4joha/centrals
I0606 12:50:26.114504 1 reconciler.go:79] Update central tenant rhacs-centrals
I0606 12:50:26.114523 1 reconciler.go:80] Implement update logic for Centrals

# and a central CR is created
jrodrig-mac:acs-fleet-manager jrodrig$ oc -n rhacs-centrals get centrals
NAME             AGE
rhacs-centrals   2m59s
jrodrig-mac:acs-fleet-manager jrodrig$ oc -n rhacs-centrals get deployments
NAME         READY   UP-TO-DATE   AVAILABLE   AGE
central      1/1     1            1           2m56s
scanner      3/3     3            3           2m56s
scanner-db   1/1     1            1           2m56s
jrodrig-mac:acs-fleet-manager jrodrig$ 
```


