### PR TITLE
ROX-11414: Send routes statuses

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -303,13 +303,13 @@
         "is_secret": false
       }
     ],
-    "fleetshard/pkg/central/reconciler/reconciler.go": [
+    "fleetshard/pkg/k8s/route.go": [
       {
         "type": "Secret Keyword",
-        "filename": "fleetshard/pkg/central/reconciler/reconciler.go",
+        "filename": "fleetshard/pkg/k8s/route.go",
         "hashed_secret": "511c3c365008972c1bc955150cc039ebe2b67cbd",
         "is_verified": false,
-        "line_number": 38,
+        "line_number": 20,
         "is_secret": false
       }
     ],
@@ -319,7 +319,7 @@
         "filename": "fleetshard/pkg/testutils/k8s.go",
         "hashed_secret": "bae12e76fa88f17b1600e44598fd9b672a1689fc",
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 28,
         "is_secret": false
       }
     ],
@@ -852,5 +852,5 @@
       }
     ]
   },
-  "generated_at": "2022-07-20T16:35:29Z"
+  "generated_at": "2022-07-21T08:19:47Z"
 }

--- a/dev/env/defaults/00-defaults.env
+++ b/dev/env/defaults/00-defaults.env
@@ -7,6 +7,7 @@ export DOCKER_DEFAULT="docker"
 export CLUSTER_TYPE_DEFAULT=""
 export INHERIT_IMAGEPULLSECRETS_DEFAULT="false" # pragma: allowlist secret
 export CLUSTER_ID_DEFAULT="1234567890abcdef1234567890abcdef"
+export CLUSTER_DNS_DEFAULT="cluster.local"
 
 export IMAGE_REGISTRY_DEFAULT="quay.io/rhacs-eng"
 STACKROX_VERSION_TAG="3.70.0-nightly-20220707"

--- a/dev/env/defaults/cluster-type-infra-openshift/env
+++ b/dev/env/defaults/cluster-type-infra-openshift/env
@@ -7,3 +7,4 @@ export FLEET_MANAGER_RESOURCES_DEFAULT='{"requests":{"cpu":"400m","memory":"1000
 export FLEETSHARD_SYNC_RESOURCES_DEFAULT='{"requests":{"cpu":"400m","memory":"1000Mi"},"limits":{"cpu":"400m","memory":"1000Mi"}}'
 export DB_RESOURCES_DEFAULT='{"requests":{"cpu":"400m","memory":"1000Mi"},"limits":{"cpu":"400m","memory":"1000Mi"}}'
 export RHACS_OPERATOR_RESOURCES_DEFAULTS='{"requests":{"cpu":"400m","memory":"1000Mi"},"limits":{"cpu":"400m","memory":"1000Mi"}}'
+export CLUSTER_DNS_DEFAULT=$(oc get -n "openshift-ingress-operator" ingresscontrollers default -o=jsonpath='{.status.domain}' --ignore-not-found)

--- a/dev/env/defaults/cluster-type-openshift/env
+++ b/dev/env/defaults/cluster-type-openshift/env
@@ -3,3 +3,4 @@ export KUBECTL_DEFAULT="oc"
 export OPERATOR_SOURCE_DEFAULT="marketplace"
 export INSTALL_OLM_DEFAULT="false"
 export ENABLE_FM_PORT_FORWARDING_DEFAULT="true"
+export CLUSTER_DNS_DEFAULT=$(oc get -n "openshift-ingress-operator" ingresscontrollers default -o=jsonpath='{.status.domain}' --ignore-not-found)

--- a/dev/env/manifests/shared/03-configmap-config.yaml
+++ b/dev/env/manifests/shared/03-configmap-config.yaml
@@ -11,7 +11,7 @@ data:
         status: ready
         provider_type: standalone
         supported_instance_type: "eval,standard"
-        cluster_dns: cluster.local
+        cluster_dns: "$CLUSTER_DNS"
         central_instance_limit: 5
         available_central_operator_versions:
           - version: "0.1.0"

