### PR TITLE
ROX-12215 - ACS operator use manual install approval plan

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/acs-operator.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/acs-operator.yaml
@@ -12,7 +12,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   channel: latest
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: rhacs-operator
   source: {{ .Values.acsOperator.source }}
   sourceNamespace: {{ .Values.acsOperator.sourceNamespace }}


### PR DESCRIPTION
## Description

Use manual install approval plan to control operator upgrades. Fleetshard-sync later will approve manual upgrades for the operator after an API trigger.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing

## Test manual

