### PR TITLE
Error message when kubectl cannot be found

### DIFF
--- a/dev/env/scripts/bootstrap.sh
+++ b/dev/env/scripts/bootstrap.sh
@@ -18,6 +18,10 @@ Using OLM: ${INSTALL_OLM}
 
 EOF
 
+if ! command -v ${KUBECTL} &> /dev/null; then
+    die "Cannot find kubectl or equivalent tool: ${KUBECTL}"
+fi
+
 if ! kc_output=$($KUBECTL api-versions >/dev/null 2>&1); then
     die "Sanity check for contacting Kubernetes cluster failed: ${kc_output}"
 fi

--- a/dev/env/scripts/bootstrap.sh
+++ b/dev/env/scripts/bootstrap.sh
@@ -18,7 +18,7 @@ Using OLM: ${INSTALL_OLM}
 
 EOF
 
-if ! command -v ${KUBECTL} &> /dev/null; then
+if ! command -v "${KUBECTL}" &> /dev/null; then
     die "Cannot find kubectl or equivalent tool: ${KUBECTL}"
 fi
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

If `kubectl` (or `oc`) is not available, the error message was "Sanity check for contacting Kubernetes cluster failed:", which can be confusing.

This can happen e.g. when using an OpenShift cluster, and the script switches from `kubectl` to `oc`, and `oc` is not installed.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
~~- [ ] Documentation added if necessary~~
~~- [ ] CI and all relevant tests are passing~~
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~

## Test manual

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
