### PR TITLE
Add RH SSO authentication within fleetshard sync.

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/README.md
+++ b/dp-terraform/helm/rhacs-terraform/README.md
@@ -20,7 +20,7 @@ helm template rhacs-terraform \
   --debug \
   --namespace rhacs \
   --values ~/acs-terraform-values.yaml \
-  --set fleetshardSync.ocmToken=$(ocm token) \
+  --set fleetshardSync.ocmToken=$(ocm token --refresh) \
   --set fleetshardSync.fleetManagerEndpoint=${FM_ENDPOINT} \
   --set fleetshardSync.clusterId=${CLUSTER_ID} \
   --set acsOperator.enabled=true .
@@ -32,7 +32,7 @@ helm template rhacs-terraform \
 helm upgrade --install rhacs-terraform \
   --namespace rhacs \
   --values ~/acs-terraform-values.yaml \
-  --set fleetshardSync.ocmToken=$(ocm token) \
+  --set fleetshardSync.ocmToken=$(ocm token --refresh) \
   --set fleetshardSync.fleetManagerEndpoint=${FM_ENDPOINT} \
   --set fleetshardSync.clusterId=${CLUSTER_ID} \
   --set acsOperator.enabled=true .

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -20,8 +20,8 @@ spec:
       serviceAccountName: fleetshard-sync
       containers:
       - name: fleetshard-sync
-        image: fleetsync:latest
-        imagePullPolicy: Never
+        image: quay.io/app-sre/acs-fleet-manager:main
+        imagePullPolicy: Always
         command: 
         - /usr/local/bin/fleetshard-sync
         env:
@@ -35,11 +35,11 @@ spec:
           value: {{ .Values.fleetshardSync.authType }}
       {{- if and .Values.fleetshardSync.redHatSSO.clientId .Values.fleetshardSync.redHatSSO.clientSecret (eq .Values.fleetshardSync.authType "RHSSO") }}
         volumeMounts:
-          - mountPath: /run/secrets/rhsso
+          - mountPath: /run/secrets/rhsso-token
             name: rhsso-token
             readOnly: true
       - name: token-refresher
-        image: {{ .Values.fleetshardSync.tokenRefresher.image.name }}:{{ .Values.fleetshardSync.tokenRefresher.image.tag }}
+        image: {{ .Values.fleetshardSync.tokenRefresher.image }}
         imagePullPolicy: Always
         env:
           - name: CLIENT_ID
@@ -53,16 +53,16 @@ spec:
                 name: fleetshard-sync-rhsso-creds
                 key: clientSecret
           - name: ISSUER_URL
-            value: https://sso.redhat.com/auth/realms/redhat-external
+            value: {{ .Values.fleetshardSync.tokenRefresher.issuerUrl }}
         command:
           - /bin/token-refresher
           - --oidc.client-id=$(CLIENT_ID)
           - --oidc.client-secret=$(CLIENT_SECRET)
           - --oidc.issuer-url=$(ISSUER_URL)
           - --margin=1m
-          - --file=/rhsso/token
+          - --file=/rhsso-token/token
         volumeMounts:
-          - mountPath: /rhsso
+          - mountPath: /rhsso-token
             name: rhsso-token
       volumes:
         - name: rhsso-token
@@ -78,8 +78,8 @@ metadata:
   labels:
     app: fleetshard-sync
 type: Opaque
-stringData:
-  clientId: {{ .Values.fleetshardSync.redHatSSO.clientId }}
-  clientSecret: {{ .Values.fleetshardSync.redHatSSO.clientSecret }}
+data:
+  clientId: {{ .Values.fleetshardSync.redHatSSO.clientId | b64enc | quote }}
+  clientSecret: {{ .Values.fleetshardSync.redHatSSO.clientSecret | b64enc | quote }}
 ---
 {{- end }}

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -20,8 +20,8 @@ spec:
       serviceAccountName: fleetshard-sync
       containers:
       - name: fleetshard-sync
-        image: quay.io/app-sre/acs-fleet-manager:main
-        imagePullPolicy: Always
+        image: fleetsync:latest
+        imagePullPolicy: Never
         command: 
         - /usr/local/bin/fleetshard-sync
         env:
@@ -31,16 +31,43 @@ spec:
           value: {{ .Values.fleetshardSync.fleetManagerEndpoint }}
         - name: CLUSTER_ID
           value: {{ .Values.fleetshardSync.clusterId }}
-        {{- if and .Values.fleetshardSync.redHatSSO.clientId .Values.fleetshardSync.redHatSSO.clientSecret }}
+        - name: AUTH_TYPE
+          value: {{ .Values.fleetshardSync.authType }}
+      {{- if and .Values.fleetshardSync.redHatSSO.clientId .Values.fleetshardSync.redHatSSO.clientSecret (eq .Values.fleetshardSync.authType "RHSSO") }}
         volumeMounts:
