### PR TITLE
Temporarily use readiness probe as liveness

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -822,11 +822,15 @@ objects:
               limits:
                 cpu: ${CPU_LIMIT}
                 memory: ${MEMORY_LIMIT}
+            # TODO ROX-11309 Use /api based endpoint for livenessProbe
             livenessProbe:
               httpGet:
-                path: /api/dinosaurs_mgmt
-                port: 8000
+                path: /healthcheck
+                port: 8083
                 scheme: HTTPS
+                httpHeaders:
+                  - name: User-Agent
+                    value: Probe
               initialDelaySeconds: 15
               periodSeconds: 5
             readinessProbe:


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
livenessProbe failes with `Liveness probe failed: HTTP probe failed with statuscode: 401` so use `/healthcheck` temporarily until 401 is resolved