### PR TITLE
ROX-11917: Create passthrough route from the fleetshard sync

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -286,6 +286,10 @@ func TestReportRoutesStatuses(t *testing.T) {
 			Domain: "acs-cb45idheg5ip6dq1jo4g.acs.rhcloud.test",
 			Router: "router-default.apps.test.local",
 		},
+		{
+			Domain: "acs-data-cb45idheg5ip6dq1jo4g.acs.rhcloud.test",
+			Router: "router-default.apps.test.local",
+		},
 	}
 	actual := status.Routes
 	assert.ElementsMatch(t, expected, actual)
@@ -306,6 +310,10 @@ func TestReportRoutesStatusWhenCentralNotChanged(t *testing.T) {
 	expected := []private.DataPlaneCentralStatusRoutes{
 		{
 			Domain: "acs-cb45idheg5ip6dq1jo4g.acs.rhcloud.test",
+			Router: "router-default.apps.test.local",
+		},
+		{
+			Domain: "acs-data-cb45idheg5ip6dq1jo4g.acs.rhcloud.test",
 			Router: "router-default.apps.test.local",
 		},
 	}

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -26,7 +26,7 @@ const (
 	centralName               = "test-central"
 	centralID                 = "cb45idheg5ip6dq1jo4g"
 	centralNamespace          = "rhacs-" + centralID
-	centralReencryptRouteName = "central-reencrypt"
+	centralReencryptRouteName = "managed-central-reencrypt"
 	conditionTypeReady        = "Ready"
 )
 

--- a/fleetshard/pkg/k8s/route.go
+++ b/fleetshard/pkg/k8s/route.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	centralReencryptRouteName = "central-reencrypt"
-	centralMTLSRouteName      = "central-mtls"
-	centralTLSSecretName      = "central-tls"
+	centralReencryptRouteName   = "managed-central-reencrypt"
+	centralPassthroughRouteName = "managed-central-passthrough"
+	centralTLSSecretName        = "central-tls"
 )
 
 // RouteService is responsible for performing read and write operations on the OpenShift Route objects in the cluster.
@@ -36,14 +36,19 @@ func (s *RouteService) FindReencryptRoute(ctx context.Context, namespace string)
 	return s.findRoute(ctx, namespace, centralReencryptRouteName)
 }
 
+// FindPassthroughRoute returns central passthrough route or error if not found.
+func (s *RouteService) FindPassthroughRoute(ctx context.Context, namespace string) (*openshiftRouteV1.Route, error) {
+	return s.findRoute(ctx, namespace, centralPassthroughRouteName)
+}
+
 // FindReencryptIngress returns central reencrypt route ingress or error if not found.
 func (s *RouteService) FindReencryptIngress(ctx context.Context, namespace string) (*openshiftRouteV1.RouteIngress, error) {
 	return s.findFirstAdmittedIngress(ctx, namespace, centralReencryptRouteName)
 }
 
-// FindMTLSIngress returns central MTLS route ingress or error if not found.
-func (s *RouteService) FindMTLSIngress(ctx context.Context, namespace string) (*openshiftRouteV1.RouteIngress, error) {
-	return s.findFirstAdmittedIngress(ctx, namespace, centralMTLSRouteName)
+// FindPassthroughIngress returns central passthrough route ingress or error if not found.
+func (s *RouteService) FindPassthroughIngress(ctx context.Context, namespace string) (*openshiftRouteV1.RouteIngress, error) {
+	return s.findFirstAdmittedIngress(ctx, namespace, centralPassthroughRouteName)
 }
 
 // FindFirstAdmittedIngress returns first admitted ingress or error if not found
@@ -108,6 +113,35 @@ func (s *RouteService) CreateReencryptRoute(ctx context.Context, remoteCentral p
 	err = s.client.Create(ctx, route)
 	if err != nil {
 		return fmt.Errorf("creating reencrypt route: %w", err)
+	}
+	return nil
+}
+
+// CreatePassthroughRoute creates a new managed central passthrough route.
+func (s *RouteService) CreatePassthroughRoute(ctx context.Context, remoteCentral private.ManagedCentral) error {
+	route := &openshiftRouteV1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      centralPassthroughRouteName,
+			Namespace: remoteCentral.Metadata.Namespace,
+			Labels:    map[string]string{ManagedByLabelKey: ManagedByFleetshardValue},
+		},
+		Spec: openshiftRouteV1.RouteSpec{
+			Host: remoteCentral.Spec.DataEndpoint.Host,
+			Port: &openshiftRouteV1.RoutePort{
+				TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: "https"},
+			},
+			To: openshiftRouteV1.RouteTargetReference{
+				Kind: "Service",
+				Name: "central",
+			},
+			TLS: &openshiftRouteV1.TLSConfig{
+				Termination: openshiftRouteV1.TLSTerminationPassthrough,
+			},
+		},
+	}
+
+	if err := s.client.Create(ctx, route); err != nil {
+		return fmt.Errorf("creating passthrough route: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
This PR adds an ability to create and delete an additional passthrough route from the fleetshard sync. The intension is to set a custom hostname. This is currently not possible on the SRox operator side

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

Tested manually on the dedicated OCM cluster

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
