### PR TITLE
WARNING WARNING Temporarily replace migration init container with DB wipe

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -670,6 +670,7 @@ objects:
             command:
             - /usr/local/bin/fleet-manager
             - migrate
+            - rollback-all
             - --db-host-file=/secrets/rds/db.host
             - --db-port-file=/secrets/rds/db.port
             - --db-user-file=/secrets/rds/db.user


### PR DESCRIPTION
## Description
This is a one-time hack to prepare for an incompatible schema change #82 
The procedure will be:
- merge this one (should not affect developers' environments)
- wait for the rollback to be applied in staging env (should cause the service container to crash due to missing tables)
- merge #82 
- (at this point a rollout to staging can happen but will not have much impact since there is still no real migration container)
- roll back this one (at this point the new schema will be applied)

@johannes94 and I have established that the `rollback-all` command deletes all tables, including the migrations table.