### PR TITLE
fix host name generation in fleet-manager

### DIFF
--- a/config/fleetshard-authz-org-ids-development.yaml
+++ b/config/fleetshard-authz-org-ids-development.yaml
@@ -8,3 +8,5 @@
 - "16134752"
 # org_id for the static token
 - "12345678"
+# ACS RH SSO ORG Development
+- "16155304"

--- a/internal/dinosaur/pkg/config/dinosaur.go
+++ b/internal/dinosaur/pkg/config/dinosaur.go
@@ -31,7 +31,7 @@ func NewDinosaurConfig() *DinosaurConfig {
 		DinosaurTLSCertFile:               "secrets/dinosaur-tls.crt",
 		DinosaurTLSKeyFile:                "secrets/dinosaur-tls.key",
 		EnableDinosaurExternalCertificate: false,
-		DinosaurDomainName:                "dinosaur.devshift.org",
+		DinosaurDomainName:                "rhacs-dev.com",
 		DinosaurLifespan:                  NewDinosaurLifespanConfig(),
 		Quota:                             NewDinosaurQuotaConfig(),
 	}

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -255,12 +255,6 @@ func (k *dinosaurService) RegisterDinosaurJob(dinosaurRequest *dbapi.CentralRequ
 }
 
 func (k *dinosaurService) PrepareDinosaurRequest(dinosaurRequest *dbapi.CentralRequest) *errors.ServiceError {
-	truncatedDinosaurIdentifier := buildTruncateDinosaurIdentifier(dinosaurRequest)
-	truncatedDinosaurIdentifier, replaceErr := replaceHostSpecialChar(truncatedDinosaurIdentifier)
-	if replaceErr != nil {
-		return errors.NewWithCause(errors.ErrorGeneral, replaceErr, "generated host is not valid")
-	}
-
 	clusterDNS, err := k.clusterService.GetClusterDNS(dinosaurRequest.ClusterID)
 	if err != nil {
 		return errors.NewWithCause(errors.ErrorGeneral, err, "error retrieving cluster DNS")
@@ -272,11 +266,11 @@ func (k *dinosaurService) PrepareDinosaurRequest(dinosaurRequest *dbapi.CentralR
 	}
 	dinosaurRequest.Namespace = namespace
 	clusterDNS = strings.Replace(clusterDNS, constants2.DefaultIngressDnsNamePrefix, constants2.ManagedDinosaurIngressDnsNamePrefix, 1)
-	dinosaurRequest.Host = fmt.Sprintf("%s.%s", truncatedDinosaurIdentifier, clusterDNS)
+	dinosaurRequest.Host = fmt.Sprintf("%s.%s", namespace, clusterDNS)
 
 	if k.dinosaurConfig.EnableDinosaurExternalCertificate {
 		// If we enable DinosaurTLS, the host should use the external domain name rather than the cluster domain
-		dinosaurRequest.Host = fmt.Sprintf("%s.%s", truncatedDinosaurIdentifier, k.dinosaurConfig.DinosaurDomainName)
+		dinosaurRequest.Host = fmt.Sprintf("%s.%s", namespace, k.dinosaurConfig.DinosaurDomainName)
 	}
 
 	// Update the Dinosaur Request record in the database

--- a/internal/dinosaur/pkg/services/util.go
+++ b/internal/dinosaur/pkg/services/util.go
@@ -5,8 +5,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
-
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
@@ -33,12 +31,6 @@ func truncateString(str string, num int) string {
 		truncatedString = str[0:num]
 	}
 	return truncatedString
-}
-
-// buildTruncateDinosaurIdentifier creates a unique identifier for a dinosaur cluster given
-// the dinosaur request object
-func buildTruncateDinosaurIdentifier(dinosaurRequest *dbapi.CentralRequest) string {
-	return fmt.Sprintf("%s-%s", truncateString(dinosaurRequest.Name, truncatedNameLen), strings.ToLower(dinosaurRequest.ID))
 }
 
 // maskProceedingandTrailingDash replaces the first and final character of a string with a subdomain safe

--- a/internal/dinosaur/pkg/services/util_test.go
+++ b/internal/dinosaur/pkg/services/util_test.go
@@ -2,12 +2,11 @@ package services
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"reflect"
-	"strings"
 	"testing"
 
-	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stackrox/acs-fleet-manager/pkg/services"
 	"github.com/stackrox/acs-fleet-manager/pkg/shared"
 
@@ -180,47 +179,6 @@ func Test_truncateString(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := truncateString(tt.args.str, tt.args.num); got != tt.want {
 				t.Errorf("truncateString() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_buildTruncateDinosaurIdentifier(t *testing.T) {
-	mockShortDinosaurName := "dinosaur"
-	mockLongDinosaurName := "sample-dinosaur-name-long"
-
-	type args struct {
-		dinosaurRequest *dbapi.CentralRequest
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			name: "build dinosaur identifier with a short name successfully",
-			args: args{
-				dinosaurRequest: &dbapi.CentralRequest{
-					Name: mockShortDinosaurName,
-				},
-			},
-			want: fmt.Sprintf("%s-%s", mockShortDinosaurName, strings.ToLower(mockDinosaurRequestID)),
-		},
-		{
-			name: "build dinosaur identifier with a long name successfully",
-			args: args{
-				dinosaurRequest: &dbapi.CentralRequest{
-					Name: mockLongDinosaurName,
-				},
-			},
-			want: fmt.Sprintf("%s-%s", mockLongDinosaurName[0:truncatedNameLen], strings.ToLower(mockDinosaurRequestID)),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tt.args.dinosaurRequest.ID = mockDinosaurRequestID
-			if got := buildTruncateDinosaurIdentifier(tt.args.dinosaurRequest); got != tt.want {
-				t.Errorf("buildTruncateDinosaurIdentifier() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Description
This PR changes fleet-manager to use the external domain name scheme specified in this [ADR](https://github.com/stackrox/architecture-decision-records/blob/main/managed_service/ADR-0008-central-dns-name-scheme.md). I also tested that CNAME creation in Route53 works as expected. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

Manual testing:
```
make binary
make secrets/touch
make db/teardown db/setup db/migrate

# put AWS access key and secret key from BitWarden secret: 
# Development Environment OSD Data Plane Clusters PnT AWS account 047735621815
# in the files secrets/aws.route53accesskey and secrets/aws.route53secretaccesskey

# copy config for your local k8s
cp dev/config/dataplane-cluster-configuration-minikube.yaml ./config/dataplane-cluster-configuration.yaml 

# run fleet-manager with external certificate enabled
./fleet-manager serve --enable-dinosaur-external-certificate --dinosaur-domain-name "rhacs-dev.com"

# create a central
./scripts/create-central.sh

# wait for central to get to provisioning state

export cluster_id=1234567890abcdef1234567890abcdef
# Send a PUT status request for your central specifying routes to create
# replace $central_id with the ID assigned to your central
fmcurl "rhacs/v1/agent-clusters/$cluster_id/centrals/status" -XPUT -d '{
    "$central_id": {
        "conditions": [
            {
                "type": "Ready",
                "reason": "CentralInstanceReady",
                "message": "Installing",
                "status": "True",
                "lastTransitionTime": "2018-01-01T00:00:00Z"
            }
        ],
        "routes": [
            {
                "name": "ui-route",
                "prefix": "ui",
                "router": "cluster.local"
            },
            {
                "name": "api-route",
                "prefix": "api",
                "router": "cluster.local"
            }
        ],
        "versions": {
            "central": "0.1.0",
            "centralOperator": "0.1.0"
        }
    }
}

# Login to AWS with the username and password in BitWarden:
# Development Environment OSD Data Plane Clusters PnT AWS account 047735621815
# Go to Route53 and make sure the CNAME is created and has expected values in rhacs-dev.com hosted zone
```


```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
