### PR TITLE
Redact request logs to make them less noisy and leaky

### DIFF
--- a/pkg/server/logging/writer.go
+++ b/pkg/server/logging/writer.go
@@ -15,7 +15,7 @@ func redactRequest(request *http.Request) *http.Request {
 
 	requestCopy.Header = make(map[string][]string, len(request.Header))
 NEXT_HEADER:
-	for headerName, _ := range request.Header {
+	for headerName, headerValue := range request.Header {
 		for _, secretName := range secretNames {
 			if strings.EqualFold(headerName, secretName) {
 				// Redact this header.
@@ -23,7 +23,7 @@ NEXT_HEADER:
 				continue NEXT_HEADER
 			}
 		}
-		requestCopy.Header[headerName] = request.Header[headerName]
+		requestCopy.Header[headerName] = headerValue
 	}
 	return &requestCopy
 }

--- a/pkg/server/logging/writer.go
+++ b/pkg/server/logging/writer.go
@@ -2,12 +2,34 @@ package logging
 
 import (
 	"net/http"
+	"strings"
 
-	"github.com/stackrox/acs-fleet-manager/pkg/logger"
 	"github.com/pkg/errors"
+	"github.com/stackrox/acs-fleet-manager/pkg/logger"
 )
 
+func redactRequest(request *http.Request) *http.Request {
+	secretNames := []string{"authorization"}
+	redacted := "REDACTED"
+	requestCopy := *request
+
+	requestCopy.Header = make(map[string][]string, len(request.Header))
+NEXT_HEADER:
+	for headerName, _ := range request.Header {
+		for _, secretName := range secretNames {
+			if strings.EqualFold(headerName, secretName) {
+				// Redact this header.
+				requestCopy.Header[headerName] = []string{redacted}
+				continue NEXT_HEADER
+			}
+		}
+		requestCopy.Header[headerName] = request.Header[headerName]
+	}
+	return &requestCopy
+}
+
 func NewLoggingWriter(w http.ResponseWriter, r *http.Request, f LogFormatter) *loggingWriter {
+	r = redactRequest(r)
 	return &loggingWriter{ResponseWriter: w, request: r, formatter: f}
 }
 


### PR DESCRIPTION
## Description

fleet-manager logs currently include all requests including authentication tokens. Tokens should not be logged!
This PR takes care of removing them prior to logging.

This also makes fleet-manager logs much easier to read.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
