### PR TITLE
ROX-12072: Route update optimizations

### DIFF
--- a/fleetshard/pkg/central/reconciler/errors.go
+++ b/fleetshard/pkg/central/reconciler/errors.go
@@ -1,0 +1,19 @@
+package reconciler
+
+import "github.com/pkg/errors"
+
+var (
+	// ErrBusy returned when reconciliation for the same central is already in progress
+	ErrBusy = errors.New("reconciler still busy")
+	// ErrCentralNotChanged is an error returned when reconciliation runs more than once in a row with equal central
+	ErrCentralNotChanged = errors.New("central not changed")
+	// ErrDeletionInProgress returned when central resources are currently deleting
+	ErrDeletionInProgress = errors.New("deletion in progress")
+)
+
+// IsSkippable indicates that the reconciliation was skipped and the status should NOT be reported.
+func IsSkippable(err error) bool {
+	return errors.Is(err, ErrBusy) ||
+		errors.Is(err, ErrCentralNotChanged) ||
+		errors.Is(err, ErrDeletionInProgress)
+}

--- a/fleetshard/pkg/central/reconciler/init_auth.go
+++ b/fleetshard/pkg/central/reconciler/init_auth.go
@@ -57,7 +57,7 @@ var (
 	}
 )
 
-func isCentralReady(ctx context.Context, client ctrlClient.Client, central private.ManagedCentral) (bool, error) {
+func isCentralDeploymentReady(ctx context.Context, client ctrlClient.Client, central private.ManagedCentral) (bool, error) {
 	deployment := &appsv1.Deployment{}
 	err := client.Get(ctx,
 		ctrlClient.ObjectKey{Name: "central", Namespace: central.Metadata.Namespace},
@@ -75,7 +75,7 @@ func isCentralReady(ctx context.Context, client ctrlClient.Client, central priva
 }
 
 func existsRHSSOAuthProvider(ctx context.Context, central private.ManagedCentral, client ctrlClient.Client) (bool, error) {
-	ready, err := isCentralReady(ctx, client, central)
+	ready, err := isCentralDeploymentReady(ctx, client, central)
 	if !ready || err != nil {
 		return false, err
 	}

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -222,12 +222,6 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		r.hasAuthProvider = true
 	}
 
-	// Setting the last central hash must always be executed as the last step.
-	// defer can't be used for this call because it is also executed after the reconcile failed.
-	if err := r.setLastCentralHash(remoteCentral); err != nil {
-		return nil, errors.Wrapf(err, "setting central reconcilation cache")
-	}
-
 	// TODO(create-ticket): When should we create failed conditions for the reconciler?
 	status := readyStatus()
 	// Do not report routes statuses if:
@@ -240,8 +234,8 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		}
 	}
 
-	// Cache MUST be updated right before returning "ready" result.
-	// Otherwise, the hash will be saved without sending the actual status (in case of error).
+	// Setting the last central hash must always be executed as the last step.
+	// defer can't be used for this call because it is also executed after the reconcile failed.
 	if err := r.setLastCentralHash(remoteCentral); err != nil {
 		return nil, errors.Wrapf(err, "setting central reconcilation cache")
 	}

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -63,9 +63,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 
 	remoteCentralName := remoteCentral.Metadata.Name
 	remoteCentralNamespace := remoteCentral.Metadata.Namespace
-	remoteCentralReady := isRemoteCentralReady(remoteCentral)
-
-	if !changed && r.wantsAuthProvider == r.hasAuthProvider && remoteCentralReady {
+	if !changed && r.wantsAuthProvider == r.hasAuthProvider && isRemoteCentralReady(remoteCentral) {
 		return nil, ErrCentralNotChanged
 	}
 
@@ -216,7 +214,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	// 1. Auth provider is already created
 	// 2. OR reconciler creator specified auth provider not to be created
 	// 3. OR Central request is in status "Ready" - meaning auth provider should've been initialised earlier
-	if r.wantsAuthProvider && !r.hasAuthProvider && !remoteCentralReady {
+	if r.wantsAuthProvider && !r.hasAuthProvider && !isRemoteCentralReady(remoteCentral) {
 		err = createRHSSOAuthProvider(ctx, remoteCentral, r.client)
 		if err != nil {
 			return nil, err
@@ -235,7 +233,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	// Do not report routes statuses if:
 	// 1. Routes are not used on the cluster
 	// 2. Central request is in status "Ready" - assuming that routes are already reported and saved
-	if r.useRoutes && !remoteCentralReady {
+	if r.useRoutes && !isRemoteCentralReady(remoteCentral) {
 		status.Routes, err = r.getRoutesStatuses(ctx, remoteCentralNamespace)
 		if err != nil {
 			return nil, err

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -63,7 +63,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 
 	remoteCentralName := remoteCentral.Metadata.Name
 	remoteCentralNamespace := remoteCentral.Metadata.Namespace
-	remoteCentralReady := remoteCentral.RequestStatus == centralConstants.DinosaurRequestStatusReady.String()
+	remoteCentralReady := isRemoteCentralReady(remoteCentral)
 
 	if !changed && r.wantsAuthProvider == r.hasAuthProvider && remoteCentralReady {
 		return nil, ErrCentralNotChanged
@@ -206,8 +206,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		return nil, err
 	}
 	if !centralDeploymentReady || !centralTLSSecretFound {
-		remoteCentralProvisioning := remoteCentral.RequestStatus == centralConstants.DinosaurRequestStatusProvisioning.String()
-		if remoteCentralProvisioning && !changed { // no changes detected, wait until central become ready
+		if isRemoteCentralProvisioning(remoteCentral) && !changed { // no changes detected, wait until central become ready
 			return nil, ErrCentralNotChanged
 		}
 		return installingStatus(), nil
@@ -250,6 +249,14 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	}
 
 	return status, nil
+}
+
+func isRemoteCentralProvisioning(remoteCentral private.ManagedCentral) bool {
+	return remoteCentral.RequestStatus == centralConstants.DinosaurRequestStatusProvisioning.String()
+}
+
+func isRemoteCentralReady(remoteCentral private.ManagedCentral) bool {
+	return remoteCentral.RequestStatus == centralConstants.DinosaurRequestStatusReady.String()
 }
 
 func (r *CentralReconciler) getRoutesStatuses(ctx context.Context, namespace string) ([]private.DataPlaneCentralStatusRoutes, error) {

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -201,11 +201,11 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	}
 
 	// Check whether deployment is ready.
-	centralReady, err := isCentralReady(ctx, r.client, remoteCentral)
+	centralDeploymentReady, err := isCentralDeploymentReady(ctx, r.client, remoteCentral)
 	if err != nil {
 		return nil, err
 	}
-	if !centralReady || !centralTLSSecretFound {
+	if !centralDeploymentReady || !centralTLSSecretFound {
 		remoteCentralProvisioning := remoteCentral.RequestStatus == centralConstants.DinosaurRequestStatusProvisioning.String()
 		if remoteCentralProvisioning && !changed { // no changes detected, wait until central become ready
 			return nil, ErrCentralNotChanged

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -150,6 +150,11 @@ func TestReconcileLastHashSetOnSuccess(t *testing.T) {
 
 	_, err = r.Reconcile(context.TODO(), managedCentral)
 	require.ErrorIs(t, err, ErrCentralNotChanged)
+
+	central := &v1alpha1.Central{}
+	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralName, Namespace: centralNamespace}, central)
+	require.NoError(t, err)
+	assert.Equal(t, "4", central.Annotations[revisionAnnotationKey])
 }
 
 func TestIgnoreCacheForCentralNotReady(t *testing.T) {

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -148,7 +148,8 @@ func TestReconcileLastHashSetOnSuccess(t *testing.T) {
 
 	assert.Equal(t, expectedHash, r.lastCentralHash)
 
-	_, err = r.Reconcile(context.TODO(), managedCentral)
+	status, err := r.Reconcile(context.TODO(), managedCentral)
+	require.Nil(t, status)
 	require.ErrorIs(t, err, ErrCentralNotChanged)
 
 	central := &v1alpha1.Central{}
@@ -288,18 +289,6 @@ func TestReportRoutesStatuses(t *testing.T) {
 	}
 	actual := status.Routes
 	assert.ElementsMatch(t, expected, actual)
-}
-
-func TestReportRoutesStatusWhenCentralNotChanged(t *testing.T) {
-	fakeClient := testutils.NewFakeClientBuilder(t, centralDeploymentObject()).Build()
-	r := NewCentralReconciler(fakeClient, private.ManagedCentral{}, true, false)
-	existingCentral := simpleManagedCentral
-	existingCentral.RequestStatus = centralConstants.DinosaurRequestStatusReady.String()
-	_, err := r.Reconcile(context.TODO(), existingCentral)
-	require.NoError(t, err)
-	status, err := r.Reconcile(context.TODO(), existingCentral) // cache hit
-	require.Nil(t, status)
-	require.ErrorIs(t, err, ErrCentralNotChanged)
 }
 
 func TestNoRoutesSentWhenOneNotCreated(t *testing.T) {

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -148,15 +148,8 @@ func TestReconcileLastHashSetOnSuccess(t *testing.T) {
 
 	assert.Equal(t, expectedHash, r.lastCentralHash)
 
-	status, err := r.Reconcile(context.TODO(), managedCentral)
-	require.NoError(t, err)
-	assert.Equal(t, "Ready", status.Conditions[0].Type)
-	assert.Equal(t, "True", status.Conditions[0].Status)
-
-	central := &v1alpha1.Central{}
-	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralName, Namespace: centralNamespace}, central)
-	require.NoError(t, err)
-	assert.Equal(t, "4", central.Annotations[revisionAnnotationKey])
+	_, err = r.Reconcile(context.TODO(), managedCentral)
+	require.ErrorIs(t, err, ErrCentralNotChanged)
 }
 
 func TestIgnoreCacheForCentralNotReady(t *testing.T) {
@@ -195,7 +188,7 @@ func TestReconcileDelete(t *testing.T) {
 
 	// trigger deletion
 	statusTrigger, err := r.Reconcile(context.TODO(), deletedCentral)
-	require.NoError(t, err)
+	require.Error(t, err, ErrDeletionInProgress)
 	require.Nil(t, statusTrigger)
 
 	// deletion completed needs second reconcile to check as deletion is async in a kubernetes cluster
@@ -293,27 +286,15 @@ func TestReportRoutesStatuses(t *testing.T) {
 }
 
 func TestReportRoutesStatusWhenCentralNotChanged(t *testing.T) {
-	fakeClient := testutils.NewFakeClientBuilder(t).Build()
+	fakeClient := testutils.NewFakeClientBuilder(t, centralDeploymentObject()).Build()
 	r := NewCentralReconciler(fakeClient, private.ManagedCentral{}, true, false)
-
-	_, err := r.Reconcile(context.TODO(), simpleManagedCentral)
-	require.NoError(t, err)
-
 	existingCentral := simpleManagedCentral
 	existingCentral.RequestStatus = centralConstants.DinosaurRequestStatusReady.String()
-	status, _ := r.Reconcile(context.TODO(), existingCentral) // cache hit
-	expected := []private.DataPlaneCentralStatusRoutes{
-		{
-			Domain: "acs-cb45idheg5ip6dq1jo4g.acs.rhcloud.test",
-			Router: "router-default.apps.test.local",
-		},
-		{
-			Domain: "acs-data-cb45idheg5ip6dq1jo4g.acs.rhcloud.test",
-			Router: "router-default.apps.test.local",
-		},
-	}
-	actual := status.Routes
-	assert.ElementsMatch(t, expected, actual)
+	_, err := r.Reconcile(context.TODO(), existingCentral)
+	require.NoError(t, err)
+	status, err := r.Reconcile(context.TODO(), existingCentral) // cache hit
+	require.Nil(t, status)
+	require.ErrorIs(t, err, ErrCentralNotChanged)
 }
 
 func TestNoRoutesSentWhenOneNotCreated(t *testing.T) {

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -107,7 +107,11 @@ func (r *Runtime) Start() error {
 
 func (r *Runtime) handleReconcileResult(central private.ManagedCentral, status *private.DataPlaneCentralStatus, err error) {
 	if err != nil {
-		glog.Errorf("error occurred %s/%s: %s", central.Metadata.Namespace, central.Metadata.Name, err.Error())
+		if centralReconciler.IsSkippable(err) {
+			glog.Infof("Skip sending the status for central %s/%s: %v", central.Metadata.Namespace, central.Metadata.Name, err)
+		} else {
+			glog.Errorf("Unexpected error occurred %s/%s: %s", central.Metadata.Namespace, central.Metadata.Name, err.Error())
+		}
 		return
 	}
 	if status == nil {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
This change adds a few optimizations dedicated to reduce a number of status reports back to the fleet manager. The changes are:
1. Skip sending an update when central is **ready** and not changed (revert to the previous state)
2. Skip sending an update when central is **installing** and not changed.
3. Do not return and print errors when central is not ready (secrets, deployments) not created.
4. Return "skippable" error instead of `nil` to indicate that deletion is in progress
5. Minor fixes to cache and pointer reference

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
