### PR TITLE
Temporarily use a minimum envoy configmap under dev control.

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -508,6 +508,76 @@ objects:
     data:
       tls.crt: badger
       tls.key: badger
+
+  # This is a copy of the configmap from envoy-config-configmap.yml but only containing the parts
+  # which are strictly necessary to get readiness/liveness probes to pass.
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: fleet-manager-envoy-config-cd
+      annotations:
+        qontract.recycle: "true"
+    data:
+      main.yaml: |
+        # The administration endpoint uses a Unix socket instead of TCP in order
+        # to avoid exposing it outside of the pod. Requests for metrics and
+        # probes will go via an HTTP listener that only accepts requests for the
+        # /metrics and /ready paths.
+        admin:
+        access_log_path: /dev/null
+        address:
+        pipe:
+        path: /sockets/admin.socket
+    
+        static_resources:
+        
+        clusters:
+        
+        # This backend is used to send metrics and probes requests to the
+        # administration endpoint.
+        - name: admin
+        connect_timeout: 1s
+        type: STATIC
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+        cluster_name: admin
+        endpoints:
+        - lb_endpoints:
+        - endpoint:
+           address:
+             pipe:
+               path: /sockets/admin.socket
+       
+        listeners:
+    
+          # This listener is used to accept /ready requests.
+          # Everything else will be rejected.
+          - name: admin
+            address:
+              socket_address:
+                address: 0.0.0.0
+                port_value: 9000
+            filter_chains:
+              - filters:
+                  - name: envoy.filters.network.http_connection_manager
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                      stat_prefix: admin
+                      route_config:
+                        name: admin
+                        virtual_hosts:
+                          - name: admin
+                            domains:
+                              - "*"
+                            routes:
+                              - name: ready
+                                match:
+                                  path: /ready
+                                route:
+                                  cluster: admin
+                      http_filters:
+                        - name: envoy.filters.http.router
+
   - kind: Deployment
     apiVersion: apps/v1
     metadata:
@@ -576,7 +646,9 @@ objects:
               name: fleet-manager-dataplane-cluster-scaling-config
           - name: envoy-config
             configMap:
-              name: fleet-manager-envoy-config
+              # Temporarily use a minimum version of the configmap deployed from this file
+              # (-cd for Continuous Deployment).
+              name: fleet-manager-envoy-config-cd
           - name: envoy-tls
             secret:
               secretName: fleet-manager-envoy-tls


### PR DESCRIPTION
## Description
Once we get it under control we can think about whether to:
- keep using this embedded configmap, or
- use the one in `envoy-config-configmap.yml` (by listing it in the SAAS file), or
- switch back to the copy under `app-interface/resources/...`