### PR TITLE
fix PodDisruptionBudget maxUnavailable typo

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -1179,7 +1179,7 @@ objects:
     metadata:
       name: fleet-manager-pdb
     spec:
-      maxUnavailabe: "50%"
+      maxUnavailable: "50%"
       selector:
         matchLabels:
           app: fleet-manager


### PR DESCRIPTION
## Description
typo, causing the maxUnavailable to not be set in the PDB and forbidding any pod deletion

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~Unit and integration tests added~~
- [ ] ~~Documentation added if necessary~~
- [ ] ~~CI and all relevant tests are passing~~

## Test manual
None