### PR TITLE
Small fixes for setup dev OSD cluster guide

### DIFF
--- a/docs/development/setup-developer-osd-cluster.md
+++ b/docs/development/setup-developer-osd-cluster.md
@@ -196,7 +196,7 @@ helm upgrade --install rhacs-terraform \
   --set fleetshardSync.staticToken="${STATIC_TOKEN}" \
   --set fleetshardSync.clusterId="${CLUSTER_ID}" \
   --set acsOperator.enabled=true \
-  --set acsOperator.source="rhacs-operators" \
+  --set acsOperator.source="${RHACS_OPERATOR_CATALOG_NAME}" \
   --set acsOperator.startingCSV="${STARTING_CSV}" \
   --set observability.enabled=false ./dp-terraform/helm/rhacs-terraform
 ```

--- a/docs/development/setup-developer-osd-cluster.md
+++ b/docs/development/setup-developer-osd-cluster.md
@@ -333,12 +333,12 @@ After that, you can open the following URL in your browser: https://stage.foo.re
 
 By default, staging cluster will be up for 2 days. You can extend it to 7 days. To do that, execute the following command for MacOS:
 ```
-echo "{\"expiration_timestamp\":\"$(date --iso-8601=seconds -d '+7 days')\"}" | ocm patch "/api/clusters_mgmt/v1/clusters/${CLUSTER_ID}"
+echo "{\"expiration_timestamp\":\"$(date -v+7d -u +'%Y-%m-%dT%H:%M:%SZ')\"}" | ocm patch "/api/clusters_mgmt/v1/clusters/${CLUSTER_ID}"
 ```
 
 Or on Linux:
 ```
-echo "{\"expiration_timestamp\":\"$(date -v+7d -u +'%Y-%m-%dT%H:%M:%SZ')\"}" | ocm patch "/api/clusters_mgmt/v1/clusters/${CLUSTER_ID}"
+echo "{\"expiration_timestamp\":\"$(date --iso-8601=seconds -d '+7 days')\"}" | ocm patch "/api/clusters_mgmt/v1/clusters/${CLUSTER_ID}"
 ```
 
 ### Re-deploy new Fleetshard synchronizer


### PR DESCRIPTION
## Description

Small fixes discovered during testing of the guide:
1. fixed usage of the `RHACS_OPERATOR_CATALOG_NAME` variable in the execution of helm terraform template. This is required to support ACS Operator installed via RH Marketplace and custom deployed ACS operator
2. fixed issues with swapped Linux and macOS commands for extending the lifetime of the OSD cluster

## Checklist (Definition of Done)
- ~[ ] Unit and integration tests added~
- [x] Documentation added if necessary
- [x] CI and all relevant tests are passing

## Test manual

1. This can be tested by following the guide where the custom ACS Operator is not installed (skip steps 6. and 7.).
2. Can be simply tested by running commands in macOS and/or Linux
