### PR TITLE
ROX-11514: Make FM base url configurable for e2e

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -20,9 +20,16 @@ $ go clean -testcache && CLUSTER_ID=1234567890abcdef1234567890abcdef RUN_E2E=tru
 $ ./e2e/cleanup.sh
 ```
 
-The following env vars can also be adjusted for using a different types of dataplane clusters. If not set the test will assume a local minikube cluster:
+The following env vars can also be adjusted for using a different types of data plane clusters. If not set the test will assume a local minikube cluster:
 
 - `DP_CLOUD_PROVIDER`: cloud provider for the data plane cluster.
 - `DP_REGION`: region for the data plane cluster.
+- `CLUSTER_ID`: name of the cluster with fleetshard-sync in the data plane.
+
+In addition, you can specify how test should connect to the fleet-manager instance with the following environment variables:
+
+- `FLEET_MANAGER_ENDPOINT`: base fleet-manager url for API calls.
+- `OCM_TOKEN`: OCM token for fleet-manager auth api calls.
+
 
 The env var `WAIT_TIMEOUT` can be used to adjust the timeout of each individual tests, using a string compatible with Golang's `time.ParseDuration`, e.g. `WAIT_TIMEOUT=20s`. If not set all tests use 5 minutes as timeout.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -36,9 +36,14 @@ var _ = Describe("Central", func() {
 		if val := os.Getenv("AUTH_TYPE"); val != "" {
 			authType = val
 		}
+		fleetManagerEndpoint := "http://localhost:8000"
+		if fmEndpointEnv := os.Getenv("FLEET_MANAGER_ENDPOINT"); fmEndpointEnv != "" {
+			fleetManagerEndpoint = fmEndpointEnv
+		}
+
 		auth, err := fleetmanager.NewAuth(authType)
 		Expect(err).ToNot(HaveOccurred())
-		client, err = fleetmanager.NewClient("http://localhost:8000", "cluster-id", auth)
+		client, err = fleetmanager.NewClient(fleetManagerEndpoint, "cluster-id", auth)
 		Expect(err).ToNot(HaveOccurred())
 	})
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Add fleet-manager base URL env to e2e tests. 

## Test manual

manual run of e2e with specifying fleet-manager endpoint via env
