### PR TITLE
CI build root image: Change dnf update command

### DIFF
--- a/.openshift-ci/build-root/Dockerfile
+++ b/.openshift-ci/build-root/Dockerfile
@@ -34,7 +34,7 @@ RUN rm -f /etc/yum.repos.d/* && { \
     echo "enabled=1"; \
     } > "/etc/yum.repos.d/centos.repo"
 
-RUN dnf update && dnf -y install make which git gettext jq gcc
+RUN dnf update -y && dnf -y install make which git gettext jq gcc
 
 RUN curl -L --retry 10 --silent --show-error --fail -o /tmp/go1.17.12.linux-amd64.tar.gz \
     https://go.dev/dl/go1.17.12.linux-amd64.tar.gz && \


### PR DESCRIPTION
## Description

Tried building locally and it failed with:
```
Step 3/22 : RUN dnf update && dnf -y install make which git gettext jq gcc
 ---> Running in bf3af5cc1930
CentOS Stream 9 - BaseOS                        5.3 MB/s | 5.8 MB     00:01    
CentOS Stream  - AppStream                      4.0 MB/s |  15 MB     00:03    
Last metadata expiration check: 0:00:01 ago on Wed Aug 24 07:42:08 2022.
Dependencies resolved.
================================================================================
 Package                   Arch     Version                      Repo      Size
================================================================================
Upgrading:
 crypto-policies           noarch   20220815-1.git0fbe86f.el9    baseos    81 k
 crypto-policies-scripts   noarch   20220815-1.git0fbe86f.el9    baseos    93 k
 curl-minimal              x86_64   7.76.1-19.el9                baseos   130 k
 gnupg2                    x86_64   2.3.3-2.el9                  baseos   2.5 M
 gnutls                    x86_64   3.7.6-5.el9                  baseos   937 k
 libcurl-minimal           x86_64   7.76.1-19.el9                baseos   228 k
 libgcrypt                 x86_64   1.10.0-5.el9                 baseos   510 k
 openssl-libs              x86_64   1:3.0.1-41.el9               baseos   2.1 M
 tpm2-tss                  x86_64   3.0.3-8.el9                  baseos   576 k
 tzdata                    noarch   2022c-1.el9                  baseos   835 k

Transaction Summary
================================================================================
Upgrade  10 Packages

Total download size: 8.0 M
Is this ok [y/N]: Operation aborted.
The command '/bin/sh -c dnf update && dnf -y install make which git gettext jq gcc' returned a non-zero code: 1
```

Apparently `dnf update` can also install packages and require confirmation.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
