### PR TITLE
Use correct file name.

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -472,7 +472,7 @@ objects:
             }
           ]
         }
-    jwks-static-file.json: |
+    jwks-file-static.json: |
         {
           "keys": [
             {


### PR DESCRIPTION
## Description

The wrong filename was used within the item of the configmap, leading to
```
E0704 15:38:18.408903 1 server.go:31] Unable to create authentication handler: keys file '/config/authentication/jwks-file-static.json' doesn't exist: stat /config/authentication/jwks-file-static.json: no such file or directory
```

