### PR TITLE
fix secret reference for aws stage

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -1060,10 +1060,10 @@ objects:
             - --central-lifespan=${CENTRAL_LIFE_SPAN}
             - --enable-deletion-of-expired-central=${ENABLE_CENTRAL_LIFE_SPAN}
             - --aws-access-key-file=/secrets/service/aws.accesskey
-            - --aws-account-id-file=/secrets/service/aws.accountid
+            - --aws-account-id-file=/secrets/fleet-manager-credentials/aws.accountid
             - --aws-secret-access-key-file=/secrets/service/aws.secretaccesskey
-            - --aws-route53-access-key-file=/secrets/service/aws.route53accesskey
-            - --aws-route53-secret-access-key-file=/secrets/service/aws.route53secretaccesskey
+            - --aws-route53-access-key-file=/secrets/fleet-manager-credentials/aws.route53accesskey
+            - --aws-route53-secret-access-key-file=/secrets/fleet-manager-credentials/aws.route53secretaccesskey
             - --rhsso-client-secret-file=/secrets/rhsso-client-secret/clientSecret
             - --observatorium-debug=${ENABLE_OBSERVATORIUM_DEBUG}
             - --observatorium-ignore-ssl=${OBSERVATORIUM_INSECURE}


### PR DESCRIPTION
## Description
Fix the secret reference for aws credentials in stage fleet-manager deployment

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
