### PR TITLE
CI: Use oc instead of kubectl for auto-sensing for infra clusters

### DIFF
--- a/dev/env/defaults/02-infra.env
+++ b/dev/env/defaults/02-infra.env
@@ -2,7 +2,7 @@
 
 is_infra_cluster() {
     local server
-    server=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
+    server=$(try_kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
     if [[ "$server" =~ infra\.rox\.systems ]]; then
         return 0
     else


### PR DESCRIPTION
## Description

The auto-sensing for infra clusters uses `kubectl` unconditionally. This produces (harmless) error messages on OSCI:
```
/go/src/github.com/stackrox/acs-fleet-manager/dev/env/defaults/02-infra.env: line 5: kubectl: command not found
```

This PR includes a fix, making sure that `kubectl` or `oc` will be used, depending on what is available.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
