### PR TITLE
Embed centos repo configuration in Dockerfile

### DIFF
--- a/.openshift-ci/build-root/Dockerfile
+++ b/.openshift-ci/build-root/Dockerfile
@@ -12,8 +12,19 @@
 
 FROM quay.io/centos/centos:stream9
 
-RUN rm -f /etc/yum.repos.d/*
-COPY centos.repo /etc/yum.repos.d
+# syntax=docker/dockerfile:1
+RUN rm -f /etc/yum.repos.d/* && cat <<EOT > "/etc/yum.repos.d/centos.repo"
+[baseos]
+name=CentOS Stream \$releasever - BaseOS
+baseurl=http://mirror.stream.centos.org/\$releasever-stream/BaseOS/\$basearch/os/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+gpgcheck=1
+repo_gpgcheck=0
+metadata_expire=6h
+countme=1
+enabled=1
+EOT
+
 RUN dnf update && dnf -y install make which
 
 RUN curl -L --retry 10 --silent --show-error --fail -o /tmp/go1.17.12.linux-amd64.tar.gz \

--- a/.openshift-ci/build-root/centos.repo
+++ b/.openshift-ci/build-root/centos.repo
@@ -1,9 +1,0 @@
-[baseos]
-name=CentOS Stream $releasever - BaseOS
-baseurl=http://mirror.stream.centos.org/$releasever-stream/BaseOS/$basearch/os/
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
-gpgcheck=1
-repo_gpgcheck=0
-metadata_expire=6h
-countme=1
-enabled=1


### PR DESCRIPTION
## Description

Looking at the failure here https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_acs-fleet-manager/230/pull-ci-stackrox-acs-fleet-manager-main-images/1554101901472043008 I have the feeling that OpenShift CI doesn't like `COPY` directives for Dockerfiles referenced from within `openshift/release`.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
