### PR TITLE
Add E2E test suite for authN/Z.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -269,6 +269,16 @@
         "is_secret": false
       }
     ],
+    "e2e/e2e_auth_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "e2e/e2e_auth_test.go",
+        "hashed_secret": "9b8b876c2782fa992fab14095267bb8757b9fabc",
+        "is_verified": false,
+        "line_number": 273,
+        "is_secret": false
+      }
+    ],
     "fleetshard/pkg/central/reconciler/init_auth.go": [
       {
         "type": "Secret Keyword",

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -275,7 +275,7 @@
         "filename": "e2e/e2e_auth_test.go",
         "hashed_secret": "9b8b876c2782fa992fab14095267bb8757b9fabc",
         "is_verified": false,
-        "line_number": 273,
+        "line_number": 268,
         "is_secret": false
       }
     ],
@@ -862,5 +862,5 @@
       }
     ]
   },
-  "generated_at": "2022-07-25T14:56:11Z"
+  "generated_at": "2022-07-26T09:34:11Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -275,7 +275,7 @@
         "filename": "e2e/e2e_auth_test.go",
         "hashed_secret": "9b8b876c2782fa992fab14095267bb8757b9fabc",
         "is_verified": false,
-        "line_number": 268,
+        "line_number": 271,
         "is_secret": false
       }
     ],
@@ -862,5 +862,5 @@
       }
     ]
   },
-  "generated_at": "2022-07-26T09:34:11Z"
+  "generated_at": "2022-07-26T11:57:07Z"
 }

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -16,6 +16,16 @@ $ CLUSTER_ID=1234567890abcdef1234567890abcdef OCM_TOKEN=$(ocm token --refresh) .
 # Run e2e tests (invalidate cache to run it multiple times)
 $ go clean -testcache && CLUSTER_ID=1234567890abcdef1234567890abcdef RUN_E2E=true OCM_TOKEN=$(ocm token --refresh) go test ./e2e/...
 
