### PR TITLE
Remove github CODEOWNERS in favor of openshift-ci

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,0 @@
-
-# For further documentation on CODEOWNERS, visit
-# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners
-# This will automatically assign a team / people as reviewers for PRs based on the files changed within the PR.
-
-* @stackrox/draco


### PR DESCRIPTION
## Description

Remove code owners from github because the code is not owned by a single team.