### PR TITLE
ROX-11862: Match DNS name to the ADR

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -503,7 +503,7 @@
         "filename": "openapi/fleet-manager-private.yaml",
         "hashed_secret": "2774b5ad0fae1c8b8dc897b89db85529d45cb5cf",
         "is_verified": false,
-        "line_number": 474,
+        "line_number": 468,
         "is_secret": false
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -503,7 +503,7 @@
         "filename": "openapi/fleet-manager-private.yaml",
         "hashed_secret": "2774b5ad0fae1c8b8dc897b89db85529d45cb5cf",
         "is_verified": false,
-        "line_number": 470,
+        "line_number": 472,
         "is_secret": false
       }
     ],
@@ -844,5 +844,5 @@
       }
     ]
   },
-  "generated_at": "2022-08-01T10:44:49Z"
+  "generated_at": "2022-08-01T14:52:53Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -503,7 +503,7 @@
         "filename": "openapi/fleet-manager-private.yaml",
         "hashed_secret": "2774b5ad0fae1c8b8dc897b89db85529d45cb5cf",
         "is_verified": false,
-        "line_number": 468,
+        "line_number": 470,
         "is_secret": false
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -449,7 +449,7 @@
         "filename": "internal/dinosaur/pkg/services/dinosaur.go",
         "hashed_secret": "bae666efd375b31ee4ba6e4ed05a31c84b916b9c",
         "is_verified": false,
-        "line_number": 695,
+        "line_number": 693,
         "is_secret": false
       }
     ],

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -171,35 +171,27 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 func (r *CentralReconciler) readyStatus(ctx context.Context, namespace string) (*private.DataPlaneCentralStatus, error) {
 	status := readyStatus()
 	if r.useRoutes {
-		routesStatuses, err := r.getRoutesStatuses(ctx, namespace)
+		statusRoutes, err := r.getStatusRoutes(ctx, namespace)
 		if err != nil {
 			return nil, err
 		}
-		status.Routes = routesStatuses
+		status.Routes = statusRoutes
 	}
 	return status, nil
 }
 
