### PR TITLE
Reconcile ClusterDNS

### DIFF
--- a/internal/dinosaur/pkg/config/dataplane_cluster_config.go
+++ b/internal/dinosaur/pkg/config/dataplane_cluster_config.go
@@ -239,6 +239,19 @@ func (conf *ClusterConfig) MissingClusters(clusterMap map[string]api.Cluster) []
 	return res
 }
 
+// ExistingClusters produces the subset of clusters which do already exist for fleet-manager.
+func (conf *ClusterConfig) ExistingClusters(clusterMap map[string]api.Cluster) []ManualCluster {
+	var res []ManualCluster
+
+	// ensure the order
+	for _, p := range conf.clusterList {
+		if _, exists := clusterMap[p.ClusterID]; exists {
+			res = append(res, p)
+		}
+	}
+	return res
+}
+
 // IsDataPlaneManualScalingEnabled ...
 func (c *DataplaneClusterConfig) IsDataPlaneManualScalingEnabled() bool {
 	return c.DataPlaneClusterScalingType == ManualScaling


### PR DESCRIPTION
## Description

This allows updating the cluster_dns column in the `clusters` table in the DB.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
