### PR TITLE
Add entrypoint for e2e testing in OpenShift CI

### DIFF
--- a/.openshift-ci/tests/e2e.sh
+++ b/.openshift-ci/tests/e2e.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo "** Entrypoint for e2e tests running in OpenShift CI **"
+
+echo "(nothing yet)"


### PR DESCRIPTION
## Description

This will be referenced from within the ci-operator configuration so that whatever is in this file will be executed in a test environment with an OpenShift cluster available.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
