### PR TITLE
ROX-12052: Add script commands for quickly adding/removing hostnames locally

### DIFF
--- a/docs/development/test-locally-route-hosts.md
+++ b/docs/development/test-locally-route-hosts.md
@@ -10,6 +10,14 @@ Below is the example of adding the route hostname to `/etc/hosts` using `hostctl
 
 ### Adding a host
 After the central instance is provisioned and the routes are created, it's time to add the host to the `/etc/hosts`
+#### Using the script
+
+```
+# requires: kubectl, hostctl, fzf, jq
+./scripts/ingress-router.sh host add
+```
+
+#### Manually
 ```
 # Get hostname
 $ kubectl get routes managed-central-reencrypt -n rhacs-cblb0hq87d5sb2n3aesg -o jsonpath='{.spec.host}'
@@ -29,6 +37,13 @@ $ sudo hostctl add domains acs acs-cblb0hq87d5sb2n3aesg.kubernetes.docker.intern
 ```
 After the host is added, you can access it in a browser
 ### Removing the host
+#### Using the script
+
+```
+# requires: kubectl, hostctl, fzf, jq
+./scripts/ingress-router.sh host remove
+```
+#### Manually
 When you are finished with testing the concrete instance, you can remove the host from the list
 ```
 $ sudo hostctl remove domains acs acs-cblb0hq87d5sb2n3aesg.kubernetes.docker.internal

--- a/scripts/ingress-router.sh
+++ b/scripts/ingress-router.sh
@@ -8,13 +8,19 @@ ROUTER_RBAC_YAML="https://raw.githubusercontent.com/openshift/router/master/depl
 ROUTER_CRD_YAML="https://raw.githubusercontent.com/openshift/api/master/route/v1/route.crd.yaml"
 ROUTER_DEPLOYMENT_YAML="https://raw.githubusercontent.com/openshift/router/master/deploy/router.yaml"
 APPS_OPENSHIFT_CRD_YAML="$SCRIPT_DIR/../dev/env/manifests/ingress-router/dummy.crd.yaml"
+HOSTCTL_PROFILE="acs"
 
 usage() {
   echo "Usage: $(basename "$0") [-h | --help] <command> [<args>]"
   echo ""
   echo "Available commands:"
-  echo "  deploy               Deploys ingress router on an active k8s cluster in kubectl context"
-  echo "  undeploy             Un-deploys ingress router on an active k8s cluster in kubectl context"
+  echo "  deploy                                                          Deploys ingress router on an active k8s cluster in kubectl context (requires kubectl)"
+  echo "  undeploy                                                        Un-deploys ingress router on an active k8s cluster in kubectl context (requires kubectl)"
+  echo "  host                                                            Helper commands for exposing Routes locally"
+  echo "                                                                  See more: https://github.com/stackrox/acs-fleet-manager/blob/main/docs/development/test-locally-route-hosts.md"
+  echo "    host add (--profile=<profile> | -p <profile>) <hostname>      Adds the selected hostname to /etc/hosts (requires: kubectl, jq, hostctl, fzf). Profile: hostctl profile. Default: 'acs'"
+  echo "    host remove (--profile=<profile> | -p <profile>) <hostname>   Removes the selected hostname from /etc/host (requires: kubectl, jq, hostctl, fzf). Profile: hostctl profile. Default: 'acs'"
+
   if [[ -n "${1:-}" ]]; then
     echo ""
     echo >&2 "Error: $1"
@@ -43,12 +49,34 @@ list_manifests_reversed() {
   list_manifests | tac
 }
 
+add_host() {
+  local host context
+  context=$(kubectl config current-context)
+  host=$(kubectl get routes -l 'app.kubernetes.io/managed-by=rhacs-fleetshard' --all-namespaces -o json | jq -r '.items[].spec.host' | fzf --header "Using context $context")
+  sudo hostctl add domains "$HOSTCTL_PROFILE" "$host"
+}
+
+remove_host() {
+  local host
+  host=$(hostctl list "$HOSTCTL_PROFILE" -o json | jq -r ".[].Host" | fzf)
+  sudo hostctl remove domains "$HOSTCTL_PROFILE" "$host"
+}
+
 POSITIONAL_ARGS=()
 
 while (("$#")); do
   case "$1" in
   -h | --help)
     usage
+    ;;
+  -p)
+    shift
+    HOSTCTL_PROFILE="$1"
+    shift
+    ;;
+  --profile=*)
+    HOSTCTL_PROFILE="${1#*=}"
+    shift
     ;;
   -*)
     usage "Unknown option $1"
