### PR TITLE
pass through cert data to route

### DIFF
--- a/fleetshard/pkg/centralreconciler/reconciler.go
+++ b/fleetshard/pkg/centralreconciler/reconciler.go
@@ -5,11 +5,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	openshiftRouteV1 "github.com/openshift/api/route/v1"
-	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/tls"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"strconv"
 	"sync/atomic"
+
+	openshiftRouteV1 "github.com/openshift/api/route/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -280,10 +280,12 @@ func (r CentralReconciler) ensureReencryptRouteExists(ctx context.Context, remot
 					Name: "central",
 				},
 				TLS: &openshiftRouteV1.TLSConfig{
-					Termination:              openshiftRouteV1.TLSTerminationReencrypt,
-					Key:                      tls.SelfSignedKey(),  // TODO(ROX-11523): Load from fleet manager
-					Certificate:              tls.SelfSignedCert(), // TODO(ROX-11523): Load from fleet manager
-					CACertificate:            tls.SelfSignedCA(),   // TODO(ROX-11523): Load from fleet manager
+					Termination: openshiftRouteV1.TLSTerminationReencrypt,
+					Key:         remoteCentral.Spec.Endpoint.Tls.Key,
+					Certificate: remoteCentral.Spec.Endpoint.Tls.Cert,
+					// TODO: should we even set that? There is no config in fleet-manager template and we probably
+					// won't need it because it should be a publicly trusted certificate
+					// CACertificate:            tls.SelfSignedCA(),   // TODO(ROX-11523): Load from fleet manager
 					DestinationCACertificate: string(centralCA),
 				},
 			}

--- a/fleetshard/pkg/centralreconciler/reconciler.go
+++ b/fleetshard/pkg/centralreconciler/reconciler.go
@@ -280,12 +280,9 @@ func (r CentralReconciler) ensureReencryptRouteExists(ctx context.Context, remot
 					Name: "central",
 				},
 				TLS: &openshiftRouteV1.TLSConfig{
-					Termination: openshiftRouteV1.TLSTerminationReencrypt,
-					Key:         remoteCentral.Spec.Endpoint.Tls.Key,
-					Certificate: remoteCentral.Spec.Endpoint.Tls.Cert,
-					// TODO: should we even set that? There is no config in fleet-manager template and we probably
-					// won't need it because it should be a publicly trusted certificate
-					// CACertificate:            tls.SelfSignedCA(),   // TODO(ROX-11523): Load from fleet manager
+					Termination:              openshiftRouteV1.TLSTerminationReencrypt,
+					Key:                      remoteCentral.Spec.Endpoint.Tls.Key,
+					Certificate:              remoteCentral.Spec.Endpoint.Tls.Cert,
 					DestinationCACertificate: string(centralCA),
 				},
 			}

--- a/internal/dinosaur/pkg/api/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/private/api/openapi.yaml
@@ -419,7 +419,6 @@ components:
         deletionTimestamp:
           type: string
     ManagedCentral_allOf_spec_endpoint_tls:
-      nullable: true
       properties:
         cert:
           type: string

--- a/internal/dinosaur/pkg/api/private/model_managed_central_all_of_spec_endpoint.go
+++ b/internal/dinosaur/pkg/api/private/model_managed_central_all_of_spec_endpoint.go
@@ -11,6 +11,6 @@ package private
 
 // ManagedCentralAllOfSpecEndpoint struct for ManagedCentralAllOfSpecEndpoint
 type ManagedCentralAllOfSpecEndpoint struct {
-	Host string                              `json:"host,omitempty"`
-	Tls  *ManagedCentralAllOfSpecEndpointTls `json:"tls,omitempty"`
+	Host string                             `json:"host,omitempty"`
+	Tls  ManagedCentralAllOfSpecEndpointTls `json:"tls,omitempty"`
 }

--- a/internal/dinosaur/pkg/presenters/manageddinosaur.go
+++ b/internal/dinosaur/pkg/presenters/manageddinosaur.go
@@ -42,8 +42,8 @@ func PresentManagedDinosaur(from *v1.ManagedDinosaur) private.ManagedCentral {
 			Endpoint: private.ManagedCentralAllOfSpecEndpoint{
 				Host: from.Spec.Endpoint.Host,
 				Tls: &private.ManagedCentralAllOfSpecEndpointTls{
-					Cert: "cert-data",
-					Key:  "key-data",
+					Cert: from.Spec.Endpoint.Tls.Cert,
+					Key:  from.Spec.Endpoint.Tls.Key,
 				},
 			},
 			Versions: private.ManagedCentralVersions{

--- a/internal/dinosaur/pkg/presenters/manageddinosaur.go
+++ b/internal/dinosaur/pkg/presenters/manageddinosaur.go
@@ -41,7 +41,7 @@ func PresentManagedDinosaur(from *v1.ManagedDinosaur) private.ManagedCentral {
 			Owners: from.Spec.Owners,
 			Endpoint: private.ManagedCentralAllOfSpecEndpoint{
 				Host: from.Spec.Endpoint.Host,
-				Tls: &private.ManagedCentralAllOfSpecEndpointTls{
+				Tls: private.ManagedCentralAllOfSpecEndpointTls{
 					Cert: from.Spec.Endpoint.Tls.Cert,
 					Key:  from.Spec.Endpoint.Tls.Key,
 				},

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -3,9 +3,10 @@ package services
 import (
 	"context"
 	"fmt"
-	"github.com/stackrox/acs-fleet-manager/pkg/services/sso"
 	"strings"
 	"sync"
+
+	"github.com/stackrox/acs-fleet-manager/pkg/services/sso"
 
 	constants2 "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
@@ -816,6 +817,10 @@ func BuildManagedDinosaurCR(dinosaurRequest *dbapi.CentralRequest, dinosaurConfi
 		Spec: manageddinosaur.ManagedDinosaurSpec{
 			Endpoint: manageddinosaur.EndpointSpec{
 				Host: dinosaurRequest.Host,
+				Tls: &manageddinosaur.TlsSpec{
+					Cert: dinosaurConfig.DinosaurTLSCert,
+					Key:  dinosaurConfig.DinosaurTLSKey,
+				},
 			},
 			Versions: manageddinosaur.VersionsSpec{
 				Dinosaur:         dinosaurRequest.DesiredCentralVersion,

--- a/openapi/fleet-manager-private.yaml
+++ b/openapi/fleet-manager-private.yaml
@@ -259,7 +259,6 @@ components:
                       type: string
                     tls:
                       type: object
-                      nullable: true
                       properties:
                         cert:
                           type: string


### PR DESCRIPTION
## Description
Add certificate data to ManagedCentral response of fleet manager and use it to configure reencrypt route.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
