### PR TITLE
ROX-11619: Make issuer configurable

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -285,7 +285,7 @@
         "filename": "fleetshard/pkg/central/reconciler/init_auth.go",
         "hashed_secret": "e70828d09cb504216324cd5ff78dce0496ffbabc",
         "is_verified": false,
-        "line_number": 16,
+        "line_number": 18,
         "is_secret": false
       },
       {
@@ -293,7 +293,7 @@
         "filename": "fleetshard/pkg/central/reconciler/init_auth.go",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 19,
         "is_secret": false
       },
       {
@@ -301,7 +301,7 @@
         "filename": "fleetshard/pkg/central/reconciler/init_auth.go",
         "hashed_secret": "3bd3b54392b8e030b7f8f49e7d9aac679c825055",
         "is_verified": false,
-        "line_number": 96,
+        "line_number": 97,
         "is_secret": false
       },
       {
@@ -309,7 +309,7 @@
         "filename": "fleetshard/pkg/central/reconciler/init_auth.go",
         "hashed_secret": "6d11570a9cca0e18aeaf174e65fc6d8af01a4626",
         "is_verified": false,
-        "line_number": 132,
+        "line_number": 133,
         "is_secret": false
       }
     ],
@@ -521,7 +521,7 @@
         "filename": "openapi/fleet-manager-private.yaml",
         "hashed_secret": "2774b5ad0fae1c8b8dc897b89db85529d45cb5cf",
         "is_verified": false,
-        "line_number": 472,
+        "line_number": 474,
         "is_secret": false
       }
     ],
@@ -862,5 +862,5 @@
       }
     ]
   },
-  "generated_at": "2022-07-29T13:35:13Z"
+  "generated_at": "2022-07-29T16:03:16Z"
 }

