### PR TITLE
ROX-11729: Add unit tests to ensure that routes are sent at once

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -23,12 +23,11 @@ import (
 )
 
 const (
-	centralName                 = "test-central"
-	centralID                   = "cb45idheg5ip6dq1jo4g"
-	centralNamespace            = "rhacs-" + centralID
-	centralReencryptRouteName   = "managed-central-reencrypt"
-	centralPassthroughRouteName = "managed-central-passthrough"
-	conditionTypeReady          = "Ready"
+	centralName               = "test-central"
+	centralID                 = "cb45idheg5ip6dq1jo4g"
+	centralNamespace          = "rhacs-" + centralID
+	centralReencryptRouteName = "managed-central-reencrypt"
+	conditionTypeReady        = "Ready"
 )
 
 var simpleManagedCentral = private.ManagedCentral{
@@ -342,13 +341,5 @@ func TestNoRoutesSentWhenOneNotCreatedYet(t *testing.T) {
 }
 
 func centralDeploymentObject() *appsv1.Deployment {
-	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "central",
-			Namespace: centralNamespace,
-		},
-		Status: appsv1.DeploymentStatus{
-			AvailableReplicas: 1,
-		},
-	}
+	return testutils.NewCentralDeployment(centralNamespace)
 }

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -186,13 +186,11 @@ func TestIgnoreCacheForCentralNotReady(t *testing.T) {
 }
 
 func TestReconcileDelete(t *testing.T) {
-	// given
 	fakeClient := testutils.NewFakeClientBuilder(t).Build()
 	r := NewCentralReconciler(fakeClient, private.ManagedCentral{}, true, false)
 
 	_, err := r.Reconcile(context.TODO(), simpleManagedCentral)
 	require.NoError(t, err)
-	// when
 	deletedCentral := simpleManagedCentral
 	deletedCentral.Metadata.DeletionTimestamp = "2006-01-02T15:04:05Z07:00"
 
@@ -296,17 +294,15 @@ func TestReportRoutesStatuses(t *testing.T) {
 }
 
 func TestReportRoutesStatusWhenCentralNotChanged(t *testing.T) {
-	// given
 	fakeClient := testutils.NewFakeClientBuilder(t).Build()
 	r := NewCentralReconciler(fakeClient, private.ManagedCentral{}, true, false)
 
 	_, err := r.Reconcile(context.TODO(), simpleManagedCentral)
 	require.NoError(t, err)
-	// when
+
 	existingCentral := simpleManagedCentral
 	existingCentral.RequestStatus = centralConstants.DinosaurRequestStatusReady.String()
 	status, _ := r.Reconcile(context.TODO(), existingCentral) // cache hit
-	// then
 	expected := []private.DataPlaneCentralStatusRoutes{
 		{
 			Domain: "acs-cb45idheg5ip6dq1jo4g.acs.rhcloud.test",

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -322,35 +322,26 @@ func TestReportRoutesStatusWhenCentralNotChanged(t *testing.T) {
 }
 
 func TestNoRoutesSentWhenOneNotCreated(t *testing.T) {
-	// given
 	fakeClient, tracker := testutils.NewFakeClientWithTracker(t)
 	tracker.AddRouteError(centralReencryptRouteName, errors.New("fake error"))
 	r := NewCentralReconciler(fakeClient, private.ManagedCentral{}, true, false)
-	// when
 	_, err := r.Reconcile(context.TODO(), simpleManagedCentral)
-	// then
 	require.Errorf(t, err, "fake error")
 }
 
 func TestNoRoutesSentWhenOneNotAdmitted(t *testing.T) {
-	// given
 	fakeClient, tracker := testutils.NewFakeClientWithTracker(t)
 	tracker.SetRouteAdmitted(centralReencryptRouteName, false)
 	r := NewCentralReconciler(fakeClient, private.ManagedCentral{}, true, false)
-	// when
 	_, err := r.Reconcile(context.TODO(), simpleManagedCentral)
-	// then
 	require.Errorf(t, err, "unable to find admitted ingress")
 }
 
 func TestNoRoutesSentWhenOneNotCreatedYet(t *testing.T) {
-	// given
 	fakeClient, tracker := testutils.NewFakeClientWithTracker(t)
 	tracker.SetSkipRoute(centralReencryptRouteName, true)
 	r := NewCentralReconciler(fakeClient, private.ManagedCentral{}, true, false)
-	// when
 	_, err := r.Reconcile(context.TODO(), simpleManagedCentral)
-	// then
 	require.Errorf(t, err, "unable to find admitted ingress")
 }
 

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -5,16 +5,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
-	appsv1 "k8s.io/api/apps/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	openshiftRouteV1 "github.com/openshift/api/route/v1"
+	"github.com/pkg/errors"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/testutils"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/util"
 	centralConstants "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
 	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -325,12 +323,7 @@ func TestReportRoutesStatusWhenCentralNotChanged(t *testing.T) {
 
 func TestNoRoutesSentWhenOneNotCreated(t *testing.T) {
 	// given
-	scheme := testutils.NewScheme(t)
-	tracker := testutils.NewReconcileTracker(scheme)
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjectTracker(tracker).
-		Build()
+	fakeClient, tracker := testutils.NewFakeClientWithTracker(t)
 	tracker.AddRouteError(centralReencryptRouteName, errors.New("fake error"))
 	r := NewCentralReconciler(fakeClient, private.ManagedCentral{}, true, false)
 	// when
@@ -341,12 +334,7 @@ func TestNoRoutesSentWhenOneNotCreated(t *testing.T) {
 
 func TestNoRoutesSentWhenOneNotAdmitted(t *testing.T) {
 	// given
-	scheme := testutils.NewScheme(t)
-	tracker := testutils.NewReconcileTracker(scheme)
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjectTracker(tracker).
-		Build()
+	fakeClient, tracker := testutils.NewFakeClientWithTracker(t)
 	tracker.SetRouteAdmitted(centralReencryptRouteName, false)
 	r := NewCentralReconciler(fakeClient, private.ManagedCentral{}, true, false)
 	// when
@@ -357,12 +345,7 @@ func TestNoRoutesSentWhenOneNotAdmitted(t *testing.T) {
 
 func TestNoRoutesSentWhenOneNotCreatedYet(t *testing.T) {
 	// given
-	scheme := testutils.NewScheme(t)
-	tracker := testutils.NewReconcileTracker(scheme)
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjectTracker(tracker).
-		Build()
+	fakeClient, tracker := testutils.NewFakeClientWithTracker(t)
 	tracker.SetSkipRoute(centralReencryptRouteName, true)
 	r := NewCentralReconciler(fakeClient, private.ManagedCentral{}, true, false)
 	// when

--- a/fleetshard/pkg/testutils/k8s.go
+++ b/fleetshard/pkg/testutils/k8s.go
@@ -7,8 +7,10 @@ import (
 	"github.com/hashicorp/go-multierror"
 	openshiftOperatorV1 "github.com/openshift/api/operator/v1"
 	openshiftRouteV1 "github.com/openshift/api/route/v1"
+	"github.com/pkg/errors"
 	platform "github.com/stackrox/rox/operator/apis/platform/v1alpha1"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	coreV1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,42 +37,94 @@ var (
 		Version:  "v1",
 		Resource: "routes",
 	}
+	deploymentGVR = schema.GroupVersionResource{
+		Group:    "apps",
+		Version:  "v1",
+		Resource: "deployments",
+	}
 )
 
-// CentralCA ...
 const (
-	// CentralCA ...
+	// CentralCA certificate authority which is used by central and included with the stackrox distribution.
 	CentralCA     = "test CA"
 	clusterDomain = "test.local"
 )
 
-type reconcileTracker struct {
+var centralLabels = map[string]string{
+	"app.kubernetes.io/name":      "stackrox",
+	"app.kubernetes.io/component": "central",
+}
+
+// ReconcileTracker keeps track of objects. It is intended to be used to
+// fake calls to a server by returning objects based on their kind,
+// namespace and name. This is fleetshard specific implementation of k8sTesting.ObjectTracker
+type ReconcileTracker struct {
 	k8sTesting.ObjectTracker
+	routeErrors     map[string]error
+	routeConditions map[string]*openshiftRouteV1.RouteIngressCondition
+	skipRoute       map[string]bool
 }
 
 // NewFakeClientBuilder returns a new fake client builder with registered custom resources
 func NewFakeClientBuilder(t *testing.T, objects ...ctrlClient.Object) *fake.ClientBuilder {
+	scheme := NewScheme(t)
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjectTracker(NewReconcileTracker(scheme)).
+		WithObjects(objects...)
+}
+
+// NewScheme returns a new scheme instance used for fleetshard testing
+func NewScheme(t *testing.T) *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	require.NoError(t, platform.AddToScheme(scheme))
 	require.NoError(t, clientgoscheme.AddToScheme(scheme))
 	require.NoError(t, openshiftRouteV1.Install(scheme))
 	require.NoError(t, openshiftOperatorV1.Install(scheme))
 
-	return fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjectTracker(newReconcileTracker(scheme)).
-		WithObjects(objects...)
+	return scheme
 }
 
-func newReconcileTracker(scheme *runtime.Scheme) k8sTesting.ObjectTracker {
-	return reconcileTracker{ObjectTracker: k8sTesting.NewObjectTracker(scheme, clientgoscheme.Codecs.UniversalDecoder())}
+// NewReconcileTracker creates a new instance of ReconcileTracker
+func NewReconcileTracker(scheme *runtime.Scheme) *ReconcileTracker {
+	return &ReconcileTracker{
+		ObjectTracker:   k8sTesting.NewObjectTracker(scheme, clientgoscheme.Codecs.UniversalDecoder()),
+		routeErrors:     map[string]error{},
+		routeConditions: map[string]*openshiftRouteV1.RouteIngressCondition{},
+		skipRoute:       map[string]bool{},
+	}
 }
 
-// Create ...
-func (t reconcileTracker) Create(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
+// AddRouteError add a new error on a given route creation
+func (t *ReconcileTracker) AddRouteError(routeName string, err error) {
+	t.routeErrors[routeName] = err
+}
+
+// SetRouteAdmitted add a rule to set RouteIngressCondition for a given route
+func (t *ReconcileTracker) SetRouteAdmitted(routeName string, admitted bool) {
+	condition := &openshiftRouteV1.RouteIngressCondition{
+		Type: openshiftRouteV1.RouteAdmitted,
+	}
+	if admitted {
+		condition.Status = coreV1.ConditionTrue
+	} else {
+		condition.Status = coreV1.ConditionFalse
+	}
+	t.routeConditions[routeName] = condition
+}
+
+// SetSkipRoute do not create route with a given name when flag is true
+func (t *ReconcileTracker) SetSkipRoute(routeName string, skip bool) {
+	t.skipRoute[routeName] = skip
+}
+
+// Create adds an object to the tracker in the specified namespace.
+func (t *ReconcileTracker) Create(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
 	if gvr == routesGVR {
 		route := obj.(*openshiftRouteV1.Route)
-		route.Status = admittedStatus(route.Spec.Host)
+		route.Status = t.admittedStatus(route.Name, route.Spec.Host)
+		return t.createRoute(route)
 	}
 	if err := t.ObjectTracker.Create(gvr, obj, ns); err != nil {
 		return fmt.Errorf("adding GVR %q to reconcile tracker: %w", gvr, err)
@@ -78,8 +132,9 @@ func (t reconcileTracker) Create(gvr schema.GroupVersionResource, obj runtime.Ob
 	if gvr == centralsGVR {
 		var multiErr *multierror.Error
 		multiErr = multierror.Append(multiErr, t.ObjectTracker.Create(secretsGVR, newCentralTLSSecret(ns), ns))
-		multiErr = multierror.Append(multiErr, t.ObjectTracker.Create(routesGVR, newCentralRoute(ns), ns))
-		multiErr = multierror.Append(multiErr, t.ObjectTracker.Create(routesGVR, newCentralMtlsRoute(ns), ns))
+		multiErr = multierror.Append(multiErr, t.createRoute(t.newCentralRoute(ns)))
+		multiErr = multierror.Append(multiErr, t.createRoute(t.newCentralMtlsRoute(ns)))
+		multiErr = multierror.Append(multiErr, t.ObjectTracker.Create(deploymentGVR, t.newCentralDeployment(ns), ns))
 		err := multiErr.ErrorOrNil()
 		if err != nil {
 			return fmt.Errorf("creating group version resource: %w", err)
@@ -100,55 +155,76 @@ func newCentralTLSSecret(ns string) *coreV1.Secret {
 	}
 }
 
-func newCentralRoute(ns string) *openshiftRouteV1.Route {
+func (t *ReconcileTracker) createRoute(route *openshiftRouteV1.Route) error {
+	name := route.GetName()
+	if err := t.routeErrors[name]; err != nil {
+		return err
+	}
+	if t.skipRoute[name] {
+		return nil
+	}
+	err := t.ObjectTracker.Create(routesGVR, route, route.GetNamespace())
+	return errors.Wrapf(err, "create route")
+}
+
+func (t *ReconcileTracker) newCentralRoute(ns string) *openshiftRouteV1.Route {
 	host := fmt.Sprintf("central-%s.%s", ns, clusterDomain)
+	name := "central"
 	return &openshiftRouteV1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "central",
+			Name:      name,
 			Namespace: ns,
-			Labels: map[string]string{
-				"app.kubernetes.io/name":      "stackrox",
-				"app.kubernetes.io/component": "central",
-			},
+			Labels:    centralLabels,
 		},
 		Spec: openshiftRouteV1.RouteSpec{
 			Host: host,
 		},
-		Status: admittedStatus(host),
+		Status: t.admittedStatus(name, host),
 	}
 }
 
-func newCentralMtlsRoute(ns string) *openshiftRouteV1.Route {
+func (t *ReconcileTracker) newCentralMtlsRoute(ns string) *openshiftRouteV1.Route {
 	host := fmt.Sprintf("central.%s", ns)
+	name := "central-mtls"
 	return &openshiftRouteV1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "central-mtls",
+			Name:      name,
 			Namespace: ns,
-			Labels: map[string]string{
-				"app.kubernetes.io/name":      "stackrox",
-				"app.kubernetes.io/component": "central",
-			},
+			Labels:    centralLabels,
 		},
 		Spec: openshiftRouteV1.RouteSpec{
 			Host: host,
 		},
-		Status: admittedStatus(host),
+		Status: t.admittedStatus(name, host),
 	}
 }
 
-func admittedStatus(host string) openshiftRouteV1.RouteStatus {
+func (t *ReconcileTracker) admittedStatus(routeName string, host string) openshiftRouteV1.RouteStatus {
+	routeCondition := t.routeConditions[routeName]
+	if routeCondition == nil {
+		routeCondition = &openshiftRouteV1.RouteIngressCondition{
+			Type:   openshiftRouteV1.RouteAdmitted,
+			Status: coreV1.ConditionTrue,
+		}
+	}
+
 	return openshiftRouteV1.RouteStatus{
 		Ingress: []openshiftRouteV1.RouteIngress{
 			{
-				Conditions: []openshiftRouteV1.RouteIngressCondition{
-					{
-						Type:   openshiftRouteV1.RouteAdmitted,
-						Status: coreV1.ConditionTrue,
-					},
-				},
+				Conditions:              []openshiftRouteV1.RouteIngressCondition{*routeCondition},
 				Host:                    host,
 				RouterCanonicalHostname: "router-default.apps.test.local",
 			},
+		},
+	}
+}
+
+func (t *ReconcileTracker) newCentralDeployment(ns string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "central",
+			Namespace: ns,
+			Labels:    centralLabels,
 		},
 	}
 }

--- a/fleetshard/pkg/testutils/k8s.go
+++ b/fleetshard/pkg/testutils/k8s.go
@@ -75,6 +75,17 @@ func NewFakeClientBuilder(t *testing.T, objects ...ctrlClient.Object) *fake.Clie
 		WithObjects(objects...)
 }
 
+// NewFakeClientWithTracker returns a new fake client and a ReconcileTracker to mock k8s responses
+func NewFakeClientWithTracker(t *testing.T) (ctrlClient.WithWatch, *ReconcileTracker) {
+	scheme := NewScheme(t)
+	tracker := NewReconcileTracker(scheme)
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjectTracker(tracker).
+		Build()
+	return client, tracker
+}
+
 // NewScheme returns a new scheme instance used for fleetshard testing
 func NewScheme(t *testing.T) *runtime.Scheme {
 	scheme := runtime.NewScheme()

--- a/fleetshard/pkg/testutils/k8s.go
+++ b/fleetshard/pkg/testutils/k8s.go
@@ -145,7 +145,7 @@ func (t *ReconcileTracker) Create(gvr schema.GroupVersionResource, obj runtime.O
 		multiErr = multierror.Append(multiErr, t.ObjectTracker.Create(secretsGVR, newCentralTLSSecret(ns), ns))
 		multiErr = multierror.Append(multiErr, t.createRoute(t.newCentralRoute(ns)))
 		multiErr = multierror.Append(multiErr, t.createRoute(t.newCentralMtlsRoute(ns)))
-		multiErr = multierror.Append(multiErr, t.ObjectTracker.Create(deploymentGVR, t.newCentralDeployment(ns), ns))
+		multiErr = multierror.Append(multiErr, t.ObjectTracker.Create(deploymentGVR, NewCentralDeployment(ns), ns))
 		err := multiErr.ErrorOrNil()
 		if err != nil {
 			return fmt.Errorf("creating group version resource: %w", err)
@@ -230,12 +230,16 @@ func (t *ReconcileTracker) admittedStatus(routeName string, host string) openshi
 	}
 }
 
-func (t *ReconcileTracker) newCentralDeployment(ns string) *appsv1.Deployment {
+// NewCentralDeployment creates a new k8s Deployment in a given namespace
+func NewCentralDeployment(ns string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "central",
 			Namespace: ns,
 			Labels:    centralLabels,
+		},
+		Status: appsv1.DeploymentStatus{
+			AvailableReplicas: 1,
 		},
 	}
 }


### PR DESCRIPTION
## Description
This PR adds a few unit tests to ensure that there is no inconsistent state when the routes are sent to the fleet manager

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual
Build is green

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
