### PR TITLE
CentOS root image: Install gcc

### DIFF
--- a/.openshift-ci/build-root/Dockerfile
+++ b/.openshift-ci/build-root/Dockerfile
@@ -34,7 +34,7 @@ RUN rm -f /etc/yum.repos.d/* && { \
     echo "enabled=1"; \
     } > "/etc/yum.repos.d/centos.repo"
 
-RUN dnf update && dnf -y install make which git gettext jq
+RUN dnf update && dnf -y install make which git gettext jq gcc
 
 RUN curl -L --retry 10 --silent --show-error --fail -o /tmp/go1.17.12.linux-amd64.tar.gz \
     https://go.dev/dl/go1.17.12.linux-amd64.tar.gz && \


### PR DESCRIPTION
## Description

Apparently gcc is required during execution of `go test`, which uses `cgo` under the hood. See https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_acs-fleet-manager/230/pull-ci-stackrox-acs-fleet-manager-main-e2e/1554160585518616576.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
