### PR TITLE
Read data plane cluster id for staging e2e from env

### DIFF
--- a/e2e/run_e2e_stage.sh
+++ b/e2e/run_e2e_stage.sh
@@ -12,7 +12,7 @@
 echo "ACS fleet manager base url: ${ACS_FLEET_MANAGER_ENDPOINT}"
 
 make \
-  CLUSTER_ID="1smhq7nc0ncfv2jbjgf48q7e6qb943ou" \
+  CLUSTER_ID="${DATA_PLANE_CLUSTER_ID}" \
   DP_CLOUD_PROVIDER="aws" \
   DP_REGION="us-east-1" \
   FLEET_MANAGER_ENDPOINT="${ACS_FLEET_MANAGER_ENDPOINT}" \


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Use env based  data plane `cluster_id` in e2e staging tests. This env is mapped from `acs-fleet-manager-ci/e2e/data-plane-cluster-id` appSRE vault secret
`