### PR TITLE
Extend build root Dockerfile

### DIFF
--- a/.openshift-ci/build-root/Dockerfile
+++ b/.openshift-ci/build-root/Dockerfile
@@ -16,8 +16,19 @@ RUN curl -L --silent --show-error --fail -o "/usr/local/bin/yq" \
     chmod +x /usr/local/bin/yq
 RUN curl -L --silent --show-error --fail -O https://nodejs.org/dist/v16.15.1/node-v16.15.1-linux-x64.tar.xz && \
     mkdir -p /usr/local/lib/nodejs && \
-    tar -xJvf node-v16.15.1-linux-x64.tar.xz -C /usr/local/lib/nodejs
+    tar -xJvf node-v16.15.1-linux-x64.tar.xz -C /usr/local/lib/nodejs && \
+    rm node-v16.15.1-linux-x64.tar.xz
 RUN curl -L --silent --show-error --fail -o "/usr/local/bin/stern" \
     https://github.com/wercker/stern/releases/download/1.11.0/stern_linux_amd64 && \
     chmod +x /usr/local/bin/stern
+RUN curl -L --silent --show-error --fail -O https://github.com/gotestyourself/gotestsum/releases/download/v1.8.1/gotestsum_1.8.1_linux_amd64.tar.gz && \
+    tar -xzvf gotestsum_1.8.1_linux_amd64.tar.gz gotestsum && \
+    mv gotestsum /usr/local/bin && \
+    chmod +x /usr/local/bin/gotestsum && \
+    rm gotestsum_1.8.1_linux_amd64.tar.gz
+RUN mkdir -p /stackrox/crds && \
+    curl -L --silent --show-error --fail -o /stackrox/crds/platform.stackrox.io_centrals.yaml \
+    https://raw.githubusercontent.com/stackrox/stackrox/release/3.70.x/operator/config/crd/bases/platform.stackrox.io_centrals.yaml && \
+    curl -L --silent --show-error --fail -o /stackrox/crds/platform.stackrox.io_securedclusters.yaml \
+    https://raw.githubusercontent.com/stackrox/stackrox/release/3.70.x/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
 ENV PATH="/usr/local/lib/nodejs/node-v16.15.1-linux-x64/bin:${PATH}"


### PR DESCRIPTION
## Description

This extends the build root Dockerfile, which is used in CI as base image for all other pipeline images.

* Installs gotestsum, which can produce output looking good in CI.
* Download StackRox CRDs in order to reduce code duplication.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
