### PR TITLE
Integrate pre-commit plugin detect-secrets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.2.0
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,712 @@
+{
+  "version": "1.2.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    ".github/workflows/ci.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/ci.yaml",
+        "hashed_secret": "e7ea02f9561b93b1b57f70cb49d7dd521f3a8ab4",
+        "is_verified": false,
+        "line_number": 47,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/ci.yaml",
+        "hashed_secret": "f1936880eee185392c4ba0b55ba8826287e3b05d",
+        "is_verified": false,
+        "line_number": 58,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/ci.yaml",
+        "hashed_secret": "c149692162b626934a3779a9d501349fe084287b",
+        "is_verified": false,
+        "line_number": 60,
+        "is_secret": false
+      }
+    ],
+    "config/jwks-file.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "config/jwks-file.json",
+        "hashed_secret": "551c2aa179bc3c0e2e8176d4b458d077ed358e25",
+        "is_verified": false,
+        "line_number": 8,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "config/jwks-file.json",
+        "hashed_secret": "f05bf8a9b8521955a5fa259abd1d5a6d269273ec",
+        "is_verified": false,
+        "line_number": 16,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "config/jwks-file.json",
+        "hashed_secret": "e23d321e76d1144e48b7f1d05dfd0d5036031003",
+        "is_verified": false,
+        "line_number": 24,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "config/jwks-file.json",
+        "hashed_secret": "9b87ab16703bb0ccd78aee2f69bd0e604f7a42dc",
+        "is_verified": false,
+        "line_number": 32,
+        "is_secret": false
+      }
+    ],
+    "db_setup_docker.sql": [
+      {
+        "type": "Secret Keyword",
+        "filename": "db_setup_docker.sql",
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_verified": false,
+        "line_number": 1,
+        "is_secret": false
+      }
+    ],
+    "dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml",
+        "hashed_secret": "97b510880880a92bb3429d8854f0d38dcc849af8",
+        "is_verified": false,
+        "line_number": 42,
+        "is_secret": false
+      }
+    ],
+    "internal/dinosaur/pkg/api/private/api/openapi.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/dinosaur/pkg/api/private/api/openapi.yaml",
+        "hashed_secret": "2774b5ad0fae1c8b8dc897b89db85529d45cb5cf",
+        "is_verified": false,
+        "line_number": 193,
+        "is_secret": false
+      }
+    ],
+    "internal/dinosaur/pkg/api/public/api/openapi.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/dinosaur/pkg/api/public/api/openapi.yaml",
+        "hashed_secret": "a5f0056c7d0ca4ed78e2f3b551554daaf4721934",
+        "is_verified": false,
+        "line_number": 883,
+        "is_secret": false
+      }
+    ],
+    "internal/dinosaur/pkg/clusters/ocm_provider_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/clusters/ocm_provider_test.go",
+        "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
+        "is_verified": false,
+        "line_number": 381,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/clusters/ocm_provider_test.go",
+        "hashed_secret": "3897acbc1a0c2d800969d4d599520739e8d17c34",
+        "is_verified": false,
+        "line_number": 386,
+        "is_secret": false
+      }
+    ],
+    "internal/dinosaur/pkg/clusters/standalone_provider.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/clusters/standalone_provider.go",
+        "hashed_secret": "981da8a7314f1c0997979d9600ac357f88f6bf68",
+        "is_verified": false,
+        "line_number": 34,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/clusters/standalone_provider.go",
+        "hashed_secret": "4bfa77220acb4871ad543d6a2fb5d5b386208cf5",
+        "is_verified": false,
+        "line_number": 45,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/clusters/standalone_provider.go",
+        "hashed_secret": "4fb395ee78ec5a467a639024b3037c5b4785af69",
+        "is_verified": false,
+        "line_number": 292,
+        "is_secret": false
+      }
+    ],
+    "internal/dinosaur/pkg/clusters/standalone_provider_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/clusters/standalone_provider_test.go",
+        "hashed_secret": "ea06090a0b9590add823ade2334090fa216acb2b",
+        "is_verified": false,
+        "line_number": 196,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/clusters/standalone_provider_test.go",
+        "hashed_secret": "595c14227acdc1cbf7fae43b358ab46bbc7abb96",
+        "is_verified": false,
+        "line_number": 220,
+        "is_secret": false
+      }
+    ],
+    "internal/dinosaur/pkg/config/aws.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/config/aws.go",
+        "hashed_secret": "a7a1409da575fd6716dc3cac70ba51eb65fa74a0",
+        "is_verified": false,
+        "line_number": 28,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/config/aws.go",
+        "hashed_secret": "e342e21e5f9459373d057c924e8ba5e04aa91c06",
+        "is_verified": false,
+        "line_number": 30,
+        "is_secret": false
+      }
+    ],
+    "internal/dinosaur/pkg/services/clusters_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/services/clusters_test.go",
+        "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
+        "is_verified": false,
+        "line_number": 1877,
+        "is_secret": false
+      }
+    ],
+    "internal/dinosaur/pkg/services/dinosaur.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/services/dinosaur.go",
+        "hashed_secret": "bae666efd375b31ee4ba6e4ed05a31c84b916b9c",
+        "is_verified": false,
+        "line_number": 689,
+        "is_secret": false
+      }
+    ],
+    "internal/dinosaur/pkg/services/fleetshard_operator_addon.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/services/fleetshard_operator_addon.go",
+        "hashed_secret": "de8b5c97d82759c77b96a3fd0acb1030e11c5f58",
+        "is_verified": false,
+        "line_number": 23,
+        "is_secret": false
+      }
+    ],
+    "internal/dinosaur/pkg/workers/clusters_mgr.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/workers/clusters_mgr.go",
+        "hashed_secret": "a6e4653f54561ded823537b9ed07aab449cc72c2",
+        "is_verified": false,
+        "line_number": 44,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/workers/clusters_mgr.go",
+        "hashed_secret": "af8bd5f9fa23e6c5faadecb87910d595cac48aa8",
+        "is_verified": false,
+        "line_number": 47,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/workers/clusters_mgr.go",
+        "hashed_secret": "a4f2b95d16786cd9c4f86404cb519f18b7e33113",
+        "is_verified": false,
+        "line_number": 800,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/workers/clusters_mgr.go",
+        "hashed_secret": "a6b7aa0f297935e4e49d200f7505873d8cd470ce",
+        "is_verified": false,
+        "line_number": 802,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/workers/clusters_mgr.go",
+        "hashed_secret": "9b8b876c2782fa992fab14095267bb8757b9fabc",
+        "is_verified": false,
+        "line_number": 995,
+        "is_secret": false
+      }
+    ],
+    "openapi/fleet-manager-private.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "openapi/fleet-manager-private.yaml",
+        "hashed_secret": "2774b5ad0fae1c8b8dc897b89db85529d45cb5cf",
+        "is_verified": false,
+        "line_number": 467,
+        "is_secret": false
+      }
+    ],
+    "openapi/fleet-manager.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "openapi/fleet-manager.yaml",
+        "hashed_secret": "a5f0056c7d0ca4ed78e2f3b551554daaf4721934",
+        "is_verified": false,
+        "line_number": 1100,
+        "is_secret": false
+      }
+    ],
+    "pkg/auth/helper.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/auth/helper.go",
+        "hashed_secret": "248133ee1f089f95dd147dffc73a43319c2ecc90",
+        "is_verified": false,
+        "line_number": 45,
+        "is_secret": false
+      }
+    ],
+    "pkg/client/keycloak/client_moq.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/keycloak/client_moq.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 640,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/keycloak/client_moq.go",
+        "hashed_secret": "ef0b0964f3cf5c2da4fc3833d06f3b3e1f444531",
+        "is_verified": false,
+        "line_number": 641,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/keycloak/client_moq.go",
+        "hashed_secret": "86e30009a86bbfcb7195178129832850ae4ba771",
+        "is_verified": false,
+        "line_number": 972,
+        "is_secret": false
+      }
+    ],
+    "pkg/client/keycloak/config.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/keycloak/config.go",
+        "hashed_secret": "85716713a2f64ab8193fd7abf2de3237a5ccae09",
+        "is_verified": false,
+        "line_number": 53,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/keycloak/config.go",
+        "hashed_secret": "8059b8f7acd5ab09f92010b99a1593019d6969e9",
+        "is_verified": false,
+        "line_number": 63,
+        "is_secret": false
+      }
+    ],
+    "pkg/client/keycloak/constants.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/keycloak/constants.go",
+        "hashed_secret": "a931c2a572165b673d42afcdbde0abec3d43f2d2",
+        "is_verified": false,
+        "line_number": 4,
+        "is_secret": false
+      }
+    ],
+    "pkg/client/keycloak/gocloak_moq.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/keycloak/gocloak_moq.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 9597,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/keycloak/gocloak_moq.go",
+        "hashed_secret": "7f0b58c8f07c09a5ed45a784a8e1ea4d3e983d59",
+        "is_verified": false,
+        "line_number": 9598,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/keycloak/gocloak_moq.go",
+        "hashed_secret": "9b8b876c2782fa992fab14095267bb8757b9fabc",
+        "is_verified": false,
+        "line_number": 12902,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/keycloak/gocloak_moq.go",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 12905,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/keycloak/gocloak_moq.go",
+        "hashed_secret": "eb1b883e199141e362a143c51178ab8f09c87751",
+        "is_verified": false,
+        "line_number": 13513,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/keycloak/gocloak_moq.go",
+        "hashed_secret": "1b46ecc8fb47b1b39a420f00f08dbd58e0313188",
+        "is_verified": false,
+        "line_number": 13813,
+        "is_secret": false
+      }
+    ],
+    "pkg/client/observatorium/observability_config.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/observatorium/observability_config.go",
+        "hashed_secret": "2b75527d264f77ec1084028955c0f05777750c34",
+        "is_verified": false,
+        "line_number": 52,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/observatorium/observability_config.go",
+        "hashed_secret": "74ac575474b8458aca4c76a9da1958074d1bd480",
+        "is_verified": false,
+        "line_number": 54,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/observatorium/observability_config.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 104,
+        "is_secret": false
+      }
+    ],
+    "pkg/client/ocm/config.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/ocm/config.go",
+        "hashed_secret": "1b9118168ed0f38bff724496e64ce21857a63530",
+        "is_verified": false,
+        "line_number": 39,
+        "is_secret": false
+      }
+    ],
+    "pkg/client/redhatsso/client_moq.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/redhatsso/client_moq.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 384,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/redhatsso/client_moq.go",
+        "hashed_secret": "5394d7802ce230899b9befae3d5e1d53c5a4dbb6",
+        "is_verified": false,
+        "line_number": 385,
+        "is_secret": false
+      }
+    ],
+    "pkg/db/config.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/db/config.go",
+        "hashed_secret": "c11470a785cfb6230c00c2b74acbac3807e92b40",
+        "is_verified": false,
+        "line_number": 41,
+        "is_secret": false
+      }
+    ],
+    "pkg/server/logging/writer.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/server/logging/writer.go",
+        "hashed_secret": "dbe6a29075a279abe17382f866e9882aa665b0e8",
+        "is_verified": false,
+        "line_number": 19,
+        "is_secret": false
+      }
+    ],
+    "pkg/services/sso/keycloakservice_moq.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/services/sso/keycloakservice_moq.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 367,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/services/sso/keycloakservice_moq.go",
+        "hashed_secret": "d0c0fbcb5d9eec638d2f91f0a514e06725100f90",
+        "is_verified": false,
+        "line_number": 368,
+        "is_secret": false
+      }
+    ],
+    "pkg/services/sso/redhatsso_service_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/services/sso/redhatsso_service_test.go",
+        "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
+        "is_verified": false,
+        "line_number": 151,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/services/sso/redhatsso_service_test.go",
+        "hashed_secret": "591a65fb8cf971fc4aefa197102ad5cda3a21f18",
+        "is_verified": false,
+        "line_number": 190,
+        "is_secret": false
+      }
+    ],
+    "pkg/shared/secrets/secrets_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/shared/secrets/secrets_test.go",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 112,
+        "is_secret": false
+      }
+    ],
+    "pr_check_docker.sh": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pr_check_docker.sh",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 9,
+        "is_secret": false
+      }
+    ],
+    "templates/service-template.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "templates/service-template.yml",
+        "hashed_secret": "4e199b4a1c40b497a95fcd1cd896351733849949",
+        "is_verified": false,
+        "line_number": 490,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "templates/service-template.yml",
+        "hashed_secret": "f262552238937b43102d7308422fc567e8aed4ba",
+        "is_verified": false,
+        "line_number": 797,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "templates/service-template.yml",
+        "hashed_secret": "e2b7ddca9ab1066c1e5b368f2c2e5da70c5e54bc",
+        "is_verified": false,
+        "line_number": 800,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "templates/service-template.yml",
+        "hashed_secret": "1d82918cd9745c60d712b5369a7635afe06e225b",
+        "is_verified": false,
+        "line_number": 809,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "templates/service-template.yml",
+        "hashed_secret": "85c26a4496699ef15ea9398004057710222ae9bc",
+        "is_verified": false,
+        "line_number": 835,
+        "is_secret": false
+      }
+    ],
+    "test/helper.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "test/helper.go",
+        "hashed_secret": "06c5dd974b4f80bf5c103e80e79f9b037e2ba020",
+        "is_verified": false,
+        "line_number": 116,
+        "is_secret": false
+      }
+    ],
+    "test/mocks/redhatsso.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "test/mocks/redhatsso.go",
+        "hashed_secret": "9834c6d2aa77444d881f9f50ca1c0e6d9cbdc773",
+        "is_verified": false,
+        "line_number": 80,
+        "is_secret": false
+      }
+    ],
+    "test/support/certs.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "test/support/certs.json",
+        "hashed_secret": "d59844c767c4c6c3840f8cabbc04b1e5ed2acc22",
+        "is_verified": false,
+        "line_number": 8,
+        "is_secret": false
+      }
+    ],
+    "test/support/jwt_private_key.pem": [
+      {
+        "type": "Private Key",
+        "filename": "test/support/jwt_private_key.pem",
+        "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
+        "is_verified": false,
+        "line_number": 1,
+        "is_secret": false
+      }
+    ]
+  },
+  "generated_at": "2022-06-27T12:18:52Z"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,15 +78,13 @@ $GOPATH
 ```
 
 ## Set up Git Hooks
-Run the following command to set up git hooks for the project. 
+Run the following command to set up git hooks for the project. pre-commit is used under the hood, see [https://pre-commit.com](https://pre-commit.com/) for more information.
 
 ```
 make setup/git/hooks
 ```
 
-The following git hooks are currently available:
-- **pre-commit**:
-  - This runs checks to ensure that the staged `.go` files passes formatting and standard checks using gofmt and go vet.
+Currently the only activated pre-commit plugin is `detect-secrets`.
 
 ## Debugging
 ### VS Code

--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,14 @@ all: openapi/generate binary
 # Set git hook path to .githooks/
 .PHONY: setup/git/hooks
 setup/git/hooks:
-	git config core.hooksPath .githooks
+	-git config --unset-all core.hooksPath
+	@if which -s pre-commit; then \
+		echo "Installing pre-commit hooks"; \
+		pre-commit install; \
+	else \
+		echo "Please install pre-commit: See https://pre-commit.com/index.html for installation instructions."; \
+		echo "Re-run `make setup/git/hooks` setup step after pre-commit has been installed."; \
+	fi
 
 # Checks if a GOPATH is set, or emits an error message
 check-gopath:


### PR DESCRIPTION
## Description

See https://pre-commit.com/index.html.
This is an extensible mechanism for integrating pre-commit hooks.
I suggest to use the `detect-secrets` plugin. I have tried out `ripsecrets` but for some reason it did not catch some example secrets (high entropy secrets) I have added into the codebase for testing.

Installation instructions are behind the above link.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
