### PR TITLE
Fix identation within the configmap

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -472,7 +472,7 @@ objects:
             }
           ]
         }
-    jwks-file-static.json: |
+      jwks-file-static.json: |
         {
           "keys": [
             {


### PR DESCRIPTION
## Description

The additional item's identation was not correctly formatted. 
This lead to the rendered config map to only contain a single item.
