### PR TITLE
Revert "WARNING WARNING Temporarily replace migration init container with DB wipe"

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -670,7 +670,6 @@ objects:
             command:
             - /usr/local/bin/fleet-manager
             - migrate
-            - rollback-all
             - --db-host-file=/secrets/rds/db.host
             - --db-port-file=/secrets/rds/db.port
             - --db-user-file=/secrets/rds/db.user


### PR DESCRIPTION
Reverts stackrox/acs-fleet-manager#114
Database on staging was wiped (mostly) successfully.
The only caveat is that compared to the plan enumerated in #114 we mixed up the order of PR merges, which resulted in an orphaned dinosaurs table. We're leaving it as is because such empty table is not an issue.