### PR TITLE
[CI Test Env] Prevent access to uninitialized variable and simplify propagation of static token

### DIFF
--- a/.openshift-ci/tests/e2e.sh
+++ b/.openshift-ci/tests/e2e.sh
@@ -54,11 +54,11 @@ log "Executing Auth E2E tests: ${RUN_AUTH_E2E}"
 # If auth E2E tests shall be run, ensure we have all authentication related secrets correctly set up.
 if [[ "$RUN_AUTH_E2E" == "true" ]]; then
     log "Setting up authentication related environment variables for auth E2E tests"
-    # FLEET_STATIC_TOKEN is the name of the secret in Vault,
-    # STATIC_TOKEN is the name expected by the application (when running directly),
-    # hence we support both names here.
-    FLEET_STATIC_TOKEN=${FLEET_STATIC_TOKEN:-}
-    export STATIC_TOKEN=${STATIC_TOKEN:-$FLEET_STATIC_TOKEN}
+
+    OCM_OFFLINE_TOKEN=${OCM_OFFLINE_TOKEN:-}
+    if [[ -z "$OCM_OFFLINE_TOKEN" ]]; then
+        die "Error: OCM_OFFLINE_TOKEN not set, which is required for execution of Auth E2E tests"
+    fi
 
     # Ensure we set the OCM refresh token once more, in case AUTH_TYPE!=OCM.
     ocm login --token "${OCM_OFFLINE_TOKEN}"


### PR DESCRIPTION
## Description

1. There was an access to an uninitialized variable in case `RUN_AUTH_E2E=true` and `OCM_OFFLINE_TOKEN` is unset.

```
$ ./.openshift-ci/tests/e2e.sh 

** Entrypoint for ACS MS E2E Tests **

Cluster type: infra-openshift
Cluster name: mc-test
Image: quay.io/rhacs-eng/fleet-manager:v0.0.0-178-ge60a311383
Log directory: (none)
Executing Auth E2E tests: true
Setting up authentication related environment variables for auth E2E tests
./.openshift-ci/tests/e2e.sh: line 64: OCM_OFFLINE_TOKEN: unbound variable
```
2. It seems to me that some lines related to the (re-)exporting of `STATIC_TOKEN` were not required: In case we are running in CI this export has already been done at the top of the script. And if we are not running on CI the expectation is that the user has the environment set up properly prior to running `e2e.sh`.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
