### PR TITLE
[CI] Fix container waiting logic

### DIFF
--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -156,8 +156,8 @@ wait_for_container_to_appear() {
     log "Waiting for container ${container_name} within pod ${pod_selector} in namespace ${namespace} to appear..."
     for i in $(seq "$seconds"); do
         local status
-        status=$($KUBECTL -n "$namespace" get pod -l "$pod_selector" -o jsonpath="{.items[0].status.initContainerStatuses[?(@.name == '${container_name}')]} {.items[0].status.containerStatuses[?(@.name == '${container_name}')]}" 2>/dev/null)
-        local state=
+        status=$($KUBECTL -n "$namespace" get pod -l "$pod_selector" -o jsonpath="{.items[0].status.initContainerStatuses[?(@.name == '${container_name}')]} {.items[0].status.containerStatuses[?(@.name == '${container_name}')]}" 2>/dev/null || true)
+        local state=""
         state=$(echo "${status}" | jq -r ".state | keys[]")
         if [[ "$state" == "running" ]]; then
             echo "Container ${pod_selector}/${container_name} is in state ${state}"


### PR DESCRIPTION
## Description

If a container is slow to start, the kubectl command for retrieving that pod will fail. If that is not protected by `|| true`, then the whole bootstrapping will terminate with failure early.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