--- a/fleetshard/pkg/central/reconciler/init_auth.go
+++ b/fleetshard/pkg/central/reconciler/init_auth.go
@@ -3,11 +3,13 @@ package reconciler
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	centralClientPkg "github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/client"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/ternary"
 	core "k8s.io/api/core/v1"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -84,14 +86,13 @@ func createRHSSOAuthProvider(ctx context.Context, central private.ManagedCentral
 
 func createAuthProviderRequest(central private.ManagedCentral) *storage.AuthProvider {
 	request := &storage.AuthProvider{
-		// TODO: ROX-11619: change depending on whether environment is stage or not
-		Name:       "Red Hat SSO(Stage)",
+		Name: ternary.String(strings.Contains(central.Spec.Auth.Issuer, "stage"),
+			" Red Hat SSO (Stage)", "Red Hat SSO"),
 		Type:       "oidc",
 		UiEndpoint: central.Spec.UiEndpoint.Host,
 		Enabled:    true,
 		Config: map[string]string{
-			// TODO: ROX-11619: make configurable
-			"issuer":        "https://sso.stage.redhat.com/auth/realms/redhat-external",
+			"issuer":        central.Spec.Auth.Issuer,
 			"client_id":     central.Spec.Auth.ClientId,
 			"client_secret": central.Spec.Auth.ClientSecret,
 			"mode":          "post",

--- a/fleetshard/pkg/central/reconciler/init_auth.go
+++ b/fleetshard/pkg/central/reconciler/init_auth.go
@@ -87,7 +87,7 @@ func createRHSSOAuthProvider(ctx context.Context, central private.ManagedCentral
 func createAuthProviderRequest(central private.ManagedCentral) *storage.AuthProvider {
 	request := &storage.AuthProvider{
 		Name: ternary.String(strings.Contains(central.Spec.Auth.Issuer, "stage"),
-			" Red Hat SSO (Stage)", "Red Hat SSO"),
+			"Red Hat SSO (Stage)", "Red Hat SSO"),
 		Type:       "oidc",
 		UiEndpoint: central.Spec.UiEndpoint.Host,
 		Enabled:    true,

--- a/internal/dinosaur/pkg/api/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/private/api/openapi.yaml
@@ -432,6 +432,8 @@ components:
           type: string
         ownerOrgId:
           type: string
+        issuer:
+          type: string
     ManagedCentral_allOf_spec_uiEndpoint_tls:
       properties:
         cert:

--- a/internal/dinosaur/pkg/api/private/model_managed_central_all_of_spec_auth.go
+++ b/internal/dinosaur/pkg/api/private/model_managed_central_all_of_spec_auth.go
@@ -15,4 +15,5 @@ type ManagedCentralAllOfSpecAuth struct {
 	ClientId     string `json:"clientId,omitempty"`
 	OwnerUserId  string `json:"ownerUserId,omitempty"`
 	OwnerOrgId   string `json:"ownerOrgId,omitempty"`
+	Issuer       string `json:"issuer,omitempty"`
 }

--- a/internal/dinosaur/pkg/config/dinosaur.go
+++ b/internal/dinosaur/pkg/config/dinosaur.go
@@ -28,6 +28,7 @@ type DinosaurConfig struct {
 	Quota                 *DinosaurQuotaConfig    `json:"dinosaur_quota"`
 	RhSsoClientSecret     string                  `json:"rhsso_client_secret"`
 	RhSsoClientSecretFile string                  `json:"rhsso_client_secret_file"`
+	RHSsoIssuer           string                  `json:"rhsso_issuer"`
 }
 
 // NewDinosaurConfig ...
@@ -39,6 +40,7 @@ func NewDinosaurConfig() *DinosaurConfig {
 		DinosaurDomainName:                "rhacs-dev.com",
 		DinosaurLifespan:                  NewDinosaurLifespanConfig(),
 		Quota:                             NewDinosaurQuotaConfig(),
+		RHSsoIssuer:                       "https://sso.redhat.com/auth/realsm/redhat-external",
 	}
 }
 
@@ -53,6 +55,7 @@ func (c *DinosaurConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.Quota.Type, "quota-type", c.Quota.Type, "The type of the quota service to be used. The available options are: 'ams' for AMS backed implementation and 'quota-management-list' for quota list backed implementation (default).")
 	fs.BoolVar(&c.Quota.AllowEvaluatorInstance, "allow-evaluator-instance", c.Quota.AllowEvaluatorInstance, "Allow the creation of dinosaur evaluator instances")
 	fs.StringVar(&c.RhSsoClientSecretFile, "rhsso-client-secret-file", c.RhSsoClientSecretFile, "File containing OIDC client secret of sso.redhat.com client")
+	fs.StringVar(&c.RHSsoIssuer, "rhsso-issuer", c.RHSsoIssuer, "Issuer of sso.redhat.com client")
 }
 
 // ReadFiles ...

--- a/internal/dinosaur/pkg/config/dinosaur.go
+++ b/internal/dinosaur/pkg/config/dinosaur.go
@@ -28,7 +28,7 @@ type DinosaurConfig struct {
 	Quota                 *DinosaurQuotaConfig    `json:"dinosaur_quota"`
 	RhSsoClientSecret     string                  `json:"rhsso_client_secret"`
 	RhSsoClientSecretFile string                  `json:"rhsso_client_secret_file"`
-	RHSsoIssuer           string                  `json:"rhsso_issuer"`
+	RhSsoIssuer           string                  `json:"rhsso_issuer"`
 }
 
 // NewDinosaurConfig ...
@@ -40,7 +40,7 @@ func NewDinosaurConfig() *DinosaurConfig {
 		DinosaurDomainName:                "rhacs-dev.com",
 		DinosaurLifespan:                  NewDinosaurLifespanConfig(),
 		Quota:                             NewDinosaurQuotaConfig(),
-		RHSsoIssuer:                       "https://sso.redhat.com/auth/realms/redhat-external",
+		RhSsoIssuer:                       "https://sso.redhat.com/auth/realms/redhat-external",
 	}
 }
 
@@ -55,7 +55,7 @@ func (c *DinosaurConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.Quota.Type, "quota-type", c.Quota.Type, "The type of the quota service to be used. The available options are: 'ams' for AMS backed implementation and 'quota-management-list' for quota list backed implementation (default).")
 	fs.BoolVar(&c.Quota.AllowEvaluatorInstance, "allow-evaluator-instance", c.Quota.AllowEvaluatorInstance, "Allow the creation of dinosaur evaluator instances")
 	fs.StringVar(&c.RhSsoClientSecretFile, "rhsso-client-secret-file", c.RhSsoClientSecretFile, "File containing OIDC client secret of sso.redhat.com client")
-	fs.StringVar(&c.RHSsoIssuer, "rhsso-issuer", c.RHSsoIssuer, "Issuer identifier for sso.redhat.com. Should be equal to value returned in ID Token issuer('iss') field")
+	fs.StringVar(&c.RhSsoIssuer, "rhsso-issuer", c.RhSsoIssuer, "Issuer identifier for sso.redhat.com. Should be equal to value returned in ID Token issuer('iss') field")
 }
 
 // ReadFiles ...

--- a/internal/dinosaur/pkg/config/dinosaur.go
+++ b/internal/dinosaur/pkg/config/dinosaur.go
@@ -55,7 +55,7 @@ func (c *DinosaurConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.Quota.Type, "quota-type", c.Quota.Type, "The type of the quota service to be used. The available options are: 'ams' for AMS backed implementation and 'quota-management-list' for quota list backed implementation (default).")
 	fs.BoolVar(&c.Quota.AllowEvaluatorInstance, "allow-evaluator-instance", c.Quota.AllowEvaluatorInstance, "Allow the creation of dinosaur evaluator instances")
 	fs.StringVar(&c.RhSsoClientSecretFile, "rhsso-client-secret-file", c.RhSsoClientSecretFile, "File containing OIDC client secret of sso.redhat.com client")
-	fs.StringVar(&c.RHSsoIssuer, "rhsso-issuer", c.RHSsoIssuer, "Issuer of sso.redhat.com client")
+	fs.StringVar(&c.RHSsoIssuer, "rhsso-issuer", c.RHSsoIssuer, "Issuer identifier for sso.redhat.com. Should be equal to value returned in ID Token issuer('iss') field")
 }
 
 // ReadFiles ...

--- a/internal/dinosaur/pkg/config/dinosaur.go
+++ b/internal/dinosaur/pkg/config/dinosaur.go
@@ -40,7 +40,7 @@ func NewDinosaurConfig() *DinosaurConfig {
 		DinosaurDomainName:                "rhacs-dev.com",
 		DinosaurLifespan:                  NewDinosaurLifespanConfig(),
 		Quota:                             NewDinosaurQuotaConfig(),
-		RHSsoIssuer:                       "https://sso.redhat.com/auth/realsm/redhat-external",
+		RHSsoIssuer:                       "https://sso.redhat.com/auth/realms/redhat-external",
 	}
 }
 

