### PR TITLE
Use STATIC_OCM_TOKEN instead of regular one in e2e staging tests

### DIFF
--- a/e2e/run_e2e_stage.sh
+++ b/e2e/run_e2e_stage.sh
@@ -4,7 +4,7 @@
 #
 # FLEET_MANAGER_ENDPOINT - The base URL endpoint of the sage fleet manager instance.
 #
-# OCM_TOKEN - The static token for the SSO.
+# STATIC_OCM_TOKEN - The static token for the SSO.
 #
 # By default AWS provider on `us-east-1` region is used because stage Data Plane is configured that way.
 #
@@ -15,5 +15,5 @@ make \
   DP_REGION="us-east-1" \
   FLEET_MANAGER_ENDPOINT="${ACS_FLEET_MANAGER_ENDPOINT}" \
   AUTH_TYPE="STATIC_TOKEN" \
-  STATIC_TOKEN="${OCM_TOKEN}" \
+  STATIC_TOKEN="${STATIC_OCM_TOKEN}" \
   test/e2e


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
`STATIC_OCM_TOKEN` was added to the app-interface Vault CI mappings so we can use it in e2e staging tests instead of regular ocm token

