### PR TITLE
Use gotestsum in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,10 @@ ifeq (, $(shell which $(LOCAL_BIN_PATH)/golangci-lint 2> /dev/null))
 	}
 endif
 
-GOTESTSUM ?=$(LOCAL_BIN_PATH)/gotestsum
+LOCAL_GOTESTSUM = $(LOCAL_BIN_PATH)/gotestsum
+GOTESTSUM ?= $(LOCAL_GOTESTSUM)
 gotestsum:
+ifeq ($(GOTESTSUM), $(LOCAL_GOTESTSUM))
 ifeq (, $(shell which $(LOCAL_BIN_PATH)/gotestsum 2> /dev/null))
 	@{ \
 	set -e ;\
@@ -93,6 +95,7 @@ ifeq (, $(shell which $(LOCAL_BIN_PATH)/gotestsum 2> /dev/null))
 	$(GO) build -o ${LOCAL_BIN_PATH}/gotestsum gotest.tools/gotestsum ;\
 	rm -rf $$GOTESTSUM_TMP_DIR ;\
 	}
+endif
 endif
 
 MOQ ?= ${LOCAL_BIN_PATH}/moq
@@ -185,9 +188,7 @@ ifndef OCM_ENV
 	OCM_ENV:=integration
 endif
 
-ifndef TEST_SUMMARY_FORMAT
-	TEST_SUMMARY_FORMAT=short-verbose
-endif
+GOTESTSUM_FORMAT ?= standard-verbose
 
 # Enable Go modules:
 export GO111MODULE=on
@@ -317,7 +318,7 @@ clean:
 # Examples:
 #   make test TESTFLAGS="-run TestSomething"
 test: gotestsum
-	OCM_ENV=testing $(GOTESTSUM) --junitfile data/results/unit-tests.xml --format $(TEST_SUMMARY_FORMAT) -- -p 1 -v -count=1 $(TESTFLAGS) \
+	OCM_ENV=testing $(GOTESTSUM) --junitfile data/results/unit-tests.xml --format $(GOTESTSUM_FORMAT) -- -p 1 -v -count=1 $(TESTFLAGS) \
 		$(shell go list ./... | grep -v /test)
 .PHONY: test
 
@@ -337,7 +338,7 @@ test/prepare:
 #   make test/integration TESTFLAGS="-run TestAccountsGet"  runs TestAccountsGet
 #   make test/integration TESTFLAGS="-short"                skips long-run tests
 test/integration/dinosaur: test/prepare gotestsum
-	$(GOTESTSUM) --junitfile data/results/fleet-manager-integration-tests.xml --format $(TEST_SUMMARY_FORMAT) -- -p 1 -ldflags -s -v -timeout $(TEST_TIMEOUT) -count=1 $(TESTFLAGS) \
+	$(GOTESTSUM) --junitfile data/results/fleet-manager-integration-tests.xml --format $(GOTESTSUM_FORMAT) -- -p 1 -ldflags -s -v -timeout $(TEST_TIMEOUT) -count=1 $(TESTFLAGS) \
 				./internal/dinosaur/test/integration/...
 .PHONY: test/integration/dinosaur
 
@@ -350,8 +351,10 @@ test/cluster/cleanup:
 	./scripts/cleanup_test_cluster.sh
 .PHONY: test/cluster/cleanup
 
-test/e2e:
-	CLUSTER_ID=1234567890abcdef1234567890abcdef RUN_E2E=true go test $(GOARGS) -bench -v -count=1 ./e2e/...
+test/e2e: gotestsum
+	CLUSTER_ID=1234567890abcdef1234567890abcdef \
+	RUN_E2E=true \
+	$(GOTESTSUM) --format $(GOTESTSUM_FORMAT) -- $(GOARGS) -bench -v -count=1 -p 1 -timeout $(TEST_TIMEOUT) $(TESTFLAGS) ./e2e/...
 .PHONY: test/e2e
 
 test/e2e/cleanup:

--- a/dev/env/defaults/cluster-type-openshift-ci/env
+++ b/dev/env/defaults/cluster-type-openshift-ci/env
@@ -2,6 +2,8 @@ export SPAWN_LOGGER_DEFAULT="true"
 export DUMP_LOGS_DEFAULT="true"
 export AUTH_TYPE_DEFAULT="STATIC_TOKEN"
 export FINAL_TEAR_DOWN_DEFAULT="true"
+export GOTESTSUM="/usr/local/bin/gotestsum"
+export GOTESTSUM_FORMAT="testname"
 
 # To be adjusted for runnign in OpenShift CI
 # export FLEET_MANAGER_RESOURCES_DEFAULT='{"requests":{"cpu":"200m","memory":"300Mi"},"limits":{"cpu":"200m","memory":"300Mi"}}'


### PR DESCRIPTION
## Description

Use `gotestsum` in CI instead of plain `go test`, because the former can be configured to use an output formatter suitable for CI use (no color escape codes -> easier to read).

The `Makefile` has already some support for `gotestsum` built-in, I am only modifying is such that it can *also* use a system-wide installed `/usr/local/bin/gotestsum` (we have this in our CI root image) instead of a locally built one.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
