### PR TITLE
Fix detect-secrets pre-commit hook.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -135,6 +135,48 @@
         "is_secret": false
       }
     ],
+    "config/jwks-file-static.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "config/jwks-file-static.json",
+        "hashed_secret": "551c2aa179bc3c0e2e8176d4b458d077ed358e25",
+        "is_verified": false,
+        "line_number": 8,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "config/jwks-file-static.json",
+        "hashed_secret": "f05bf8a9b8521955a5fa259abd1d5a6d269273ec",
+        "is_verified": false,
+        "line_number": 16,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "config/jwks-file-static.json",
+        "hashed_secret": "e23d321e76d1144e48b7f1d05dfd0d5036031003",
+        "is_verified": false,
+        "line_number": 24,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "config/jwks-file-static.json",
+        "hashed_secret": "9b87ab16703bb0ccd78aee2f69bd0e604f7a42dc",
+        "is_verified": false,
+        "line_number": 32,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "config/jwks-file-static.json",
+        "hashed_secret": "3744e3d32aa35c3bb53d76d1832699b723f07812",
+        "is_verified": false,
+        "line_number": 41,
+        "is_secret": false
+      }
+    ],
     "config/jwks-file.json": [
       {
         "type": "Base64 High Entropy String",
@@ -179,13 +221,23 @@
         "is_secret": false
       }
     ],
-    "dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml": [
+    "fleetshard/pkg/centralreconciler/reconciler.go": [
       {
         "type": "Secret Keyword",
-        "filename": "dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml",
-        "hashed_secret": "97b510880880a92bb3429d8854f0d38dcc849af8",
+        "filename": "fleetshard/pkg/centralreconciler/reconciler.go",
+        "hashed_secret": "511c3c365008972c1bc955150cc039ebe2b67cbd",
         "is_verified": false,
-        "line_number": 42,
+        "line_number": 36,
+        "is_secret": false
+      }
+    ],
+    "fleetshard/pkg/testutils/k8s.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "fleetshard/pkg/testutils/k8s.go",
+        "hashed_secret": "bae12e76fa88f17b1600e44598fd9b672a1689fc",
+        "is_verified": false,
+        "line_number": 24,
         "is_secret": false
       }
     ],
@@ -289,6 +341,16 @@
         "is_secret": false
       }
     ],
+    "internal/dinosaur/pkg/presenters/manageddinosaur.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/presenters/manageddinosaur.go",
+        "hashed_secret": "88aed2eb58047bc915fe60b441c59c0003cc970f",
+        "is_verified": false,
+        "line_number": 43,
+        "is_secret": false
+      }
+    ],
     "internal/dinosaur/pkg/services/clusters_test.go": [
       {
         "type": "Secret Keyword",
@@ -305,7 +367,15 @@
         "filename": "internal/dinosaur/pkg/services/dinosaur.go",
         "hashed_secret": "bae666efd375b31ee4ba6e4ed05a31c84b916b9c",
         "is_verified": false,
-        "line_number": 689,
+        "line_number": 690,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/services/dinosaur.go",
+        "hashed_secret": "aa6f1fcd9883c364b3b176d182927ee515b5ec52",
+        "is_verified": false,
+        "line_number": 819,
         "is_secret": false
       }
     ],
@@ -325,7 +395,7 @@
         "filename": "internal/dinosaur/pkg/workers/clusters_mgr.go",
         "hashed_secret": "a6e4653f54561ded823537b9ed07aab449cc72c2",
         "is_verified": false,
-        "line_number": 44,
+        "line_number": 41,
         "is_secret": false
       },
       {
@@ -333,7 +403,7 @@
         "filename": "internal/dinosaur/pkg/workers/clusters_mgr.go",
         "hashed_secret": "af8bd5f9fa23e6c5faadecb87910d595cac48aa8",
         "is_verified": false,
-        "line_number": 47,
+        "line_number": 44,
         "is_secret": false
       },
       {
@@ -341,7 +411,7 @@
         "filename": "internal/dinosaur/pkg/workers/clusters_mgr.go",
         "hashed_secret": "a4f2b95d16786cd9c4f86404cb519f18b7e33113",
         "is_verified": false,
-        "line_number": 800,
+        "line_number": 790,
         "is_secret": false
       },
       {
@@ -349,15 +419,7 @@
         "filename": "internal/dinosaur/pkg/workers/clusters_mgr.go",
         "hashed_secret": "a6b7aa0f297935e4e49d200f7505873d8cd470ce",
         "is_verified": false,
-        "line_number": 802,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "internal/dinosaur/pkg/workers/clusters_mgr.go",
-        "hashed_secret": "9b8b876c2782fa992fab14095267bb8757b9fabc",
-        "is_verified": false,
-        "line_number": 995,
+        "line_number": 792,
         "is_secret": false
       }
     ],
