### PR TITLE
Get rid of vendor directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -364,8 +364,6 @@ test/e2e/cleanup:
 # generate files
 generate: moq openapi/generate
 	$(GO) generate ./...
-	$(GO) mod vendor
-	$(MOQ) -out ./pkg/client/iam/gocloak_moq.go -pkg iam vendor/github.com/Nerzal/gocloak/v11 GoCloak:GoCloakMock
 .PHONY: generate
 
 # validate the openapi schema

--- a/pkg/client/iam/client.go
+++ b/pkg/client/iam/client.go
@@ -81,6 +81,10 @@ type iamClient struct {
 
 var _ IAMClient = &iamClient{}
 
+// GoCloak an alias for gocloak.GoCloak
+//go:generate moq -out gocloak_moq.go . GoCloak
+type GoCloak = gocloak.GoCloak
+
 // NewClient ...
 func NewClient(config *IAMConfig, realmConfig *IAMRealmConfig) *iamClient {
 	setTokenEndpoints(config, realmConfig)

--- a/pkg/client/iam/gocloak_moq.go
+++ b/pkg/client/iam/gocloak_moq.go
@@ -12,15 +12,15 @@ import (
 	"sync"
 )
 
-// Ensure, that GoCloakMock does implement gocloak.GoCloak.
+// Ensure, that GoCloakMock does implement GoCloak.
 // If this is not the case, regenerate this file with moq.
-var _ gocloak.GoCloak = &GoCloakMock{}
+var _ GoCloak = &GoCloakMock{}
 
-// GoCloakMock is a mock implementation of gocloak.GoCloak.
+// GoCloakMock is a mock implementation of GoCloak.
 //
 // 	func TestSomethingThatUsesGoCloak(t *testing.T) {
 //
-// 		// make and configure a mocked gocloak.GoCloak
+// 		// make and configure a mocked GoCloak
 // 		mockedGoCloak := &GoCloakMock{
 // 			AddClientRoleCompositeFunc: func(ctx context.Context, token string, realm string, roleID string, roles []gocloak.Role) error {
 // 				panic("mock out the AddClientRoleComposite method")
@@ -729,7 +729,7 @@ var _ gocloak.GoCloak = &GoCloakMock{}
 // 			},
 // 		}
 //
-// 		// use mockedGoCloak in code that requires gocloak.GoCloak
+// 		// use mockedGoCloak in code that requires GoCloak
 // 		// and then make assertions.
 //
 // 	}


### PR DESCRIPTION
## Description
I think we're currently misusing the vendor directory concept. It is used only to mock *one* interface. Each dependency update requires `go mod vendor` because of that.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~Unit and integration tests added~
- [x] ~Documentation added if necessary~
- [x] CI and all relevant tests are passing
- [x] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
