### PR TITLE
ROX-10835: enable gosec linter, add fixes to suppress warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,7 +98,7 @@ linters:
     # - revive # replaces golint TODO(ROX-10828): enable revive checks
     # - gomnd
     # - goprintffuncname
-    # - gosec TODO(ROX-10835): enable gosec checks
+    - gosec
     - gosimple
     - govet
     - ineffassign

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -493,7 +493,7 @@
         "filename": "internal/dinosaur/pkg/workers/clusters_mgr.go",
         "hashed_secret": "a4f2b95d16786cd9c4f86404cb519f18b7e33113",
         "is_verified": false,
-        "line_number": 790,
+        "line_number": 793,
         "is_secret": false
       },
       {
@@ -501,7 +501,7 @@
         "filename": "internal/dinosaur/pkg/workers/clusters_mgr.go",
         "hashed_secret": "a6b7aa0f297935e4e49d200f7505873d8cd470ce",
         "is_verified": false,
-        "line_number": 792,
+        "line_number": 795,
         "is_secret": false
       }
     ],
@@ -852,5 +852,5 @@
       }
     ]
   },
-  "generated_at": "2022-07-18T10:14:37Z"
+  "generated_at": "2022-07-19T08:42:05Z"
 }

--- a/internal/dinosaur/pkg/cmd/cloudprovider/providerlist.go
+++ b/internal/dinosaur/pkg/cmd/cloudprovider/providerlist.go
@@ -43,8 +43,9 @@ func runProviderList(
 
 	supportedProviders := providerConfig.ProvidersConfig.SupportedProviders
 	for i := range cloudProviders {
-		_, cloudProviders[i].Enabled = supportedProviders.GetByName(cloudProviders[i].Id)
-		converted := presenters.PresentCloudProvider(&cloudProviders[i])
+		cloudProvider := cloudProviders[i]
+		_, cloudProvider.Enabled = supportedProviders.GetByName(cloudProvider.Id)
+		converted := presenters.PresentCloudProvider(&cloudProvider)
 		cloudProviderList.Items = append(cloudProviderList.Items, converted)
 	}
 

--- a/internal/dinosaur/pkg/cmd/cloudprovider/providerlist.go
+++ b/internal/dinosaur/pkg/cmd/cloudprovider/providerlist.go
@@ -42,9 +42,9 @@ func runProviderList(
 	}
 
 	supportedProviders := providerConfig.ProvidersConfig.SupportedProviders
-	for _, cloudProvider := range cloudProviders {
-		_, cloudProvider.Enabled = supportedProviders.GetByName(cloudProvider.Id)
-		converted := presenters.PresentCloudProvider(&cloudProvider)
+	for i := range cloudProviders {
+		_, cloudProviders[i].Enabled = supportedProviders.GetByName(cloudProviders[i].Id)
+		converted := presenters.PresentCloudProvider(&cloudProviders[i])
 		cloudProviderList.Items = append(cloudProviderList.Items, converted)
 	}
 

--- a/internal/dinosaur/pkg/cmd/cloudprovider/regionlist.go
+++ b/internal/dinosaur/pkg/cmd/cloudprovider/regionlist.go
@@ -51,18 +51,18 @@ func runRegionsList(env *environments.Env, cmd *cobra.Command, _ []string) {
 
 	supportedProviders := providerConfig.ProvidersConfig.SupportedProviders
 	provider, _ := supportedProviders.GetByName(id)
-	for _, cloudRegion := range cloudRegions {
-		region, _ := provider.Regions.GetByName(cloudRegion.Id)
+	for i := range cloudRegions {
+		region, _ := provider.Regions.GetByName(cloudRegions[i].Id)
 
 		// if instance_type was specified, only set enabled to true for regions that supports the specified instance type. Otherwise,
 		// set enable to true for all region that supports any instance types
 		if instanceTypeFilter != "" {
-			cloudRegion.Enabled = region.IsInstanceTypeSupported(config.InstanceType(instanceTypeFilter))
+			cloudRegions[i].Enabled = region.IsInstanceTypeSupported(config.InstanceType(instanceTypeFilter))
 		} else {
-			cloudRegion.Enabled = len(region.SupportedInstanceTypes) > 0
+			cloudRegions[i].Enabled = len(region.SupportedInstanceTypes) > 0
 		}
 
-		converted := presenters.PresentCloudRegion(&cloudRegion)
+		converted := presenters.PresentCloudRegion(&cloudRegions[i])
 		regionList.Items = append(regionList.Items, converted)
 	}
 

--- a/internal/dinosaur/pkg/cmd/cloudprovider/regionlist.go
+++ b/internal/dinosaur/pkg/cmd/cloudprovider/regionlist.go
@@ -52,17 +52,18 @@ func runRegionsList(env *environments.Env, cmd *cobra.Command, _ []string) {
 	supportedProviders := providerConfig.ProvidersConfig.SupportedProviders
 	provider, _ := supportedProviders.GetByName(id)
 	for i := range cloudRegions {
-		region, _ := provider.Regions.GetByName(cloudRegions[i].Id)
+		cloudRegion := cloudRegions[i]
+		region, _ := provider.Regions.GetByName(cloudRegion.Id)
 
 		// if instance_type was specified, only set enabled to true for regions that supports the specified instance type. Otherwise,
 		// set enable to true for all region that supports any instance types
 		if instanceTypeFilter != "" {
-			cloudRegions[i].Enabled = region.IsInstanceTypeSupported(config.InstanceType(instanceTypeFilter))
+			cloudRegion.Enabled = region.IsInstanceTypeSupported(config.InstanceType(instanceTypeFilter))
 		} else {
-			cloudRegions[i].Enabled = len(region.SupportedInstanceTypes) > 0
+			cloudRegion.Enabled = len(region.SupportedInstanceTypes) > 0
 		}
 
-		converted := presenters.PresentCloudRegion(&cloudRegions[i])
+		converted := presenters.PresentCloudRegion(&cloudRegion)
 		regionList.Items = append(regionList.Items, converted)
 	}
 

--- a/internal/dinosaur/pkg/cmd/errors/list.go
+++ b/internal/dinosaur/pkg/cmd/errors/list.go
@@ -46,8 +46,8 @@ func runList(cmd *cobra.Command, _ []string) {
 	})
 
 	// add code prefix to service error code
-	for _, err := range errors {
-		svcErrors = append(svcErrors, handlers.PresentError(&err, ""))
+	for i := range errors {
+		svcErrors = append(svcErrors, handlers.PresentError(&errors[i], ""))
 	}
 
 	svcErrorsJson, err := json.MarshalIndent(svcErrors, "", "\t")

--- a/internal/dinosaur/pkg/converters/cluster.go
+++ b/internal/dinosaur/pkg/converters/cluster.go
@@ -40,8 +40,8 @@ func ConvertCluster(cluster *api.Cluster) []map[string]interface{} {
 func ConvertClusterList(clusterList []api.Cluster) []map[string]interface{} {
 	var convertedClusterList []map[string]interface{}
 
-	for _, cluster := range clusterList {
-		data := ConvertCluster(&cluster)
+	for i := range clusterList {
+		data := ConvertCluster(&clusterList[i])
 		convertedClusterList = append(convertedClusterList, data...)
 	}
 

--- a/internal/dinosaur/pkg/handlers/cloud_providers.go
+++ b/internal/dinosaur/pkg/handlers/cloud_providers.go
@@ -107,8 +107,9 @@ func (h cloudProvidersHandler) ListCloudProviders(w http.ResponseWriter, r *http
 			}
 
 			for i := range cloudProviders {
-				_, cloudProviders[i].Enabled = h.supportedProviders.GetByName(cloudProviders[i].Id)
-				converted := presenters.PresentCloudProvider(&cloudProviders[i])
+				cloudProvider := cloudProviders[i]
+				_, cloudProvider.Enabled = h.supportedProviders.GetByName(cloudProvider.Id)
+				converted := presenters.PresentCloudProvider(&cloudProvider)
 				cloudProviderList.Items = append(cloudProviderList.Items, converted)
 			}
 			h.cache.Set(cloudProvidersCacheKey, cloudProviderList, cache.DefaultExpiration)

--- a/internal/dinosaur/pkg/handlers/cloud_providers.go
+++ b/internal/dinosaur/pkg/handlers/cloud_providers.go
@@ -61,8 +61,8 @@ func (h cloudProvidersHandler) ListCloudProviderRegions(w http.ResponseWriter, r
 			}
 
 			provider, _ := h.supportedProviders.GetByName(id)
-			for _, cloudRegion := range cloudRegions {
-				region, _ := provider.Regions.GetByName(cloudRegion.Id)
+			for i := range cloudRegions {
+				region, _ := provider.Regions.GetByName(cloudRegions[i].Id)
 
 				// skip any regions that do not support the specified instance type so its not included in the response
 				if instanceTypeFilter != "" && !region.IsInstanceTypeSupported(config.InstanceType(instanceTypeFilter)) {
@@ -70,9 +70,9 @@ func (h cloudProvidersHandler) ListCloudProviderRegions(w http.ResponseWriter, r
 				}
 
 				// Only set enabled to true if the region supports at least one instance type
-				cloudRegion.Enabled = len(region.SupportedInstanceTypes) > 0
-				cloudRegion.SupportedInstanceTypes = region.SupportedInstanceTypes.AsSlice()
-				converted := presenters.PresentCloudRegion(&cloudRegion)
+				cloudRegions[i].Enabled = len(region.SupportedInstanceTypes) > 0
+				cloudRegions[i].SupportedInstanceTypes = region.SupportedInstanceTypes.AsSlice()
+				converted := presenters.PresentCloudRegion(&cloudRegions[i])
 				regionList.Items = append(regionList.Items, converted)
 			}
 
@@ -105,9 +105,9 @@ func (h cloudProvidersHandler) ListCloudProviders(w http.ResponseWriter, r *http
 				Items: []public.CloudProvider{},
 			}
 
-			for _, cloudProvider := range cloudProviders {
-				_, cloudProvider.Enabled = h.supportedProviders.GetByName(cloudProvider.Id)
-				converted := presenters.PresentCloudProvider(&cloudProvider)
+			for i := range cloudProviders {
+				_, cloudProviders[i].Enabled = h.supportedProviders.GetByName(cloudProviders[i].Id)
+				converted := presenters.PresentCloudProvider(&cloudProviders[i])
 				cloudProviderList.Items = append(cloudProviderList.Items, converted)
 			}
 			h.cache.Set(cloudProvidersCacheKey, cloudProviderList, cache.DefaultExpiration)

--- a/internal/dinosaur/pkg/handlers/cloud_providers.go
+++ b/internal/dinosaur/pkg/handlers/cloud_providers.go
@@ -62,7 +62,8 @@ func (h cloudProvidersHandler) ListCloudProviderRegions(w http.ResponseWriter, r
 
 			provider, _ := h.supportedProviders.GetByName(id)
 			for i := range cloudRegions {
-				region, _ := provider.Regions.GetByName(cloudRegions[i].Id)
+				cloudRegion := cloudRegions[i]
+				region, _ := provider.Regions.GetByName(cloudRegion.Id)
 
 				// skip any regions that do not support the specified instance type so its not included in the response
 				if instanceTypeFilter != "" && !region.IsInstanceTypeSupported(config.InstanceType(instanceTypeFilter)) {
@@ -70,9 +71,9 @@ func (h cloudProvidersHandler) ListCloudProviderRegions(w http.ResponseWriter, r
 				}
 
 				// Only set enabled to true if the region supports at least one instance type
-				cloudRegions[i].Enabled = len(region.SupportedInstanceTypes) > 0
-				cloudRegions[i].SupportedInstanceTypes = region.SupportedInstanceTypes.AsSlice()
-				converted := presenters.PresentCloudRegion(&cloudRegions[i])
+				cloudRegion.Enabled = len(region.SupportedInstanceTypes) > 0
+				cloudRegion.SupportedInstanceTypes = region.SupportedInstanceTypes.AsSlice()
+				converted := presenters.PresentCloudRegion(&cloudRegion)
 				regionList.Items = append(regionList.Items, converted)
 			}
 

--- a/internal/dinosaur/pkg/handlers/data_plane_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/data_plane_dinosaur.go
@@ -59,8 +59,8 @@ func (h *dataPlaneDinosaurHandler) GetAll(w http.ResponseWriter, r *http.Request
 				Items: []private.ManagedCentral{},
 			}
 
-			for _, mk := range managedDinosaurs {
-				converted := presenters.PresentManagedDinosaur(&mk)
+			for i := range managedDinosaurs {
+				converted := presenters.PresentManagedDinosaur(&managedDinosaurs[i])
 				managedDinosaurList.Items = append(managedDinosaurList.Items, converted)
 			}
 			return managedDinosaurList, nil

--- a/internal/dinosaur/pkg/presenters/metric.go
+++ b/internal/dinosaur/pkg/presenters/metric.go
@@ -34,8 +34,8 @@ func convertSampleStream(from *pmod.SampleStream) public.RangeQuery {
 		labelSet[string(k)] = string(v)
 	}
 	values := make([]public.Values, len(from.Values))
-	for i, v := range from.Values {
-		values[i] = convertSamplePair(&v)
+	for i := range from.Values {
+		values[i] = convertSamplePair(&from.Values[i])
 	}
 	return public.RangeQuery{
 		Metric: labelSet,

--- a/internal/dinosaur/pkg/workers/clusters_mgr.go
+++ b/internal/dinosaur/pkg/workers/clusters_mgr.go
@@ -191,10 +191,10 @@ func (c *ClusterManager) processDeprovisioningClusters() []error {
 		glog.Infof("deprovisioning clusters count = %d", len(deprovisioningClusters))
 	}
 
-	for _, cluster := range deprovisioningClusters {
+	for i, cluster := range deprovisioningClusters {
 		glog.V(10).Infof("deprovision cluster ClusterID = %s", cluster.ClusterID)
 		metrics.UpdateClusterStatusSinceCreatedMetric(cluster, api.ClusterDeprovisioning)
-		if err := c.reconcileDeprovisioningCluster(&cluster); err != nil {
+		if err := c.reconcileDeprovisioningCluster(&deprovisioningClusters[i]); err != nil {
 			errs = append(errs, errors.Wrapf(err, "failed to reconcile deprovisioning cluster %s", cluster.ID))
 		}
 	}
@@ -231,10 +231,10 @@ func (c *ClusterManager) processAcceptedClusters() []error {
 		glog.Infof("accepted clusters count = %d", len(acceptedClusters))
 	}
 
-	for _, cluster := range acceptedClusters {
+	for i, cluster := range acceptedClusters {
 		glog.V(10).Infof("accepted cluster ClusterID = %s", cluster.ClusterID)
 		metrics.UpdateClusterStatusSinceCreatedMetric(cluster, api.ClusterAccepted)
-		if err := c.reconcileAcceptedCluster(&cluster); err != nil {
+		if err := c.reconcileAcceptedCluster(&acceptedClusters[i]); err != nil {
 			errs = append(errs, errors.Wrapf(err, "failed to reconcile accepted cluster %s", cluster.ID))
 			continue
 		}
@@ -253,10 +253,10 @@ func (c *ClusterManager) processProvisioningClusters() []error {
 	}
 
 	// process each local pending cluster and compare to the underlying ocm cluster
-	for _, provisioningCluster := range provisioningClusters {
+	for i, provisioningCluster := range provisioningClusters {
 		glog.V(10).Infof("provisioning cluster ClusterID = %s", provisioningCluster.ClusterID)
 		metrics.UpdateClusterStatusSinceCreatedMetric(provisioningCluster, api.ClusterProvisioning)
-		_, err := c.reconcileClusterStatus(&provisioningCluster)
+		_, err := c.reconcileClusterStatus(&provisioningClusters[i])
 		if err != nil {
 			errs = append(errs, errors.Wrapf(err, "failed to reconcile cluster %s status", provisioningCluster.ClusterID))
 			continue

--- a/internal/dinosaur/pkg/workers/clusters_mgr.go
+++ b/internal/dinosaur/pkg/workers/clusters_mgr.go
@@ -191,10 +191,11 @@ func (c *ClusterManager) processDeprovisioningClusters() []error {
 		glog.Infof("deprovisioning clusters count = %d", len(deprovisioningClusters))
 	}
 
-	for i, cluster := range deprovisioningClusters {
+	for i := range deprovisioningClusters {
+		cluster := deprovisioningClusters[i]
 		glog.V(10).Infof("deprovision cluster ClusterID = %s", cluster.ClusterID)
 		metrics.UpdateClusterStatusSinceCreatedMetric(cluster, api.ClusterDeprovisioning)
-		if err := c.reconcileDeprovisioningCluster(&deprovisioningClusters[i]); err != nil {
+		if err := c.reconcileDeprovisioningCluster(&cluster); err != nil {
 			errs = append(errs, errors.Wrapf(err, "failed to reconcile deprovisioning cluster %s", cluster.ID))
 		}
 	}
@@ -231,10 +232,11 @@ func (c *ClusterManager) processAcceptedClusters() []error {
 		glog.Infof("accepted clusters count = %d", len(acceptedClusters))
 	}
 
-	for i, cluster := range acceptedClusters {
+	for i := range acceptedClusters {
+		cluster := acceptedClusters[i]
 		glog.V(10).Infof("accepted cluster ClusterID = %s", cluster.ClusterID)
 		metrics.UpdateClusterStatusSinceCreatedMetric(cluster, api.ClusterAccepted)
-		if err := c.reconcileAcceptedCluster(&acceptedClusters[i]); err != nil {
+		if err := c.reconcileAcceptedCluster(&cluster); err != nil {
 			errs = append(errs, errors.Wrapf(err, "failed to reconcile accepted cluster %s", cluster.ID))
 			continue
 		}
@@ -253,10 +255,11 @@ func (c *ClusterManager) processProvisioningClusters() []error {
 	}
 
 	// process each local pending cluster and compare to the underlying ocm cluster
-	for i, provisioningCluster := range provisioningClusters {
+	for i := range provisioningClusters {
+		provisioningCluster := provisioningClusters[i]
 		glog.V(10).Infof("provisioning cluster ClusterID = %s", provisioningCluster.ClusterID)
 		metrics.UpdateClusterStatusSinceCreatedMetric(provisioningCluster, api.ClusterProvisioning)
-		_, err := c.reconcileClusterStatus(&provisioningClusters[i])
+		_, err := c.reconcileClusterStatus(&provisioningCluster)
 		if err != nil {
 			errs = append(errs, errors.Wrapf(err, "failed to reconcile cluster %s status", provisioningCluster.ClusterID))
 			continue

--- a/pkg/client/observatorium/api.go
+++ b/pkg/client/observatorium/api.go
@@ -98,7 +98,7 @@ func (obs *ServiceObservatorium) GetMetrics(metrics *DinosaurMetrics, namespace 
 	for msg, f := range fetchers {
 		fetchAll := len(rq.Filters) == 0
 		if fetchAll {
-			result := obs.fetchMetricsResult(rq, &f)
+			result := obs.fetchMetricsResult(rq, f)
 			if result.Err != nil {
 				glog.Error("error from metric ", result.Err)
 				failedMetrics = append(failedMetrics, fmt.Sprintf("%s: %s", msg, result.Err))
@@ -108,7 +108,7 @@ func (obs *ServiceObservatorium) GetMetrics(metrics *DinosaurMetrics, namespace 
 		if !fetchAll {
 			for _, filter := range rq.Filters {
 				if filter == msg {
-					result := obs.fetchMetricsResult(rq, &f)
+					result := obs.fetchMetricsResult(rq, f)
 					if result.Err != nil {
 						glog.Error("error from metric ", result.Err)
 						failedMetrics = append(failedMetrics, fmt.Sprintf("%s: %s", msg, result.Err))
@@ -126,7 +126,7 @@ func (obs *ServiceObservatorium) GetMetrics(metrics *DinosaurMetrics, namespace 
 	return nil
 }
 
-func (obs *ServiceObservatorium) fetchMetricsResult(rq *MetricsReqParams, f *fetcher) Metric {
+func (obs *ServiceObservatorium) fetchMetricsResult(rq *MetricsReqParams, f fetcher) Metric {
 	c := obs.client
 	var result Metric
 	switch rq.ResultType {


### PR DESCRIPTION
The changes are workarounds so that gosec does not warn about
G601: Implicit memory aliasing in for loop.

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] ~~Documentation added if necessary~~
- [ ] ~~CI and all relevant tests are passing~~

## Test manual

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
