### PR TITLE
Make e2e test output more verbose

### DIFF
--- a/dev/env/defaults/cluster-type-openshift-ci/env
+++ b/dev/env/defaults/cluster-type-openshift-ci/env
@@ -3,7 +3,6 @@ export DUMP_LOGS_DEFAULT="true"
 export AUTH_TYPE_DEFAULT="STATIC_TOKEN"
 export FINAL_TEAR_DOWN_DEFAULT="true"
 export GOTESTSUM="/usr/local/bin/gotestsum"
-export GOTESTSUM_FORMAT="testname"
 export ENABLE_CENTRAL_EXTERNAL_CERTIFICATE=true
 # To be adjusted for runnign in OpenShift CI
 # export FLEET_MANAGER_RESOURCES_DEFAULT='{"requests":{"cpu":"200m","memory":"300Mi"},"limits":{"cpu":"200m","memory":"300Mi"}}'


### PR DESCRIPTION
## Description
This PR makes e2e test output more verbose. Currently it is not clear which steps were passed and which were skipped.
Since we have only one test - the output with the `testname` format is very short.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
