### PR TITLE
ROX-11287: Remove OSDKeycloakService.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,7 +107,7 @@ jobs:
         run: make db/migrate
       - name: Setup tests secrets
         run: |
-          make ocm/setup aws/setup osd/setup redhatsso/setup dinosaurcert/setup observatorium/setup secrets/touch
+          make ocm/setup aws/setup redhatsso/setup dinosaurcert/setup observatorium/setup secrets/touch
       - name: Lint & Test
         run: |
           export GOPATH=$(go env GOPATH)

--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,6 @@ help:
 	@echo "make image/push                  push docker image"
 	@echo "make setup/git/hooks             setup git hooks"
 	@echo "make secrets/touch               touch all required secret files"
-	@echo "make osd/setup                   setup OSD SSO clientId, clientSecret & crt"
 	@echo "make dinosaurcert/setup          setup the dinosaur TLS certificate used for Managed Dinosaur Service"
 	@echo "make observatorium/setup         setup observatorium secrets used by CI"
 	@echo "make observatorium/token-refresher/setup" setup a local observatorium token refresher
@@ -514,8 +513,6 @@ secrets/touch:
           secrets/ocm-service.clientId \
           secrets/ocm-service.clientSecret \
           secrets/ocm-service.token \
-          secrets/osd-idp-keycloak-service.clientId \
-          secrets/osd-idp-keycloak-service.clientSecret \
           secrets/rhsso-logs.clientId \
           secrets/rhsso-logs.clientSecret \
           secrets/rhsso-metrics.clientId \
@@ -533,12 +530,6 @@ aws/setup:
 	@echo -n "$(ROUTE53_ACCESS_KEY)" > secrets/aws.route53accesskey
 	@echo -n "$(ROUTE53_SECRET_ACCESS_KEY)" > secrets/aws.route53secretaccesskey
 .PHONY: aws/setup
-
-# Setup for osd sso credentials
-osd/setup:
-	@echo -n "$(OSD_IDP_SSO_CLIENT_ID)" > secrets/osd-idp-keycloak-service.clientId
-	@echo -n "$(OSD_IDP_SSO_CLIENT_SECRET)" > secrets/osd-idp-keycloak-service.clientSecret
-.PHONY:osd/setup
 
 redhatsso/setup:
 	@echo -n "$(SSO_CLIENT_ID)" > secrets/redhatsso-service.clientId
@@ -621,8 +612,6 @@ deploy/secrets:
 		-p ROUTE53_SECRET_ACCESS_KEY="$(shell ([ -s './secrets/aws.route53secretaccesskey' ] && [ -z '${ROUTE53_SECRET_ACCESS_KEY}' ]) && cat ./secrets/aws.route53secretaccesskey || echo '${ROUTE53_SECRET_ACCESS_KEY}')" \
 		-p SSO_CLIENT_ID="$(shell ([ -s './secrets/redhatsso-service.clientId' ] && [ -z '${SSO_CLIENT_ID}' ]) && cat ./secrets/redhatsso-service.clientId || echo '${SSO_CLIENT_ID}')" \
 		-p SSO_CLIENT_SECRET="$(shell ([ -s './secrets/redhatsso-service.clientSecret' ] && [ -z '${SSO_CLIENT_SECRET}' ]) && cat ./secrets/redhatsso-service.clientSecret || echo '${SSO_CLIENT_SECRET}')" \