-func (r *CentralReconciler) getRoutesStatuses(ctx context.Context, namespace string) ([]private.DataPlaneCentralStatusRoutes, error) {
+func (r *CentralReconciler) getStatusRoutes(ctx context.Context, namespace string) (private.DataPlaneCentralStatusRoutes, error) {
 	reencryptHostname, err := r.routeService.FindReencryptCanonicalHostname(ctx, namespace)
 	if err != nil {
-		return nil, fmt.Errorf("obtaining canonical hostname for reencrypt route: %w", err)
+		return private.DataPlaneCentralStatusRoutes{}, fmt.Errorf("obtaining canonical hostname for reencrypt route: %w", err)
 	}
 	mtlsHostname, err := r.routeService.FindMTLSCanonicalHostname(ctx, namespace)
 	if err != nil {
-		return nil, fmt.Errorf("obtaining canonical hostname for MTLS route: %w", err)
+		return private.DataPlaneCentralStatusRoutes{}, fmt.Errorf("obtaining canonical hostname for MTLS route: %w", err)
 	}
-	return []private.DataPlaneCentralStatusRoutes{
-		{
-			Name:   "central-reencrypt",
-			Prefix: "",
-			Router: reencryptHostname,
-		},
-		{
-			Name:   "central-mtls",
-			Prefix: "data",
-			Router: mtlsHostname,
-		},
+	return private.DataPlaneCentralStatusRoutes{
+		UiRouter:   reencryptHostname,
+		DataRouter: mtlsHostname,
 	}, nil
 }
 

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -186,13 +186,13 @@ func (r *CentralReconciler) getRoutesStatuses(ctx context.Context, namespace str
 	if err != nil {
 		return nil, fmt.Errorf("obtaining ingress for reencrypt route: %w", err)
 	}
-	mtlsIngress, err := r.routeService.FindMTLSIngress(ctx, namespace)
-	if err != nil {
-		return nil, fmt.Errorf("obtaining ingress for MTLS route: %w", err)
-	}
+	// mtlsIngress, err := r.routeService.FindMTLSIngress(ctx, namespace)
+	// if err != nil {
+	//	 return nil, fmt.Errorf("obtaining ingress for MTLS route: %w", err)
+	// }
 	return []private.DataPlaneCentralStatusRoutes{
 		getRouteStatus(reencryptIngress),
-		getRouteStatus(mtlsIngress),
+		// getRouteStatus(mtlsIngress),
 	}, nil
 }
 

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -287,7 +287,7 @@ func TestReportRoutesStatuses(t *testing.T) {
 			Router: "router-default.apps.test.local",
 		},
 		{
-			Domain: "central.rhacs-cb45idheg5ip6dq1jo4g",
+			Domain: "central-rhacs-cb45idheg5ip6dq1jo4g.test.local",
 			Router: "router-default.apps.test.local",
 		},
 	}
@@ -313,7 +313,7 @@ func TestReportRoutesStatusWhenCentralNotChanged(t *testing.T) {
 			Router: "router-default.apps.test.local",
 		},
 		{
-			Domain: "central.rhacs-cb45idheg5ip6dq1jo4g",
+			Domain: "central-rhacs-cb45idheg5ip6dq1jo4g.test.local",
 			Router: "router-default.apps.test.local",
 		},
 	}

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -23,7 +24,8 @@ import (
 
 const (
 	centralName               = "test-central"
-	centralNamespace          = "rhacs-cb45idheg5ip6dq1jo4g"
+	centralID                 = "cb45idheg5ip6dq1jo4g"
+	centralNamespace          = "rhacs-" + centralID
 	centralReencryptRouteName = "central-reencrypt"
 	conditionTypeReady        = "Ready"
 )
@@ -32,6 +34,14 @@ var simpleManagedCentral = private.ManagedCentral{
 	Metadata: private.ManagedCentralAllOfMetadata{
 		Name:      centralName,
 		Namespace: centralNamespace,
+	},
+	Spec: private.ManagedCentralAllOfSpec{
+		UiEndpoint: private.ManagedCentralAllOfSpecUiEndpoint{
+			Host: fmt.Sprintf("acs-%s.acs.rhcloud.test", centralID),
+		},
+		DataEndpoint: private.ManagedCentralAllOfSpecDataEndpoint{
+			Host: fmt.Sprintf("acs-data-%s.acs.rhcloud.test", centralID),
+		},
 	},
 }
 
@@ -271,19 +281,12 @@ func TestReportRoutesStatuses(t *testing.T) {
 	status, err := r.Reconcile(context.TODO(), simpleManagedCentral)
 	require.NoError(t, err)
 
-	expected := []private.DataPlaneCentralStatusRoutes{
-		{
-			Name:   "central-reencrypt",
-			Router: "router-default.apps.test.local",
-		},
-		{
-			Name:   "central-mtls",
-			Prefix: "data",
-			Router: "router-default.apps.test.local",
-		},
+	expected := private.DataPlaneCentralStatusRoutes{
+		UiRouter:   "router-default.apps.test.local",
+		DataRouter: "router-default.apps.test.local",
 	}
 	actual := status.Routes
-	assert.ElementsMatch(t, expected, actual)
+	assert.Equal(t, expected, actual)
 }
 
 func TestReportRoutesStatusWhenCentralNotChanged(t *testing.T) {
@@ -298,19 +301,12 @@ func TestReportRoutesStatusWhenCentralNotChanged(t *testing.T) {
 	existingCentral.RequestStatus = centralConstants.DinosaurRequestStatusReady.String()
 	status, _ := r.Reconcile(context.TODO(), existingCentral) // cache hit
 	// then
-	expected := []private.DataPlaneCentralStatusRoutes{
-		{
-			Name:   "central-reencrypt",
-			Router: "router-default.apps.test.local",
-		},
-		{
-			Name:   "central-mtls",
-			Prefix: "data",
-			Router: "router-default.apps.test.local",
-		},
+	expected := private.DataPlaneCentralStatusRoutes{
+		UiRouter:   "router-default.apps.test.local",
+		DataRouter: "router-default.apps.test.local",
 	}
 	actual := status.Routes
-	assert.ElementsMatch(t, expected, actual)
+	assert.Equal(t, expected, actual)
 }
 
 func centralDeploymentObject() *appsv1.Deployment {

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -286,10 +286,6 @@ func TestReportRoutesStatuses(t *testing.T) {
 			Domain: "acs-cb45idheg5ip6dq1jo4g.acs.rhcloud.test",
 			Router: "router-default.apps.test.local",
 		},
-		{
-			Domain: "central-rhacs-cb45idheg5ip6dq1jo4g.test.local",
-			Router: "router-default.apps.test.local",
-		},
 	}
 	actual := status.Routes
 	assert.ElementsMatch(t, expected, actual)
@@ -310,10 +306,6 @@ func TestReportRoutesStatusWhenCentralNotChanged(t *testing.T) {
 	expected := []private.DataPlaneCentralStatusRoutes{
 		{
 			Domain: "acs-cb45idheg5ip6dq1jo4g.acs.rhcloud.test",
-			Router: "router-default.apps.test.local",
-		},
-		{
-			Domain: "central-rhacs-cb45idheg5ip6dq1jo4g.test.local",
 			Router: "router-default.apps.test.local",
 		},
 	}

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -281,12 +281,18 @@ func TestReportRoutesStatuses(t *testing.T) {
 	status, err := r.Reconcile(context.TODO(), simpleManagedCentral)
 	require.NoError(t, err)
 
-	expected := private.DataPlaneCentralStatusRoutes{
-		UiRouter:   "router-default.apps.test.local",
-		DataRouter: "router-default.apps.test.local",
+	expected := []private.DataPlaneCentralStatusRoutes{
+		{
+			Domain: "acs-cb45idheg5ip6dq1jo4g.acs.rhcloud.test",
+			Router: "router-default.apps.test.local",
+		},
+		{
+			Domain: "central.rhacs-cb45idheg5ip6dq1jo4g",
+			Router: "router-default.apps.test.local",
+		},
 	}
 	actual := status.Routes
-	assert.Equal(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }
 
 func TestReportRoutesStatusWhenCentralNotChanged(t *testing.T) {
@@ -301,12 +307,18 @@ func TestReportRoutesStatusWhenCentralNotChanged(t *testing.T) {
 	existingCentral.RequestStatus = centralConstants.DinosaurRequestStatusReady.String()
 	status, _ := r.Reconcile(context.TODO(), existingCentral) // cache hit
 	// then
-	expected := private.DataPlaneCentralStatusRoutes{
-		UiRouter:   "router-default.apps.test.local",
-		DataRouter: "router-default.apps.test.local",
+	expected := []private.DataPlaneCentralStatusRoutes{
+		{
+			Domain: "acs-cb45idheg5ip6dq1jo4g.acs.rhcloud.test",
+			Router: "router-default.apps.test.local",
+		},
+		{
+			Domain: "central.rhacs-cb45idheg5ip6dq1jo4g",
+			Router: "router-default.apps.test.local",
+		},
 	}
 	actual := status.Routes
-	assert.Equal(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }
 
 func centralDeploymentObject() *appsv1.Deployment {

--- a/fleetshard/pkg/k8s/route.go
+++ b/fleetshard/pkg/k8s/route.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	centralReencryptRouteName = "central-reencrypt"
-	centralMTLSRouteName      = "central-mtls"
+	centralMTLSRouteName      = "central"
 	centralTLSSecretName      = "central-tls"
 )
 

--- a/fleetshard/pkg/k8s/route.go
+++ b/fleetshard/pkg/k8s/route.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	centralReencryptRouteName = "central-reencrypt"
-	centralMTLSRouteName      = "central"
+	centralMTLSRouteName      = "central-mtls"
 	centralTLSSecretName      = "central-tls"
 )
 

--- a/internal/dinosaur/constants/cluster.go
+++ b/internal/dinosaur/constants/cluster.go
@@ -11,9 +11,8 @@ const (
 	// ClusterOperationDelete - OpenShift/k8s cluster delete operation
 	ClusterOperationDelete ClusterOperation = "delete"
 
-	// The DNS prefixes used for traffic ingress
-	ManagedDinosaurIngressDNSNamePrefix = "acs"
-	DefaultIngressDNSNamePrefix         = "apps"
+	// DefaultIngressDNSNamePrefix DNS prefix used for traffic ingress
+	DefaultIngressDNSNamePrefix = "apps"
 )
 
 // String ...

--- a/internal/dinosaur/constants/cluster.go
+++ b/internal/dinosaur/constants/cluster.go
@@ -10,9 +10,6 @@ const (
 
 	// ClusterOperationDelete - OpenShift/k8s cluster delete operation
 	ClusterOperationDelete ClusterOperation = "delete"
-
-	// DefaultIngressDNSNamePrefix DNS prefix used for traffic ingress
-	DefaultIngressDNSNamePrefix = "apps"
 )
 
 // String ...

--- a/internal/dinosaur/pkg/api/dbapi/central_request_types.go
+++ b/internal/dinosaur/pkg/api/dbapi/central_request_types.go
@@ -97,3 +97,19 @@ func (k *CentralRequest) SetRoutes(routes []DataPlaneCentralRoute) error {
 	k.Routes = r
 	return nil
 }
+
+// GetUIHost returns host for CLI/GUI/API connections
+func (k *CentralRequest) GetUIHost() string {
+	if k.Host == "" {
+		return ""
+	}
+	return fmt.Sprintf("acs-%s.%s", k.ID, k.Host)
+}
+
+// GetDataHost return host for Sensor connections
+func (k *CentralRequest) GetDataHost() string {
+	if k.Host == "" {
+		return ""
+	}
+	return fmt.Sprintf("acs-data-%s.%s", k.ID, k.Host)
+}

--- a/internal/dinosaur/pkg/api/dbapi/data_plane_central_status.go
+++ b/internal/dinosaur/pkg/api/dbapi/data_plane_central_status.go
@@ -9,7 +9,7 @@ type DataPlaneCentralStatus struct {
 	CentralClusterID string
 	Conditions       []DataPlaneCentralStatusCondition
 	// Going to ignore the rest of fields (like capacity and versions) for now, until when they are needed
-	Routes                 []DataPlaneCentralRouteRequest
+	Routes                 DataPlaneCentralRoutesRequest
 	CentralVersion         string
 	CentralOperatorVersion string
 }
@@ -28,11 +28,10 @@ type DataPlaneCentralRoute struct {
 	Router string
 }
 
-// DataPlaneCentralRouteRequest ...
-type DataPlaneCentralRouteRequest struct {
-	Name   string
-	Prefix string
-	Router string
+// DataPlaneCentralRoutesRequest ...
+type DataPlaneCentralRoutesRequest struct {
+	UIRouter   string
+	DataRouter string
 }
 
 // GetReadyCondition ...

--- a/internal/dinosaur/pkg/api/dbapi/data_plane_central_status.go
+++ b/internal/dinosaur/pkg/api/dbapi/data_plane_central_status.go
@@ -9,7 +9,7 @@ type DataPlaneCentralStatus struct {
 	CentralClusterID string
 	Conditions       []DataPlaneCentralStatusCondition
 	// Going to ignore the rest of fields (like capacity and versions) for now, until when they are needed
-	Routes                 DataPlaneCentralRoutesRequest
+	Routes                 []DataPlaneCentralRoute
 	CentralVersion         string
 	CentralOperatorVersion string
 }
@@ -26,12 +26,6 @@ type DataPlaneCentralStatusCondition struct {
 type DataPlaneCentralRoute struct {
 	Domain string
 	Router string
-}
-
-// DataPlaneCentralRoutesRequest ...
-type DataPlaneCentralRoutesRequest struct {
-	UIRouter   string
-	DataRouter string
 }
 
 // GetReadyCondition ...

--- a/internal/dinosaur/pkg/api/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/private/api/openapi.yaml
@@ -354,7 +354,10 @@ components:
         versions:
           $ref: '#/components/schemas/DataPlaneCentralStatus_versions'
         routes:
-          $ref: '#/components/schemas/DataPlaneCentralStatus_routes'
+          description: Routes created for a Central
+          items:
+            $ref: '#/components/schemas/DataPlaneCentralStatus_routes'
+          type: array
       type: object
     DataPlaneCentralStatusUpdateRequest:
       additionalProperties:
@@ -561,11 +564,10 @@ components:
         centralOperator:
           type: string
     DataPlaneCentralStatus_routes:
-      description: Routes created for a Central
       properties:
-        uiRouter:
+        domain:
           type: string
-        dataRouter:
+        router:
           type: string
     DataplaneClusterAgentConfig_spec_observability:
       description: Observability configurations

--- a/internal/dinosaur/pkg/api/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/private/api/openapi.yaml
@@ -354,10 +354,7 @@ components:
         versions:
           $ref: '#/components/schemas/DataPlaneCentralStatus_versions'
         routes:
-          description: Routes created for a Central
-          items:
-            $ref: '#/components/schemas/DataPlaneCentralStatus_routes'
-          type: array
+          $ref: '#/components/schemas/DataPlaneCentralStatus_routes'
       type: object
     DataPlaneCentralStatusUpdateRequest:
       additionalProperties:
@@ -564,12 +561,11 @@ components:
         centralOperator:
           type: string
     DataPlaneCentralStatus_routes:
+      description: Routes created for a Central
       properties:
-        name:
+        uiRouter:
           type: string
-        prefix:
-          type: string
-        router:
+        dataRouter:
           type: string
     DataplaneClusterAgentConfig_spec_observability:
       description: Observability configurations

--- a/internal/dinosaur/pkg/api/private/model_data_plane_central_status.go
+++ b/internal/dinosaur/pkg/api/private/model_data_plane_central_status.go
@@ -14,5 +14,6 @@ type DataPlaneCentralStatus struct {
 	// The status conditions of a Central
 	Conditions []DataPlaneClusterUpdateStatusRequestConditions `json:"conditions,omitempty"`
 	Versions   DataPlaneCentralStatusVersions                  `json:"versions,omitempty"`
-	Routes     DataPlaneCentralStatusRoutes                    `json:"routes,omitempty"`
+	// Routes created for a Central
+	Routes []DataPlaneCentralStatusRoutes `json:"routes,omitempty"`
 }

--- a/internal/dinosaur/pkg/api/private/model_data_plane_central_status.go
+++ b/internal/dinosaur/pkg/api/private/model_data_plane_central_status.go
@@ -14,6 +14,5 @@ type DataPlaneCentralStatus struct {
 	// The status conditions of a Central
 	Conditions []DataPlaneClusterUpdateStatusRequestConditions `json:"conditions,omitempty"`
 	Versions   DataPlaneCentralStatusVersions                  `json:"versions,omitempty"`
-	// Routes created for a Central
-	Routes []DataPlaneCentralStatusRoutes `json:"routes,omitempty"`
+	Routes     DataPlaneCentralStatusRoutes                    `json:"routes,omitempty"`
 }

--- a/internal/dinosaur/pkg/api/private/model_data_plane_central_status_routes.go
+++ b/internal/dinosaur/pkg/api/private/model_data_plane_central_status_routes.go
@@ -9,8 +9,8 @@
 
 package private
 
-// DataPlaneCentralStatusRoutes Routes created for a Central
+// DataPlaneCentralStatusRoutes struct for DataPlaneCentralStatusRoutes
 type DataPlaneCentralStatusRoutes struct {
-	UiRouter   string `json:"uiRouter,omitempty"`
-	DataRouter string `json:"dataRouter,omitempty"`
+	Domain string `json:"domain,omitempty"`
+	Router string `json:"router,omitempty"`
 }

--- a/internal/dinosaur/pkg/api/private/model_data_plane_central_status_routes.go
+++ b/internal/dinosaur/pkg/api/private/model_data_plane_central_status_routes.go
@@ -9,9 +9,8 @@
 
 package private
 
-// DataPlaneCentralStatusRoutes struct for DataPlaneCentralStatusRoutes
+// DataPlaneCentralStatusRoutes Routes created for a Central
 type DataPlaneCentralStatusRoutes struct {
-	Name   string `json:"name,omitempty"`
-	Prefix string `json:"prefix,omitempty"`
-	Router string `json:"router,omitempty"`
+	UiRouter   string `json:"uiRouter,omitempty"`
+	DataRouter string `json:"dataRouter,omitempty"`
 }

--- a/internal/dinosaur/pkg/presenters/data_plane_dinosaur_status.go
+++ b/internal/dinosaur/pkg/presenters/data_plane_dinosaur_status.go
@@ -11,6 +11,7 @@ func ConvertDataPlaneDinosaurStatus(status map[string]private.DataPlaneCentralSt
 
 	for k, v := range status {
 		c := make([]dbapi.DataPlaneCentralStatusCondition, 0, len(v.Conditions))
+		var routes []dbapi.DataPlaneCentralRoute
 		for _, s := range v.Conditions {
 			c = append(c, dbapi.DataPlaneCentralStatusCondition{
 				Type:    s.Type,
@@ -19,13 +20,19 @@ func ConvertDataPlaneDinosaurStatus(status map[string]private.DataPlaneCentralSt
 				Message: s.Message,
 			})
 		}
+		if v.Routes != nil {
+			routes = make([]dbapi.DataPlaneCentralRoute, 0, len(v.Routes))
+			for _, ro := range v.Routes {
+				routes = append(routes, dbapi.DataPlaneCentralRoute{
+					Domain: ro.Domain,
+					Router: ro.Router,
+				})
+			}
+		}
 		res = append(res, &dbapi.DataPlaneCentralStatus{
-			CentralClusterID: k,
-			Conditions:       c,
-			Routes: dbapi.DataPlaneCentralRoutesRequest{
-				UIRouter:   v.Routes.UiRouter,
-				DataRouter: v.Routes.DataRouter,
-			},
+			CentralClusterID:       k,
+			Conditions:             c,
+			Routes:                 routes,
 			CentralVersion:         v.Versions.Central,
 			CentralOperatorVersion: v.Versions.CentralOperator,
 		})

--- a/internal/dinosaur/pkg/presenters/data_plane_dinosaur_status.go
+++ b/internal/dinosaur/pkg/presenters/data_plane_dinosaur_status.go
@@ -11,7 +11,6 @@ func ConvertDataPlaneDinosaurStatus(status map[string]private.DataPlaneCentralSt
 
 	for k, v := range status {
 		c := make([]dbapi.DataPlaneCentralStatusCondition, 0, len(v.Conditions))
-		var routes []dbapi.DataPlaneCentralRouteRequest
 		for _, s := range v.Conditions {
 			c = append(c, dbapi.DataPlaneCentralStatusCondition{
 				Type:    s.Type,
@@ -20,20 +19,13 @@ func ConvertDataPlaneDinosaurStatus(status map[string]private.DataPlaneCentralSt
 				Message: s.Message,
 			})
 		}
-		if v.Routes != nil {
-			routes = make([]dbapi.DataPlaneCentralRouteRequest, 0, len(v.Routes))
-			for _, ro := range v.Routes {
-				routes = append(routes, dbapi.DataPlaneCentralRouteRequest{
-					Name:   ro.Name,
-					Prefix: ro.Prefix,
-					Router: ro.Router,
-				})
-			}
-		}
 		res = append(res, &dbapi.DataPlaneCentralStatus{
-			CentralClusterID:       k,
-			Conditions:             c,
-			Routes:                 routes,
+			CentralClusterID: k,
+			Conditions:       c,
+			Routes: dbapi.DataPlaneCentralRoutesRequest{
+				UIRouter:   v.Routes.UiRouter,
+				DataRouter: v.Routes.DataRouter,
+			},
 			CentralVersion:         v.Versions.Central,
 			CentralOperatorVersion: v.Versions.CentralOperator,
 		})

--- a/internal/dinosaur/pkg/presenters/dinosaur.go
+++ b/internal/dinosaur/pkg/presenters/dinosaur.go
@@ -32,7 +32,7 @@ func PresentDinosaurRequest(request *dbapi.CentralRequest) public.CentralRequest
 		Region:        request.Region,
 		Owner:         request.Owner,
 		Name:          request.Name,
-		Host:          request.Host,
+		Host:          request.GetUIHost(), // TODO(ROX-11990): Split the Host in Fleet Manager Public API to UI and Data hosts
 		CreatedAt:     request.CreatedAt,
 		UpdatedAt:     request.UpdatedAt,
 		FailedReason:  request.FailedReason,

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -62,11 +62,14 @@ func (c *ManagedCentralPresenter) PresentManagedCentral(from *dbapi.CentralReque
 				Issuer:      c.centralConfig.RhSsoIssuer,
 			},
 			UiEndpoint: private.ManagedCentralAllOfSpecUiEndpoint{
-				Host: from.Host,
+				Host: from.GetUIHost(),
 				Tls: private.ManagedCentralAllOfSpecUiEndpointTls{
 					Cert: c.centralConfig.DinosaurTLSCert,
 					Key:  c.centralConfig.DinosaurTLSKey,
 				},
+			},
+			DataEndpoint: private.ManagedCentralAllOfSpecDataEndpoint{
+				Host: from.GetDataHost(),
 			},
 			Versions: private.ManagedCentralVersions{
 				Central:         from.DesiredCentralVersion,

--- a/internal/dinosaur/pkg/services/data_plane_dinosaur.go
+++ b/internal/dinosaur/pkg/services/data_plane_dinosaur.go
@@ -300,13 +300,12 @@ func (d *dataPlaneDinosaurService) persistDinosaurRoutes(dinosaur *dbapi.Central
 	}
 
 	routesInRequest := dinosaurStatus.Routes
-	var routes []dbapi.DataPlaneCentralRoute
 
 	if routesErr := validateRouters(routesInRequest, dinosaur, clusterDNS); routesErr != nil {
 		return serviceError.NewWithCause(serviceError.ErrorBadRequest, routesErr, "routes are not valid")
 	}
 
-	if err := dinosaur.SetRoutes(routes); err != nil {
+	if err := dinosaur.SetRoutes(routesInRequest); err != nil {
 		return serviceError.NewWithCause(serviceError.ErrorGeneral, err, "failed to set routes for dinosaur %s", dinosaur.ID)
 	}
 

--- a/internal/dinosaur/pkg/services/util.go
+++ b/internal/dinosaur/pkg/services/util.go
@@ -9,7 +9,6 @@ import (
 )
 
 const (
-	truncatedNameLen = 10
 	// Maximum namespace name length is 63
 	// Namespace name is built using the dinosaur request id (always generated with 27 length) and the owner (truncated with this var).
 	// Set the truncate index to 35 to ensure that the namespace name does not go over the maximum limit.

--- a/openapi/fleet-manager-private.yaml
+++ b/openapi/fleet-manager-private.yaml
@@ -403,16 +403,12 @@ components:
               type: string
         routes:
           description: "Routes created for a Central"
-          type: array
-          items:
-            type: object
-            properties:
-              name:
-                type: string
-              prefix:
-                type: string
-              router:
-                type: string
+          type: object
+          properties:
+            uiRouter:
+              type: string
+            dataRouter:
+              type: string
       example:
         $ref: '#/components/examples/DataPlaneCentralStatusRequestExample'
 

--- a/openapi/fleet-manager-private.yaml
+++ b/openapi/fleet-manager-private.yaml
@@ -403,12 +403,14 @@ components:
               type: string
         routes:
           description: "Routes created for a Central"
-          type: object
-          properties:
-            uiRouter:
-              type: string
-            dataRouter:
-              type: string
+          type: array
+          items:
+            type: object
+            properties:
+              domain:
+                type: string
+              router:
+                type: string
       example:
         $ref: '#/components/examples/DataPlaneCentralStatusRequestExample'
 


### PR DESCRIPTION
## Description
This PR aligns the routes creation implementation with URI scheme we decided to use in the ADR.
Previously there was a heuristic approach to determine a hostname using a prefix and subdomain. After this change, UI and data hostnames can be set separately on the fleetmanager with any pattern we want.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual
Tested manually on a dedicated OSD cluster

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
