### PR TITLE
Add RHSSO central OIDC secret to configuration and service-template.yml

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -35,6 +35,7 @@ This lists the feature flags and their sub-configurations to enable/disable and 
     - `dinosaur-tls-cert-file` [Required]: The path to the file containing the Dinosaur TLS certificate (default: `'secrets/dinosaur-tls.crt'`).
     - `dinosaur-tls-key-file` [Required]: The path to the file containing the Dinosaur TLS private key (default: `'secrets/dinosaur-tls.key'`).
 - **enable-evaluator-instance**: Enable the creation of one dinosaur evaluator instances per user    
+- **rhsso-client-secret-file**: OIDC client secret to connect Dinosaur instances to sso.redhat.com
 - **quota-type**: Sets the quota service to be used for access control when requesting Dinosaur instances (options: `ams` or `quota-management-list`, default: `quota-management-list`).
     > For more information on the quota service implementation, see the [quota service architecture](./architecture/quota-service-implementation) architecture documentation.
     - If this is set to `quota-management-list`, quotas will be managed via the quota management list configuration. 

--- a/internal/dinosaur/pkg/config/dinosaur.go
+++ b/internal/dinosaur/pkg/config/dinosaur.go
@@ -22,8 +22,8 @@ type DinosaurConfig struct {
 
 	DinosaurLifespan      *DinosaurLifespanConfig `json:"dinosaur_lifespan"`
 	Quota                 *DinosaurQuotaConfig    `json:"dinosaur_quota"`
-	RhSsoClientSecretFile string                  `json:"rhsso_client_secret_file"`
 	RhSsoClientSecret     string                  `json:"rhsso_client_secret"`
+	RhSsoClientSecretFile string                  `json:"rhsso_client_secret_file"`
 }
 
 func NewDinosaurConfig() *DinosaurConfig {
@@ -63,9 +63,9 @@ func (c *DinosaurConfig) ReadFiles() error {
 		return err
 	}
 	if c.RhSsoClientSecret != "" {
-		glog.Info("Central OIDC client secret is configured.")
+		glog.Info("Central Red Hat OIDC client secret is configured.")
 	} else {
-		glog.Infof("Central OIDC client secret from secret file %q is missing.", c.RhSsoClientSecretFile)
+		glog.Infof("Central Red Hat OIDC client secret from secret file %q is missing.", c.RhSsoClientSecretFile)
 	}
 	// TODO(ROX-11289): drop MaxCapacity
 	// MaxCapacity is deprecated and will not be used.

--- a/internal/dinosaur/pkg/config/dinosaur.go
+++ b/internal/dinosaur/pkg/config/dinosaur.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 	"github.com/stackrox/acs-fleet-manager/pkg/shared"
 )
@@ -19,8 +20,10 @@ type DinosaurConfig struct {
 	// TODO(ROX-11289): drop MaxCapacity
 	MaxCapacity MaxCapacityConfig `json:"max_capacity_config"`
 
-	DinosaurLifespan *DinosaurLifespanConfig `json:"dinosaur_lifespan"`
-	Quota            *DinosaurQuotaConfig    `json:"dinosaur_quota"`
+	DinosaurLifespan      *DinosaurLifespanConfig `json:"dinosaur_lifespan"`
+	Quota                 *DinosaurQuotaConfig    `json:"dinosaur_quota"`
+	RhSsoClientSecretFile string                  `json:"rhsso_client_secret_file"`
+	RhSsoClientSecret     string                  `json:"rhsso_client_secret"`
 }
 
 func NewDinosaurConfig() *DinosaurConfig {
@@ -43,6 +46,7 @@ func (c *DinosaurConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.DinosaurDomainName, "dinosaur-domain-name", c.DinosaurDomainName, "The domain name to use for Dinosaur instances")
 	fs.StringVar(&c.Quota.Type, "quota-type", c.Quota.Type, "The type of the quota service to be used. The available options are: 'ams' for AMS backed implementation and 'quota-management-list' for quota list backed implementation (default).")
 	fs.BoolVar(&c.Quota.AllowEvaluatorInstance, "allow-evaluator-instance", c.Quota.AllowEvaluatorInstance, "Allow the creation of dinosaur evaluator instances")
+	fs.StringVar(&c.RhSsoClientSecretFile, "rhsso-client-secret-file", c.RhSsoClientSecretFile, "File containing OIDC client secret of sso.redhat.com client")
 }
 
 func (c *DinosaurConfig) ReadFiles() error {
@@ -53,6 +57,15 @@ func (c *DinosaurConfig) ReadFiles() error {
 	err = shared.ReadFileValueString(c.DinosaurTLSKeyFile, &c.DinosaurTLSKey)
 	if err != nil {
 		return err
+	}
+	err = shared.ReadFileValueString(c.RhSsoClientSecretFile, &c.RhSsoClientSecret)
+	if err != nil {
+		return err
+	}
+	if c.RhSsoClientSecret != "" {
+		glog.Info("Central OIDC client secret is configured.")
+	} else {
+		glog.Infof("Central OIDC client secret from secret file %q is missing.", c.RhSsoClientSecretFile)
 	}
 	// TODO(ROX-11289): drop MaxCapacity
 	// MaxCapacity is deprecated and will not be used.

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -782,6 +782,9 @@ objects:
           serviceAccount: fleet-manager
           serviceAccountName: fleet-manager
           volumes:
+          - name: rhsso-client-secret
+            secret:
+              secretName: fleet-manager-central-rhsso-client-secret
           - name: tls
             secret:
               secretName: fleet-manager-tls
@@ -856,6 +859,8 @@ objects:
             volumeMounts:
             - name: tls
               mountPath: /secrets/tls
+            - name: rhsso-client-secret
+              mountPath: /secrets/rhsso-client-secret
             - name: service
               mountPath: /secrets/service
             - name: dataplane-certificate
@@ -901,6 +906,7 @@ objects:
             - --aws-secret-access-key-file=/secrets/service/aws.secretaccesskey
             - --aws-route53-access-key-file=/secrets/service/aws.route53accesskey
             - --aws-route53-secret-access-key-file=/secrets/service/aws.route53secretaccesskey
+            - --rhsso-client-secret-file=/secrets/rhsso-client-secret/clientSecret
             - --observatorium-debug=${ENABLE_OBSERVATORIUM_DEBUG}
             - --observatorium-ignore-ssl=${OBSERVATORIUM_INSECURE}
             - --observatorium-timeout=${OBSERVATORIUM_TIMEOUT}


### PR DESCRIPTION
## Description
This PR adds sso.redhat.com OIDC client secret to fleet-manager. This secret is used by Central instances to integrate with sso.redhat.com. 
This PR is done as part of prototyping for [ROX-11063](https://issues.redhat.com/browse/ROX-11063)
Corresponding secret is added to the staging cluster here: [gitlab](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/41397)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

1. Deployed fleet-manager using `--rhsso-client-secret-file` parameter