-		-p OSD_IDP_SSO_CLIENT_ID="$(shell ([ -s './secrets/osd-idp-keycloak-service.clientId' ] && [ -z '${OSD_IDP_SSO_CLIENT_ID}' ]) && cat ./secrets/osd-idp-keycloak-service.clientId || echo '${OSD_IDP_SSO_CLIENT_ID}')" \
-		-p OSD_IDP_SSO_CLIENT_SECRET="$(shell ([ -s './secrets/osd-idp-keycloak-service.clientSecret' ] && [ -z '${OSD_IDP_SSO_CLIENT_SECRET}' ]) && cat ./secrets/osd-idp-keycloak-service.clientSecret || echo '${OSD_IDP_SSO_CLIENT_SECRET}')" \
 		-p DINOSAUR_TLS_CERT="$(shell ([ -s './secrets/dinosaur-tls.crt' ] && [ -z '${DINOSAUR_TLS_CERT}' ]) && cat ./secrets/dinosaur-tls.crt || echo '${DINOSAUR_TLS_CERT}')" \
 		-p DINOSAUR_TLS_KEY="$(shell ([ -s './secrets/dinosaur-tls.key' ] && [ -z '${DINOSAUR_TLS_KEY}' ]) && cat ./secrets/dinosaur-tls.key || echo '${DINOSAUR_TLS_KEY}')" \
 		-p OBSERVABILITY_CONFIG_ACCESS_TOKEN="$(shell ([ -s './secrets/observability-config-access.token' ] && [ -z '${OBSERVABILITY_CONFIG_ACCESS_TOKEN}' ]) && cat ./secrets/observability-config-access.token || echo '${OBSERVABILITY_CONFIG_ACCESS_TOKEN}')" \
@@ -657,7 +646,6 @@ deploy/service: OCM_URL ?= "https://api.stage.openshift.com"
 deploy/service: SSO_BASE_URL ?= "https://identity.api.stage.openshift.com"
 deploy/service: SSO_REALM ?= "rhoas"
 deploy/service: MAX_LIMIT_FOR_SSO_GET_CLIENTS ?= "100"
-deploy/service: OSD_IDP_SSO_REALM ?= "rhoas-dinosaur-sre"
 deploy/service: TOKEN_ISSUER_URL ?= "https://sso.redhat.com/auth/realms/redhat-external"
 deploy/service: SERVICE_PUBLIC_HOST_URL ?= "https://api.openshift.com"
 deploy/service: ENABLE_TERMS_ACCEPTANCE ?= "false"
@@ -692,7 +680,6 @@ deploy/service: deploy/envoy deploy/route
 		-p SSO_BASE_URL="$(SSO_BASE_URL)" \
 		-p SSO_REALM="$(SSO_REALM)" \
 		-p MAX_LIMIT_FOR_SSO_GET_CLIENTS="${MAX_LIMIT_FOR_SSO_GET_CLIENTS}" \
-		-p OSD_IDP_SSO_REALM="$(OSD_IDP_SSO_REALM)" \
 		-p TOKEN_ISSUER_URL="${TOKEN_ISSUER_URL}" \
 		-p SERVICE_PUBLIC_HOST_URL="https://$(shell oc get routes/fleet-manager -o jsonpath="{.spec.host}" -n $(NAMESPACE))" \
 		-p OBSERVATORIUM_RHSSO_GATEWAY="${OBSERVATORIUM_RHSSO_GATEWAY}" \

