### PR TITLE
ROX-11614: Add PagerDuty secret to the observability helm chart

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-03-secret-pagerduty.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-03-secret-pagerduty.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhacs-pagerduty
+  namespace: {{ include "observability.namespace" . }}
+  labels:
+    configures: observability-operator
+stringData:
+  PAGERDUTY_KEY: {{ .Values.pagerduty.key | quote }}
+type: Opaque

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-03-secret-pagerduty.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-03-secret-pagerduty.yaml
@@ -3,8 +3,6 @@ kind: Secret
 metadata:
   name: rhacs-pagerduty
   namespace: {{ include "observability.namespace" . }}
-  labels:
-    configures: observability-operator
 stringData:
   PAGERDUTY_KEY: {{ .Values.pagerduty.key | quote }}
 type: Opaque

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
@@ -23,3 +23,7 @@ observatorium:
   gateway: ""
   metricsClientId: ""
   metricsSecret: ""
+
+pagerduty:
+  # PagerDuty integration key, which is generated within a Ruleset.
+  key: ""

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -44,6 +44,8 @@ observability:
     gateway: ""
     metricsClientId: ""
     metricsSecret: ""
+  pagerduty:
+    key: ""
 
 # See available parameters in charts/logging/values.yaml
 # - enabled flag is used to completely enable/disable logging sub-chart


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

[ROX-11614](https://issues.redhat.com/browse/ROX-11614) - Setup ACS PagerDuty as backend for alerting rules.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~Unit and integration tests added~
- [ ] ~Documentation added if necessary~
- [ ] CI and all relevant tests are passing
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

```sh
$ helm template . --namespace rhacs --set "pagerduty.key=abcdef" | grep -A2 -B9 KEY
# Source: observability/templates/01-operator-03-secret-pagerduty.yaml
apiVersion: v1
kind: Secret
metadata:
  name: rhacs-pagerduty
  namespace: rhacs-observability
  labels:
    configures: observability-operator
stringData:
  PAGERDUTY_KEY: "abcdef"
type: Opaque
---
```
