### PR TITLE
ROX-11593: Made RH SSO client_id configurable

### DIFF
--- a/docs/legacy/feature-flags.md
+++ b/docs/legacy/feature-flags.md
@@ -36,6 +36,7 @@ This lists the feature flags and their sub-configurations to enable/disable and 
     - `central-tls-key-file` [Required]: The path to the file containing the Central TLS private key (default: `'secrets/central-tls.key'`).
 - **enable-evaluator-instance**: Enable the creation of one central evaluator instances per user  
 - **rhsso-client-secret-file**: OIDC client secret to connect Central instances to sso.redhat.com
+- **rhsso-issuer**: RHSSO issuer to pass to Central's auth config to set up RHSSO IdP
 - **quota-type**: Sets the quota service to be used for access control when requesting Central instances (options: `ams` or `quota-management-list`, default: `quota-management-list`).
     > For more information on the quota service implementation, see the [quota service architecture](./architecture/quota-service-implementation) architecture documentation.
     - If this is set to `quota-management-list`, quotas will be managed via the quota management list configuration.

--- a/docs/legacy/feature-flags.md
+++ b/docs/legacy/feature-flags.md
@@ -35,7 +35,8 @@ This lists the feature flags and their sub-configurations to enable/disable and 
     - `central-tls-cert-file` [Required]: The path to the file containing the Central TLS certificate (default: `'secrets/central-tls.crt'`).
     - `central-tls-key-file` [Required]: The path to the file containing the Central TLS private key (default: `'secrets/central-tls.key'`).
 - **enable-evaluator-instance**: Enable the creation of one central evaluator instances per user  
-- **rhsso-client-secret-file**: OIDC client secret to connect Central instances to sso.redhat.com
+- **rhsso-client-id**: RHSSO client ID to pass to Central's auth config to set up RHSSO IdP
+- **rhsso-client-secret-file**: File containing RHSSO client secret to pass to Central's auth config to set up RHSSO IdP
 - **rhsso-issuer**: RHSSO issuer to pass to Central's auth config to set up RHSSO IdP
 - **quota-type**: Sets the quota service to be used for access control when requesting Central instances (options: `ams` or `quota-management-list`, default: `quota-management-list`).
     > For more information on the quota service implementation, see the [quota service architecture](./architecture/quota-service-implementation) architecture documentation.

--- a/fleetshard/pkg/central/reconciler/init_auth.go
+++ b/fleetshard/pkg/central/reconciler/init_auth.go
@@ -12,7 +12,7 @@ import (
 	centralClientPkg "github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/client"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/ternary"
+	"github.com/stackrox/rox/pkg/urlfmt"
 	core "k8s.io/api/core/v1"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -157,9 +157,17 @@ func createAuthProviderRequest(central private.ManagedCentral) *storage.AuthProv
 	return request
 }
 
