### PR TITLE
enable central external certificate only if route53 credentials are set

### DIFF
--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -144,6 +144,13 @@ init() {
     export CENTRAL_DOMAIN_NAME=${CENTRAL_DOMAIN_NAME:-$CENTRAL_DOMAIN_NAME_DEFAULT}
     export FLEET_MANAGER_IMAGE="${FLEET_MANAGER_IMAGE:-$FLEET_MANAGER_IMAGE_DEFAULT}"
 
+
+    if [[ "$ROUTE53_ACCESS_KEY" == "" || "$ROUTE53_SECRET_ACCESS_KEY" == "" ]]; then
+        log "setting ENABLE_CENTRAL_EXTERNAL_CERTIFICATE to false since no Route53 credentials were provided"
+        ENABLE_CENTRAL_EXTERNAL_CERTIFICATE=false
+    fi
+
+
     if [[ "$CLUSTER_TYPE" == "minikube" ]]; then
         eval "$(minikube docker-env)"
     fi


### PR DESCRIPTION
## Description
Central is stuck in provisioning in e2e Tests if external certificate is enabled without route53 credentials. So this changes set it to false in case no credentials for route53 were provided.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
