### PR TITLE
Fix colima test environment and review leftovers

### DIFF
--- a/dev/env/defaults/cluster-type-colima/env
+++ b/dev/env/defaults/cluster-type-colima/env
@@ -1,8 +1,12 @@
-export COLIMA="${COLIMA:-colima}"
 export KUBECONF_CLUSTER_SERVER_OVERRIDE_DEFAULT="true"
 export ENABLE_DB_PORT_FORWARDING_DEFAULT="true"
 export ENABLE_FM_PORT_FORWARDING_DEFAULT="true"
 export OPERATOR_SOURCE_DEFAULT="quay"
 export INHERIT_IMAGEPULLSECRETS_DEFAULT="true" # pragma: allowlist secret
 export INSTALL_OLM_DEFAULT="true"
-export DOCKER_DEFAULT="colima nerdctl -- -n k8s.io" # When nerdctl and docker can be used
+
+if grep -q "runtime: docker" <(colima status 2>&1); then
+  export DOCKER_HOST="unix://$HOME/.colima/docker.sock"
+else
+  export DOCKER_DEFAULT="colima nerdctl -- -n k8s.io" # When nerdctl and docker can be used
+fi

--- a/dev/env/defaults/cluster-type-infra-openshift/env
+++ b/dev/env/defaults/cluster-type-infra-openshift/env
@@ -7,4 +7,4 @@ export FLEET_MANAGER_RESOURCES_DEFAULT='{"requests":{"cpu":"400m","memory":"1000
 export FLEETSHARD_SYNC_RESOURCES_DEFAULT='{"requests":{"cpu":"400m","memory":"1000Mi"},"limits":{"cpu":"400m","memory":"1000Mi"}}'
 export DB_RESOURCES_DEFAULT='{"requests":{"cpu":"400m","memory":"1000Mi"},"limits":{"cpu":"400m","memory":"1000Mi"}}'
 export RHACS_OPERATOR_RESOURCES_DEFAULTS='{"requests":{"cpu":"400m","memory":"1000Mi"},"limits":{"cpu":"400m","memory":"1000Mi"}}'
-export CLUSTER_DNS_DEFAULT=$(oc get -n "openshift-ingress-operator" ingresscontrollers default -o=jsonpath='{.status.domain}' --ignore-not-found)
+export CLUSTER_DNS_DEFAULT=$(try_kubectl get -n "openshift-ingress-operator" ingresscontrollers default -o=jsonpath='{.status.domain}' --ignore-not-found)

--- a/dev/env/defaults/cluster-type-openshift/env
+++ b/dev/env/defaults/cluster-type-openshift/env
@@ -3,4 +3,4 @@ export KUBECTL_DEFAULT="oc"
 export OPERATOR_SOURCE_DEFAULT="marketplace"
 export INSTALL_OLM_DEFAULT="false"
 export ENABLE_FM_PORT_FORWARDING_DEFAULT="true"
-export CLUSTER_DNS_DEFAULT=$(oc get -n "openshift-ingress-operator" ingresscontrollers default -o=jsonpath='{.status.domain}' --ignore-not-found)
+export CLUSTER_DNS_DEFAULT=$(try_kubectl get -n "openshift-ingress-operator" ingresscontrollers default -o=jsonpath='{.status.domain}' --ignore-not-found)


### PR DESCRIPTION
## Description
Fix colima E2E test setup with docker runtime + fixes from the [previous review](https://github.com/stackrox/acs-fleet-manager/pull/197#discussion_r925264484)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
