### PR TITLE
ROX-11469: Add dedicated script for running e2e on stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,6 @@ help:
 	@echo "make run/docs                    run swagger and host the api spec"
 	@echo "make test                        run unit tests"
 	@echo "make test/integration            run integration tests"
-	@echo "make test/e2e/stage              run e2e tests on stage environment"
 	@echo "make code/fix                    format files"
 	@echo "make generate                    generate go and openapi modules"
 	@echo "make openapi/generate            generate openapi modules"
@@ -358,10 +357,6 @@ test/e2e:
 test/e2e/cleanup:
 	./e2e/cleanup.sh
 .PHONY: test/e2e/cleanup
-
-test/e2e/stage:
-	CLUSTER_ID=1smhq7nc0ncfv2jbjgf48q7e6qb943ou RUN_E2E=true go test $(GOARGS) -bench -v -count=1 ./e2e/...
-.PHONY: test/e2e
 
 # generate files
 generate: moq openapi/generate

--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,7 @@ help:
 	@echo "make run/docs                    run swagger and host the api spec"
 	@echo "make test                        run unit tests"
 	@echo "make test/integration            run integration tests"
+	@echo "make test/e2e/stage              run e2e tests on stage environment"
 	@echo "make code/fix                    format files"
 	@echo "make generate                    generate go and openapi modules"
 	@echo "make openapi/generate            generate openapi modules"
@@ -357,6 +358,10 @@ test/e2e:
 test/e2e/cleanup:
 	./e2e/cleanup.sh
 .PHONY: test/e2e/cleanup
+
+test/e2e/stage:
+	CLUSTER_ID=1smhq7nc0ncfv2jbjgf48q7e6qb943ou RUN_E2E=true go test $(GOARGS) -bench -v -count=1 ./e2e/...
+.PHONY: test/e2e
 
 # generate files
 generate: moq openapi/generate

--- a/e2e/run_e2e_stage.sh
+++ b/e2e/run_e2e_stage.sh
@@ -10,8 +10,10 @@
 #
 
 make \
+  CLUSTER_ID="1smhq7nc0ncfv2jbjgf48q7e6qb943ou" \
   DP_CLOUD_PROVIDER="aws" \
   DP_REGION="us-east-1" \
   FLEET_MANAGER_ENDPOINT="${ACS_FLEET_MANAGER_ENDPOINT}" \
-  OCM_TOKEN="${OCM_TOKEN}" \
-  test/e2e/stage
+  AUTH_TYPE="STATIC_TOKEN" \
+  STATIC_TOKEN="${OCM_TOKEN}" \
+  test/e2e

--- a/e2e/run_e2e_stage.sh
+++ b/e2e/run_e2e_stage.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -ex
+#
+# This script runs E22 tests against stage environment on app-interface CI for ACS Fleet manager.
+#
+# FLEET_MANAGER_ENDPOINT - The base URL endpoint of the sage fleet manager instance.
+#
+# OCM_TOKEN - The static token for the SSO.
+#
+# By default AWS provider on `us-east-1` region is used because stage Data Plane is configured that way.
+#
+
+make \
+  DP_CLOUD_PROVIDER="aws" \
+  DP_REGION="us-east-1" \
+  FLEET_MANAGER_ENDPOINT="${ACS_FLEET_MANAGER_ENDPOINT}" \
+  OCM_TOKEN="${OCM_TOKEN}" \
+  test/e2e/stage


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Add dedicated script for using on app-interface to make e2e flow more concise and manageable in the original repo.

## Test manual

Manually worked
```
$ e2e/run_e2e_stage.sh

...

plate.openshift.io/v1?timeout=32s
••••
------------------------------
• [SLOW TEST] [30.726 seconds]
Central should be created and deployed to k8s should transition central's state to ready
/Users/akurlov/go/src/github.com/stackrox/acs-fleet-manager/e2e/e2e_test.go:95
------------------------------
••
------------------------------
• [SLOW TEST] [37.416 seconds]
Central should be created and deployed to k8s should remove central namespace
/Users/akurlov/go/src/github.com/stackrox/acs-fleet-manager/e2e/e2e_test.go:119
------------------------------

Ran 8 of 8 Specs in 76.703 seconds
SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
ok  	github.com/stackrox/acs-fleet-manager/e2e	77.541s
```