-        - name: rhsso-creds
-          mountPath: /run/secrets/rhsso-creds
-          readOnly: true
+          - mountPath: /run/secrets/rhsso
+            name: rhsso-token
+            readOnly: true
+      - name: token-refresher
+        image: {{ .Values.fleetshardSync.tokenRefresher.image.name }}:{{ .Values.fleetshardSync.tokenRefresher.image.tag }}
+        imagePullPolicy: Always
+        env:
+          - name: CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: fleetshard-sync-rhsso-creds
+                key: clientId
+          - name: CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: fleetshard-sync-rhsso-creds
+                key: clientSecret
+          - name: ISSUER_URL
+            value: https://sso.redhat.com/auth/realms/redhat-external
+        command:
+          - /bin/token-refresher
+          - --oidc.client-id=$(CLIENT_ID)
+          - --oidc.client-secret=$(CLIENT_SECRET)
+          - --oidc.issuer-url=$(ISSUER_URL)
+          - --margin=1m
+          - --file=/rhsso/token
+        volumeMounts:
+          - mountPath: /rhsso
+            name: rhsso-token
       volumes:
-        - name: rhsso-creds
-          secret:
-            secretName: fleetshard-sync-rhsso-creds
-        {{- end }}
+        - name: rhsso-token
+          emptyDir: {}
+      {{- end }}
 ---
 {{- if and .Values.fleetshardSync.redHatSSO.clientId .Values.fleetshardSync.redHatSSO.clientSecret }}
 apiVersion: v1
@@ -52,8 +79,7 @@ metadata:
     app: fleetshard-sync
 type: Opaque
 stringData:
-  clientId: |
-    {{ .Values.fleetshardSync.redHatSSO.clientId | nindent 4 }}
-  clientSecret: |
-    {{ .Values.fleetshardSync.redHatSSO.clientSecret | nindent 4 }}
+  clientId: {{ .Values.fleetshardSync.redHatSSO.clientId }}
+  clientSecret: {{ .Values.fleetshardSync.redHatSSO.clientSecret }}
+---
 {{- end }}

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -14,9 +14,7 @@ fleetshardSync:
   # Will be created when the auth type RHSSO is used. It will handle obtaining access tokens and storing those within a
   # shared volume of token-refresher and fleetshard-sync.
   tokenRefresher:
-    image:
-      tag: "latest"
-      name: "quay.io/rhoas/mk-token-refresher"
+    image: "quay.io/rhoas/mk-token-refresher:latest"
     issuerUrl: "https://sso.redhat.com/auth/realms/redhat-external"
   
 acsOperator:

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -3,12 +3,18 @@
 # Declare variables to be passed into your templates.
 
 fleetshardSync:
+  authType: ""
   ocmToken: ""
   fleetManagerEndpoint: ""
   clusterId: ""
   redHatSSO:
     clientId: ""
     clientSecret: ""
+  tokenRefresher:
+    image:
+      tag: "latest"
+      name: "quay.io/rhoas/mk-token-refresher"
+    issuerUrl: "https://sso.redhat.com/auth/realms/redhat-external"
   
 acsOperator:
   enabled: false

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 fleetshardSync:
+  # Can be either OCM, RHSSO. When choosing RHSSO, make sure the clientId/secret is set.
   authType: ""
   ocmToken: ""
   fleetManagerEndpoint: ""
@@ -10,6 +11,8 @@ fleetshardSync:
   redHatSSO:
     clientId: ""
     clientSecret: ""
+  # Will be created when the auth type RHSSO is used. It will handle obtaining access tokens and storing those within a
+  # shared volume of token-refresher and fleetshard-sync.
   tokenRefresher:
     image:
       tag: "latest"

--- a/fleetshard/README.md
+++ b/fleetshard/README.md
@@ -32,3 +32,12 @@ Execute all commands from git root directory.
     ```
     $ ./scripts/create-central.sh
     ```
+
+## Authentication types
+
+Fleetshard sync provides different authentication types that can be used when calling the fleet manager's API:
+- OCM refresh token
+  - This will use the OCM refresh token obtained via `ocm token --refresh` and will be refreshed before expiring.
+- RH SSO
+  - This will use the client_credentials grant to obtain an access token. Additionally, it uses the [token-refresher](https://gitlab.cee.redhat.com/mk-ci-cd/mk-token-refresher)
+    for obtaining new access tokens before expiring. Currently, the token-refresher is deployed via helm.

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -43,7 +43,6 @@ func loadConfig() {
 		return
 	}
 	cfg = &c
-	return
 }
 
 // Singleton retrieves the current runtime configuration from the environment and returns it.

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/sync"
 	"time"
 