--- a/internal/dinosaur/pkg/environments/development.go
+++ b/internal/dinosaur/pkg/environments/development.go
@@ -18,7 +18,6 @@ func NewDevelopmentEnvLoader() environments.EnvLoader {
 		"enable-deny-list":                                "true",
 		"enable-instance-limit-control":                   "false",
 		"sso-base-url":                                    "https://sso.redhat.com",
-		"osd-idp-sso-realm":                               "rhoas-dinosaur-sre",
 		"enable-dinosaur-external-certificate":            "false",
 		"cluster-compute-machine-type":                    "m5.2xlarge",
 		"allow-evaluator-instance":                        "true",

--- a/internal/dinosaur/pkg/environments/integration.go
+++ b/internal/dinosaur/pkg/environments/integration.go
@@ -34,7 +34,6 @@ func (b IntegrationEnvLoader) Defaults() map[string]string {
 		"enable-instance-limit-control":        "true",
 		"max-allowed-instances":                "1",
 		"sso-base-url":                         "https://sso.redhat.com",
-		"osd-idp-sso-realm":                    "rhoas-dinosaur-sre",
 		"enable-dinosaur-external-certificate": "false",
 		"cluster-compute-machine-type":         "m5.xlarge",
 		"allow-evaluator-instance":             "true",

--- a/internal/dinosaur/pkg/handlers/authentication.go
+++ b/internal/dinosaur/pkg/handlers/authentication.go
@@ -33,10 +33,9 @@ func NewAuthenticationBuilder(ServerConfig *server.ServerConfig, KeycloakConfig 
 
 	return authenticationBuilder.
 			Logger(authnLogger).
-			KeysURL(ServerConfig.JwksURL).                              //ocm JWK JSON web token signing certificates URL
-			KeysFile(ServerConfig.JwksFile).                            //ocm JWK backup JSON web token signing certificates
-			KeysURL(KeycloakConfig.RedhatSSORealm.JwksEndpointURI).     // sso JWK Cert URL
-			KeysURL(KeycloakConfig.OSDClusterIDPRealm.JwksEndpointURI). // sso SRE realm cert URL
+			KeysURL(ServerConfig.JwksURL).                          //ocm JWK JSON web token signing certificates URL
+			KeysFile(ServerConfig.JwksFile).                        //ocm JWK backup JSON web token signing certificates
+			KeysURL(KeycloakConfig.RedhatSSORealm.JwksEndpointURI). // sso JWK Cert URL
 			Error(fmt.Sprint(errors.ErrorUnauthenticated)).
 			Service(errors.ERROR_CODE_PREFIX).
 			Public(fmt.Sprintf("^%s/%s/?$", routes.ApiEndpoint, routes.DinosaursFleetManagementApiPrefix)).

--- a/internal/dinosaur/pkg/routes/route_loader.go
+++ b/internal/dinosaur/pkg/routes/route_loader.go
@@ -211,7 +211,10 @@ func (s *options) buildApiBaseRouter(mainRouter *mux.Router, basePath string, op
 		http.MethodPatch:  {auth.FleetManagerAdminWriteRole, auth.FleetManagerAdminFullRole},
 		http.MethodDelete: {auth.FleetManagerAdminFullRole},
 	}
-	adminRouter.Use(auth.NewRequireIssuerMiddleware().RequireIssuer([]string{s.IAM.GetConfig().OSDClusterIDPRealm.ValidIssuerURI}, errors.ErrorNotFound))
+
+	// TODO(ROX-11683): For now using RH SSO issuer for the admin API, but needs to be re-visited within this ticket.
+	adminRouter.Use(auth.NewRequireIssuerMiddleware().RequireIssuer(
+		[]string{s.IAM.GetConfig().RedhatSSORealm.ValidIssuerURI}, errors.ErrorNotFound))
 	adminRouter.Use(auth.NewRolesAuhzMiddleware().RequireRolesForMethods(rolesMapping, errors.ErrorNotFound))
 	adminRouter.Use(auth.NewAuditLogMiddleware().AuditLog(errors.ErrorNotFound))
 	adminRouter.HandleFunc("/dinosaurs", adminDinosaurHandler.List).

--- a/internal/dinosaur/test/integration/admin_dinosaur_test.go
+++ b/internal/dinosaur/test/integration/admin_dinosaur_test.go
@@ -6,37 +6,16 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/golang-jwt/jwt/v4"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	adminprivate "github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/admin/private"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/test"
 	"github.com/stackrox/acs-fleet-manager/pkg/api"
 
-	// TODO(ROX-9821) restore when admin API is properly implemented "github.com/stackrox/acs-fleet-manager/pkg/auth"
-	"github.com/stackrox/acs-fleet-manager/pkg/client/iam"
 	coreTest "github.com/stackrox/acs-fleet-manager/test"
 	"github.com/stackrox/acs-fleet-manager/test/mocks"
 	// TODO(ROX-9821) restore when admin API is properly implemented . "github.com/onsi/gomega"
 )
-
-func NewAuthenticatedContextForAdminEndpoints(h *coreTest.Helper, realmRoles []string) context.Context {
-	var keycloakConfig *iam.IAMConfig
-	h.Env.MustResolveAll(&keycloakConfig)
-
-	account := h.NewAllowedServiceAccount()
-	claims := jwt.MapClaims{
-		"iss": keycloakConfig.OSDClusterIDPRealm.ValidIssuerURI,
-		"realm_access": map[string][]string{
-			"roles": realmRoles,
-		},
-		"preferred_username": "integration-test-user",
-	}
-	token := h.CreateJWTStringWithClaim(account, claims)
-	ctx := context.WithValue(context.Background(), adminprivate.ContextAccessToken, token)
-
-	return ctx
-}
 
 func TestAdminDinosaur_Get(t *testing.T) {
 	skipNotFullyImplementedYet(t)

--- a/pkg/providers/core.go
+++ b/pkg/providers/core.go
@@ -86,13 +86,6 @@ func ServiceProviders() di.Option {
 				WithConfiguration(c).
 				Build()
 		}),
-		di.Provide(func(c *iam.IAMConfig) sso.OSDKeycloakService {
-			return sso.NewKeycloakServiceBuilder().
-				ForOSD().
-				WithConfiguration(c).
-				WithRealmConfig(c.OSDClusterIDPRealm).
-				Build()
-		}),
 
 		// Types registered as a BootService are started when the env is started
 		di.Provide(server.NewAPIServer, di.As(new(environments.BootService))),

--- a/pkg/services/sso/iam_service.go
+++ b/pkg/services/sso/iam_service.go
@@ -35,12 +35,6 @@ type IAMService interface {
 	DeleteServiceAccountInternal(clientId string) *errors.ServiceError
 }
 
-type OSDKeycloakService interface {
-	IAMService
-	DeRegisterClientInSSO(namespace string) *errors.ServiceError
-	RegisterClientInSSO(clusterId string, clusterOathCallbackURI string) (string, *errors.ServiceError)
-}
-
 type keycloakServiceInternal interface {
 	DeRegisterClientInSSO(accessToken string, namespace string) *errors.ServiceError
 	RegisterClientInSSO(accessToken string, clusterId string, clusterOathCallbackURI string) (string, *errors.ServiceError)

--- a/pkg/services/sso/keycloak_service_builder.go
+++ b/pkg/services/sso/keycloak_service_builder.go
@@ -9,10 +9,8 @@ import (
 var _ KeycloakServiceBuilderSelector = &keycloakServiceBuilderSelector{}
 var _ KeycloakServiceBuilder = &keycloakServiceBuilder{}
 var _ ACSKeycloakServiceBuilderConfigurator = &keycloakBuilderConfigurator{}
-var _ OSDKeycloakServiceBuilderConfigurator = &osdBuilderConfigurator{}
 
 type KeycloakServiceBuilderSelector interface {
-	ForOSD() OSDKeycloakServiceBuilderConfigurator
 	ForACS() ACSKeycloakServiceBuilderConfigurator
 }
 
@@ -20,25 +18,12 @@ type ACSKeycloakServiceBuilderConfigurator interface {
 	WithConfiguration(config *iam.IAMConfig) KeycloakServiceBuilder
 }
 
-type OSDKeycloakServiceBuilderConfigurator interface {
-	WithConfiguration(config *iam.IAMConfig) OSDKeycloakServiceBuilder
-}
-
 type KeycloakServiceBuilder interface {
 	WithRealmConfig(realmConfig *iam.IAMRealmConfig) KeycloakServiceBuilder
 	Build() IAMService
 }
 
-type OSDKeycloakServiceBuilder interface {
-	WithRealmConfig(realmConfig *iam.IAMRealmConfig) OSDKeycloakServiceBuilder
-	Build() OSDKeycloakService
-}
-
 type keycloakServiceBuilderSelector struct {
-}
-
-func (s *keycloakServiceBuilderSelector) ForOSD() OSDKeycloakServiceBuilderConfigurator {
-	return &osdBuilderConfigurator{}
 }
 
 func (s *keycloakServiceBuilderSelector) ForACS() ACSKeycloakServiceBuilderConfigurator {
@@ -54,18 +39,10 @@ func (k *keycloakBuilderConfigurator) WithConfiguration(config *iam.IAMConfig) K
 	}
 }
 
-func (o *osdBuilderConfigurator) WithConfiguration(config *iam.IAMConfig) OSDKeycloakServiceBuilder {
-	return &osdKeycloackServiceBuilder{
-		config: config,
-	}
-}
-
 type keycloakServiceBuilder struct {
 	config      *iam.IAMConfig
 	realmConfig *iam.IAMRealmConfig
 }
-
-type osdKeycloackServiceBuilder keycloakServiceBuilder
 
 // Build returns an instance of IAMService ready to be used.
 // If a custom realm is configured (WithRealmConfig called), then always Keycloak provider is used
@@ -75,18 +52,6 @@ func (builder *keycloakServiceBuilder) Build() IAMService {
 }
 
 func (builder *keycloakServiceBuilder) WithRealmConfig(realmConfig *iam.IAMRealmConfig) KeycloakServiceBuilder {
-	builder.realmConfig = realmConfig
-	return builder
-}
-
-// Build returns an instance of IAMService ready to be used.
-// If a custom realm is configured (WithRealmConfig called), then always Keycloak provider is used
-// irrespective of the `builder.config.SelectSSOProvider` value
-func (builder *osdKeycloackServiceBuilder) Build() OSDKeycloakService {
-	return build(builder.config, builder.realmConfig).(OSDKeycloakService)
-}
-
-func (builder *osdKeycloackServiceBuilder) WithRealmConfig(realmConfig *iam.IAMRealmConfig) OSDKeycloakServiceBuilder {
 	builder.realmConfig = realmConfig
 	return builder
 }

--- a/pkg/services/sso/keycloak_service_builder.go
+++ b/pkg/services/sso/keycloak_service_builder.go
@@ -56,13 +56,13 @@ func (builder *keycloakServiceBuilder) WithRealmConfig(realmConfig *iam.IAMRealm
 	return builder
 }
 
-func build(keycloakConfig *iam.IAMConfig, realmConfig *iam.IAMRealmConfig) IAMService {
+func build(iamConfig *iam.IAMConfig, realmConfig *iam.IAMRealmConfig) IAMService {
 	notNilPredicate := func(x interface{}) bool {
 		return x.(*iam.IAMRealmConfig) != nil
 	}
 
-	_, newRealmConfig := arrays.FindFirst(notNilPredicate, realmConfig, keycloakConfig.RedhatSSORealm)
-	client := redhatsso.NewSSOClient(keycloakConfig, newRealmConfig.(*iam.IAMRealmConfig))
+	_, newRealmConfig := arrays.FindFirst(notNilPredicate, realmConfig, iamConfig.RedhatSSORealm)
+	client := redhatsso.NewSSOClient(iamConfig, newRealmConfig.(*iam.IAMRealmConfig))
 	return &keycloakServiceProxy{
 		accessTokenProvider: client,
 		service: &redhatssoService{

--- a/pkg/services/sso/keycloak_service_proxy.go
+++ b/pkg/services/sso/keycloak_service_proxy.go
@@ -18,7 +18,6 @@ type keycloakServiceProxy struct {
 }
 
 var _ IAMService = &keycloakServiceProxy{}
-var _ OSDKeycloakService = &keycloakServiceProxy{}
 
 func (r *keycloakServiceProxy) DeRegisterClientInSSO(clientId string) *errors.ServiceError {
 	if token, err := r.retrieveToken(); err != nil {

--- a/templates/secrets-template.yml
+++ b/templates/secrets-template.yml
@@ -62,12 +62,6 @@ parameters:
 - name: SSO_CLIENT_SECRET
   description: Client secret used to interact with mas sso
 
-- name: OSD_IDP_SSO_CLIENT_ID
-  description: Client id used to interact with mas sso for configuring osd identity provider
-
-- name: OSD_IDP_SSO_CLIENT_SECRET
-  description: Client secret used to interact with mas sso for configuring osd identity provider
-
 - name: DINOSAUR_TLS_CERT
   description: Dinosaur TLS certificate
 
@@ -129,8 +123,6 @@ objects:
     aws.secretaccesskey: ${AWS_SECRET_ACCESS_KEY}
     redhatsso-service.clientId: ${SSO_CLIENT_ID}
     redhatsso-service.clientSecret: ${SSO_CLIENT_SECRET}
-    osd-idp-keycloak-service.clientId: ${OSD_IDP_SSO_CLIENT_ID}
-    osd-idp-keycloak-service.clientSecret: ${OSD_IDP_SSO_CLIENT_SECRET}
     aws.route53accesskey: ${ROUTE53_ACCESS_KEY}
     aws.route53secretaccesskey: ${ROUTE53_SECRET_ACCESS_KEY}
     observability-config-access.token: ${OBSERVABILITY_CONFIG_ACCESS_TOKEN}

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -254,11 +254,6 @@ parameters:
   displayName: SSO REALM for Dinosaur SSO Clients and Service Accounts
   description: SSO realm for Dinosaur SSO Clients and Service Accounts
 
-- name: OSD_IDP_SSO_REALM
-  displayName: SSO REALM for OSD Cluster Identity Provider Clients
-  description: SSO realm for OSD Cluster Identity Provider Clients
-  value: "interim-test-realm"
-
 - name: CLUSTER_OPENSHIFT_VERSION
   displayName: The version of openshift
   description: The version of openshift to be deployed on a new created OSD cluster
@@ -549,8 +544,6 @@ objects:
       aws.secretaccesskey: badger
       redhatsso-service.clientId: badger
       redhatsso-service.clientSecret: badger
-      osd-idp-keycloak-service.clientId: badger
-      osd-idp-keycloak-service.clientSecret: badger
       aws.route53accesskey: badger
       aws.route53secretaccesskey: badger
       observability-config-access.token: badger
@@ -1028,9 +1021,6 @@ objects:
             - --ocm-client-secret-file=/secrets/service/ocm-service.clientSecret
             - --sso-base-url=${SSO_BASE_URL}
             - --max-limit-for-sso-get-clients=${MAX_LIMIT_FOR_SSO_GET_CLIENTS}
-            - --osd-idp-sso-realm=${OSD_IDP_SSO_REALM}
-            - --osd-idp-sso-client-id-file=/secrets/service/osd-idp-keycloak-service.clientId
-            - --osd-idp-sso-client-secret-file=/secrets/service/osd-idp-keycloak-service.clientSecret
             - --sso-debug=${SSO_DEBUG}
             - --self-token-file=/secrets/service/ocm-service.token
             - --ocm-base-url=${OCM_URL}


### PR DESCRIPTION
## Description

This is the second PR in a series of PR to finalize refactorings on the SSO packages and related code.

The overall goal of this is to removed unused code and complexity that initially was used to support both MAS-SSO as well as RH SSO.

Here's an overview of changes done within the series of PRs:
- Rename `KeycloakService` to `IAMService`.
- Remove the `OSDService`.
- Remove every non-internal service account API on the `IAM Service`.
- Remove the `KeycloakBuilder` and `KeycloakProxy`.

For additional context and overview, see [the ticket](https://issues.redhat.com/browse/ROX-11287) as well as [the notes made together with
Kafkanians](https://docs.google.com/document/d/1nlEM15eC48PhK8ieleMAfIlPivvh-enp6aN2M7dyDLo/edit?usp=sharing).

Within the second PR, the `OSDKeycloakService` and its usages are removed.
Previously, the `OSDKeycloakService` was used to configure an IdP within the OSD dataplane clusters during dynamic provisioning (for more info on the configuration of IdP's within OpenShift [you can check this 
doc](https://docs.openshift.com/container-platform/4.10/authentication/understanding-identity-provider.html)). The IdP configured was MAS-SSO as an OpenID connect identity provider.

Now, we cannot re-use this implementation for the following reasons:
- MAS-SSO will not be re-used within ACS MS, we shall use RH SSO.
- Dynamic cluster provisioning is (currently) out-of-scope.
- The implementation of the provider configuration would require migration. Currently, Kafkanians are thinking about migrating to an internal SSO option.

After deciding together with the Kafkanians, it seems best to simply remove the interface and its usage for now and add a replacement later on, once available / required.
