### PR TITLE
Temporarily use a configmap in place of the service secret.

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -471,6 +471,27 @@ objects:
         app: fleet-manager
     imagePullSecrets:
     - name: quay.io
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: fake-fleet-manager-secret
+    data:
+      ocm-service.clientId: badger
+      ocm-service.clientSecret: badger
+      ocm-service.token: badger
+      sentry.key: badger
+      aws.accesskey: badger
+      aws.accountid: badger
+      aws.secretaccesskey: badger
+      keycloak-service.clientId: badger
+      keycloak-service.clientSecret: badger
+      osd-idp-keycloak-service.clientId: badger
+      osd-idp-keycloak-service.clientSecret: badger
+      aws.route53accesskey: badger
+      aws.route53secretaccesskey: badger
+      observability-config-access.token: badger
+      image-pull.dockerconfigjson: badger
+      kubeconfig: badger
   - kind: Deployment
     apiVersion: apps/v1
     metadata:
@@ -511,8 +532,8 @@ objects:
             secret:
               secretName: fleet-manager-tls
           - name: service
-            secret:
-              secretName: fleet-manager
+            configMap:
+              name: fake-fleet-manager-secret
           - name: dataplane-certificate
             secret:
               secretName: fleet-manager-dataplane-certificate


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Temporary hack to figure out the simplest content of configuration files to keep the containers up and running.
Figuring out viable values using a real secret would take an AppSRE approval round for every iteration.
Once we know which values are OK we will go back to using a secret.