@@ -26,23 +27,25 @@ type Config struct {
 
 func loadConfig() {
 	c := Config{}
+	var configErrors errorhelpers.ErrorList
+
 	if err := env.Parse(&c); err != nil {
 		cfgErr = errors.Wrapf(err, "Unable to parse runtime configuration from environment")
 		return
 	}
 	if c.ClusterID == "" {
-		cfgErr = errors.New("CLUSTER_ID unset in the environment")
-		return
+		configErrors.AddError(errors.New("CLUSTER_ID unset in the environment"))
 	}
 	if c.FleetManagerEndpoint == "" {
-		cfgErr = errors.New("FLEET_MANAGER_ENDPOINT unset in the environment")
-		return
+		configErrors.AddError(errors.New("FLEET_MANAGER_ENDPOINT unset in the environment"))
 	}
 	if c.AuthType == "" {
-		cfgErr = errors.New("AUTH_TYPE unset in the environment")
-		return
+		configErrors.AddError(errors.New("AUTH_TYPE unset in the environment"))
 	}
-	cfg = &c
+	cfgErr = configErrors.ToError()
+	if cfgErr == nil {
+		cfg = &c
+	}
 }
 
 // Singleton retrieves the current runtime configuration from the environment and returns it.

--- a/fleetshard/config/config_test.go
+++ b/fleetshard/config/config_test.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestSingleton_Success(t *testing.T) {
+	t.Setenv("CLUSTER_ID", "some-value")
+	t.Cleanup(func() {
+		_ = os.Unsetenv("CLUSTER_ID")
+		cfg = nil
+		cfgErr = nil
+	})
+	loadConfig()
+	require.NoError(t, cfgErr)
+	assert.Equal(t, cfg.FleetManagerEndpoint, "http://127.0.0.1:8000")
+	assert.Equal(t, cfg.ClusterID, "some-value")
+	assert.Equal(t, cfg.RuntimePollPeriod, 5*time.Second)
+	assert.Equal(t, cfg.AuthType, "OCM")
+	assert.Equal(t, cfg.RHSSOTokenFilePath, "/run/secrets/rhsso-token/token")
+	assert.Empty(t, cfg.OCMRefreshToken)
+}
+
+func TestSingleton_Failure(t *testing.T) {
+	t.Cleanup(func() {
+		cfg = nil
+		cfgErr = nil
+	})
+	loadConfig()
+	assert.Error(t, cfgErr)
+	assert.Nil(t, cfg)
+}

--- a/fleetshard/main.go
+++ b/fleetshard/main.go
@@ -23,7 +23,7 @@ func main() {
 		glog.Info("Unable to set logtostderr to true")
 	}
 
-	config, err := config.Load()
+	config, err := config.Singleton()
 	if err != nil {
 		glog.Fatalf("Failed to load configuration: %v", err)
 	}

--- a/fleetshard/pkg/fleetmanager/auth.go
+++ b/fleetshard/pkg/fleetmanager/auth.go
@@ -8,10 +8,6 @@ import (
 	"strings"
 )
 
-const (
-	tokenPath = "/run/secrets/rhsso/token"
-)
-
 // AuthType represents the supported authentication types for the client.
 type AuthType int
 
@@ -62,12 +58,6 @@ func NewAuth(t AuthType) (Auth, error) {
 	default:
 		return newOcmAuth()
 	}
-}
-
-type noAuth struct{}
-
-func (n noAuth) AddAuth(_ *http.Request) error {
-	return nil
 }
 
 // setBearer is a helper to set a bearer token as authorization header on the http.Request.

--- a/fleetshard/pkg/fleetmanager/auth.go
+++ b/fleetshard/pkg/fleetmanager/auth.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/pkg/errors"
 	"net/http"
-	"os"
 	"strings"
 )
 
