### PR TITLE
Don't swallow bootstrapping error logs

### DIFF
--- a/.openshift-ci/tests/e2e-test.sh
+++ b/.openshift-ci/tests/e2e-test.sh
@@ -6,6 +6,13 @@ export GITROOT
 source "${GITROOT}/dev/env/scripts/lib.sh"
 init
 
+bootstrap.sh
+
+if [[ "$CLUSTER_TYPE" != "openshift-ci" ]]; then
+    log "Cleaning up left-over resource (if any)"
+    down.sh 2>/dev/null
+fi
+
 up.sh
 
 log "Environment up and running"

--- a/.openshift-ci/tests/e2e.sh
+++ b/.openshift-ci/tests/e2e.sh
@@ -27,6 +27,12 @@ if [[ "${OPENSHIFT_CI:-}" == "true" ]]; then
     export GOARGS="-mod=mod" # For some reason we need this in the offical base images.
 fi
 
+LOG_DIR=""
+if [[ "$SPAWN_LOGGER" == "true" ]]; then
+    LOG_DIR=$(mktemp -d)
+fi
+export LOG_DIR
+
 init
 
 log
@@ -36,11 +42,7 @@ log
 log "Cluster type: ${CLUSTER_TYPE}"
 log "Cluster name: ${CLUSTER_NAME}"
 log "Image: ${FLEET_MANAGER_IMAGE}"
-if [[ "$SPAWN_LOGGER" == "true" ]]; then
-    LOG_DIR=$(mktemp -d)
-    export LOG_DIR
-    log "Log directory: ${LOG_DIR}"
-fi
+log "Log directory: ${LOG_DIR:-(none)}"
 
 case "$AUTH_TYPE" in
 OCM)
@@ -72,24 +74,30 @@ fi
 # Configuration specific to this e2e test suite:
 export ENABLE_DB_PORT_FORWARDING="false"
 
-bootstrap.sh
-
-if [[ "$CLUSTER_TYPE" != "openshift-ci" ]]; then
-    log "Cleaning up left-over resource (if any)"
-    down.sh 2>/dev/null
-fi
-
-MAIN_LOG="log.txt"
-
 if [[ "$SPAWN_LOGGER" == "true" ]]; then
+    # Need to create the namespaces prior to spawning the stern loggers.
+    apply "${MANIFESTS_DIR}/shared/00-namespace.yaml"
+    apply "${MANIFESTS_DIR}/rhacs-operator/00-namespace.yaml"
+    sleep 2
     log "Spawning logger, log directory is ${LOG_DIR}"
-    stern -n "$ACSMS_NAMESPACE" '.*' --color=never --template '[{{.ContainerName}}] {{.Message}}{{"\n"}}' >"${LOG_DIR}/${MAIN_LOG}" 2>&1 &
+    stern -n "$ACSMS_NAMESPACE" '.*' --color=never --template '[{{.ContainerName}}] {{.Message}}{{"\n"}}' >"${LOG_DIR}/namespace-${ACSMS_NAMESPACE}.txt" 2>&1 &
+    stern -n "$STACKROX_OPERATOR_NAMESPACE" '.*' --color=never --template '[{{.ContainerName}}] {{.Message}}{{"\n"}}' >"${LOG_DIR}/namespace-${STACKROX_OPERATOR_NAMESPACE}.txt" 2>&1 &
 fi
 
 FAIL=0
 if ! "${GITROOT}/.openshift-ci/tests/e2e-test.sh"; then
     FAIL=1
 fi
+
+# Terminate loggers.
+for p in $(jobs -pr); do
+    log "Terminating background process ${p}"
+    kill $p || true
+done
+
+log
+log "=========="
+log
 
 if [[ "$DUMP_LOGS" == "true" ]]; then
     if [[ "$SPAWN_LOGGER" == "true" ]]; then
@@ -132,9 +140,16 @@ if [[ "$DUMP_LOGS" == "true" ]]; then
         log "Logs are in ${LOG_DIR}"
         log
     fi
+else
+    if [[ "$SPAWN_LOGGER" == "true" ]]; then
+        log "Not dumping logs, logs are in ${LOG_DIR}"
+        log
+    fi
 fi
 
+log
 log "=========="
+log
 
 if [[ $FAIL == 0 ]]; then
     log

--- a/.openshift-ci/tests/e2e.sh
+++ b/.openshift-ci/tests/e2e.sh
@@ -27,13 +27,13 @@ if [[ "${OPENSHIFT_CI:-}" == "true" ]]; then
     export GOARGS="-mod=mod" # For some reason we need this in the offical base images.
 fi
 
-LOG_DIR=""
-if [[ "$SPAWN_LOGGER" == "true" ]]; then
+init
+
+LOG_DIR=${LOG_DIR:-}
+if [[ "$SPAWN_LOGGER" == "true" && "$LOG_DIR" == "" ]]; then
     LOG_DIR=$(mktemp -d)
 fi
 export LOG_DIR
-
-init
 
 log
 log "** Entrypoint for ACS MS E2E Tests **"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -141,7 +141,7 @@
         "filename": ".openshift-ci/tests/e2e.sh",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 63,
+        "line_number": 65,
         "is_secret": false
       }
     ],
@@ -852,5 +852,5 @@
       }
     ]
   },
-  "generated_at": "2022-07-19T08:42:05Z"
+  "generated_at": "2022-07-20T11:05:46Z"
 }


### PR DESCRIPTION
## Description

Until now the bootstrapping was executed directly from within `e2e.sh` before any loggers are started, which means that if the bootstrapping fails then we don't see why it failed.

This PR shuffles the order so that `e2e.sh` takes care of starting loggers before bootstrapping (which is executed as part of the inner `e2e-test.sh` script).


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