-func authProviderName(central private.ManagedCentral) string {
-	return ternary.String(strings.Contains(central.Spec.Auth.Issuer, "stage"),
-		"Red Hat SSO (Stage)", "Red Hat SSO")
+// authProviderName deduces auth provider name from issuer URL.
+func authProviderName(central private.ManagedCentral) (name string) {
+	switch {
+	case strings.Contains(central.Spec.Auth.Issuer, "sso.stage.redhat"): name = "Red Hat SSO (stage)"
+	case strings.Contains(central.Spec.Auth.Issuer, "sso.redhat"): name = "Red Hat SSO"
+	default: name = urlfmt.GetServerFromURL(central.Spec.Auth.Issuer)
+	}
+	if name == "" {
+		name = "SSO"
+	}
+	return
 }
 
 // TODO: ROX-11644: doesn't work when fleetshard-sync deployed outside of Central's cluster

--- a/fleetshard/pkg/central/reconciler/init_auth.go
+++ b/fleetshard/pkg/central/reconciler/init_auth.go
@@ -160,9 +160,12 @@ func createAuthProviderRequest(central private.ManagedCentral) *storage.AuthProv
 // authProviderName deduces auth provider name from issuer URL.
 func authProviderName(central private.ManagedCentral) (name string) {
 	switch {
-	case strings.Contains(central.Spec.Auth.Issuer, "sso.stage.redhat"): name = "Red Hat SSO (stage)"
-	case strings.Contains(central.Spec.Auth.Issuer, "sso.redhat"): name = "Red Hat SSO"
-	default: name = urlfmt.GetServerFromURL(central.Spec.Auth.Issuer)
+	case strings.Contains(central.Spec.Auth.Issuer, "sso.stage.redhat"):
+		name = "Red Hat SSO (stage)"
+	case strings.Contains(central.Spec.Auth.Issuer, "sso.redhat"):
+		name = "Red Hat SSO"
+	default:
+		name = urlfmt.GetServerFromURL(central.Spec.Auth.Issuer)
 	}
 	if name == "" {
 		name = "SSO"

--- a/internal/dinosaur/pkg/config/central.go
+++ b/internal/dinosaur/pkg/config/central.go
@@ -24,11 +24,13 @@ type CentralConfig struct {
 	// TODO(ROX-11289): drop MaxCapacity
 	MaxCapacity MaxCapacityConfig `json:"max_capacity_config"`
 
-	CentralLifespan       *CentralLifespanConfig `json:"central_lifespan"`
-	Quota                 *CentralQuotaConfig    `json:"central_quota"`
-	RhSsoClientSecret     string                 `json:"rhsso_client_secret"`
-	RhSsoClientSecretFile string                 `json:"rhsso_client_secret_file"`
-	RhSsoIssuer           string                 `json:"rhsso_issuer"`
+	CentralLifespan *CentralLifespanConfig `json:"central_lifespan"`
+	Quota           *CentralQuotaConfig    `json:"central_quota"`
+
+	RhSsoClientID         string `json:"rhsso_client_id"`
+	RhSsoClientSecret     string `json:"rhsso_client_secret"`
+	RhSsoClientSecretFile string `json:"rhsso_client_secret_file"`
+	RhSsoIssuer           string `json:"rhsso_issuer"`
 }
 
 // NewCentralConfig ...
@@ -54,8 +56,9 @@ func (c *CentralConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.CentralDomainName, "central-domain-name", c.CentralDomainName, "The domain name to use for Central instances")
 	fs.StringVar(&c.Quota.Type, "quota-type", c.Quota.Type, "The type of the quota service to be used. The available options are: 'ams' for AMS backed implementation and 'quota-management-list' for quota list backed implementation (default).")
 	fs.BoolVar(&c.Quota.AllowEvaluatorInstance, "allow-evaluator-instance", c.Quota.AllowEvaluatorInstance, "Allow the creation of central evaluator instances")
-	fs.StringVar(&c.RhSsoClientSecretFile, "rhsso-client-secret-file", c.RhSsoClientSecretFile, "File containing OIDC client secret of sso.redhat.com client")
-	fs.StringVar(&c.RhSsoIssuer, "rhsso-issuer", c.RhSsoIssuer, "Issuer identifier for sso.redhat.com. Should be equal to value returned in ID Token issuer('iss') field")
+	fs.StringVar(&c.RhSsoClientID, "rhsso-client-id", c.RhSsoClientID, "RHSSO client ID to pass to Central's auth config")
+	fs.StringVar(&c.RhSsoClientSecretFile, "rhsso-client-secret-file", c.RhSsoClientSecretFile, "File containing RHSSO client secret to pass to Central's auth config")
+	fs.StringVar(&c.RhSsoIssuer, "rhsso-issuer", c.RhSsoIssuer, "Issuer identifier for sso.redhat.com. Should be equal to value returned in ID Token issuer ('iss') field")
 }
 
 // ReadFiles ...

--- a/internal/dinosaur/pkg/environments/development.go
+++ b/internal/dinosaur/pkg/environments/development.go
@@ -35,6 +35,7 @@ func NewDevelopmentEnvLoader() environments.EnvLoader {
 		"additional-sso-issuers-file":                     "config/additional-sso-issuers.yaml",
 		"jwks-file":                                       "config/jwks-file-static.json",
 		"fleetshard-authz-config-file":                    "config/fleetshard-authz-org-ids-development.yaml",
+		"rhsso-client-id":                                 "rhacs-ms-dev",
 		"rhsso-issuer":                                    "https://sso.stage.redhat.com/auth/realms/redhat-external",
 		"admin-authz-config-file":                         "config/admin-authz-roles-dev.yaml",
 	}

--- a/internal/dinosaur/pkg/environments/integration.go
+++ b/internal/dinosaur/pkg/environments/integration.go
@@ -45,6 +45,7 @@ func (b IntegrationEnvLoader) Defaults() map[string]string {
 		"dataplane-cluster-scaling-type":      "auto", // need to set this to 'auto' for integration environment as some tests rely on this
 		"central-operator-addon-id":           "managed-central-qe",
 		"fleetshard-addon-id":                 "fleetshard-operator-qe",
+		"rhsso-client-id":                     "rhacs-ms-dev",
 	}
 }
 

--- a/internal/dinosaur/pkg/environments/stage.go
+++ b/internal/dinosaur/pkg/environments/stage.go
@@ -17,6 +17,7 @@ func NewStageEnvLoader() environments.EnvLoader {
 		"additional-sso-issuers-file":         "config/additional-sso-issuers.yaml",
 		"jwks-file":                           "config/jwks-file-static.json",
 		"fleetshard-authz-config-file":        "config/fleetshard-authz-org-ids-development.yaml",
+		"rhsso-client-id":                     "rhacs-ms-dev",
 		"rhsso-issuer":                        "https://sso.stage.redhat.com/auth/realms/redhat-external",
 		"admin-authz-config-file":             "config/admin-authz-roles-dev.yaml",
 	}

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -66,8 +66,7 @@ func (c *ManagedCentralPresenter) PresentManagedCentral(from *dbapi.CentralReque
 			},
 			Auth: private.ManagedCentralAllOfSpecAuth{
 				ClientSecret: c.centralConfig.RhSsoClientSecret, // pragma: allowlist secret
-				// TODO(ROX-11593): make part of centralConfig
-				ClientId:    "rhacs-ms-dev",
+				ClientId:    c.centralConfig.RhSsoClientID,
 				OwnerOrgId:  from.OrganisationID,
 				OwnerUserId: from.OwnerUserID,
 				Issuer:      c.centralConfig.RhSsoIssuer,


### PR DESCRIPTION
## Description
Currently, RH SSO `client_id` which is passed to Central to configure SSO is hard coded. This PR makes it configurable.

In addition, a doc entry for `rhsso-issuer` config param is added and SSO name deduction supports more than just stage or prod RH SSO.

## Checklist (Definition of Done)
- [ ] ~Unit and integration tests added~
- [x] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