+# Run auth e2e tests:
+$ go clean -testcache && CLUSTER_ID=1234567890abcdef1234567890abcdef \
+  RUN_E2E=true \
+  RUN_AUTH_E2E=true \
+  CLUSTER_ID=1234567890abcdef1234567890abcdef \
+  STATIC_TOKEN=<bitwarden value> \
+  OCM_TOKEN=$(ocm token --refresh) \
+  RHSSO_CLIENT_ID=<bitwarden value> RHSSO_CLIENT_SECRET=<bitwarden value> \
+  go test ./e2e/...
+
 # To clean up the environment run
 $ ./e2e/cleanup.sh
 ```

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -21,9 +21,9 @@ $ go clean -testcache && CLUSTER_ID=1234567890abcdef1234567890abcdef \
   RUN_E2E=true \
   RUN_AUTH_E2E=true \
   CLUSTER_ID=1234567890abcdef1234567890abcdef \
-  STATIC_TOKEN=<bitwarden value> \
+  STATIC_TOKEN=$(bw get item "64173bbc-d9fb-4d4a-b397-aec20171b025" | jq '.fields[] | select(.name | contains("JWT")) | .value' --raw-output) \
   OCM_TOKEN=$(ocm token --refresh) \
-  RHSSO_CLIENT_ID=<bitwarden value> RHSSO_CLIENT_SECRET=<bitwarden value> \
+  RHSSO_CLIENT_ID=$(bw get username 028ce1a9-f751-4056-9c72-aea70052728b) RHSSO_CLIENT_SECRET=$(bw get password 028ce1a9-f751-4056-9c72-aea70052728b) \
   go test ./e2e/...
 
 # To clean up the environment run

--- a/e2e/e2e_auth_test.go
+++ b/e2e/e2e_auth_test.go
@@ -120,9 +120,9 @@ var _ = Describe("AuthN/Z Fleet* components", func() {
 			Entry("should allow access to fleet manager's public API endpoints",
 				publicAPI, false, 0, false),
 			Entry("should allow access to fleet manager's internal API endpoints in non-prod environment",
-				internalAPI, false, 0, skipOnNonProd),
+				internalAPI, false, 0, skipOnProd),
 			Entry("should not allow access to fleet manager's internal API endpoints in prod environment",
-				internalAPI, true, http.StatusNotFound, skipOnProd),
+				internalAPI, true, http.StatusNotFound, skipOnNonProd),
 			Entry("should not allow access to fleet manager's the admin API",
 				adminAPI, true, http.StatusNotFound, false),
 		)

--- a/e2e/e2e_auth_test.go
+++ b/e2e/e2e_auth_test.go
@@ -34,6 +34,9 @@ const (
 )
 
 var _ = Describe("AuthN/Z Fleet* components", func() {
+	// Need the GinkgoRecover due to Skip being called within the Describe node.
+	defer GinkgoRecover()
+
 	if env := getEnvDefault("RUN_AUTH_E2E", "false"); env == "false" {
 		Skip("The RUN_AUTH_E2E variable was not set, skipping the tests. If you want to run the auth tests, " +
 			"set RUN_AUTH_E2E=true")

--- a/e2e/e2e_auth_test.go
+++ b/e2e/e2e_auth_test.go
@@ -1,0 +1,279 @@
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/fleetmanager"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/compat"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/admin/private"
+	"github.com/stackrox/acs-fleet-manager/pkg/client/iam"
+	"github.com/stackrox/acs-fleet-manager/pkg/client/redhatsso"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+)
+
+const (
+	ocmAuthType         = "OCM"
+	rhSSOAuthType       = "RHSSO"
+	staticTokenAuthType = "STATIC_TOKEN"
+)
+
+var _ = Describe("AuthN/Z Fleet* components", func() {
+	if env := getEnvDefault("RUN_AUTH_E2E", "false"); env == "false" {
+		Skip("The RUN_AUTH_E2E variable was not set, skipping the tests. If you want to run the auth tests, " +
+			"set RUN_AUTH_E2E=true")
+	}
+
+	defer GinkgoRecover()
+
+	var client *authTestClientFleetManager
+
+	Describe("OCM auth type", func() {
+		BeforeEach(func() {
+			auth, err := fleetmanager.NewAuth(ocmAuthType)
+			Expect(err).ToNot(HaveOccurred())
+			fmClient, err := fleetmanager.NewClient("http://localhost:8000", "1234567890abcdef1234567890abcdef", auth)
+			Expect(err).ToNot(HaveOccurred())
+			client = newAuthTestClient(fmClient, auth, "http://localhost:8000")
+		})
+
+		It("should allow access to fleet manager's public API endpoints", func() {
+			_, err := client.ListCentrals()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should allow access to fleet manager's internal API endpoints in dev / staging environment", func() {
+			_, err := client.GetManagedCentralList()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should not allow access to fleet manager's internal API endpoints in production environment", func() {
+			// OCM_ENV specifies which environment configuration to use when deploying fleet manager.
+			if env := getEnvDefault("OCM_ENV", "DEVELOPMENT"); env != "production" {
+				Skip("Fleet manager is deployed using non-production configuration settings")
+			}
+
+			_, err := client.GetManagedCentralList()
+			Expect(err).To(HaveOccurred())
+			// Currently the errors exposed by the generated open API clients do not satisfy the error interface, hence
+			// we can't check for error types via MatchError matcher but have to resort to string checking.
+			// Instead of http.StatusUnauthorized, we will retrieve http.StatusNotFound.
+			Expect(err.Error()).To(ContainSubstring(strconv.Itoa(http.StatusNotFound)))
+		})
+
+		It("should not allow access to fleet manager's the admin API", func() {
+			_, err := client.ListAdminAPI()
+
+			Expect(err).To(HaveOccurred())
+			// Currently the errors exposed by the generated open API clients do not satisfy the error interface, hence
+			// we can't check for error types via MatchError matcher but have to resort to string checking.
+			// Instead of http.StatusUnauthorized, we will retrieve http.StatusNotFound.
+			Expect(err.Error()).To(ContainSubstring(strconv.Itoa(http.StatusNotFound)))
+		})
+	})
+
+	Describe("Static token auth type", func() {
+		BeforeEach(func() {
+			auth, err := fleetmanager.NewAuth(staticTokenAuthType)
+			Expect(err).ToNot(HaveOccurred())
+			fmClient, err := fleetmanager.NewClient("http://localhost:8000", "cluster-id", auth)
+			Expect(err).ToNot(HaveOccurred())
+			client = newAuthTestClient(fmClient, auth, "http://localhost:8000")
+		})
+
+		It("should allow access to fleet manager's public API endpoints", func() {
+			_, err := client.ListCentrals()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should allow access to fleet manager's internal API endpoints in dev / staging environment", func() {
+			_, err := client.GetManagedCentralList()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should not allow access to fleet manager's internal API endpoints in production environment", func() {
+			// OCM_ENV specifies which environment configuration to use when deploying fleet manager.
+			if env := getEnvDefault("OCM_ENV", "DEVELOPMENT"); env != "production" {
+				Skip("Fleet manager is deployed using non-production configuration settings")
+			}
+
+			_, err := client.GetManagedCentralList()
+			Expect(err).To(HaveOccurred())
+			// Currently the errors exposed by the generated open API clients do not satisfy the error interface, hence
+			// we can't check for error types via MatchError matcher but have to resort to string checking.
+			// Instead of http.StatusUnauthorized, we will retrieve http.StatusNotFound.
+			Expect(err.Error()).To(ContainSubstring(strconv.Itoa(http.StatusNotFound)))
+		})
+
+		It("should not allow access to fleet manager's the admin API", func() {
+			_, err := client.ListAdminAPI()
+
+			Expect(err).To(HaveOccurred())
+			// Currently the errors exposed by the generated open API clients do not satisfy the error interface, hence
+			// we can't check for error types via MatchError matcher but have to resort to string checking.
+			// Instead of http.StatusUnauthorized, we will retrieve http.StatusNotFound.
+			Expect(err.Error()).To(ContainSubstring(strconv.Itoa(http.StatusNotFound)))
+		})
+	})
+
+	Describe("RH SSO auth type", func() {
+		BeforeEach(func() {
+			// Read the client ID / secret from environment variables. If not set, skip the tests.
+			clientID := os.Getenv("RHSSO_CLIENT_ID")
+			clientSecret := os.Getenv("RHSSO_CLIENT_SECRET")
+			if clientID == "" || clientSecret == "" {
+				Skip("RHSSO_CLIENT_ID / RHSSO_CLIENT_SECRET not set, cannot initialize auth type")
+			}
+
+			// Create a temporary file where the token will be stored.
+			f, err := os.CreateTemp("", "token")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Set the RHSSO_TOKEN_FILE environment variable, pointing to the temporary file.
+			err = os.Setenv("RHSSO_TOKEN_FILE", f.Name())
+			Expect(err).ToNot(HaveOccurred())
+
+			// Obtain a token from RH SSO using the client ID / secret + client_credentials grant. Write the token to
+			// the temporary file.
+			token, err := obtainRHSSOToken(clientID, clientSecret)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = f.WriteString(token)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create the auth type for RH SSO.
+			auth, err := fleetmanager.NewAuth(rhSSOAuthType)
+			Expect(err).ToNot(HaveOccurred())
+			fmClient, err := fleetmanager.NewClient("http://localhost:8000", "cluster-id", auth)
+			Expect(err).ToNot(HaveOccurred())
+			client = newAuthTestClient(fmClient, auth, "http://localhost:8000")
+
+			DeferCleanup(func() {
+				// Unset the environment variable.
+				err := os.Unsetenv("RHSSO_TOKEN_FILE")
+				Expect(err).ToNot(HaveOccurred())
+
+				// Close and delete the temporarily created file.
+				err = f.Close()
+				Expect(err).ToNot(HaveOccurred())
+				err = os.Remove(f.Name())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		It("should allow access to fleet manager's public API endpoints", func() {
+			_, err := client.ListCentrals()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should allow access to fleet manager's internal API endpoints in dev / staging environment", func() {
+			_, err := client.GetManagedCentralList()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should not allow access to fleet manager's internal API endpoints in production environment", func() {
+			// OCM_ENV specifies which environment configuration to use when deploying fleet manager.
+			if env := getEnvDefault("OCM_ENV", "DEVELOPMENT"); env != "production" {
+				Skip("Fleet manager is deployed using non-production configuration settings")
+			}
+
+			_, err := client.GetManagedCentralList()
+			Expect(err).To(HaveOccurred())
+			// Currently the errors exposed by the generated open API clients do not satisfy the error interface, hence
+			// we can't check for error types via MatchError matcher but have to resort to string checking.
+			// Instead of http.StatusUnauthorized, we will retrieve http.StatusNotFound.
+			Expect(err.Error()).To(ContainSubstring(strconv.Itoa(http.StatusNotFound)))
+		})
+
+		It("should not allow access to fleet manager's the admin API", func() {
+			_, err := client.ListAdminAPI()
+
+			Expect(err).To(HaveOccurred())
+			// Currently the errors exposed by the generated open API clients do not satisfy the error interface, hence
+			// we can't check for error types via MatchError matcher but have to resort to string checking.
+			// Instead of http.StatusUnauthorized, we will retrieve http.StatusNotFound.
+			Expect(err.Error()).To(ContainSubstring(strconv.Itoa(http.StatusNotFound)))
+		})
+	})
+})
+
+// Helpers.
+
+// authTestClientFleetManager embeds the fleetmanager.Client and adds additional method for admin API (which shouldn't
+// be a part of the fleetmanager.Client as it is only used within tests).
+type authTestClientFleetManager struct {
+	*fleetmanager.Client
+	auth     fleetmanager.Auth
+	h        http.Client
+	endpoint string
+}
+
+func newAuthTestClient(c *fleetmanager.Client, auth fleetmanager.Auth, endpoint string) *authTestClientFleetManager {
+	return &authTestClientFleetManager{c, auth, http.Client{}, endpoint}
+}
+
+func (a *authTestClientFleetManager) ListAdminAPI() (*private.DinosaurList, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", a.endpoint, "admin/dinosaurs"), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := a.auth.AddAuth(req); err != nil {
+		return nil, err
+	}
+
+	resp, err := a.h.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	into := struct {
+		Kind string `json:"kind"`
+	}{}
+	err = json.Unmarshal(data, &into)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal error
+	if into.Kind == "Error" || into.Kind == "error" {
+		apiError := compat.Error{}
+		err = json.Unmarshal(data, &apiError)
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.Errorf("API error (HTTP status %d) occured %s: %s", resp.StatusCode, apiError.Code, apiError.Reason)
+	}
+
+	var dinosaurList *private.DinosaurList
+
+	err = json.Unmarshal(data, dinosaurList)
+	return dinosaurList, err
+}
+
+// obtainRHSSOToken will create a redhatsso.SSOClient and retrieve an access token for the specified client ID / secret
+// using the client_credentials grant.
+func obtainRHSSOToken(clientID, clientSecret string) (string, error) {
+	client := redhatsso.NewSSOClient(&iam.IAMConfig{}, &iam.IAMRealmConfig{
+		BaseURL:          "https://sso.redhat.com",
+		Realm:            "redhat-external",
+		ClientID:         clientID,
+		ClientSecret:     clientSecret,
+		TokenEndpointURI: "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token",
+		JwksEndpointURI:  "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs",
+		APIEndpointURI:   "/auth/realms/redhat-external",
+	})
+	return client.GetToken()
+}

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -1,20 +1,12 @@
 package config
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/stackrox/rox/pkg/errorhelpers"
-	"github.com/stackrox/rox/pkg/sync"
 
 	"github.com/caarlos0/env/v6"
 	"github.com/pkg/errors"
-)
-
-var (
-	once   sync.Once
-	cfg    *Config
-	cfgErr error
 )
 
 // Config contains this application's runtime configuration.
@@ -29,13 +21,13 @@ type Config struct {
 	CreateAuthProvider   bool          `env:"CREATE_AUTH_PROVIDER" envDefault:"false"`
 }
 
-func loadConfig() {
+// GetConfig retrieves the current runtime configuration from the environment and returns it.
+func GetConfig() (*Config, error) {
 	c := Config{}
 	var configErrors errorhelpers.ErrorList
 
 	if err := env.Parse(&c); err != nil {
-		cfgErr = errors.Wrapf(err, "Unable to parse runtime configuration from environment")
-		return
+		return nil, errors.Wrapf(err, "Unable to parse runtime configuration from environment")
 	}
 	if c.ClusterID == "" {
 		configErrors.AddError(errors.New("CLUSTER_ID unset in the environment"))
@@ -46,17 +38,9 @@ func loadConfig() {
 	if c.AuthType == "" {
 		configErrors.AddError(errors.New("AUTH_TYPE unset in the environment"))
 	}
-	cfgErr = configErrors.ToError()
-	if cfgErr == nil {
-		cfg = &c
-	}
-}
-
-// Singleton retrieves the current runtime configuration from the environment and returns it.
-func Singleton() (*Config, error) {
-	once.Do(loadConfig)
+	cfgErr := configErrors.ToError()
 	if cfgErr != nil {
-		return cfg, fmt.Errorf("loading configuration: %w", cfgErr)
+		return nil, cfgErr
 	}
-	return cfg, nil
+	return &c, nil
 }

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -40,7 +40,7 @@ func GetConfig() (*Config, error) {
 	}
 	cfgErr := configErrors.ToError()
 	if cfgErr != nil {
-		return nil, cfgErr
+		return nil, errors.Wrap(cfgErr, "unexpected configuration settings")
 	}
 	return &c, nil
 }

--- a/fleetshard/config/config_test.go
+++ b/fleetshard/config/config_test.go
@@ -13,11 +13,9 @@ func TestSingleton_Success(t *testing.T) {
 	t.Setenv("CLUSTER_ID", "some-value")
 	t.Cleanup(func() {
 		_ = os.Unsetenv("CLUSTER_ID")
-		cfg = nil
-		cfgErr = nil
 	})
-	loadConfig()
-	require.NoError(t, cfgErr)
+	cfg, err := GetConfig()
+	require.NoError(t, err)
 	assert.Equal(t, cfg.FleetManagerEndpoint, "http://127.0.0.1:8000")
 	assert.Equal(t, cfg.ClusterID, "some-value")
 	assert.Equal(t, cfg.RuntimePollPeriod, 5*time.Second)
@@ -28,10 +26,8 @@ func TestSingleton_Success(t *testing.T) {
 
 func TestSingleton_Failure(t *testing.T) {
 	t.Cleanup(func() {
-		cfg = nil
-		cfgErr = nil
 	})
-	loadConfig()
-	assert.Error(t, cfgErr)
+	cfg, err := GetConfig()
+	assert.Error(t, err)
 	assert.Nil(t, cfg)
 }

--- a/fleetshard/main.go
+++ b/fleetshard/main.go
@@ -23,7 +23,7 @@ func main() {
 		glog.Info("Unable to set logtostderr to true")
 	}
 
-	config, err := config.Singleton()
+	config, err := config.GetConfig()
 	if err != nil {
 		glog.Fatalf("Failed to load configuration: %v", err)
 	}

--- a/fleetshard/pkg/fleetmanager/auth_ocm.go
+++ b/fleetshard/pkg/fleetmanager/auth_ocm.go
@@ -35,7 +35,7 @@ func (f *ocmAuthFactory) GetName() string {
 
 // CreateAuth ...
 func (f *ocmAuthFactory) CreateAuth() (Auth, error) {
-	cfg, err := config.Singleton()
+	cfg, err := config.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("creating the config singleton: %w", err)
 	}

--- a/fleetshard/pkg/fleetmanager/auth_rhsso.go
+++ b/fleetshard/pkg/fleetmanager/auth_rhsso.go
@@ -32,7 +32,7 @@ func (f *rhSSOAuthFactory) GetName() string {
 
 // CreateAuth ...
 func (f *rhSSOAuthFactory) CreateAuth() (Auth, error) {
-	cfg, err := config.Singleton()
+	cfg, err := config.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("creating the config singleton: %w", err)
 	}

--- a/fleetshard/pkg/fleetmanager/auth_static_token.go
+++ b/fleetshard/pkg/fleetmanager/auth_static_token.go
@@ -31,7 +31,7 @@ func (f *staticTokenAuthFactory) GetName() string {
 
 // CreateAuth ...
 func (f *staticTokenAuthFactory) CreateAuth() (Auth, error) {
-	cfg, err := config.Singleton()
+	cfg, err := config.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("creating the config singleton: %w", err)
 	}

--- a/fleetshard/pkg/fleetmanager/client.go
+++ b/fleetshard/pkg/fleetmanager/client.go
@@ -134,22 +134,6 @@ func (c *Client) DeleteCentral(id string) error {
 	return nil
 }
 
-func (c *Client) ListCentrals() (*public.CentralRequestList, error) {
-	resp, err := c.newRequest(http.MethodGet, c.consoleAPIEndpoint, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	centralList := &public.CentralRequestList{}
-
-	err = c.unmarshalResponse(resp, centralList)
-	if err != nil {
-		return nil, err
-	}
-
-	return centralList, nil
-}
-
 func (c *Client) newRequest(method string, url string, body io.Reader) (*http.Response, error) {
 	glog.Infof("Send request to %s", url)
 	r, err := http.NewRequest(method, url, body)

--- a/fleetshard/pkg/fleetmanager/client.go
+++ b/fleetshard/pkg/fleetmanager/client.go
@@ -134,6 +134,22 @@ func (c *Client) DeleteCentral(id string) error {
 	return nil
 }
 
+func (c *Client) ListCentrals() (*public.CentralRequestList, error) {
+	resp, err := c.newRequest(http.MethodGet, c.consoleAPIEndpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	centralList := &public.CentralRequestList{}
+
+	err = c.unmarshalResponse(resp, centralList)
+	if err != nil {
+		return nil, err
+	}
+
+	return centralList, nil
+}
+
 func (c *Client) newRequest(method string, url string, body io.Reader) (*http.Response, error) {
 	glog.Infof("Send request to %s", url)
 	r, err := http.NewRequest(method, url, body)

--- a/pkg/client/redhatsso/client.go
+++ b/pkg/client/redhatsso/client.go
@@ -127,7 +127,7 @@ func (c *rhSSOClient) GetToken() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("getting token: %w", err)
 	}
-	defer resp.Body.Close()
+	defer shared.CloseResponseBody(resp)
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("error getting token [%d]", resp.StatusCode)
@@ -181,10 +181,8 @@ func (c *rhSSOClient) GetServiceAccount(accessToken string, clientID string) (*s
 		Execute()
 
 	defer shared.CloseResponseBody(resp)
-	if resp != nil {
-		if resp.StatusCode == http.StatusNotFound {
-			return nil, false, nil
-		}
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, false, nil
 	}
 
 	if err != nil {


### PR DESCRIPTION
## Description

This PR will introduce the following:
- small refactor of the config within fleetshard, switchin from Singleton to non-singleton.
- added a E2E test suite for authN/Z tests.


The change of the config singleton was required within the test setup, as changes to i.e. the environment variable configuration was not propagated within the client.
This should generally be cheap and not too big of a disadvantage, as we only rely on the configuration when initially creating the Auth interface during startup of the fleetshard-synchronizer, but will
make our lifes definitely easier when using the client within tests.

The tests themselves cover the following:
- Use all three different auth types (RH SSO, static token, personalized OCM token).
- Check for the three API groups of fleet-manager whether requests are authorized or not.

The E2E tests will be added to the CI within a follow-up PR, as more work is required to firstly create / run an instance of fleet-manager within CI.

## Test manual

```
# Run the E2E tests locally:
$ go clean -testcache && CLUSTER_ID=1234567890abcdef1234567890abcdef \
  RUN_E2E=true \
  RUN_AUTH_E2E=true \
  CLUSTER_ID=1234567890abcdef1234567890abcdef \
  STATIC_TOKEN=<bitwarden value> \
  OCM_TOKEN=$(ocm token --refresh) \
  RHSSO_CLIENT_ID=<bitwarden value> RHSSO_CLIENT_SECRET=<bitwarden value> \
  go test ./e2e/...
```
