### PR TITLE
Pass auth config to fleetshard

### DIFF
--- a/internal/dinosaur/pkg/api/dbapi/central_request_types.go
+++ b/internal/dinosaur/pkg/api/dbapi/central_request_types.go
@@ -19,7 +19,7 @@ type CentralRequest struct {
 	SubscriptionId string `json:"subscription_id"`
 	Owner          string `json:"owner" gorm:"index"` // TODO: ocm owner?
 	OwnerAccountId string `json:"owner_account_id"`
-	OwnerUserid    string `json:"owner_userid"`
+	OwnerUserId    string `json:"owner_user_id"`
 	// The DNS host (domain) of the Central service
 	Host           string `json:"host"`
 	OrganisationId string `json:"organisation_id" gorm:"index"`

--- a/internal/dinosaur/pkg/api/dbapi/central_request_types.go
+++ b/internal/dinosaur/pkg/api/dbapi/central_request_types.go
@@ -19,7 +19,7 @@ type CentralRequest struct {
 	SubscriptionId string `json:"subscription_id"`
 	Owner          string `json:"owner" gorm:"index"` // TODO: ocm owner?
 	OwnerAccountId string `json:"owner_account_id"`
-	OwnerUserid    string `json:"userid"`
+	OwnerUserid    string `json:"owner_userid"`
 	// The DNS host (domain) of the Central service
 	Host           string `json:"host"`
 	OrganisationId string `json:"organisation_id" gorm:"index"`

--- a/internal/dinosaur/pkg/api/dbapi/central_request_types.go
+++ b/internal/dinosaur/pkg/api/dbapi/central_request_types.go
@@ -19,6 +19,7 @@ type CentralRequest struct {
 	SubscriptionId string `json:"subscription_id"`
 	Owner          string `json:"owner" gorm:"index"` // TODO: ocm owner?
 	OwnerAccountId string `json:"owner_account_id"`
+	OwnerUserid    string `json:"userid"`
 	// The DNS host (domain) of the Central service
 	Host           string `json:"host"`
 	OrganisationId string `json:"organisation_id" gorm:"index"`

--- a/internal/dinosaur/pkg/handlers/validation.go
+++ b/internal/dinosaur/pkg/handlers/validation.go
@@ -103,7 +103,7 @@ func ValidateDinosaurClaims(ctx context.Context, dinosaurRequestPayload *public.
 		dinosaurRequest.Owner, _ = claims.GetUsername()
 		dinosaurRequest.OrganisationId, _ = claims.GetOrgId()
 		dinosaurRequest.OwnerAccountId, _ = claims.GetAccountId()
-		dinosaurRequest.OwnerUserid, _ = claims.GetUserId()
+		dinosaurRequest.OwnerUserId, _ = claims.GetUserId()
 
 		return nil
 	}

--- a/internal/dinosaur/pkg/handlers/validation.go
+++ b/internal/dinosaur/pkg/handlers/validation.go
@@ -103,7 +103,7 @@ func ValidateDinosaurClaims(ctx context.Context, dinosaurRequestPayload *public.
 		dinosaurRequest.Owner, _ = claims.GetUsername()
 		dinosaurRequest.OrganisationId, _ = claims.GetOrgId()
 		dinosaurRequest.OwnerAccountId, _ = claims.GetAccountId()
-		dinosaurRequest.OwnerUserid, _ = claims.GetSub()
+		dinosaurRequest.OwnerUserid, _ = claims.GetUserId()
 
 		return nil
 	}

--- a/internal/dinosaur/pkg/handlers/validation.go
+++ b/internal/dinosaur/pkg/handlers/validation.go
@@ -103,6 +103,7 @@ func ValidateDinosaurClaims(ctx context.Context, dinosaurRequestPayload *public.
 		dinosaurRequest.Owner, _ = claims.GetUsername()
 		dinosaurRequest.OrganisationId, _ = claims.GetOrgId()
 		dinosaurRequest.OwnerAccountId, _ = claims.GetAccountId()
+		dinosaurRequest.OwnerUserid, _ = claims.GetSub()
 
 		return nil
 	}

--- a/internal/dinosaur/pkg/migrations/20220114114500_add_centrals.go
+++ b/internal/dinosaur/pkg/migrations/20220114114500_add_centrals.go
@@ -26,6 +26,7 @@ func addCentralRequest() *gormigrate.Migration {
 		SubscriptionId                string     `json:"subscription_id"`
 		Owner                         string     `json:"owner" gorm:"index"`
 		OwnerAccountId                string     `json:"owner_account_id"`
+		OwnerUserid                   string     `json:"owner_userid"`
 		Host                          string     `json:"host"`
 		OrganisationId                string     `json:"organisation_id" gorm:"index"`
 		FailedReason                  string     `json:"failed_reason"`

--- a/internal/dinosaur/pkg/migrations/20220630220500_add_owner_userid_to_centrals.go
+++ b/internal/dinosaur/pkg/migrations/20220630220500_add_owner_userid_to_centrals.go
@@ -1,20 +1,14 @@
 package migrations
 
-// Migrations should NEVER use types from other packages. Types can change
-// and then migrations run on a _new_ database will fail or behave unexpectedly.
-// Instead of importing types, always re-create the type in the migration, as
-// is done here, even though the same type is defined in pkg/api
-
 import (
-	"time"
-
 	"github.com/go-gormigrate/gormigrate/v2"
 	"github.com/stackrox/acs-fleet-manager/pkg/api"
 	"github.com/stackrox/acs-fleet-manager/pkg/db"
 	"gorm.io/gorm"
+	"time"
 )
 
-func addCentralRequest() *gormigrate.Migration {
+func addOwnerUseridToCentralRequest() *gormigrate.Migration {
 	type CentralRequest struct {
 		db.Model
 		Region                        string     `json:"region"`
@@ -26,6 +20,7 @@ func addCentralRequest() *gormigrate.Migration {
 		SubscriptionId                string     `json:"subscription_id"`
 		Owner                         string     `json:"owner" gorm:"index"`
 		OwnerAccountId                string     `json:"owner_account_id"`
+		OwnerUserid                   string     `json:"owner_userid"`
 		Host                          string     `json:"host"`
 		OrganisationId                string     `json:"organisation_id" gorm:"index"`
 		FailedReason                  string     `json:"failed_reason"`
@@ -46,12 +41,12 @@ func addCentralRequest() *gormigrate.Migration {
 	}
 
 	return &gormigrate.Migration{
-		ID: "20220114114500",
+		ID: "20220630220500",
 		Migrate: func(tx *gorm.DB) error {
-			return tx.AutoMigrate(&CentralRequest{})
+			return tx.Migrator().AddColumn(&CentralRequest{}, "OwnerUserid")
 		},
 		Rollback: func(tx *gorm.DB) error {
-			return tx.Migrator().DropTable(&CentralRequest{})
+			return tx.Migrator().DropColumn(&CentralRequest{}, "OwnerUserid")
 		},
 	}
 }

--- a/internal/dinosaur/pkg/migrations/20220630220500_add_owner_userid_to_centrals.go
+++ b/internal/dinosaur/pkg/migrations/20220630220500_add_owner_userid_to_centrals.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func addOwnerUseridToCentralRequest() *gormigrate.Migration {
+func addOwnerUserIdToCentralRequest() *gormigrate.Migration {
 	type CentralRequest struct {
 		db.Model
 		Region                        string     `json:"region"`
@@ -20,7 +20,7 @@ func addOwnerUseridToCentralRequest() *gormigrate.Migration {
 		SubscriptionId                string     `json:"subscription_id"`
 		Owner                         string     `json:"owner" gorm:"index"`
 		OwnerAccountId                string     `json:"owner_account_id"`
-		OwnerUserid                   string     `json:"owner_userid"`
+		OwnerUserId                   string     `json:"owner_user_id"`
 		Host                          string     `json:"host"`
 		OrganisationId                string     `json:"organisation_id" gorm:"index"`
 		FailedReason                  string     `json:"failed_reason"`
@@ -43,10 +43,10 @@ func addOwnerUseridToCentralRequest() *gormigrate.Migration {
 	return &gormigrate.Migration{
 		ID: "20220630220500",
 		Migrate: func(tx *gorm.DB) error {
-			return tx.Migrator().AddColumn(&CentralRequest{}, "OwnerUserid")
+			return tx.Migrator().AddColumn(&CentralRequest{}, "OwnerUserId")
 		},
 		Rollback: func(tx *gorm.DB) error {
-			return tx.Migrator().DropColumn(&CentralRequest{}, "OwnerUserid")
+			return tx.Migrator().DropColumn(&CentralRequest{}, "OwnerUserId")
 		},
 	}
 }

--- a/internal/dinosaur/pkg/migrations/migrations.go
+++ b/internal/dinosaur/pkg/migrations/migrations.go
@@ -20,12 +20,14 @@ import (
 // 3. Migrations must be backwards compatible. There are no new required fields allowed.
 //    See $project_home/db/README.md
 //
-// 4. Create one function in a separate file that returns your Migration. Add that single function call to this list.
+// 4. Create one function in a separate file that returns your Migration. Add that single function call
+//    to the end of this list.
 var migrations = []*gormigrate.Migration{
 	addCentralRequest(),
 	addClusters(),
 	addLeaderLease(),
 	sampleMigration(),
+	addOwnerUseridToCentralRequest(),
 }
 
 func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {

--- a/internal/dinosaur/pkg/migrations/migrations.go
+++ b/internal/dinosaur/pkg/migrations/migrations.go
@@ -27,7 +27,7 @@ var migrations = []*gormigrate.Migration{
 	addClusters(),
 	addLeaderLease(),
 	sampleMigration(),
-	addOwnerUseridToCentralRequest(),
+	addOwnerUserIdToCentralRequest(),
 }
 
 func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {

--- a/internal/dinosaur/pkg/presenters/manageddinosaur.go
+++ b/internal/dinosaur/pkg/presenters/manageddinosaur.go
@@ -39,6 +39,12 @@ func PresentManagedDinosaur(from *v1.ManagedDinosaur) private.ManagedCentral {
 		},
 		Spec: private.ManagedCentralAllOfSpec{
 			Owners: from.Spec.Owners,
+			Auth: private.ManagedCentralAllOfSpecAuth{
+				ClientSecret: from.Spec.Auth.ClientSecret,
+				ClientId:     from.Spec.Auth.ClientId,
+				OwnerUserId:  from.Spec.Auth.OwnerUserId,
+				OwnerOrgId:   from.Spec.Auth.OwnerOrgId,
+			},
 			Endpoint: private.ManagedCentralAllOfSpecEndpoint{
 				Host: from.Spec.Endpoint.Host,
 				Tls: &private.ManagedCentralAllOfSpecEndpointTls{

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -814,6 +814,13 @@ func BuildManagedDinosaurCR(dinosaurRequest *dbapi.CentralRequest, dinosaurConfi
 			},
 		},
 		Spec: manageddinosaur.ManagedDinosaurSpec{
+			Auth: manageddinosaur.AuthSpec{
+				ClientSecret: dinosaurConfig.RhSsoClientSecret,
+				// TODO: make part of dinosaurConfig
+				ClientId:    "rhacs-ms-dev",
+				OwnerOrgId:  dinosaurRequest.OrganisationId,
+				OwnerUserId: dinosaurRequest.OwnerUserid,
+			},
 			Endpoint: manageddinosaur.EndpointSpec{
 				Host: dinosaurRequest.Host,
 			},

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -816,7 +816,7 @@ func BuildManagedDinosaurCR(dinosaurRequest *dbapi.CentralRequest, dinosaurConfi
 		Spec: manageddinosaur.ManagedDinosaurSpec{
 			Auth: manageddinosaur.AuthSpec{
 				ClientSecret: dinosaurConfig.RhSsoClientSecret,
-				// TODO: make part of dinosaurConfig
+				// TODO: ROX-11593: make part of dinosaurConfig
 				ClientId:    "rhacs-ms-dev",
 				OwnerOrgId:  dinosaurRequest.OrganisationId,
 				OwnerUserId: dinosaurRequest.OwnerUserid,

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -819,7 +819,7 @@ func BuildManagedDinosaurCR(dinosaurRequest *dbapi.CentralRequest, dinosaurConfi
 				// TODO: ROX-11593: make part of dinosaurConfig
 				ClientId:    "rhacs-ms-dev",
 				OwnerOrgId:  dinosaurRequest.OrganisationId,
-				OwnerUserId: dinosaurRequest.OwnerUserid,
+				OwnerUserId: dinosaurRequest.OwnerUserId,
 			},
 			Endpoint: manageddinosaur.EndpointSpec{
 				Host: dinosaurRequest.Host,

--- a/pkg/api/manageddinosaurs.manageddinosaur.mas/v1/types.go
+++ b/pkg/api/manageddinosaurs.manageddinosaur.mas/v1/types.go
@@ -41,7 +41,15 @@ type EndpointSpec struct {
 	Tls  *TlsSpec `json:"tls,omitempty"`
 }
 
+type AuthSpec struct {
+	ClientSecret string `json:"clientSecret,omitempty"`
+	ClientId     string `json:"clientId,omitempty"`
+	OwnerUserId  string `json:"ownerUserId,omitempty"`
+	OwnerOrgId   string `json:"ownerOrgId,omitempty"`
+}
+
 type ManagedDinosaurSpec struct {
+	Auth     AuthSpec     `json:"auth"`
 	Endpoint EndpointSpec `json:"endpoint"`
 	Versions VersionsSpec `json:"versions"`
 	Deleted  bool         `json:"deleted"`

--- a/pkg/auth/acs_claims.go
+++ b/pkg/auth/acs_claims.go
@@ -36,6 +36,16 @@ func (c *ACSClaims) GetOrgId() (string, error) {
 	return "", fmt.Errorf("can't find %q attribute in claims", tenantIdClaim)
 }
 
+func (c *ACSClaims) GetSub() (string, error) {
+	if (*c)[subClaim] != nil {
+		if sub, ok := (*c)[subClaim].(string); ok {
+			return sub, nil
+		}
+	}
+
+	return "", fmt.Errorf("can't find %q attribute in claims", subClaim)
+}
+
 func (c *ACSClaims) IsOrgAdmin() bool {
 	if (*c)[tenantOrgAdminClaim] != nil {
 		return (*c)[tenantOrgAdminClaim].(bool)

--- a/pkg/auth/acs_claims.go
+++ b/pkg/auth/acs_claims.go
@@ -36,14 +36,14 @@ func (c *ACSClaims) GetOrgId() (string, error) {
 	return "", fmt.Errorf("can't find %q attribute in claims", tenantIdClaim)
 }
 
-func (c *ACSClaims) GetSub() (string, error) {
-	if (*c)[subClaim] != nil {
-		if sub, ok := (*c)[subClaim].(string); ok {
+func (c *ACSClaims) GetUserId() (string, error) {
+	if (*c)[tenantSubClaim] != nil {
+		if sub, ok := (*c)[tenantSubClaim].(string); ok {
 			return sub, nil
 		}
 	}
 
-	return "", fmt.Errorf("can't find %q attribute in claims", subClaim)
+	return "", fmt.Errorf("can't find %q attribute in claims", tenantSubClaim)
 }
 
 func (c *ACSClaims) IsOrgAdmin() bool {

--- a/pkg/auth/context_config.go
+++ b/pkg/auth/context_config.go
@@ -13,6 +13,7 @@ var (
 	// sso.redhat.com token claim keys
 	alternateTenantUsernameClaim string = "preferred_username"
 	tenantUserIdClaim            string = "account_id"
+	subClaim                     string = "sub"
 )
 
 type ContextConfig struct {

--- a/pkg/auth/context_config.go
+++ b/pkg/auth/context_config.go
@@ -13,7 +13,7 @@ var (
 	// sso.redhat.com token claim keys
 	alternateTenantUsernameClaim string = "preferred_username"
 	tenantUserIdClaim            string = "account_id"
-	subClaim                     string = "sub"
+	tenantSubClaim               string = "sub"
 )
 
 type ContextConfig struct {


### PR DESCRIPTION
## Description
This PR passes auth provider config for `sso.redhat.com` from `acs-fleet-manager` to `fleetshard-sync`.

`sub` needed to be extracted from the token passed to `acs-fleet-manager`

This should close the work on [ROX-11063](https://issues.redhat.com/browse/ROX-11063) as well as help make progress on [ROX-11428](https://issues.redhat.com/browse/ROX-11428)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

Manual test: 
1. Added logging to `fleetshard-sync`
2. Created central and looked into the central request sent to fleetshard-sync
