### PR TITLE
Install git in custom root image

### DIFF
--- a/.openshift-ci/build-root/Dockerfile
+++ b/.openshift-ci/build-root/Dockerfile
@@ -24,7 +24,7 @@ RUN rm -f /etc/yum.repos.d/* && { \
     echo "enabled=1"; \
     } > "/etc/yum.repos.d/centos.repo"
 
-RUN dnf update && dnf -y install make which
+RUN dnf update && dnf -y install make which git
 
 RUN curl -L --retry 10 --silent --show-error --fail -o /tmp/go1.17.12.linux-amd64.tar.gz \
     https://go.dev/dl/go1.17.12.linux-amd64.tar.gz && \


### PR DESCRIPTION
## Description

According to https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_acs-fleet-manager/230/pull-ci-stackrox-acs-fleet-manager-main-images/1554115653571448832 we need git installed in the root image.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
