### PR TITLE
Drop check for fleetshard-sync rbac existence

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-rbac.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-rbac.yaml
@@ -17,7 +17,6 @@ subjects:
   name: fleetshard-sync
   namespace: {{ .Release.Namespace }}
 ---
-{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "fleetshard-sync-role") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -30,4 +29,3 @@ rules:
   - '*'
   verbs:
   - '*'
-{{- end }}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Drop fleetshard-sync RBAC role lookup in the helm chart. With such check only every second deployment will create correct RBAC role for fleet.
Thanks @mtodor for spotting it