### PR TITLE
Increase wait timeout for CI e2e tests

### DIFF
--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -186,7 +186,7 @@ wait_for_container_to_become_ready() {
     local namespace="$1"
     local pod_selector="$2"
     local container_name="$3"
-    local timeout="120s"
+    local timeout="${4:-300}s"
 
     log "Waiting for pod ${pod_selector} within namespace ${namespace} to become ready..."
     wait_for_container_to_appear "$namespace" "$pod_selector" "$container_name" || return 1


### PR DESCRIPTION
## Description

Seen a CI e2e failure, which was most likely be caused by a slow container startup.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
