### PR TITLE
fix central request transition to ready and add e2e for it

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Central", func() {
 
 func centralStatus(createdCentral *public.CentralRequest, client *fleetmanager.Client) string {
 	Expect(createdCentral).NotTo(BeNil())
-	provisioningCentral, err := client.GetCentral(createdCentral.Id)
+	central, err := client.GetCentral(createdCentral.Id)
 	Expect(err).To(BeNil())
-	return provisioningCentral.Status
+	return central.Status
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -53,10 +53,7 @@ var _ = Describe("Central", func() {
 
 		It("should transition central's state to provisioning", func() {
 			Eventually(func() string {
-				Expect(createdCentral).NotTo(BeNil())
-				provisioningCentral, err := client.GetCentral(createdCentral.Id)
-				Expect(err).To(BeNil())
-				return provisioningCentral.Status
+				return centralStatus(createdCentral, client)
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Equal(constants.DinosaurRequestStatusProvisioning.String()))
 		})
 
@@ -76,9 +73,14 @@ var _ = Describe("Central", func() {
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Succeed())
 		})
 
-		//TODO(create-ticket): Add test to eventually reach ready state
 		//TODO(create-ticket): create test to check that Central and Scanner are healthy
 		//TODO(create-ticket): Create test to check Central is correctly exposed
+
+		It("should transition central's state to ready", func() {
+			Eventually(func() string {
+				return centralStatus(createdCentral, client)
+			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Equal(constants.DinosaurRequestStatusReady.String()))
+		})
 
 		It("should transition central to deprovisioning state", func() {
 			err = client.DeleteCentral(createdCentral.Id)
@@ -108,3 +110,10 @@ var _ = Describe("Central", func() {
 
 	})
 })
+
+func centralStatus(createdCentral *public.CentralRequest, client *fleetmanager.Client) string {
+	Expect(createdCentral).NotTo(BeNil())
+	provisioningCentral, err := client.GetCentral(createdCentral.Id)
+	Expect(err).To(BeNil())
+	return provisioningCentral.Status
+}

--- a/fleetshard/pkg/centralreconciler/reconciler.go
+++ b/fleetshard/pkg/centralreconciler/reconciler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/util"
+	centralConstants "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
 	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
 	v1 "k8s.io/api/core/v1"
@@ -57,7 +58,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		return nil, errors.Wrapf(err, "checking if central changed")
 	}
 
-	if !changed {
+	if !changed && remoteCentral.RequestStatus == centralConstants.DinosaurRequestStatusReady.String() {
 		return nil, ErrTypeCentralNotChanged
 	}
 

--- a/fleetshard/pkg/centralreconciler/reconciler_test.go
+++ b/fleetshard/pkg/centralreconciler/reconciler_test.go
@@ -165,7 +165,6 @@ func TestIgnoreCacheForCentralNotReady(t *testing.T) {
 
 	_, err = r.Reconcile(context.TODO(), managedCentral)
 	require.NoError(t, err)
-
 	assert.Equal(t, expectedHash, r.lastCentralHash)
 
 	_, err = r.Reconcile(context.TODO(), managedCentral)

--- a/fleetshard/pkg/centralreconciler/reconciler_test.go
+++ b/fleetshard/pkg/centralreconciler/reconciler_test.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/testutils"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/util"
+	centralConstants "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
 	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -125,16 +127,49 @@ func TestReconicleLastHashSetOnSuccess(t *testing.T) {
 		central: private.ManagedCentral{},
 	}
 
-	expectedHash, err := util.MD5SumFromJSONStruct(&simpleManagedCentral)
+	managedCentral := simpleManagedCentral
+	managedCentral.RequestStatus = centralConstants.DinosaurRequestStatusReady.String()
+
+	expectedHash, err := util.MD5SumFromJSONStruct(&managedCentral)
 	require.NoError(t, err)
 
-	_, err = r.Reconcile(context.TODO(), simpleManagedCentral)
+	_, err = r.Reconcile(context.TODO(), managedCentral)
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedHash, r.lastCentralHash)
 
-	_, err = r.Reconcile(context.TODO(), simpleManagedCentral)
+	_, err = r.Reconcile(context.TODO(), managedCentral)
 	require.ErrorIs(t, err, ErrTypeCentralNotChanged)
+}
+
+func TestIgnoreCacheForCentralNotReady(t *testing.T) {
+	fakeClient := testutils.NewFakeClientBuilder(t, &v1alpha1.Central{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        centralName,
+			Namespace:   centralName,
+			Annotations: map[string]string{revisionAnnotationKey: "3"},
+		},
+	}).Build()
+
+	r := CentralReconciler{
+		status:  pointer.Int32(0),
+		client:  fakeClient,
+		central: private.ManagedCentral{},
+	}
+
+	managedCentral := simpleManagedCentral
+	managedCentral.RequestStatus = centralConstants.DinosaurRequestStatusProvisioning.String()
+
+	expectedHash, err := util.MD5SumFromJSONStruct(&managedCentral)
+	require.NoError(t, err)
+
+	_, err = r.Reconcile(context.TODO(), managedCentral)
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedHash, r.lastCentralHash)
+
+	_, err = r.Reconcile(context.TODO(), managedCentral)
+	require.NoError(t, err)
 }
 
 func TestCentralChanged(t *testing.T) {

--- a/internal/dinosaur/pkg/api/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/private/api/openapi.yaml
@@ -504,6 +504,8 @@ components:
           $ref: '#/components/schemas/ManagedCentral_allOf_metadata'
         spec:
           $ref: '#/components/schemas/ManagedCentral_allOf_spec'
+        requestStatus:
+          type: string
     ManagedCentralList_allOf:
       example: '{"kind":"ManagedCentralList","items":{"$ref":"#/components/examples/ManagedCentralExample"}}'
       properties:

--- a/internal/dinosaur/pkg/api/private/model_managed_central.go
+++ b/internal/dinosaur/pkg/api/private/model_managed_central.go
@@ -11,8 +11,9 @@ package private
 
 // ManagedCentral struct for ManagedCentral
 type ManagedCentral struct {
-	Id       string                      `json:"id,omitempty"`
-	Kind     string                      `json:"kind,omitempty"`
-	Metadata ManagedCentralAllOfMetadata `json:"metadata,omitempty"`
-	Spec     ManagedCentralAllOfSpec     `json:"spec,omitempty"`
+	Id            string                      `json:"id,omitempty"`
+	Kind          string                      `json:"kind,omitempty"`
+	Metadata      ManagedCentralAllOfMetadata `json:"metadata,omitempty"`
+	Spec          ManagedCentralAllOfSpec     `json:"spec,omitempty"`
+	RequestStatus string                      `json:"requestStatus,omitempty"`
 }

--- a/internal/dinosaur/pkg/presenters/manageddinosaur.go
+++ b/internal/dinosaur/pkg/presenters/manageddinosaur.go
@@ -94,6 +94,7 @@ func PresentManagedDinosaur(from *v1.ManagedDinosaur) private.ManagedCentral {
 				},
 			},
 		},
