### PR TITLE
do not skip all tests if RUN_AUTH_E2E not set

### DIFF
--- a/e2e/e2e_auth_test.go
+++ b/e2e/e2e_auth_test.go
@@ -34,13 +34,13 @@ const (
 )
 
 var _ = Describe("AuthN/Z Fleet* components", func() {
-	// Need the GinkgoRecover due to Skip being called within the Describe node.
-	defer GinkgoRecover()
 
-	if env := getEnvDefault("RUN_AUTH_E2E", "false"); env == "false" {
-		Skip("The RUN_AUTH_E2E variable was not set, skipping the tests. If you want to run the auth tests, " +
-			"set RUN_AUTH_E2E=true")
-	}
+	BeforeEach(func() {
+		if env := getEnvDefault("RUN_AUTH_E2E", "false"); env == "false" {
+			Skip("The RUN_AUTH_E2E variable was not set, skipping the tests. If you want to run the auth tests, " +
+				"set RUN_AUTH_E2E=true")
+		}
+	})
 
 	fleetManagerEndpoint := "http://localhost:8000"
 	if fmEndpointEnv := os.Getenv("FLEET_MANAGER_ENDPOINT"); fmEndpointEnv != "" {


### PR DESCRIPTION
## Description
We have the issue that **all** e2e tests are skipped if RUN_AUTH_E2E was not set, but it should only skip **auth** e2e tests. For more context see:
https://issues.redhat.com/browse/ROX-12073

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
