### PR TITLE
Move image to values and improve README

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/README.md
+++ b/dp-terraform/helm/rhacs-terraform/README.md
@@ -31,6 +31,7 @@ helm template rhacs-terraform \
 ```bash
 helm upgrade --install rhacs-terraform \
   --namespace rhacs \
+  --create-namespace \
   --values ~/acs-terraform-values.yaml \
   --set fleetshardSync.ocmToken=$(ocm token --refresh) \
   --set fleetshardSync.fleetManagerEndpoint=${FM_ENDPOINT} \

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/README.md
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/README.md
@@ -18,6 +18,7 @@ helm template rhacs-terraform-obs \
 ```bash
 helm upgrade --install rhacs-terraform-obs \
   --namespace rhacs \
+  --create-namespace \
   --values ~/acs-terraform-obs-values.yaml .
 ```
 

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -20,9 +20,9 @@ spec:
       serviceAccountName: fleetshard-sync
       containers:
       - name: fleetshard-sync
-        image: quay.io/app-sre/acs-fleet-manager:main
+        image: {{ .Values.fleetshardSync.image | quote }}
         imagePullPolicy: Always
-        command: 
+        command:
         - /usr/local/bin/fleetshard-sync
         env:
         - name: OCM_TOKEN

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 fleetshardSync:
+  image: "quay.io/app-sre/acs-fleet-manager:main"
   # Can be either OCM, RHSSO, STATIC_TOKEN. When choosing RHSSO, make sure the clientId/secret is set. By default, uses OCM.
   authType: "OCM"
   # OCM refresh token, only required in combination with authType=OCM.
@@ -22,7 +23,7 @@ fleetshardSync:
   tokenRefresher:
     image: "quay.io/rhoas/mk-token-refresher:latest"
     issuerUrl: "https://sso.redhat.com/auth/realms/redhat-external"
-  
+
 acsOperator:
   enabled: false
   startingCSV: rhacs-operator.v3.70.0


### PR DESCRIPTION
## Description

This PR provides two small tweaks:
1. Image from terraforming helm template is moved to `values.yaml` - this will help us define different images on staging/production/dev environments
2. Improved README to use helm upgrade command with `--create-namespace` - this helps when the OSD cluster is new and we do not have the required namespace created. This option will simply create it.

## Checklist (Definition of Done)
- ~[ ] Unit and integration tests added~ - this is not important for this PR
- [x] Documentation added if necessary
- [x] CI and all relevant tests are passing

## Test manual

1. You can execute the following commands to test it:
```
# in root of the project
cd dp-terraform/helm/rhacs-terraform

helm template rhacs-terraform \
  --debug \
  --namespace rhacs \
  --values ./values.yaml \
  --set fleetshardSync.image="test-image" .
```
After that check output and search for Deployment with the name `fleetshard-sync`. Check that the specified `fleetshardSync.image` is used there for the `image` property of the first container.

2. It's possible to test by selecting not existing namespace. Also, documentation is available here: https://helm.sh/docs/helm/helm_upgrade/