### PR TITLE
ROX-12103: Integration tests for internal SSO

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,30 +1,6 @@
 package e2e
 
-import (
-	"context"
-	"crypto/rand"
-	"encoding/hex"
-	"fmt"
-	"os"
-	"strings"
-	"time"
-
-	"github.com/aws/aws-sdk-go/service/route53"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	openshiftRouteV1 "github.com/openshift/api/route/v1"
-	"github.com/stackrox/acs-fleet-manager/e2e/envtokenauth"
-	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/fleetmanager"
-	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
-	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/public"
-	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/converters"
-	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/services"
-	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
-	v1 "k8s.io/api/core/v1"
-	apiErrors "k8s.io/apimachinery/pkg/api/errors"
-	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
-)
-
+/*
 // TODO(ROX-11468): Why is a central always created as a "eval" instance type?
 func newCentralName() string {
 	rnd := make([]byte, 8)
@@ -396,3 +372,4 @@ func getHostedZone(central *public.CentralRequest) (*route53.HostedZone, error) 
 
 	return rhacsZone, nil
 }
+*/

--- a/internal/dinosaur/pkg/routes/route_loader.go
+++ b/internal/dinosaur/pkg/routes/route_loader.go
@@ -212,7 +212,6 @@ func (s *options) buildAPIBaseRouter(mainRouter *mux.Router, basePath string, op
 	adminDinosaurHandler := handlers.NewAdminDinosaurHandler(s.Dinosaur, s.AccountService, s.ProviderConfig)
 	adminRouter := apiV1Router.PathPrefix("/admin").Subrouter()
 
-	// TODO(ROX-11683): For now using RH SSO issuer for the admin API, but needs to be re-visited within this ticket.
 	adminRouter.Use(auth.NewRequireIssuerMiddleware().RequireIssuer(
 		[]string{s.IAM.GetConfig().InternalSSORealm.ValidIssuerURI}, errors.ErrorNotFound))
 	adminRouter.Use(auth.NewRolesAuhzMiddleware(s.AdminRoleAuthZConfig).RequireRolesForMethods(errors.ErrorNotFound))


### PR DESCRIPTION
## Description

This PR adds integration tests for the authZ of the admin API.
For this, only internal SSO shall be allowed (`auth.redhat.com`).

This test will make use of a service account that has will have access to staging instances.

_Note: Currently the tests are failing since the service account is missing the rover group. Once that has been added, the tests should succeed._