+		RequestStatus: from.RequestStatus,
 	}
 
 	if from.DeletionTimestamp != nil {

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -3,9 +3,10 @@ package services
 import (
 	"context"
 	"fmt"
-	"github.com/stackrox/acs-fleet-manager/pkg/services/sso"
 	"strings"
 	"sync"
+
+	"github.com/stackrox/acs-fleet-manager/pkg/services/sso"
 
 	constants2 "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
@@ -833,7 +834,8 @@ func BuildManagedDinosaurCR(dinosaurRequest *dbapi.CentralRequest, dinosaurConfi
 				dinosaurRequest.Owner,
 			},
 		},
-		Status: manageddinosaur.ManagedDinosaurStatus{},
+		Status:        manageddinosaur.ManagedDinosaurStatus{},
+		RequestStatus: dinosaurRequest.Status,
 	}
 
 	if dinosaurConfig.EnableDinosaurExternalCertificate {

--- a/openapi/fleet-manager-private.yaml
+++ b/openapi/fleet-manager-private.yaml
@@ -243,8 +243,7 @@ components:
                     mas/placementId:
                       type: string
                 deletionTimestamp:
-                      type: string
-
+                  type: string
             spec:
               type: object
               properties:   
@@ -313,7 +312,8 @@ components:
                       properties:
                         host:
                           type: string
-
+            requestStatus:
+              type: string
     ManagedCentralList:
       description: >-
         A list of ManagedCentral

--- a/pkg/api/manageddinosaurs.manageddinosaur.mas/v1/types.go
+++ b/pkg/api/manageddinosaurs.manageddinosaur.mas/v1/types.go
@@ -60,7 +60,8 @@ type ManagedDinosaur struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Id     string                `json:"id,omitempty"`
-	Spec   ManagedDinosaurSpec   `json:"spec,omitempty"`
-	Status ManagedDinosaurStatus `json:"status,omitempty"`
+	Id            string                `json:"id,omitempty"`
+	Spec          ManagedDinosaurSpec   `json:"spec,omitempty"`
+	Status        ManagedDinosaurStatus `json:"status,omitempty"`
+	RequestStatus string                `json:"requestStatus,omitempty"`
 }


### PR DESCRIPTION
## Description
The transition of central requests to `ready` does not work because of the cache implementation in fleetshard-sync skipping the second ready request required for state transition. It was fixed by only using the cache if central is not in ready state.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

- Run operator, fleet-manager and fleetshard-sync
- Create central
- make sure it transitions to `ready`
- Reset your env (shutdown and delete everything you created)
- run e2e tests like documented in `e2e/README.md`

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
