### PR TITLE
Remove heredoc from Dockerfile

### DIFF
--- a/.openshift-ci/build-root/Dockerfile
+++ b/.openshift-ci/build-root/Dockerfile
@@ -12,18 +12,17 @@
 
 FROM quay.io/centos/centos:stream9
 
-# syntax=docker/dockerfile:1
-RUN rm -f /etc/yum.repos.d/* && cat <<EOT > "/etc/yum.repos.d/centos.repo"
-[baseos]
-name=CentOS Stream \$releasever - BaseOS
-baseurl=http://mirror.stream.centos.org/\$releasever-stream/BaseOS/\$basearch/os/
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
-gpgcheck=1
-repo_gpgcheck=0
-metadata_expire=6h
-countme=1
-enabled=1
-EOT
+RUN rm -f /etc/yum.repos.d/* && { \
+    echo "[baseos]"; \
+    echo "name=CentOS Stream \$releasever - BaseOS"; \
+    echo "baseurl=http://mirror.stream.centos.org/\$releasever-stream/BaseOS/\$basearch/os/"; \
+    echo "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"; \
+    echo "gpgcheck=1"; \
+    echo "repo_gpgcheck=0"; \
+    echo "metadata_expire=6h"; \
+    echo "countme=1"; \
+    echo "enabled=1"; \
+    } > "/etc/yum.repos.d/centos.repo"
 
 RUN dnf update && dnf -y install make which
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
