### PR TITLE
Improve error output in bootstrap script in case K8s cannot be reached

### DIFF
--- a/dev/env/scripts/bootstrap.sh
+++ b/dev/env/scripts/bootstrap.sh
@@ -19,7 +19,11 @@ Using OLM: ${INSTALL_OLM}
 EOF
 
 if ! kc_output=$($KUBECTL api-versions >/dev/null 2>&1); then
-    die "Sanity check for contacting Kubernetes cluster failed: ${kc_output}"
+    die "Error: Sanity check for contacting Kubernetes cluster failed:
+
+Command tried: '$KUBECTL api-versions'
+Output:
+${kc_output:-(no output)}"
 fi
 
 # Create Namespaces.


### PR DESCRIPTION
## Description

I once stumbled upon the problem that the bootstrap script terminated due to this without any error output.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
