### PR TITLE
CI E2E Tests: Make sure that RUN_AUTH_E2E variable is initialized

### DIFF
--- a/.openshift-ci/tests/e2e.sh
+++ b/.openshift-ci/tests/e2e.sh
@@ -9,6 +9,8 @@ export GITROOT
 # shellcheck source=/dev/null
 source "${GITROOT}/dev/env/scripts/lib.sh"
 
+export RUN_AUTH_E2E="false"
+
 if [[ "${OPENSHIFT_CI:-}" == "true" ]]; then
     # We are running in an OpenShift CI context, configure accordingly.
     log "Executing in OpenShift CI context"
@@ -27,7 +29,6 @@ if [[ "${OPENSHIFT_CI:-}" == "true" ]]; then
     export GOARGS="-mod=mod" # For some reason we need this in the offical base images.
     # When running in OpenShift CI, ensure we also run the auth E2E tests.
     RUN_AUTH_E2E="true"
-    export RUN_AUTH_E2E
 fi
 
 init
@@ -57,7 +58,7 @@ if [[ "$RUN_AUTH_E2E" == "true" ]]; then
     export STATIC_TOKEN=${STATIC_TOKEN:-$FLEET_STATIC_TOKEN}
 
     # Ensure we set the OCM refresh token once more, in case AUTH_TYPE!=OCM.
-    ocm login --token ${OCM_OFFLINE_TOKEN}
+    ocm login --token "${OCM_OFFLINE_TOKEN}"
     OCM_TOKEN=$(ocm token --refresh)
     export OCM_TOKEN
 
@@ -68,7 +69,7 @@ case "$AUTH_TYPE" in
 OCM)
 
     log "Logging in with client credentials + Refreshing OCM Service Token"
-    ocm login --token ${OCM_OFFLINE_TOKEN}
+    ocm login --token "${OCM_OFFLINE_TOKEN}"
     OCM_TOKEN=$(ocm token --refresh)
     export OCM_TOKEN
     ;;
@@ -83,7 +84,7 @@ esac
 
 log
 
-if [[ "$INHERIT_IMAGEPULLSECRETS" == "true" ]]; then
+if [[ "$INHERIT_IMAGEPULLSECRETS" == "true" ]]; then # pragma: allowlist secret
     if [[ -z "${QUAY_USER:-}" ]]; then
         die "QUAY_USER needs to be set"
     fi
@@ -113,7 +114,7 @@ fi
 # Terminate loggers.
 for p in $(jobs -pr); do
     log "Terminating background process ${p}"
-    kill $p || true
+    kill "$p" || true
 done
 
 log

--- a/.openshift-ci/tests/e2e.sh
+++ b/.openshift-ci/tests/e2e.sh
@@ -9,7 +9,7 @@ export GITROOT
 # shellcheck source=/dev/null
 source "${GITROOT}/dev/env/scripts/lib.sh"
 
-export RUN_AUTH_E2E="false"
+RUN_AUTH_E2E_DEFAULT="false"
 
 if [[ "${OPENSHIFT_CI:-}" == "true" ]]; then
     # We are running in an OpenShift CI context, configure accordingly.
@@ -28,7 +28,7 @@ if [[ "${OPENSHIFT_CI:-}" == "true" ]]; then
     export CLUSTER_TYPE="openshift-ci"
     export GOARGS="-mod=mod" # For some reason we need this in the offical base images.
     # When running in OpenShift CI, ensure we also run the auth E2E tests.
-    RUN_AUTH_E2E="true"
+    RUN_AUTH_E2E_DEFAULT="true"
 fi
 
 init
@@ -38,6 +38,7 @@ if [[ "$SPAWN_LOGGER" == "true" && "$LOG_DIR" == "" ]]; then
     LOG_DIR=$(mktemp -d)
 fi
 export LOG_DIR
+export RUN_AUTH_E2E=${RUN_AUTH_E2E:-$RUN_AUTH_E2E_DEFAULT}
 
 log
 log "** Entrypoint for ACS MS E2E Tests **"
@@ -47,6 +48,7 @@ log "Cluster type: ${CLUSTER_TYPE}"
 log "Cluster name: ${CLUSTER_NAME}"
 log "Image: ${FLEET_MANAGER_IMAGE}"
 log "Log directory: ${LOG_DIR:-(none)}"
+log "Executing Auth E2E tests: ${RUN_AUTH_E2E}"
 
 # If auth E2E tests shall be run, ensure we have all authentication related secrets correctly set up.
 if [[ "$RUN_AUTH_E2E" == "true" ]]; then

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -135,16 +135,6 @@
         "is_secret": false
       }
     ],
-    ".openshift-ci/tests/e2e.sh": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".openshift-ci/tests/e2e.sh",
-        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
-        "is_verified": false,
-        "line_number": 86,
-        "is_secret": false
-      }
-    ],
     "config/jwks-file-static.json": [
       {
         "type": "Base64 High Entropy String",
@@ -844,5 +834,5 @@
       }
     ]
   },
-  "generated_at": "2022-08-01T14:52:53Z"
+  "generated_at": "2022-08-02T13:14:47Z"
 }


### PR DESCRIPTION
## Description

If it is not set in the environment the e2e script will abort with an error.

I noticed some linter complaints (shellcheck) and have fixed the issues in one go.
And I have removed a secrets from the baseline and added the pragma annotation in the shell script directly to reduce merge conflicts in the future.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
