### PR TITLE
Allow for disabling leader election for test environments

### DIFF
--- a/.openshift-ci/tests/e2e-test.sh
+++ b/.openshift-ci/tests/e2e-test.sh
@@ -18,7 +18,7 @@ up.sh
 log "Environment up and running"
 log "Waiting for fleet-manager to complete leader election..."
 # Don't have a better way yet to wait until fleet-manager has completed the leader election.
-$KUBECTL -n "$ACSMS_NAMESPACE" logs -l application=fleet-manager -c fleet-manager -f |
+$KUBECTL -n "$ACSMS_NAMESPACE" logs -l application=fleet-manager -c fleet-manager -f --tail=-1 |
     grep -q --line-buffered --max-count=1 'Running as the leader and starting' || true
 sleep 1
 

--- a/dev/env/manifests/fleet-manager/02-fleet-manager-deployment.yaml
+++ b/dev/env/manifests/fleet-manager/02-fleet-manager-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - command:
             - sh
             - "-c"
-            - "cd /; /usr/local/bin/fleet-manager serve --api-server-bindaddress=0.0.0.0:8000 --health-check-server-bindaddress=0.0.0.0:8083 --kubeconfig=/secrets/kubeconfig || { sleep 120; false; }"
+            - "cd /; /usr/local/bin/fleet-manager serve --force-leader --api-server-bindaddress=0.0.0.0:8000 --health-check-server-bindaddress=0.0.0.0:8083 --kubeconfig=/secrets/kubeconfig || { sleep 120; false; }"
           image: "$FLEET_MANAGER_IMAGE"
           imagePullPolicy: IfNotPresent
           name: fleet-manager

--- a/pkg/server/server_config.go
+++ b/pkg/server/server_config.go
@@ -19,6 +19,7 @@ type ServerConfig struct {
 	// For production it is "https://api.openshift.com"
 	PublicHostURL         string `json:"public_url"`
 	EnableTermsAcceptance bool   `json:"enable_terms_acceptance"`
+	ForceLeader           bool   `json:"force_leader"`
 }
 
 // NewServerConfig ...
@@ -46,6 +47,8 @@ func (s *ServerConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.JwksFile, "jwks-file", s.JwksFile, "File containing the the JSON web token signing certificates.")
 	fs.StringVar(&s.TokenIssuerURL, "token-issuer-url", s.TokenIssuerURL, "A token issuer URL. Used to validate if a JWT token used for public endpoints was issued from the given URL.")
 	fs.StringVar(&s.PublicHostURL, "public-host-url", s.PublicHostURL, "Public http host URL of the service")
+	fs.BoolVar(&s.ForceLeader, "force-leader", s.ForceLeader, "Disable leader election (for testing)")
+	fs.MarkHidden("force-leader")
 }
 
 // ReadFiles ...


### PR DESCRIPTION
## Description

I was quite annoyed by the leader election so I implemented a switch to disable it for test environments.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
