### PR TITLE
ROX-12046: Add logging helm chart for data plane logging stack

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/README.md
+++ b/dp-terraform/helm/rhacs-terraform/README.md
@@ -45,4 +45,4 @@ helm upgrade --install rhacs-terraform \
 helm uninstall rhacs-terraform --namespace rhacs
 ```
 
-See internal wiki for an example file `~/.rh/terraform-values.yaml`.
+See internal wiki for an example file `~/acs-terraform-values.yaml`.

--- a/dp-terraform/helm/rhacs-terraform/charts/logging/.helmignore
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/dp-terraform/helm/rhacs-terraform/charts/logging/Chart.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: rhacs-terraform
-description: "Chart to terraform data plane OSD clusters"
+name: logging
+description: "Chart to terraform logging stack for dataplane OSD clusters"
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -22,10 +22,3 @@ version: "0.1.0"
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "0.1.0"
-
-# List of sub-charts and other dependencies
-dependencies:
-  - name: observability
-    condition: observability.enabled
-  - name: logging
-    condition: logging.enabled

--- a/dp-terraform/helm/rhacs-terraform/charts/logging/README.md
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/README.md
@@ -30,4 +30,4 @@ helm upgrade --install rhacs-terraform-logging \
 helm uninstall rhacs-terraform-logging --namespace rhacs
 ```
 
-**NOTE:** The custom resource definitions crated by logging operator will not be removed.
+**NOTE:** The custom resource definitions created by logging operator will not be removed.

--- a/dp-terraform/helm/rhacs-terraform/charts/logging/README.md
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/README.md
@@ -1,0 +1,33 @@
+# Data plane terraform logging Helm chart
+
+This chart installs resource into `openshift-logging` namespace. This namespace is Openshift dedicated namespace for logging stack for OSD cluster.
+
+## Usage
+
+Create a file `~/acs-terraform-logging-values.yaml` with the values for the parameters in [values.yaml](./values.yaml) that are missing or that you want to override. That file will contain credentials, so make sure you put it in a safe location, and with suitable permissions.
+
+**Render the chart to see the generated templates during development**
+
+```bash
+helm template rhacs-terraform-logging \
+  --debug \
+  --namespace rhacs \
+  --values ~/acs-terraform-logging-values.yaml .
+```
+
+**Install or update the chart**
+
+```bash
+helm upgrade --install rhacs-terraform-logging \
+  --namespace rhacs \
+  --create-namespace \
+  --values ~/acs-terraform-logging-values.yaml .
+```
+
+**Uninstall the chart and cleanup all created resources**
+
+```bash
+helm uninstall rhacs-terraform-logging --namespace rhacs
+```
+
+**NOTE:** The custom resource definitions crated by logging operator will not be removed.

--- a/dp-terraform/helm/rhacs-terraform/charts/logging/templates/01-logging-01-subscription.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/templates/01-logging-01-subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: "operators.coreos.com/v1alpha1"
+kind: Subscription
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  channel: "stable"
+  name: cluster-logging
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/dp-terraform/helm/rhacs-terraform/charts/logging/templates/01-logging-02-secret-cloudwatch.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/templates/01-logging-02-secret-cloudwatch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudwatch
+  namespace: openshift-logging
+data:
+  aws_access_key_id: {{ .Values.aws.accessKeyId | b64enc | quote }}
+  aws_secret_access_key: {{ .Values.aws.secretAccessKey | b64enc | quote }}

--- a/dp-terraform/helm/rhacs-terraform/charts/logging/templates/01-logging-03-cluster-log-forwarder.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/templates/01-logging-03-cluster-log-forwarder.yaml
@@ -1,0 +1,26 @@
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: instance
+  namespace: openshift-logging
+  annotations:
+    # Add custom resource last.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+spec:
+  outputs:
+    - name: cloudwatch-output
+      type: cloudwatch
+      cloudwatch:
+        groupBy: namespaceName
+        region: {{ .Values.aws.region | quote }}
+      secret:
+        name: cloudwatch
+  pipelines:
+    - name: data-plane-logs
+      inputRefs:
+        - infrastructure
+        - audit
+        - application
+      outputRefs:
+        - cloudwatch-output

--- a/dp-terraform/helm/rhacs-terraform/charts/logging/templates/01-logging-03-cluster-logging.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/templates/01-logging-03-cluster-logging.yaml
@@ -1,0 +1,15 @@
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogging
+metadata:
+  name: instance
+  namespace: openshift-logging
+  annotations:
+    # Add custom resource last.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+spec:
+  managementState: "Managed"
+  collection:
+    logs:
+      type: "fluentd"
+      fluentd: {}

--- a/dp-terraform/helm/rhacs-terraform/charts/logging/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/values.yaml
@@ -1,0 +1,8 @@
+# Default values for logging.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+aws:
+  region: "us-east-1"
+  accessKeyId: ""
+  secretAccessKey: ""

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/README.md
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/README.md
@@ -28,4 +28,4 @@ helm upgrade --install rhacs-terraform-obs \
 helm uninstall rhacs-terraform-obs --namespace rhacs
 ```
 
-See internal wiki for an example file `~/.rh/obs-values.yaml`.
+See internal wiki for an example file `~/acs-terraform-obs-values.yaml`.

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -44,3 +44,11 @@ observability:
     gateway: ""
     metricsClientId: ""
     metricsSecret: ""
+
+# See available parameters in charts/logging/values.yaml
+# - enabled flag is used to completely enable/disable logging sub-chart
+logging:
+  enabled: true
+  aws:
+    accessKeyId: ""
+    secretAccessKey: ""


### PR DESCRIPTION
## Description

This PR adds a logging stack to the terraforming helm template for the data plane.

**Notes**
- We have added post-install/update hooks to avoid the problem of missing custom resource definitions. The problem here is that custom resource definitions are installed after the Subscription is applied for the logging operator. Usually, it takes some time for it to be applied. And that can cause problems that custom resource definition does not exist when the helm is creating custom resource. With helm post hook, custom resources will be created after everything else is successfully deployed. *still to be properly tested*
- All logging stack is deployed into the `openshift-logging` namespace. This is a namespace defined for it.
- Some resources have predefined names. i.e. `instance` - please check docs: https://docs.openshift.com/container-platform/4.10/logging/cluster-logging-external.html#cluster-logging-collector-log-forward-cloudwatch_cluster-logging-external

## Checklist (Definition of Done)
- ~[ ] Unit and integration tests added~
- [x] Documentation added if necessary
- [x] CI and all relevant tests are passing

## Test manual

The best way to test it is to use **THE GUIDE** to create a staging OSD cluster: `docs/development/setup-developer-osd-cluster.md`
The only important difference is in step 12. where we should add additional options for logging stack.

Required access keys can be found in BitWarden: `CloudWatch - Development Environment Access Key`