@@ -367,7 +429,7 @@
         "filename": "openapi/fleet-manager-private.yaml",
         "hashed_secret": "2774b5ad0fae1c8b8dc897b89db85529d45cb5cf",
         "is_verified": false,
-        "line_number": 467,
+        "line_number": 466,
         "is_secret": false
       }
     ],
@@ -391,10 +453,10 @@
         "is_secret": false
       }
     ],
-    "pkg/client/keycloak/client_moq.go": [
+    "pkg/client/iam/client_moq.go": [
       {
         "type": "Secret Keyword",
-        "filename": "pkg/client/keycloak/client_moq.go",
+        "filename": "pkg/client/iam/client_moq.go",
         "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
         "is_verified": false,
         "line_number": 640,
@@ -402,53 +464,45 @@
       },
       {
         "type": "Secret Keyword",
-        "filename": "pkg/client/keycloak/client_moq.go",
-        "hashed_secret": "ef0b0964f3cf5c2da4fc3833d06f3b3e1f444531",
+        "filename": "pkg/client/iam/client_moq.go",
+        "hashed_secret": "4595e0fe3be13544e523e5f6c1145f15007f7b58",
         "is_verified": false,
         "line_number": 641,
         "is_secret": false
       },
       {
         "type": "Secret Keyword",
-        "filename": "pkg/client/keycloak/client_moq.go",
-        "hashed_secret": "86e30009a86bbfcb7195178129832850ae4ba771",
+        "filename": "pkg/client/iam/client_moq.go",
+        "hashed_secret": "539fbe365f6c0db26d473d85a736d318c2f565e5",
         "is_verified": false,
         "line_number": 972,
         "is_secret": false
       }
     ],
-    "pkg/client/keycloak/config.go": [
+    "pkg/client/iam/config.go": [
       {
         "type": "Secret Keyword",
-        "filename": "pkg/client/keycloak/config.go",
-        "hashed_secret": "85716713a2f64ab8193fd7abf2de3237a5ccae09",
-        "is_verified": false,
-        "line_number": 53,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "pkg/client/keycloak/config.go",
+        "filename": "pkg/client/iam/config.go",
         "hashed_secret": "8059b8f7acd5ab09f92010b99a1593019d6969e9",
         "is_verified": false,
-        "line_number": 63,
+        "line_number": 68,
         "is_secret": false
       }
     ],
-    "pkg/client/keycloak/constants.go": [
+    "pkg/client/iam/constants.go": [
       {
         "type": "Secret Keyword",
-        "filename": "pkg/client/keycloak/constants.go",
+        "filename": "pkg/client/iam/constants.go",
         "hashed_secret": "a931c2a572165b673d42afcdbde0abec3d43f2d2",
         "is_verified": false,
         "line_number": 4,
         "is_secret": false
       }
     ],
-    "pkg/client/keycloak/gocloak_moq.go": [
+    "pkg/client/iam/gocloak_moq.go": [
       {
         "type": "Secret Keyword",
-        "filename": "pkg/client/keycloak/gocloak_moq.go",
+        "filename": "pkg/client/iam/gocloak_moq.go",
         "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
         "is_verified": false,
         "line_number": 9597,
@@ -456,7 +510,7 @@
       },
       {
         "type": "Secret Keyword",
-        "filename": "pkg/client/keycloak/gocloak_moq.go",
+        "filename": "pkg/client/iam/gocloak_moq.go",
         "hashed_secret": "7f0b58c8f07c09a5ed45a784a8e1ea4d3e983d59",
         "is_verified": false,
         "line_number": 9598,
@@ -464,7 +518,7 @@
       },
       {
         "type": "Secret Keyword",
-        "filename": "pkg/client/keycloak/gocloak_moq.go",
+        "filename": "pkg/client/iam/gocloak_moq.go",
         "hashed_secret": "9b8b876c2782fa992fab14095267bb8757b9fabc",
         "is_verified": false,
         "line_number": 12902,
@@ -472,7 +526,7 @@
       },
       {
         "type": "Secret Keyword",
-        "filename": "pkg/client/keycloak/gocloak_moq.go",
+        "filename": "pkg/client/iam/gocloak_moq.go",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
         "line_number": 12905,
@@ -480,7 +534,7 @@
       },
       {
         "type": "Secret Keyword",
-        "filename": "pkg/client/keycloak/gocloak_moq.go",
+        "filename": "pkg/client/iam/gocloak_moq.go",
         "hashed_secret": "eb1b883e199141e362a143c51178ab8f09c87751",
         "is_verified": false,
         "line_number": 13513,
@@ -488,7 +542,7 @@
       },
       {
         "type": "Secret Keyword",
-        "filename": "pkg/client/keycloak/gocloak_moq.go",
+        "filename": "pkg/client/iam/gocloak_moq.go",
         "hashed_secret": "1b46ecc8fb47b1b39a420f00f08dbd58e0313188",
         "is_verified": false,
         "line_number": 13813,
@@ -569,10 +623,10 @@
         "is_secret": false
       }
     ],
-    "pkg/services/sso/keycloakservice_moq.go": [
+    "pkg/services/sso/iam_service_moq.go": [
       {
         "type": "Secret Keyword",
-        "filename": "pkg/services/sso/keycloakservice_moq.go",
+        "filename": "pkg/services/sso/iam_service_moq.go",
         "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
         "is_verified": false,
         "line_number": 367,
@@ -580,8 +634,8 @@
       },
       {
         "type": "Secret Keyword",
-        "filename": "pkg/services/sso/keycloakservice_moq.go",
-        "hashed_secret": "d0c0fbcb5d9eec638d2f91f0a514e06725100f90",
+        "filename": "pkg/services/sso/iam_service_moq.go",
+        "hashed_secret": "e7544a80d44a3e22846848409c3ce24a5d618acd",
         "is_verified": false,
         "line_number": 368,
         "is_secret": false
@@ -631,7 +685,15 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "4e199b4a1c40b497a95fcd1cd896351733849949",
         "is_verified": false,
-        "line_number": 490,
+        "line_number": 539,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "templates/service-template.yml",
+        "hashed_secret": "29ca7571d5fc8779a3a4c83bfc41d980d8c78e3d",
+        "is_verified": false,
+        "line_number": 853,
         "is_secret": false
       },
       {
@@ -639,7 +701,7 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "f262552238937b43102d7308422fc567e8aed4ba",
         "is_verified": false,
-        "line_number": 797,
+        "line_number": 856,
         "is_secret": false
       },
       {
@@ -647,7 +709,7 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "e2b7ddca9ab1066c1e5b368f2c2e5da70c5e54bc",
         "is_verified": false,
-        "line_number": 800,
+        "line_number": 859,
         "is_secret": false
       },
       {
@@ -655,7 +717,7 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "1d82918cd9745c60d712b5369a7635afe06e225b",
         "is_verified": false,
-        "line_number": 809,
+        "line_number": 868,
         "is_secret": false
       },
       {
@@ -663,7 +725,7 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "85c26a4496699ef15ea9398004057710222ae9bc",
         "is_verified": false,
-        "line_number": 835,
+        "line_number": 897,
         "is_secret": false
       }
     ],
@@ -708,5 +770,5 @@
       }
     ]
   },
-  "generated_at": "2022-06-27T12:18:52Z"
+  "generated_at": "2022-07-08T17:27:15Z"
 }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,38 @@ TODO: Clean up and make this ACS Fleet Manager specific.
 
 Context: We want to fix the e2e flow in parallel across many engineers quickly, but don't want to push untested, potentially minimal / simplified code to `release`. So we will develop in `main` and later on clean things up and bring them into `release`.
 
+#### Git hooks
+
+The repository offers git hooks to run lints and checks locally before committing changes. Under the hood this uses
+[pre-commit](https://pre-commit.com/) plugins.
+
+To install the git hooks, run the following: 
+```shell
+$ make setup/git/hooks
+```
+
+Currently, the following plugins are enabled:
+- [detect-secrets](https://github.com/Yelp/detect-secrets): detect secrets to avoid accidentially commit them.
+
+
+**Troubleshooting:**
+In case you run into any issues with the secrets, the output typically is enough to highlight the problem.
+However, in the case of the `detect-secrets`, you are required to do a few more steps:
+```shell
+# Ensure you have detect-secrets installed
+$ pip3 install detect-secrets
+
+# In the repository root, scan the repo for secrets and update the .secrets.baseline file.
+$ detect-secrets scan > .secrets.baseline
+
+# Trigger an interactive audit of newly detected secrets. You will be asked to verify whether the detected secret
+# is safe to be committed to the repository or not.
+$ detect-secrets audit .secrets.baseline
+
+# Afterwards, make sure you commit the updated .secrets.baseline file and the plugin should not return any errors
+# anymore! 
+```
+
 ### Rough map
 
 Here are the key directories to know about:


### PR DESCRIPTION
## Description

When running the pre-commit against all files via:
```shell
$ pre-commit run --all-files
```

The `detect-secrets` had issues regarding undetected secrets.

Updated the `.secrets.baseline` file + audited it once more to make the pre-commit hook pass:
```shell
$ detect-secrets scan > .secrets.baseline
$ detect-secrets audit .secrets.baseline
```

## Checklist (Definition of Done)
- [x] Documentation added if necessary

## Test manual

```shell
# Run pre-commit against all files and expect no errors.
$ pre-commit run --all-files
```
