### PR TITLE
Allow configuring cloud provider and region of central request in e2e tests

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -18,3 +18,10 @@ $ RUN_E2E=true OCM_TOKEN=$(ocm token) go test ./e2e/...
 # To clean up the environment run
 $ ./e2e/cleanup.sh
 ```
+
+The following env vars can also be adjusted for using a different types of dataplane clusters. If not set the test will assume a local minikube cluster:
+
+- `DP_CLOUD_PROVIDER`: cloud provider for the data plane cluster.
+- `DP_REGION`: region for the data plane cluster.
+
+The env var `WAIT_TIMEOUT` can be used to adjust the timeout of each individual tests, using a string compatible with Golang's `time.ParseDuration`, e.g. `WAIT_TIMEOUT=20s`. If not set all tests use 5 minutes as timeout.

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -5,13 +5,41 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
 	"k8s.io/client-go/rest"
+	"fmt"
 	"os"
+	"time"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
 )
 
 var cfg *rest.Config
 var k8sClient client.Client
+
+const defaultTimeout = 5 * time.Minute
+var waitTimeout = getWaitTimeout()
+var dpCloudProvider = getEnvDefault("DP_CLOUD_PROVIDER", "standalone")
+var dpRegion = getEnvDefault("DP_REGION", "standalone")
+
+func getWaitTimeout() time.Duration {
+	timeoutStr, ok := os.LookupEnv("WAIT_TIMEOUT")
+	if ok {
+		timeout, err := time.ParseDuration(timeoutStr)
+		if err == nil {
+			return timeout
+		} else {
+			fmt.Printf("Error parsing timeout, using default timeout %v: %s", defaultTimeout, err)
+		}
+	}
+	return defaultTimeout
+}
+
+func getEnvDefault(key, defaultValue string) string {
+	value, ok := os.LookupEnv(key)
+	if !ok {
+		return defaultValue
+	}
+	return value
+}
 
 func TestE2E(t *testing.T) {
 	if os.Getenv("RUN_E2E") != "true" {

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -27,7 +27,7 @@ func getWaitTimeout() time.Duration {
 		if err == nil {
 			return timeout
 		} else {
-			fmt.Printf("Error parsing timeout, using default timeout %v: %s", defaultTimeout, err)
+			fmt.Printf("Error parsing timeout, using default timeout %v: %s\n", defaultTimeout, err)
 		}
 	}
 	return defaultTimeout

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -26,8 +26,8 @@ var _ = Describe("Central", func() {
 		request := public.CentralRequestPayload{
 			Name:          centralName,
 			MultiAz:       true,
-			CloudProvider: "standalone",
-			Region:        "standalone",
+			CloudProvider: dpCloudProvider,
+			Region:        dpRegion,
 		}
 
 		var createdCentral *public.CentralRequest
@@ -39,6 +39,7 @@ var _ = Describe("Central", func() {
 
 		It("should transition central's state to provisioning", func() {
 			Eventually(func() string {
+				Expect(createdCentral).NotTo(BeNil())
 				provisioningCentral, err := client.GetCentral(createdCentral.Id)
 				Expect(err).To(BeNil())
 				return provisioningCentral.Status
@@ -49,14 +50,14 @@ var _ = Describe("Central", func() {
 			Eventually(func() error {
 				ns := &v1.Namespace{}
 				return k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: centralName}, ns)
-			}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
+			}).WithTimeout(waitTimeout).WithPolling(1 * time.Second).Should(Succeed())
 		})
 
 		It("should create central in its namespace on a managed cluster", func() {
 			Eventually(func() error {
 				central := &v1alpha1.Central{}
 				return k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: centralName, Namespace: centralName}, central)
-			}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
+			}).WithTimeout(waitTimeout).WithPolling(1 * time.Second).Should(Succeed())
 		})
 
 		//TODO(create-ticket): Add test to eventually reach ready state

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,17 +1,14 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/fleetmanager"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/public"
-	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
-	v1 "k8s.io/api/core/v1"
-	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 // TODO(create-ticket): Why is a central always created as a "eval" instance type?
@@ -43,9 +40,12 @@ var _ = Describe("Central", func() {
 				provisioningCentral, err := client.GetCentral(createdCentral.Id)
 				Expect(err).To(BeNil())
 				return provisioningCentral.Status
-			}).WithTimeout(2 * time.Minute).Should(Equal(constants.DinosaurRequestStatusProvisioning.String()))
+			}).WithTimeout(waitTimeout).Should(Equal(constants.DinosaurRequestStatusProvisioning.String()))
 		})
 
+		/*
+		//TODO(create-ticket): fails because the namespace is not centralName anymore but `formatNamespace(dinosaurRequest.ID)`
+		// and that is not accessible from a value `*public.CentralRequest`
 		It("should create central namespace", func() {
 			Eventually(func() error {
 				ns := &v1.Namespace{}
@@ -59,7 +59,7 @@ var _ = Describe("Central", func() {
 				return k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: centralName, Namespace: centralName}, central)
 			}).WithTimeout(waitTimeout).WithPolling(1 * time.Second).Should(Succeed())
 		})
-
+		*/
 		//TODO(create-ticket): Add test to eventually reach ready state
 		//TODO(yury): Add removal test
 	})


### PR DESCRIPTION
## Description
This change adds env vars for configuring the cloud provider and region of central request in e2e tests, so tests can be run against the staging data plane OSD cluster. If not specific the previously hardcoded values are used as defaults. 
Some other minor changes:

- Add a nil check to avoid a panic if the first test fails
- Disable tests that are failing, due to the new namespace that fleet manager assigns to centrals. Added TODO to fix that eventually
- Add env var to specify test timeout

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

Run tests against staging data plane OSD cluster. First test `It("created a central"` fails with "API error (HTTP status 403) occured RHACS-MGMT-24: only one eval instance is allowed", but fixing that issue is out of the scope of this change

```bash
# setup oc with `oc login`
make db/teardown db/setup db/migrate
make osd/setup redhatsso/setup # if secrets/redhatsso-service.clientId and so it's missing

KUBECONFIG=${HOME}/.kube/config
DATAPLANE_CLUSTER_CONF="$(pwd)/dev/config/dataplane-cluster-configuration-staging.yaml"
make binary && ./fleet-manager serve \
   --dataplane-cluster-config-file=${DATAPLANE_CLUSTER_CONF} \
   --providers-config-file=$(pwd)/dev/config/provider-configuration-infractl-osd.yaml \
   --kubeconfig=${KUBECONFIG} \
   2>&1 | tee fleet-manager-serve.log

# launch fleet shard sync: assuming ACS operator running in the cluster
oc delete namespace juanrh
oc create namespace juanrh
FM_ENDPOINT=... ngrok output, or anything not emptys
DATAPLANE_CLUSTER_CONF="$(pwd)/dev/config/dataplane-cluster-configuration-staging.yaml"
cluster_id=$(grep cluster_id ${DATAPLANE_CLUSTER_CONF} | tail -n1 | tr -s ' '  | cut -d ' ' -f 3)
helm -n juanrh install rhacs-terraform dp-terraform/helm/rhacs-terraform/  \
  -f ~/.rh/terraform-values.yaml \
  --set fleetshardSync.ocmToken=$(ocm token) \
  --set fleetshardSync.fleetManagerEndpoint=${FM_ENDPOINT} \
  --set fleetshardSync.clusterId=${cluster_id} \
  --set acsOperator.enabled=false

# run e2e tests
## or just debug in VsCode as below
DP_CLOUD_PROVIDER=aws DP_REGION=us-east-1 RUN_E2E=true OCM_TOKEN=$(ocm token) go test -v ./e2e/... 2>&1 | tee e2e-test.log
```

Run tests against local minikube: tests are passing

```bash
minikube start

# launch fleet manager
# ./scripts/setup-dev-env.sh fails 
make db/teardown db/setup db/migrate
 ./fleet-manager serve --dataplane-cluster-config-file=dev/config/dataplane-cluster-configuration-minikube.yaml

# launch fleet shard sync
CLUSTER_ID=1234567890abcdef1234567890abcdef OCM_TOKEN=$(ocm token) ./fleetshard-sync

# launch operator
cdrox
make install run

# run tests
RUN_E2E=true OCM_TOKEN=$(ocm token) WAIT_TIMEOUT=20s go test -v ./e2e/... 2>&1 | tee e2e-test.log
...
Will run 2 of 2 specs
•
------------------------------
• [SLOW TEST] [7.461 seconds]
Central should be created and deployed to k8s should transition central's state to provisioning
/Users/jrodrig/go/src/github.com/stackrox/acs-fleet-manager/e2e/e2e_test.go:37
------------------------------

Ran 2 of 2 Specs in 7.777 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestE2E (7.78s)
PASS
ok      github.com/stackrox/acs-fleet-manager/e2e       8.425s
```
