### PR TITLE
Update OCM version used within CI Dockerfile

### DIFF
--- a/.openshift-ci/build-root/Dockerfile
+++ b/.openshift-ci/build-root/Dockerfile
@@ -32,6 +32,6 @@ RUN mkdir -p /stackrox/crds && \
     curl -L --retry 10 --silent --show-error --fail -o /stackrox/crds/platform.stackrox.io_securedclusters.yaml \
     https://raw.githubusercontent.com/stackrox/stackrox/release/3.70.x/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
 RUN curl -L --retry 10 --silent --show-error --fail -o "/usr/local/bin/ocm" \
-    https://github.com/openshift-online/ocm-cli/releases/download/v0.1.30/ocm-linux-amd64 && \
+    https://github.com/openshift-online/ocm-cli/releases/download/v0.1.64/ocm-linux-amd64 && \
     chmod +x /usr/local/bin/ocm
 ENV PATH="/usr/local/lib/nodejs/node-v16.15.1-linux-x64/bin:${PATH}"


### PR DESCRIPTION
## Description

Need to use a later version of the OCM CLI, as the current version is failing when trying to run auth E2E tests within #201 .

Tested locally with this version and logging in with `client-id/client-secret` flags without any issues.