### PR TITLE
ROX-11467 - Add Central deletion e2e test

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -3,7 +3,8 @@
 ## Run it
 
 ```
-# Setup a k8s cluster with the RHACS operator running
+# Setup a k8s cluster
+# Start RHACS operator
 
 # Run fleet-manager + database locally
 $ ./scripts/setup-dev-env.sh
@@ -12,8 +13,8 @@ $ ./scripts/setup-dev-env.sh
 $ make fleetshard-sync
 $ CLUSTER_ID=1234567890abcdef1234567890abcdef OCM_TOKEN=$(ocm token) ./fleetshard-sync
 
-# Run e2e tests
-$ RUN_E2E=true OCM_TOKEN=$(ocm token) go test ./e2e/...
+# Run e2e tests (invalidate cache to run it multiple times)
+$ go clean -testcache && RUN_E2E=true OCM_TOKEN=$(ocm token) go test ./e2e/...
 
 # To clean up the environment run
 $ ./e2e/cleanup.sh

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 // TODO(create-ticket): Why is a central always created as a "eval" instance type?
@@ -23,7 +23,6 @@ var (
 )
 
 const (
-	defaultTimeout = 2 * time.Minute
 	defaultPolling = 1 * time.Second
 )
 
@@ -56,26 +55,25 @@ var _ = Describe("Central", func() {
 				provisioningCentral, err := client.GetCentral(createdCentral.Id)
 				Expect(err).To(BeNil())
 				return provisioningCentral.Status
-			}).WithTimeout(defaultTimeout).WithPolling(defaultPolling).Should(Equal(constants.DinosaurRequestStatusProvisioning.String()))
+			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Equal(constants.DinosaurRequestStatusProvisioning.String()))
 		})
 
-		/*
 		//TODO(create-ticket): fails because the namespace is not centralName anymore but `formatNamespace(dinosaurRequest.ID)`
 		// and that is not accessible from a value `*public.CentralRequest`
 		It("should create central namespace", func() {
 			Eventually(func() error {
 				ns := &v1.Namespace{}
 				return k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: namespaceName}, ns)
-			}).WithTimeout(defaultTimeout).WithPolling(defaultPolling).Should(Succeed())
+			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Succeed())
 		})
 
 		It("should create central in its namespace on a managed cluster", func() {
 			Eventually(func() error {
 				central := &v1alpha1.Central{}
 				return k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: centralName, Namespace: namespaceName}, central)
-			}).WithTimeout(defaultTimeout).WithPolling(defaultPolling).Should(Succeed())
+			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Succeed())
 		})
-		*/
+
 		//TODO(create-ticket): Add test to eventually reach ready state
 		//TODO(create-ticket): create test to check that Central and Scanner are healthy
 		//TODO(create-ticket): Create test to check Central is correctly exposed
@@ -87,7 +85,7 @@ var _ = Describe("Central", func() {
 				deprovisioningCentral, err := client.GetCentral(createdCentral.Id)
 				Expect(err).To(BeNil())
 				return deprovisioningCentral.Status
-			}).WithTimeout(defaultTimeout).WithPolling(defaultPolling).Should(Equal(constants.DinosaurRequestStatusDeprovision.String()))
+			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Equal(constants.DinosaurRequestStatusDeprovision.String()))
 		})
 
 		It("should delete central CR", func() {
@@ -95,7 +93,7 @@ var _ = Describe("Central", func() {
 				central := &v1alpha1.Central{}
 				err := k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: centralName, Namespace: centralName}, central)
 				return apiErrors.IsNotFound(err)
-			}).WithTimeout(defaultTimeout).WithPolling(defaultPolling).Should(BeTrue())
+			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(BeTrue())
 		})
 
 		It("should remove central namespace", func() {
@@ -103,7 +101,7 @@ var _ = Describe("Central", func() {
 				ns := &v1.Namespace{}
 				err := k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: namespaceName}, ns)
 				return apiErrors.IsNotFound(err)
-			}).WithTimeout(defaultTimeout).WithPolling(defaultPolling).Should(BeTrue())
+			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(BeTrue())
 		})
 
 	})

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -9,10 +9,23 @@ import (
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/fleetmanager"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/public"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/services"
+	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
 )
 
 // TODO(create-ticket): Why is a central always created as a "eval" instance type?
-var centralName = fmt.Sprintf("%s-%d", "e2e-test-central", time.Now().UnixMilli())
+var (
+	centralName = fmt.Sprintf("%s-%d", "e2e-test-central", time.Now().UnixMilli())
+)
+
+const (
+	defaultTimeout = 2 * time.Minute
+	defaultPolling = 1 * time.Second
+)
 
 // TODO(create-ticket): Use correct OCM_TOKEN for different clients (console.redhat.com, fleetshard)
 var _ = Describe("Central", func() {
@@ -28,8 +41,11 @@ var _ = Describe("Central", func() {
 		}
 
 		var createdCentral *public.CentralRequest
+		var namespaceName string
 		It("created a central", func() {
 			createdCentral, err = client.CreateCentral(request)
+			Expect(err).To(BeNil())
+			namespaceName, err = services.FormatNamespace(createdCentral.Id)
 			Expect(err).To(BeNil())
 			Expect(constants.DinosaurRequestStatusAccepted.String()).To(Equal(createdCentral.Status))
 		})
@@ -40,7 +56,7 @@ var _ = Describe("Central", func() {
 				provisioningCentral, err := client.GetCentral(createdCentral.Id)
 				Expect(err).To(BeNil())
 				return provisioningCentral.Status
-			}).WithTimeout(waitTimeout).Should(Equal(constants.DinosaurRequestStatusProvisioning.String()))
+			}).WithTimeout(defaultTimeout).WithPolling(defaultPolling).Should(Equal(constants.DinosaurRequestStatusProvisioning.String()))
 		})
 
 		/*
@@ -49,18 +65,46 @@ var _ = Describe("Central", func() {
 		It("should create central namespace", func() {
 			Eventually(func() error {
 				ns := &v1.Namespace{}
-				return k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: centralName}, ns)
-			}).WithTimeout(waitTimeout).WithPolling(1 * time.Second).Should(Succeed())
+				return k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: namespaceName}, ns)
+			}).WithTimeout(defaultTimeout).WithPolling(defaultPolling).Should(Succeed())
 		})
 
 		It("should create central in its namespace on a managed cluster", func() {
 			Eventually(func() error {
 				central := &v1alpha1.Central{}
-				return k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: centralName, Namespace: centralName}, central)
-			}).WithTimeout(waitTimeout).WithPolling(1 * time.Second).Should(Succeed())
+				return k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: centralName, Namespace: namespaceName}, central)
+			}).WithTimeout(defaultTimeout).WithPolling(defaultPolling).Should(Succeed())
 		})
 		*/
 		//TODO(create-ticket): Add test to eventually reach ready state
-		//TODO(yury): Add removal test
+		//TODO(create-ticket): create test to check that Central and Scanner are healthy
+		//TODO(create-ticket): Create test to check Central is correctly exposed
+
+		It("should transition central to deprovisioning state", func() {
+			err = client.DeleteCentral(createdCentral.Id)
+			Expect(err).To(Succeed())
+			Eventually(func() string {
+				deprovisioningCentral, err := client.GetCentral(createdCentral.Id)
+				Expect(err).To(BeNil())
+				return deprovisioningCentral.Status
+			}).WithTimeout(defaultTimeout).WithPolling(defaultPolling).Should(Equal(constants.DinosaurRequestStatusDeprovision.String()))
+		})
+
+		It("should delete central CR", func() {
+			Eventually(func() bool {
+				central := &v1alpha1.Central{}
+				err := k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: centralName, Namespace: centralName}, central)
+				return apiErrors.IsNotFound(err)
+			}).WithTimeout(defaultTimeout).WithPolling(defaultPolling).Should(BeTrue())
+		})
+
+		It("should remove central namespace", func() {
+			Eventually(func() bool {
+				ns := &v1.Namespace{}
+				err := k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: namespaceName}, ns)
+				return apiErrors.IsNotFound(err)
+			}).WithTimeout(defaultTimeout).WithPolling(defaultPolling).Should(BeTrue())
+		})
+
 	})
 })

--- a/fleetshard/pkg/fleetmanager/client.go
+++ b/fleetshard/pkg/fleetmanager/client.go
@@ -127,6 +127,20 @@ func (c *Client) GetCentral(id string) (*public.CentralRequest, error) {
 	return central, nil
 }
 
+// DeleteCentral deletes a central from the public fleet-manager API
+func (c *Client) DeleteCentral(id string) error {
+	resp, err := c.newRequest(http.MethodDelete, fmt.Sprintf("%s/%s?async=true", c.consoleAPIEndpoint, id), nil)
+	if err != nil {
+		return err
+	}
+
+	err = c.unmarshalResponse(resp, nil)
+	if err != nil {
+		return errors.Wrapf(err, "deleting central %s", id)
+	}
+	return nil
+}
+
 func (c *Client) newRequest(method string, url string, body io.Reader) (*http.Response, error) {
 	glog.Infof("Send request to %s", url)
 	r, err := http.NewRequest(method, url, body)

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -72,6 +72,7 @@ func (r *Runtime) Start() error {
 		}
 
 		// Start for each Central its own reconciler which can be triggered by sending a central to the receive channel.
+		glog.Infof("Received %d centrals", len(list.Items))
 		for _, central := range list.Items {
 			if _, ok := r.reconcilers[central.Metadata.Name]; !ok {
 				r.reconcilers[central.Metadata.Name] = centralreconciler.NewCentralReconciler(r.k8sClient, central, routesAvailable)

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -265,7 +265,7 @@ func (k *dinosaurService) PrepareDinosaurRequest(dinosaurRequest *dbapi.CentralR
 		return errors.NewWithCause(errors.ErrorGeneral, err, "error retrieving cluster DNS")
 	}
 
-	namespace, formatErr := formatNamespace(dinosaurRequest.ID)
+	namespace, formatErr := FormatNamespace(dinosaurRequest.ID)
 	if formatErr != nil {
 		return errors.NewWithCause(errors.ErrorGeneral, formatErr, "invalid id format")
 	}

--- a/internal/dinosaur/pkg/services/util.go
+++ b/internal/dinosaur/pkg/services/util.go
@@ -69,8 +69,8 @@ func replaceHostSpecialChar(name string) (string, error) {
 	return replacedName, nil
 }
 
-// formatNamespace adds the rhacs prefix to the namespace name and performs the necessary validation and formatting to comply with RFC1123 that namespace names must follow.
-func formatNamespace(text string) (string, error) {
+// FormatNamespace adds the rhacs prefix to the namespace name and performs the necessary validation and formatting to comply with RFC1123 that namespace names must follow.
+func FormatNamespace(text string) (string, error) {
 	if !dns1123LabelRegexp.MatchString(text) {
 		return "", fmt.Errorf("invalid namespace %s: %s", text, validation.RegexError(dns1123LabelErrMsg, dns1123LabelFmt, "my-name", "123-abc"))
 	}

--- a/internal/dinosaur/pkg/services/util_test.go
+++ b/internal/dinosaur/pkg/services/util_test.go
@@ -380,7 +380,7 @@ func Test_formatNamespace(t *testing.T) {
 	}
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
-			namespace, err := formatNamespace(test.id)
+			namespace, err := FormatNamespace(test.id)
 			if test.expectError {
 				assert.Error(t, err)
 			} else {

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -4,6 +4,8 @@ set -oe pipefail
 SCRIPT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 DIRNAME=$(dirname "$SCRIPT")
 
+make secrets/touch
+
 set +e
 $(docker ps | grep -q fleet-manager-db)
 setup_db_container=$?


### PR DESCRIPTION
## Description

Add e2e test to remove Central. It checks for CR and Namespace deletion.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

Run e2e-tests and make sure Central was created and deleted by observing central_requests database and fleetshard-sync logs.