--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -86,9 +86,10 @@ init() {
         source "$env_file"
     done
 
+    export KUBECTL=${KUBECTL:-$KUBECTL_DEFAULT}
     export ACSMS_NAMESPACE="${ACSMS_NAMESPACE:-$ACSMS_NAMESPACE_DEFAULT}"
     export CLUSTER_ID=${CLUSTER_ID:-$CLUSTER_ID_DEFAULT}
-    export KUBECTL=${KUBECTL:-$KUBECTL_DEFAULT}
+    export CLUSTER_DNS=${CLUSTER_DNS:-$CLUSTER_DNS_DEFAULT}
     export DOCKER=${DOCKER:-$DOCKER_DEFAULT}
     export IMAGE_REGISTRY="${IMAGE_REGISTRY:-$IMAGE_REGISTRY_DEFAULT}"
     IMAGE_REGISTRY_HOST=$(if [[ "$IMAGE_REGISTRY" =~ ^[^/]*\.[^/]*/ ]]; then echo "$IMAGE_REGISTRY" | cut -d / -f 1; fi)

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -166,11 +166,11 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 func (r *CentralReconciler) readyStatus(ctx context.Context, namespace string) (*private.DataPlaneCentralStatus, error) {
 	status := readyStatus()
 	if r.useRoutes {
-		statuses, err := r.getRoutesStatuses(ctx, namespace)
+		routesStatuses, err := r.getRoutesStatuses(ctx, namespace)
 		if err != nil {
 			return nil, err
 		}
-		status.Routes = statuses
+		status.Routes = routesStatuses
 	}
 	return status, nil
 }

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -180,7 +180,7 @@ func (r *CentralReconciler) getRoutesStatuses(ctx context.Context, namespace str
 	if err != nil {
 		return nil, err
 	}
-	mtlsHostname, err := r.routeService.FindMtlsCanonicalHostname(ctx, namespace)
+	mtlsHostname, err := r.routeService.FindMTLSCanonicalHostname(ctx, namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -8,11 +8,9 @@ import (
 	"strconv"
 	"sync/atomic"
 
-	openshiftRouteV1 "github.com/openshift/api/route/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/util"
 	centralConstants "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
@@ -30,16 +28,8 @@ const (
 	FreeStatus int32 = iota
 	BlockedStatus
 
-	revisionAnnotationKey  = "rhacs.redhat.com/revision"
-	k8sManagedByLabelKey   = "app.kubernetes.io/managed-by"
-	k8sManagedByLabelValue = "rhacs-fleetshard"
-
-	centralReencryptRouteName = "central-reencrypt"
-	centralTLSSecretName      = "central-tls"
+	revisionAnnotationKey = "rhacs.redhat.com/revision"
 )
-
-// ErrTypeCentralNotChanged is an error returned when reconcilation runs more then once in a row with equal central
-var ErrTypeCentralNotChanged = errors.New("central not changed, skipping reconcilation")
 
 // CentralReconciler is a reconciler tied to a one Central instance. It installs, updates and deletes Central instances
 // in its Reconcile function.
@@ -50,6 +40,7 @@ type CentralReconciler struct {
 	lastCentralHash    [16]byte
 	useRoutes          bool
 	createAuthProvider bool
+	routeService       *k8s.RouteService
 }
 
 // Reconcile takes a private.ManagedCentral and tries to install it into the cluster managed by the fleet-shard.
@@ -68,18 +59,19 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		return nil, errors.Wrapf(err, "checking if central changed")
 	}
 
-	if !changed && !r.createAuthProvider && remoteCentral.RequestStatus == centralConstants.DinosaurRequestStatusReady.String() {
-		return nil, ErrTypeCentralNotChanged
-	}
-
 	remoteCentralName := remoteCentral.Metadata.Name
 	remoteNamespace := remoteCentral.Metadata.Namespace
+
+	if !changed && !r.createAuthProvider && remoteCentral.RequestStatus == centralConstants.DinosaurRequestStatusReady.String() {
+		glog.Infof("Central %s/%s not changed, skipping reconciliation", remoteNamespace, remoteCentralName)
+		return r.readyStatus(ctx, remoteNamespace)
+	}
 
 	central := &v1alpha1.Central{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      remoteCentralName,
 			Namespace: remoteNamespace,
-			Labels:    map[string]string{k8sManagedByLabelKey: k8sManagedByLabelValue},
+			Labels:    map[string]string{k8s.ManagedByLabelKey: k8s.ManagedByLabelValue},
 		},
 		Spec: v1alpha1.CentralSpec{
 			Central: &v1alpha1.CentralComponentSpec{
@@ -168,7 +160,42 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	}
 
 	// TODO(create-ticket): When should we create failed conditions for the reconciler?
-	return readyStatus(), nil
+	return r.readyStatus(ctx, remoteNamespace)
+}
+
+func (r *CentralReconciler) readyStatus(ctx context.Context, namespace string) (*private.DataPlaneCentralStatus, error) {
+	status := readyStatus()
+	if r.useRoutes {
+		statuses, err := r.getRoutesStatuses(ctx, namespace)
+		if err != nil {
+			return nil, err
+		}
+		status.Routes = statuses
+	}
+	return status, nil
+}
+
+func (r *CentralReconciler) getRoutesStatuses(ctx context.Context, namespace string) ([]private.DataPlaneCentralStatusRoutes, error) {
+	reencryptHostname, err := r.routeService.FindReencryptCanonicalHostname(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+	mtlsHostname, err := r.routeService.FindMtlsCanonicalHostname(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+	return []private.DataPlaneCentralStatusRoutes{
+		{
+			Name:   "central-reencrypt",
+			Prefix: "",
+			Router: reencryptHostname,
+		},
+		{
+			Name:   "central-mtls",
+			Prefix: "data",
+			Router: mtlsHostname,
+		},
+	}, nil
 }
 
 func isCentralReady(ctx context.Context, client ctrlClient.Client, central private.ManagedCentral) (bool, error) {
@@ -301,46 +328,11 @@ func (r CentralReconciler) ensureReencryptRouteExists(ctx context.Context, remot
 		return nil
 	}
 	namespace := remoteCentral.Metadata.Namespace
-	route := &openshiftRouteV1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      centralReencryptRouteName,
-			Namespace: namespace,
-			Labels:    map[string]string{k8sManagedByLabelKey: k8sManagedByLabelValue},
-		},
-	}
-	err := r.findRoute(ctx, route)
+	_, err := r.routeService.FindReencryptRoute(ctx, namespace)
 	if apiErrors.IsNotFound(err) {
-		centralTLSSecret := &corev1.Secret{}
-		err = r.client.Get(ctx, ctrlClient.ObjectKey{Namespace: namespace, Name: centralTLSSecretName}, centralTLSSecret)
-		if err != nil {
-			return errors.Wrapf(err, "get central TLS secret %s/%s", namespace, remoteCentral.Metadata.Name)
-		}
-		centralCA, ok := centralTLSSecret.Data["ca.pem"]
-		if !ok {
-			return errors.Errorf("could not find centrals ca certificate 'ca.pem' in secret/%s", centralTLSSecretName)
-		}
-		route.Spec = openshiftRouteV1.RouteSpec{
-			Port: &openshiftRouteV1.RoutePort{
-				TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: "https"},
-			},
-			To: openshiftRouteV1.RouteTargetReference{
-				Kind: "Service",
-				Name: "central",
-			},
-			TLS: &openshiftRouteV1.TLSConfig{
-				Termination:              openshiftRouteV1.TLSTerminationReencrypt,
-				Key:                      remoteCentral.Spec.Endpoint.Tls.Key,
-				Certificate:              remoteCentral.Spec.Endpoint.Tls.Cert,
-				DestinationCACertificate: string(centralCA),
-			},
-		}
-		err = r.client.Create(ctx, route)
+		err = r.routeService.CreateReencryptRoute(ctx, remoteCentral)
 	}
 	return err
-}
-
-func (r CentralReconciler) findRoute(ctx context.Context, route *openshiftRouteV1.Route) error {
-	return r.client.Get(ctx, ctrlClient.ObjectKey{Namespace: route.GetNamespace(), Name: route.GetName()}, route)
 }
 
 // TODO(ROX-9310): Move re-encrypt route reconciliation to the StackRox operator
@@ -348,14 +340,8 @@ func (r CentralReconciler) ensureReencryptRouteDeleted(ctx context.Context, name
 	if !r.useRoutes {
 		return true, nil
 	}
-	route := &openshiftRouteV1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      centralReencryptRouteName,
-			Namespace: namespace,
-			Labels:    map[string]string{k8sManagedByLabelKey: k8sManagedByLabelValue},
-		},
-	}
-	if err := r.findRoute(ctx, route); err != nil {
+	route, err := r.routeService.FindReencryptRoute(ctx, namespace)
+	if err != nil {
 		if apiErrors.IsNotFound(err) {
 			return true, nil
 		}
@@ -375,5 +361,6 @@ func NewCentralReconciler(k8sClient ctrlClient.Client, central private.ManagedCe
 		status:             pointer.Int32(FreeStatus),
 		useRoutes:          useRoutes,
 		createAuthProvider: createAuthProvider,
+		routeService:       k8s.NewRouteService(k8sClient),
 	}
 }

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -71,7 +71,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      remoteCentralName,
 			Namespace: remoteNamespace,
-			Labels:    map[string]string{k8s.ManagedByLabelKey: k8s.ManagedByLabelValue},
+			Labels:    map[string]string{k8s.ManagedByLabelKey: k8s.ManagedByFleetshardValue},
 		},
 		Spec: v1alpha1.CentralSpec{
 			Central: &v1alpha1.CentralComponentSpec{

--- a/fleetshard/pkg/k8s/client.go
+++ b/fleetshard/pkg/k8s/client.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"github.com/golang/glog"
+	openshiftOperatorV1 "github.com/openshift/api/operator/v1"
 	openshiftRouteV1 "github.com/openshift/api/route/v1"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
@@ -26,6 +27,7 @@ func CreateClientOrDie() ctrlClient.Client {
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = v1alpha1.AddToScheme(scheme)
 	_ = openshiftRouteV1.Install(scheme)
+	_ = openshiftOperatorV1.Install(scheme)
 
 	config, err := ctrl.GetConfig()
 	if err != nil {

--- a/fleetshard/pkg/k8s/constants.go
+++ b/fleetshard/pkg/k8s/constants.go
@@ -1,6 +1,8 @@
 package k8s
 
 const (
-	ManagedByLabelKey   = "app.kubernetes.io/managed-by"
-	ManagedByLabelValue = "rhacs-fleetshard"
+	// ManagedByLabelKey indicates the tool being used to manage the operation of an application.
+	ManagedByLabelKey = "app.kubernetes.io/managed-by"
+	// ManagedByFleetshardValue used for indication that the resource is managed by the fleetshard sync
+	ManagedByFleetshardValue = "rhacs-fleetshard"
 )

--- a/fleetshard/pkg/k8s/constants.go
+++ b/fleetshard/pkg/k8s/constants.go
@@ -1,0 +1,6 @@
+package k8s
+
+const (
+	ManagedByLabelKey   = "app.kubernetes.io/managed-by"
+	ManagedByLabelValue = "rhacs-fleetshard"
+)

--- a/fleetshard/pkg/k8s/route.go
+++ b/fleetshard/pkg/k8s/route.go
@@ -20,6 +20,8 @@ const (
 	centralTLSSecretName      = "central-tls"
 )
 
+// RouteService is responsible for performing read and write operations on the OpenShift Route objects in the cluster.
+// This service is specific to ACS Managed Services and provides methods to work on specific routes.
 type RouteService struct {
 	client ctrlClient.Client
 }

--- a/fleetshard/pkg/k8s/route.go
+++ b/fleetshard/pkg/k8s/route.go
@@ -1,0 +1,115 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	openshiftRouteV1 "github.com/openshift/api/route/v1"
+	"github.com/pkg/errors"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	centralReencryptRouteName = "central-reencrypt"
+	centralMtlsRouteName      = "central-mtls"
+	centralTLSSecretName      = "central-tls"
+)
+
+type RouteService struct {
+	client ctrlClient.Client
+}
+
+func NewRouteService(client ctrlClient.Client) *RouteService {
+	return &RouteService{client: client}
+}
+
+func (s *RouteService) FindReencryptRoute(ctx context.Context, namespace string) (*openshiftRouteV1.Route, error) {
+	return s.findRoute(ctx, namespace, centralReencryptRouteName)
+}
+
+func (s *RouteService) FindReencryptCanonicalHostname(ctx context.Context, namespace string) (string, error) {
+	return s.findCanonicalHostname(ctx, namespace, centralReencryptRouteName)
+}
+
+func (s *RouteService) FindMtlsCanonicalHostname(ctx context.Context, namespace string) (string, error) {
+	return s.findCanonicalHostname(ctx, namespace, centralMtlsRouteName)
+}
+
+func (s *RouteService) findCanonicalHostname(ctx context.Context, namespace string, routeName string) (string, error) {
+	route, err := s.findRoute(ctx, namespace, routeName)
+	if err != nil {
+		return "", err
+	}
+	for _, ingress := range route.Status.Ingress {
+		if isAdmitted(ingress) {
+			return ingress.RouterCanonicalHostname, nil
+		}
+	}
+	return "", fmt.Errorf("route canonical hostname is not found. route: %s/%s", namespace, routeName)
+}
+
+func isAdmitted(ingress openshiftRouteV1.RouteIngress) bool {
+	for _, condition := range ingress.Conditions {
+		if condition.Type == openshiftRouteV1.RouteAdmitted {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func newReencryptRoute(namespace string) *openshiftRouteV1.Route {
+	return &openshiftRouteV1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      centralReencryptRouteName,
+			Namespace: namespace,
+			Labels:    map[string]string{ManagedByLabelKey: ManagedByLabelValue},
+		},
+	}
+}
+
+func (s *RouteService) CreateReencryptRoute(ctx context.Context, remoteCentral private.ManagedCentral) error {
+	centralTLSSecret := &v1.Secret{}
+	namespace := remoteCentral.Metadata.Namespace
+	err := s.client.Get(ctx, ctrlClient.ObjectKey{Namespace: namespace, Name: centralTLSSecretName}, centralTLSSecret)
+	if err != nil {
+		return errors.Wrapf(err, "get central TLS secret %s/%s", namespace, remoteCentral.Metadata.Name)
+	}
+	centralCA, ok := centralTLSSecret.Data["ca.pem"]
+	if !ok {
+		return errors.Errorf("could not find centrals ca certificate 'ca.pem' in secret/%s", centralTLSSecretName)
+	}
+	route := newReencryptRoute(namespace)
+	route.Spec = openshiftRouteV1.RouteSpec{
+		Host: remoteCentral.Spec.Endpoint.Host,
+		Port: &openshiftRouteV1.RoutePort{
+			TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: "https"},
+		},
+		To: openshiftRouteV1.RouteTargetReference{
+			Kind: "Service",
+			Name: "central",
+		},
+		TLS: &openshiftRouteV1.TLSConfig{
+			Termination:              openshiftRouteV1.TLSTerminationReencrypt,
+			Key:                      remoteCentral.Spec.Endpoint.Tls.Key,
+			Certificate:              remoteCentral.Spec.Endpoint.Tls.Cert,
+			DestinationCACertificate: string(centralCA),
+		},
+	}
+	return s.client.Create(ctx, route)
+}
+
+func (s *RouteService) findRoute(ctx context.Context, namespace string, routeName string) (*openshiftRouteV1.Route, error) {
+	route := &openshiftRouteV1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routeName,
+			Namespace: namespace,
+		},
+	}
+	err := s.client.Get(ctx, ctrlClient.ObjectKey{Namespace: route.GetNamespace(), Name: route.GetName()}, route)
+	return route, err
+}

--- a/fleetshard/pkg/k8s/route.go
+++ b/fleetshard/pkg/k8s/route.go
@@ -26,18 +26,22 @@ type RouteService struct {
 	client ctrlClient.Client
 }
 
+// NewRouteService creates a new instance of RouteService.
 func NewRouteService(client ctrlClient.Client) *RouteService {
 	return &RouteService{client: client}
 }
 
+// FindReencryptRoute returns central reencrypt route or error if not found.
 func (s *RouteService) FindReencryptRoute(ctx context.Context, namespace string) (*openshiftRouteV1.Route, error) {
 	return s.findRoute(ctx, namespace, centralReencryptRouteName)
 }
 
+// FindReencryptCanonicalHostname returns a canonical hostname of central reencrypt route or error if not found.
 func (s *RouteService) FindReencryptCanonicalHostname(ctx context.Context, namespace string) (string, error) {
 	return s.findCanonicalHostname(ctx, namespace, centralReencryptRouteName)
 }
 
+// FindMTLSCanonicalHostname returns a canonical hostname of central MTLS route or error if not found.
 func (s *RouteService) FindMTLSCanonicalHostname(ctx context.Context, namespace string) (string, error) {
 	return s.findCanonicalHostname(ctx, namespace, centralMTLSRouteName)
 }
@@ -74,6 +78,7 @@ func newReencryptRoute(namespace string) *openshiftRouteV1.Route {
 	}
 }
 
+// CreateReencryptRoute creates a new managed central reencrypt route.
 func (s *RouteService) CreateReencryptRoute(ctx context.Context, remoteCentral private.ManagedCentral) error {
 	centralTLSSecret := &v1.Secret{}
 	namespace := remoteCentral.Metadata.Namespace

--- a/fleetshard/pkg/k8s/route.go
+++ b/fleetshard/pkg/k8s/route.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	centralReencryptRouteName = "central-reencrypt"
-	centralMtlsRouteName      = "central-mtls"
+	centralMTLSRouteName      = "central-mtls"
 	centralTLSSecretName      = "central-tls"
 )
 
@@ -38,8 +38,8 @@ func (s *RouteService) FindReencryptCanonicalHostname(ctx context.Context, names
 	return s.findCanonicalHostname(ctx, namespace, centralReencryptRouteName)
 }
 
-func (s *RouteService) FindMtlsCanonicalHostname(ctx context.Context, namespace string) (string, error) {
-	return s.findCanonicalHostname(ctx, namespace, centralMtlsRouteName)
+func (s *RouteService) FindMTLSCanonicalHostname(ctx context.Context, namespace string) (string, error) {
+	return s.findCanonicalHostname(ctx, namespace, centralMTLSRouteName)
 }
 
 func (s *RouteService) findCanonicalHostname(ctx context.Context, namespace string, routeName string) (string, error) {

--- a/fleetshard/pkg/k8s/route.go
+++ b/fleetshard/pkg/k8s/route.go
@@ -84,7 +84,7 @@ func (s *RouteService) CreateReencryptRoute(ctx context.Context, remoteCentral p
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      centralReencryptRouteName,
 			Namespace: namespace,
-			Labels:    map[string]string{ManagedByLabelKey: ManagedByLabelValue},
+			Labels:    map[string]string{ManagedByLabelKey: ManagedByFleetshardValue},
 		},
 		Spec: openshiftRouteV1.RouteSpec{
 			Host: remoteCentral.Spec.Endpoint.Host,

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -34,7 +34,7 @@ var backoff = wait.Backoff{
 type Runtime struct {
 	config           *config.Config
 	client           *fleetmanager.Client
-	reconcilers      reconcilerRegistry // TODO(yury): remove central instance after deletion
+	reconcilers      reconcilerRegistry // TODO(create-ticket): possible leak. consider reconcilerRegistry cleanup
 	k8sClient        ctrlClient.Client
 	statusResponseCh chan private.DataPlaneCentralStatus
 }
@@ -101,11 +101,6 @@ func (r *Runtime) Start() error {
 
 func (r *Runtime) handleReconcileResult(central private.ManagedCentral, status *private.DataPlaneCentralStatus, err error) {
 	if err != nil {
-		if errors.Is(err, centralReconciler.ErrTypeCentralNotChanged) {
-			glog.Infof("%s:%s", central.Metadata.Name, err)
-			return
-		}
-
 		glog.Errorf("error occurred %s: %s", central.Metadata.Name, err.Error())
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/lib/pq v1.10.6
 	github.com/mendsley/gojwk v0.0.0-20141217222730-4d5ec6e58103
 	github.com/olekukonko/tablewriter v0.0.5
@@ -86,6 +87,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1522,6 +1522,7 @@ github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyN
 github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -1540,6 +1541,7 @@ github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iP
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.4.3/go.mod h1:5fGEH17QVwTTcR0zV7yhDPLLmFX9YSZ38b18Udy6vYQ=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=

--- a/internal/dinosaur/pkg/api/private/model_data_plane_central_status.go
+++ b/internal/dinosaur/pkg/api/private/model_data_plane_central_status.go
@@ -15,5 +15,5 @@ type DataPlaneCentralStatus struct {
 	Conditions []DataPlaneClusterUpdateStatusRequestConditions `json:"conditions,omitempty"`
 	Versions   DataPlaneCentralStatusVersions                  `json:"versions,omitempty"`
 	// Routes created for a Central
-	Routes *[]DataPlaneCentralStatusRoutes `json:"routes,omitempty"`
+	Routes []DataPlaneCentralStatusRoutes `json:"routes,omitempty"`
 }

--- a/internal/dinosaur/pkg/presenters/data_plane_dinosaur_status.go
+++ b/internal/dinosaur/pkg/presenters/data_plane_dinosaur_status.go
@@ -21,8 +21,8 @@ func ConvertDataPlaneDinosaurStatus(status map[string]private.DataPlaneCentralSt
 			})
 		}
 		if v.Routes != nil {
-			routes = make([]dbapi.DataPlaneCentralRouteRequest, 0, len(*v.Routes))
-			for _, ro := range *v.Routes {
+			routes = make([]dbapi.DataPlaneCentralRouteRequest, 0, len(v.Routes))
+			for _, ro := range v.Routes {
 				routes = append(routes, dbapi.DataPlaneCentralRouteRequest{
 					Name:   ro.Name,
 					Prefix: ro.Prefix,


### PR DESCRIPTION
## Description
This PR adds route statuses reporting from the fleetshard sync to the Fleet Manager.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Documentation added if necessary
- [x] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
