### PR TITLE
Fix: test-locally-claims.md formatting

### DIFF
--- a/docs/test-locally-claims.md
+++ b/docs/test-locally-claims.md
@@ -8,6 +8,7 @@ Algorithm RS256: RSASSA-PKCS1-v1_5 using SHA-256
 Key ID SHA-256
 ```
 **be sure to enable: Show X.509**
+
 2. Copy `Public and Private Keypair Set` field and paste it into new file. i.e. `config/jwks-file-test.json`
 3. Copy `Public Key` field. Open: https://jwt.io/ and paste the data into `HEADER` field
 4. Copy and paste public and private keys **X.509 PEM Format** into: jwt.io related parts in `VERIFY SIGNATURE` field
@@ -51,5 +52,6 @@ Key ID SHA-256
 }
 ```
 **NOTE**: important parts could be `realm_access.roles`, `iss`, etc.
+
 6. Use generated Token from jwt.io
 7. Start application with JWKS file param: `--jwks-file config/jwks-file-test.json`


### PR DESCRIPTION
## Description

It seems that Markdown formatting for `docs/test-locally-claims.md` is broken. This PR should fix that.

## Checklist (Definition of Done)
- ~[ ] Unit and integration tests added~
- ~[ ] Documentation added if necessary~
- ~[ ] CI and all relevant tests are passing~ - changes should not affect CI and tests

## Test manual

Check the preview of the file in GitHub UI.