@@ -59,34 +58,10 @@ type Auth interface {
 func NewAuth(t AuthType) (Auth, error) {
 	switch t {
 	case RHSSOAuthType:
-		return newRHSSOAuth(tokenPath)
+		return newRHSSOAuth()
 	default:
 		return newOcmAuth()
 	}
-}
-
-type rhSSOAuth struct {
-	tokenFilePath string
-}
-
-func newRHSSOAuth(tokenFilePath string) (*rhSSOAuth, error) {
-	if _, err := os.Stat(tokenFilePath); err != nil {
-		return nil, err
-	}
-	return &rhSSOAuth{
-		tokenFilePath: tokenFilePath,
-	}, nil
-}
-
-func (r *rhSSOAuth) AddAuth(req *http.Request) error {
-	// The file is populated by the token-refresher, which will ensure the token is not expired.
-	contents, err := os.ReadFile(r.tokenFilePath)
-	if err != nil {
-		return err
-	}
-
-	setBearer(req, string(contents))
-	return nil
 }
 
 type noAuth struct{}

--- a/fleetshard/pkg/fleetmanager/auth.go
+++ b/fleetshard/pkg/fleetmanager/auth.go
@@ -35,7 +35,7 @@ func (a AuthType) String() string {
 func AuthTypeFromString(s string) (AuthType, error) {
 	switch s {
 	case RHSSOAuthType.String():
-		return RHSSOAuthType
+		return RHSSOAuthType, nil
 	case OCMTokenAuthType.String():
 		return OCMTokenAuthType, nil
 	default:

--- a/fleetshard/pkg/fleetmanager/auth_ocm.go
+++ b/fleetshard/pkg/fleetmanager/auth_ocm.go
@@ -19,6 +19,9 @@ type ocmAuth struct {
 
 func newOcmAuth() (*ocmAuth, error) {
 	cfg, err := config.Singleton()
+	if err != nil {
+		return nil, err
+	}
 	initialToken := cfg.OCMRefreshToken
 	if initialToken == "" {
 		return nil, errors.New("empty ocm token")

--- a/fleetshard/pkg/fleetmanager/auth_ocm.go
+++ b/fleetshard/pkg/fleetmanager/auth_ocm.go
@@ -3,8 +3,8 @@ package fleetmanager
 import (
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	"github.com/pkg/errors"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/config"
 	"net/http"
-	"os"
 	"time"
 )
 
@@ -18,7 +18,8 @@ type ocmAuth struct {
 }
 
 func newOcmAuth() (*ocmAuth, error) {
-	initialToken := os.Getenv("OCM_TOKEN")
+	cfg, err := config.Singleton()
+	initialToken := cfg.OCMRefreshToken
 	if initialToken == "" {
 		return nil, errors.New("empty ocm token")
 	}

--- a/fleetshard/pkg/fleetmanager/auth_rhsso.go
+++ b/fleetshard/pkg/fleetmanager/auth_rhsso.go
@@ -1,0 +1,36 @@
+package fleetmanager
+
+import (
+	"github.com/stackrox/acs-fleet-manager/fleetshard/config"
+	"net/http"
+	"os"
+)
+
+type rhSSOAuth struct {
+	tokenFilePath string
+}
+
+func newRHSSOAuth() (*rhSSOAuth, error) {
+	cfg, err := config.Singleton()
+	if err != nil {
+		return nil, err
+	}
+	tokenFilePath := cfg.RHSSOTokenFilePath
+	if _, err := os.Stat(tokenFilePath); err != nil {
+		return nil, err
+	}
+	return &rhSSOAuth{
+		tokenFilePath: tokenFilePath,
+	}, nil
+}
+
+func (r *rhSSOAuth) AddAuth(req *http.Request) error {
+	// The file is populated by the token-refresher, which will ensure the token is not expired.
+	contents, err := os.ReadFile(r.tokenFilePath)
+	if err != nil {
+		return err
+	}
+
+	setBearer(req, string(contents))
+	return nil
+}


### PR DESCRIPTION
## Description

This is the second PR in a series of PRs to add additional authentication types to the fleetshard synchronizer.
This will include the following authentication options:
- OCM authentication using the refresh token instead of short-lived access tokens.
- RH SSO authentication using the client_credentials grant with client ID / secret to retrieve access tokens.
- Static token authentication for development using a non-expiring static token valid for the fleet manager's API.

This PR will do a couple of things:
- Conditionally adding the [token-refresher](https://gitlab.cee.redhat.com/mk-ci-cd/mk-token-refresher) (which is also used for the observatorium access token) to the Helm deployment. It will write a valid access token to a file within a shared volume of fleetshard sync and the token refresher, and the token refresher will ensure the token is not expired.
- Implement the authentication using RH SSO by reading the token written to the file.
- Add a new option to the `AUTH_TYPE` called `RHSSO`, which will enabled RH SSO authentication and the deployment of the token-refresher within the Helm templated.

## Test manual

```
# Start fleet manager locally with the dev config:
./fleet-manager serve --dataplane-cluster-config-file dev/config/dataplane-cluster-configuration-minikube.yaml
# Deploy the fleetshard sync with helm
helm install -f values.yaml --set fleetshardSync.authType=RHSSO --set fleetshardSync.redhatSSO.clientId=<client-id> --set fleetshardSync.redhatSSO.clientSecret=<client-secret> --set fleetshardSync.clusterId=1234567890abcdef1234567890abcdef fleetshard dp-terraform/helm/rhacs-terraform
# Observe within the logs that requests to central are done correctly without any errors
```