@@ -71,6 +99,21 @@ deploy)
   ;;
 undeploy)
   undeploy
+  ;;
+host)
+  subcommand=$2
+  host=$3
+  case $subcommand in
+  add)
+    add_host "$host"
+    ;;
+  remove)
+    remove_host "$host"
+    ;;
+  *)
+    usage "Unknown host command: $subcommand"
+    ;;
+  esac
   ;;
 *)
   usage "Unknown command: $command"

--- a/scripts/ingress-router.sh
+++ b/scripts/ingress-router.sh
@@ -52,13 +52,18 @@ list_manifests_reversed() {
 add_host() {
   local host context
   context=$(kubectl config current-context)
-  host=$(kubectl get routes -l 'app.kubernetes.io/managed-by=rhacs-fleetshard' --all-namespaces -o json | jq -r '.items[].spec.host' | fzf --header "Using context $context")
+  host=$1
+  if [[ -z $host ]]; then
+    host=$(kubectl get routes -l 'app.kubernetes.io/managed-by=rhacs-fleetshard' --all-namespaces -o json | jq -r '.items[].spec.host' | fzf --header "Using context $context")
+  fi
   sudo hostctl add domains "$HOSTCTL_PROFILE" "$host"
 }
 
 remove_host() {
-  local host
-  host=$(hostctl list "$HOSTCTL_PROFILE" -o json | jq -r ".[].Host" | fzf)
+  local host=$1
+  if [[ -z $host ]]; then
+    host=$(hostctl list "$HOSTCTL_PROFILE" -o json | jq -r ".[].Host" | fzf)
+  fi
   sudo hostctl remove domains "$HOSTCTL_PROFILE" "$host"
 }
 

--- a/scripts/ingress-router.sh
+++ b/scripts/ingress-router.sh
@@ -54,7 +54,8 @@ add_host() {
   context=$(kubectl config current-context)
   host=$1
   if [[ -z $host ]]; then
-    host=$(kubectl get routes -l 'app.kubernetes.io/managed-by=rhacs-fleetshard' --all-namespaces -o json | jq -r '.items[].spec.host' | fzf --header "Using context $context")
+    routes=$(kubectl get routes -l 'app.kubernetes.io/managed-by=rhacs-fleetshard' --all-namespaces -o json)
+    host=$(jq -r '.items[].spec.host' <<< "$routes" | fzf --header "Using context $context")
   fi
   sudo hostctl add domains "$HOSTCTL_PROFILE" "$host"
 }

--- a/scripts/ingress-router.sh
+++ b/scripts/ingress-router.sh
@@ -9,6 +9,7 @@ ROUTER_CRD_YAML="https://raw.githubusercontent.com/openshift/api/master/route/v1
 ROUTER_DEPLOYMENT_YAML="https://raw.githubusercontent.com/openshift/router/master/deploy/router.yaml"
 APPS_OPENSHIFT_CRD_YAML="$SCRIPT_DIR/../dev/env/manifests/ingress-router/dummy.crd.yaml"
 HOSTCTL_PROFILE="acs"
+KUBECTL=${KUBECTL:-kubectl}
 
 usage() {
   echo "Usage: $(basename "$0") [-h | --help] <command> [<args>]"
@@ -31,13 +32,13 @@ usage() {
 
 deploy() {
   for manifest in $(list_manifests); do
-    kubectl create -f "$manifest"
+    $KUBECTL create -f "$manifest"
   done
 }
 
 undeploy() {
     for manifest in $(list_manifests_reversed); do
-      kubectl delete -f "$manifest" || true
+      $KUBECTL delete -f "$manifest" || true
     done
 }
 
@@ -51,10 +52,10 @@ list_manifests_reversed() {
 
 add_host() {
   local host context
-  context=$(kubectl config current-context)
+  context=$($KUBECTL config current-context)
   host=$1
   if [[ -z $host ]]; then
-    routes=$(kubectl get routes -l 'app.kubernetes.io/managed-by=rhacs-fleetshard' --all-namespaces -o json)
+    routes=$($KUBECTL get routes -l 'app.kubernetes.io/managed-by=rhacs-fleetshard' --all-namespaces -o json)
     host=$(jq -r '.items[].spec.host' <<< "$routes" | fzf --header "Using context $context")
   fi
   sudo hostctl add domains "$HOSTCTL_PROFILE" "$host"


### PR DESCRIPTION
## Description
This change simplifies routes configuration on vanilla k8s. With new script commands you can easily and interactivally add and remove exposed hosts locally  

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