--- a/internal/dinosaur/pkg/environments/development.go
+++ b/internal/dinosaur/pkg/environments/development.go
@@ -35,5 +35,6 @@ func NewDevelopmentEnvLoader() environments.EnvLoader {
 		"additional-sso-issuers-file":                     "config/additional-sso-issuers.yaml",
 		"jwks-file":                                       "config/jwks-file-static.json",
 		"fleetshard-authz-config-file":                    "config/fleetshard-authz-org-ids-development.yaml",
+		"rhsso-issuer":                                    "https://sso.stage.redhat.com/auth/realms/redhat-external",
 	}
 }

--- a/internal/dinosaur/pkg/environments/stage.go
+++ b/internal/dinosaur/pkg/environments/stage.go
@@ -17,5 +17,6 @@ func NewStageEnvLoader() environments.EnvLoader {
 		"additional-sso-issuers-file":          "config/additional-sso-issuers.yaml",
 		"jwks-file":                            "config/jwks-file-static.json",
 		"fleetshard-authz-config-file":         "config/fleetshard-authz-org-ids-development.yaml",
+		"rhsso-issuer":                         "https://sso.stage.redhat.com/auth/realms/redhat-external",
 	}
 }

--- a/internal/dinosaur/pkg/presenters/manageddinosaur.go
+++ b/internal/dinosaur/pkg/presenters/manageddinosaur.go
@@ -45,6 +45,7 @@ func PresentManagedDinosaur(from *v1.ManagedDinosaur) private.ManagedCentral {
 				ClientId:     from.Spec.Auth.ClientID,
 				OwnerUserId:  from.Spec.Auth.OwnerUserID,
 				OwnerOrgId:   from.Spec.Auth.OwnerOrgID,
+				Issuer:       from.Spec.Auth.Issuer,
 			},
 			UiEndpoint: private.ManagedCentralAllOfSpecUiEndpoint{
 				Host: from.Spec.Endpoint.Host,

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -846,6 +846,7 @@ func BuildManagedDinosaurCR(dinosaurRequest *dbapi.CentralRequest, dinosaurConfi
 				ClientID:    "rhacs-ms-dev",
 				OwnerOrgID:  dinosaurRequest.OrganisationID,
 				OwnerUserID: dinosaurRequest.OwnerUserID,
+				Issuer:      dinosaurConfig.RHSsoIssuer,
 			},
 			Endpoint: manageddinosaur.EndpointSpec{
 				Host: dinosaurRequest.Host,

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -846,7 +846,7 @@ func BuildManagedDinosaurCR(dinosaurRequest *dbapi.CentralRequest, dinosaurConfi
 				ClientID:    "rhacs-ms-dev",
 				OwnerOrgID:  dinosaurRequest.OrganisationID,
 				OwnerUserID: dinosaurRequest.OwnerUserID,
-				Issuer:      dinosaurConfig.RHSsoIssuer,
+				Issuer:      dinosaurConfig.RhSsoIssuer,
 			},
 			Endpoint: manageddinosaur.EndpointSpec{
 				Host: dinosaurRequest.Host,

--- a/openapi/fleet-manager-private.yaml
+++ b/openapi/fleet-manager-private.yaml
@@ -262,6 +262,8 @@ components:
                       type: string
                     ownerOrgId:
                       type: string
+                    issuer:
+                      type: string
                 uiEndpoint:
                   type: object
                   description: 'Handles GUI/CLI/API connections'

--- a/pkg/api/manageddinosaurs.manageddinosaur.mas/v1/types.go
+++ b/pkg/api/manageddinosaurs.manageddinosaur.mas/v1/types.go
@@ -49,6 +49,7 @@ type AuthSpec struct {
 	ClientID     string `json:"clientId,omitempty"`
 	OwnerUserID  string `json:"ownerUserId,omitempty"`
 	OwnerOrgID   string `json:"ownerOrgId,omitempty"`
+	Issuer       string `json:"issuer,omitempty"`
 }
 
 // ManagedDinosaurSpec ...


### PR DESCRIPTION
## Description

Instead of hard-coding the issuer value of the auth provider, conditionally use either `sso.stage.redhat.com/sso.redhat.com` depending on the environment in which fleet manager is deployed.

By default, `sso.redhat.com` will be assumed. In dev / staging environments, `sso.stage.redhat.com` will be used.

Additionally, the flag `rhsso-issuer` can be used to manually set the issuer for i.e. testing purposes.

Besides that, there's a small QoL change: Based on the issuer, the auth provider is either named `Red Hat SSO` (for `sso.redhat.com`) or `Red Hat SSO (Stage)` (for `sso.stage.redhat.com`).

## Test manual

```
# Start fleet manager with default flags.
./fleet-manager serve --dataplane-cluster-config-file=<your-config> --rhsso-client-secret-file=<client secret>
# Start fleetshard synchronizer
CREATE_AUTH_PROVIDER=true CLUSTER_ID=1234567890abcdef1234567890abcdef OCM_TOKEN=$(ocm token --refresh) ./fleetshard-sync
# Start operator
cdrox && make -C operator install run
# Create managed central
./scripts/create-central.sh
# Make sure reconciliation of managed central works as expected, i.e. no error logs and auth provider creation is successful 
```
This should result in the name `Red Hat SSO (Stage)` for the auth provider as well as the issuer `https://sso.stage.redhat.com/auth/realms/redhat-external`. You can observe this within the UI:
![Screenshot 2022-07-29 at 21 49 10](https://user-images.githubusercontent.com/89904305/181835349-302ab79c-b312-4170-a8c5-113091ff9d87.png)

```
# Start fleet manager with custom rhsso-issuer flag, emulating prod deployment
./fleet-manager serve --dataplane-cluster-config-file=<your-config> --rhsso-client-secret-file=<client secret> --rhsso-issuer=https://sso.redhat.com/auth/realms/redhat-external
# Start fleetshard synchronizer
CREATE_AUTH_PROVIDER=true CLUSTER_ID=1234567890abcdef1234567890abcdef OCM_TOKEN=$(ocm token --refresh) ./fleetshard-sync
# Start operator
cdrox && make -C operator install run
# Create managed central
./scripts/create-central.sh
# Make sure reconciliation of managed central works as expected, i.e. no error logs and auth provider creation is successful 
```
This should result in the name `Red Hat SSO (Stage)` for the auth provider as well as the issuer `https://sso.redhat.com/auth/realms/redhat-external`. You can observe this within the UI:
![Screenshot 2022-07-29 at 21 58 50](https://user-images.githubusercontent.com/89904305/181835525-623100da-321c-4053-a415-8fa4ed71a376.png)

