### PR TITLE
Fix reconcile cache

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -192,6 +192,8 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		r.createAuthProvider = false
 	}
 
+	// Setting the last central hash must always be executed as the last step.
+	// defer can't be used for this call because it is also executed after the reconcile failed.
 	if err := r.setLastCentralHash(remoteCentral); err != nil {
 		return nil, errors.Wrapf(err, "setting central reconcilation cache")
 	}

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -171,10 +171,6 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		}
 	}
 
-	if err := r.setLastCentralHash(remoteCentral); err != nil {
-		return nil, errors.Wrapf(err, "setting central reconcilation cache")
-	}
-
 	// Check whether deployment is ready.
 	centralReady, err := isCentralReady(ctx, r.client, remoteCentral)
 	if err != nil {
@@ -194,6 +190,10 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 			return nil, err
 		}
 		r.createAuthProvider = false
+	}
+
+	if err := r.setLastCentralHash(remoteCentral); err != nil {
+		return nil, errors.Wrapf(err, "setting central reconcilation cache")
 	}
 
 	// TODO(create-ticket): When should we create failed conditions for the reconciler?


### PR DESCRIPTION
## Description

The reconcile cache should be set after all steps were successfully completed. Here it was set before the SSO provider was initiliazed.
This can lead to skipped reconciles if the SSO registration fails, the reconciler returns. On the next reconcile the Central CR is still the same and the SSO config is never created.
Fixable by restarting fleetshard-sync.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

