### PR TITLE
Add check-json pre-commit plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,4 @@ repos:
         args: ["--markdown-linebreak-ext=md"]
       - id: end-of-file-fixer
         exclude: '^(?:secrets/db.*|.*?VERSION)$' # Matches either secrets/db.* files or the VERSION file under internal/dinosaur/pkg/api/<group>/.openapi-generator
+      - id: check-json

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Currently, the following plugins are enabled:
 - [golangci-lint](https://github.com/golangci/golangci-lint): run golangci-lint for changed go files.
 - [trailing-whitespace](https://github.com/pre-commit/pre-commit-hooks#trailing-whitespace): detect trailing whitespaces.
 - [end-of-file-fixer](https://github.com/pre-commit/pre-commit-hooks#end-of-file-fixer): ensure files end in a newline.
-
+- [check-json](https://github.com/pre-commit/pre-commit-hooks#check-json): ensure all JSON files have valid syntax.
 
 **Troubleshooting:**
 In case you run into any issues with the secrets, the output typically is enough to highlight the problem.


### PR DESCRIPTION
## Description

Add [check-json](https://github.com/pre-commit/pre-commit-hooks#check-json) to the pre-commit configuration. As we use JSON files for configuration, it would be best to check for their syntax to avoid potential issues when 
deploying i.e. fleet manager.

## Checklist (Definition of Done)
- [x] Documentation added if necessary

## Test manual

```
# Run the pre-commit against all files and expect no errors.
pre-commit run --all-files
```
