### PR TITLE
Add values to specify RHSSO user and password for fleetshard sync

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-rbac.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-rbac.yaml
@@ -7,7 +7,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ printf "%s-%s" "fleetshard-sync-role" .Release.Namespace }}
+  name: {{ printf "%s-%s" "fleetshard-sync-rb" .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-rbac.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-rbac.yaml
@@ -7,7 +7,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: fleetshard-sync-rolebinding
+  name: {{ printf "%s-%s" "fleetshard-sync-role" .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -17,6 +17,7 @@ subjects:
   name: fleetshard-sync
   namespace: {{ .Release.Namespace }}
 ---
+{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "fleetshard-sync-role") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -29,3 +30,4 @@ rules:
   - '*'
   verbs:
   - '*'
+{{- end }}

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -31,7 +31,7 @@ spec:
           value: {{ .Values.fleetshardSync.fleetManagerEndpoint }}
         - name: CLUSTER_ID
           value: {{ .Values.fleetshardSync.clusterId }}
-        {{- if and .Values.fleetshardSync.redHatSSO.user .Values.fleetshardSync.redHatSSO.password }}
+        {{- if and .Values.fleetshardSync.redHatSSO.clientId .Values.fleetshardSync.redHatSSO.clientSecret }}
         volumeMounts:
         - name: rhsso-creds
           mountPath: /run/secrets/rhsso-creds
@@ -42,7 +42,7 @@ spec:
             secretName: fleetshard-sync-rhsso-creds
         {{- end }}
 ---
-{{- if and .Values.fleetshardSync.redHatSSO.user .Values.fleetshardSync.redHatSSO.password }}
+{{- if and .Values.fleetshardSync.redHatSSO.clientId .Values.fleetshardSync.redHatSSO.clientSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -52,8 +52,8 @@ metadata:
     app: fleetshard-sync
 type: Opaque
 stringData:
-  user: |
-    {{ .Values.fleetshardSync.redHatSSO.user | nindent 4 }}
-  password: |
-    {{ .Values.fleetshardSync.redHatSSO.password | nindent 4 }}
+  clientId: |
+    {{ .Values.fleetshardSync.redHatSSO.clientId | nindent 4 }}
+  clientSecret: |
+    {{ .Values.fleetshardSync.redHatSSO.clientSecret | nindent 4 }}
 {{- end }}

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -31,7 +31,7 @@ spec:
           value: {{ .Values.fleetshardSync.fleetManagerEndpoint }}
         - name: CLUSTER_ID
           value: {{ .Values.fleetshardSync.clusterId }}
-        {{- if and .Values.fleetshardSync.redHatSso.user .Values.fleetshardSync.redHatSso.password }}
+        {{- if and .Values.fleetshardSync.redHatSSO.user .Values.fleetshardSync.redHatSSO.password }}
         volumeMounts:
         - name: rhsso-creds
           mountPath: /run/secrets/rhsso-creds
@@ -42,7 +42,7 @@ spec:
             secretName: fleetshard-sync-rhsso-creds
         {{- end }}
 ---
-{{- if and .Values.fleetshardSync.redHatSso.user .Values.fleetshardSync.redHatSso.password }}
+{{- if and .Values.fleetshardSync.redHatSSO.user .Values.fleetshardSync.redHatSSO.password }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -53,7 +53,7 @@ metadata:
 type: Opaque
 stringData:
   user: |
-    {{ .Values.fleetshardSync.redHatSso.user | nindent 4 }}
+    {{ .Values.fleetshardSync.redHatSSO.user | nindent 4 }}
   password: |
-    {{ .Values.fleetshardSync.redHatSso.password | nindent 4 }}
+    {{ .Values.fleetshardSync.redHatSSO.password | nindent 4 }}
 {{- end }}

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -31,3 +31,29 @@ spec:
           value: {{ .Values.fleetshardSync.fleetManagerEndpoint }}
         - name: CLUSTER_ID
           value: {{ .Values.fleetshardSync.clusterId }}
+        {{- if and .Values.fleetshardSync.redHatSso.user .Values.fleetshardSync.redHatSso.password }}
+        volumeMounts:
+        - name: rhsso-creds
+          mountPath: /run/secrets/rhsso-creds
+          readOnly: true
+      volumes:
+        - name: rhsso-creds
+          secret:
+            secretName: fleetshard-sync-rhsso-creds
+        {{- end }}
+---
+{{- if and .Values.fleetshardSync.redHatSso.user .Values.fleetshardSync.redHatSso.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fleetshard-sync-rhsso-creds
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: fleetshard-sync
+type: Opaque
+stringData:
+  user: |
+    {{ .Values.fleetshardSync.redHatSso.user | nindent 4 }}
+  password: |
+    {{ .Values.fleetshardSync.redHatSso.password | nindent 4 }}
+{{- end }}

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -6,6 +6,10 @@ fleetshardSync:
   ocmToken: ""
   fleetManagerEndpoint: ""
   clusterId: ""
+  redHatSso:
+    user: 
+    password: ""
+  
 acsOperator:
   enabled: false
   startingCSV: rhacs-operator.v3.70.0

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -6,7 +6,7 @@ fleetshardSync:
   ocmToken: ""
   fleetManagerEndpoint: ""
   clusterId: ""
-  redHatSso:
+  redHatSSO:
     user: 
     password: ""
   

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -7,8 +7,8 @@ fleetshardSync:
   fleetManagerEndpoint: ""
   clusterId: ""
   redHatSSO:
-    user: 
-    password: ""
+    clientId: ""
+    clientSecret: ""
   
 acsOperator:
   enabled: false


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Add values to specify RHSSO user and password for fleetshard sync. Those are stored in a secret mounted on the fleetshard synchronizer container, so it can use it to get credentials to authenticate to make requests to the private API. 

This also make a change in the handling of cluster role and cluster role binding for the fleet shard synchronizer, so the cluster terraforming helm chart can be deployed in more than 1 Helm release in the same cluster, so we can share development clusters.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

Launch local fleet manager and ngrok proxy

```bash
make db/teardown db/setup db/migrate
make osd/setup redhatsso/setup # if secrets/redhatsso-service.clientId and so it's missing

KUBECONFIG=${HOME}/.kube/config
DATAPLANE_CLUSTER_CONF="$(pwd)/dev/config/dataplane-cluster-configuration-staging.yaml"
make binary && ./fleet-manager serve \
   --dataplane-cluster-config-file=${DATAPLANE_CLUSTER_CONF} \
   --providers-config-file=$(pwd)/dev/config/provider-configuration-infractl-osd.yaml \
   --kubeconfig=${KUBECONFIG} \
   2>&1 | tee fleet-manager-serve.log
```

Install helm chart: using a values file containing the new credentials (will be updated in bitwarden)

```bash
FM_ENDPOINT=... ngrok output
DATAPLANE_CLUSTER_CONF="$(pwd)/dev/config/dataplane-cluster-configuration-staging.yaml"
cluster_id=$(grep cluster_id ${DATAPLANE_CLUSTER_CONF}  | tail -n1 | tr -s ' '  | cut -d ' ' -f 3)

oc create namespace juanrh
# With ~/.rh/terraform-values.yaml containing values for fleetshardSync.redHatSso.user 
# and fleetshardSync.redHatSso.password
helm -n juanrh install rhacs-terraform dp-terraform/helm/rhacs-terraform/ \
  -f ~/.rh/terraform-values.yaml \
  --set fleetshardSync.ocmToken=$(ocm token) \
  --set fleetshardSync.fleetManagerEndpoint=${FM_ENDPOINT} \
  --set fleetshardSync.clusterId=${cluster_id} \
  --set acsOperator.enabled=false
```

Check credentials are present in that pod

```bash
fm_pod=$(oc -n juanrh get pods -l app=fleetshard-sync -o json | jq -r .items[0].metadata.name)
# output as expected
oc -n juanrh exec --stdin --tty ${fm_pod} -- /bin/bash -c 'cat /run/secrets/rhsso-creds/clientId'
oc -n juanrh exec --stdin --tty ${fm_pod} -- /bin/bash -c 'cat /run/secrets/rhsso-creds/clientSecret'

# cleanup 
helm -n juanrh uninstall rhacs-terraform
```