### PR TITLE
Bugfix: Do not return nil in case namespace creation failed

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -287,7 +287,7 @@ func (r CentralReconciler) ensureNamespaceExists(name string) error {
 		if apiErrors.IsNotFound(err) {
 			err = r.client.Create(context.Background(), namespace)
 			if err != nil {
-				return nil
+				return fmt.Errorf("creating namespace %q: %w", name, err)
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Just noticed this.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
