### PR TITLE
ROX-11934: Fix DB status for Central stays on deprovision

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -439,7 +439,7 @@
         "filename": "internal/dinosaur/pkg/services/dinosaur.go",
         "hashed_secret": "bae666efd375b31ee4ba6e4ed05a31c84b916b9c",
         "is_verified": false,
-        "line_number": 693,
+        "line_number": 700,
         "is_secret": false
       }
     ],
@@ -834,5 +834,5 @@
       }
     ]
   },
-  "generated_at": "2022-08-05T01:18:11Z"
+  "generated_at": "2022-08-05T13:45:51Z"
 }

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/stackrox/acs-fleet-manager/pkg/services/sso"
-
 	constants2 "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/config"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/dinosaurs/types"
 	"github.com/stackrox/acs-fleet-manager/pkg/services"
+	"github.com/stackrox/acs-fleet-manager/pkg/services/sso"
 
 	"github.com/stackrox/acs-fleet-manager/pkg/services/authorization"
 	coreServices "github.com/stackrox/acs-fleet-manager/pkg/services/queryparser"
@@ -411,13 +410,17 @@ func (k *dinosaurService) RegisterDinosaurDeprovisionJob(ctx context.Context, id
 	return nil
 }
 
-// DeprovisionDinosaurForUsers ...
+// DeprovisionDinosaurForUsers registers all dinosaurs for deprovisioning given the list of owners
 func (k *dinosaurService) DeprovisionDinosaurForUsers(users []string) *errors.ServiceError {
+	now := time.Now()
 	dbConn := k.connectionFactory.New().
 		Model(&dbapi.CentralRequest{}).
 		Where("owner IN (?)", users).
 		Where("status NOT IN (?)", dinosaurDeletionStatuses).
-		Update("status", constants2.DinosaurRequestStatusDeprovision)
+		Updates(map[string]interface{}{
+			"status":             constants2.DinosaurRequestStatusDeprovision,
+			"deletion_timestamp": now,
+		})
 
 	err := dbConn.Error
 	if err != nil {
@@ -436,15 +439,19 @@ func (k *dinosaurService) DeprovisionDinosaurForUsers(users []string) *errors.Se
 	return nil
 }
 
-// DeprovisionExpiredDinosaurs ...
+// DeprovisionExpiredDinosaurs cleaning up expired dinosaurs
 func (k *dinosaurService) DeprovisionExpiredDinosaurs(dinosaurAgeInHours int) *errors.ServiceError {
+	now := time.Now()
 	dbConn := k.connectionFactory.New().
 		Model(&dbapi.CentralRequest{}).
 		Where("instance_type = ?", types.EVAL.String()).
-		Where("created_at  <=  ?", time.Now().Add(-1*time.Duration(dinosaurAgeInHours)*time.Hour)).
+		Where("created_at  <=  ?", now.Add(-1*time.Duration(dinosaurAgeInHours)*time.Hour)).
 		Where("status NOT IN (?)", dinosaurDeletionStatuses)
 
-	db := dbConn.Update("status", constants2.DinosaurRequestStatusDeprovision)
+	db := dbConn.Updates(map[string]interface{}{
+		"status":             constants2.DinosaurRequestStatusDeprovision,
+		"deletion_timestamp": now,
+	})
 	err := db.Error
 	if err != nil {
 		return errors.NewWithCause(errors.ErrorGeneral, err, "unable to deprovision expired dinosaurs")


### PR DESCRIPTION
## Description
Set `deletion_timestamp` for special cases when centrals are deprovisioned during the fleet manager reconciliation.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
~- [ ] Documentation added if necessary~
- [x] CI and all relevant tests are passing

## Test manual
Tested on a local cluster

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
