### PR TITLE
ROX-12155: Move Central's IdP setup to a worker

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.0",
+  "version": "1.2.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -113,25 +113,9 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "config/jwks-file-static.json",
-        "hashed_secret": "ed62b47fd3b50efa5ac26528e55d81092af405f9",
-        "is_verified": false,
-        "line_number": 4,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "config/jwks-file-static.json",
         "hashed_secret": "551c2aa179bc3c0e2e8176d4b458d077ed358e25",
         "is_verified": false,
         "line_number": 8,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "config/jwks-file-static.json",
-        "hashed_secret": "cfed69888acbd1a5a2dc12a093d1e1141af05807",
-        "is_verified": false,
-        "line_number": 12,
         "is_secret": false
       },
       {
@@ -145,25 +129,9 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "config/jwks-file-static.json",
-        "hashed_secret": "5ec9a1a2e3f33fdd442f873acc689c75ecb1b60a",
-        "is_verified": false,
-        "line_number": 20,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "config/jwks-file-static.json",
         "hashed_secret": "e23d321e76d1144e48b7f1d05dfd0d5036031003",
         "is_verified": false,
         "line_number": 24,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "config/jwks-file-static.json",
-        "hashed_secret": "01cfde694c3ae081d9d48c49948f83f862f11039",
-        "is_verified": false,
-        "line_number": 28,
         "is_secret": false
       },
       {
@@ -187,25 +155,9 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "config/jwks-file.json",
-        "hashed_secret": "ed62b47fd3b50efa5ac26528e55d81092af405f9",
-        "is_verified": false,
-        "line_number": 4,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "config/jwks-file.json",
         "hashed_secret": "551c2aa179bc3c0e2e8176d4b458d077ed358e25",
         "is_verified": false,
         "line_number": 8,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "config/jwks-file.json",
-        "hashed_secret": "cfed69888acbd1a5a2dc12a093d1e1141af05807",
-        "is_verified": false,
-        "line_number": 12,
         "is_secret": false
       },
       {
@@ -219,25 +171,9 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "config/jwks-file.json",
-        "hashed_secret": "5ec9a1a2e3f33fdd442f873acc689c75ecb1b60a",
-        "is_verified": false,
-        "line_number": 20,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "config/jwks-file.json",
         "hashed_secret": "e23d321e76d1144e48b7f1d05dfd0d5036031003",
         "is_verified": false,
         "line_number": 24,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "config/jwks-file.json",
-        "hashed_secret": "01cfde694c3ae081d9d48c49948f83f862f11039",
-        "is_verified": false,
-        "line_number": 28,
         "is_secret": false
       },
       {
@@ -257,71 +193,6 @@
         "is_verified": false,
         "line_number": 1,
         "is_secret": false
-      }
-    ],
-    "dev/env/manifests/shared/03-configmap-config.yaml": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
-        "hashed_secret": "13032f402fed753c2248419ea4f69f99931f6dbc",
-        "is_verified": false,
-        "line_number": 52
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
-        "hashed_secret": "30025f80f6e22cdafb85db387d50f90ea884576a",
-        "is_verified": false,
-        "line_number": 52
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
-        "hashed_secret": "355f24fd038bcaf85617abdcaa64af51ed19bbcf",
-        "is_verified": false,
-        "line_number": 52
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
-        "hashed_secret": "3d8a1dcd2c3c765ce35c9a9552d23273cc4ddace",
-        "is_verified": false,
-        "line_number": 52
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
-        "hashed_secret": "4ac7b0522761eba972467942cd5cd7499dd2c361",
-        "is_verified": false,
-        "line_number": 52
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
-        "hashed_secret": "7639ab2a6bcf2ea30a055a99468c9cd844d4c22a",
-        "is_verified": false,
-        "line_number": 52
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
-        "hashed_secret": "b56360daf4793d2a74991a972b34d95bc00fb2da",
-        "is_verified": false,
-        "line_number": 52
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
-        "hashed_secret": "c9a73ef9ee8ce9f38437227801c70bcc6740d1a1",
-        "is_verified": false,
-        "line_number": 52
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
-        "hashed_secret": "14736999d9940728c5294277831a702f7882dece",
-        "is_verified": false,
-        "line_number": 89
       }
     ],
     "pkg/client/iam/client_moq.go": [
@@ -428,79 +299,7 @@
         "is_secret": false
       }
     ],
-    "templates/envoy-config-configmap.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": "templates/envoy-config-configmap.yml",
-        "hashed_secret": "9d51dabe59aa776bef2909d3689374ebb93ab2be",
-        "is_verified": false,
-        "line_number": 10
-      }
-    ],
     "templates/service-template.yml": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "templates/service-template.yml",
-        "hashed_secret": "13032f402fed753c2248419ea4f69f99931f6dbc",
-        "is_verified": false,
-        "line_number": 469
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "templates/service-template.yml",
-        "hashed_secret": "30025f80f6e22cdafb85db387d50f90ea884576a",
-        "is_verified": false,
-        "line_number": 469
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "templates/service-template.yml",
-        "hashed_secret": "355f24fd038bcaf85617abdcaa64af51ed19bbcf",
-        "is_verified": false,
-        "line_number": 469
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "templates/service-template.yml",
-        "hashed_secret": "3d8a1dcd2c3c765ce35c9a9552d23273cc4ddace",
-        "is_verified": false,
-        "line_number": 469
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "templates/service-template.yml",
-        "hashed_secret": "4ac7b0522761eba972467942cd5cd7499dd2c361",
-        "is_verified": false,
-        "line_number": 469
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "templates/service-template.yml",
-        "hashed_secret": "7639ab2a6bcf2ea30a055a99468c9cd844d4c22a",
-        "is_verified": false,
-        "line_number": 469
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "templates/service-template.yml",
-        "hashed_secret": "b56360daf4793d2a74991a972b34d95bc00fb2da",
-        "is_verified": false,
-        "line_number": 469
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "templates/service-template.yml",
-        "hashed_secret": "c9a73ef9ee8ce9f38437227801c70bcc6740d1a1",
-        "is_verified": false,
-        "line_number": 469
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "templates/service-template.yml",
-        "hashed_secret": "14736999d9940728c5294277831a702f7882dece",
-        "is_verified": false,
-        "line_number": 506
-      },
       {
         "type": "Secret Keyword",
         "filename": "templates/service-template.yml",
@@ -508,13 +307,6 @@
         "is_verified": false,
         "line_number": 599,
         "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "templates/service-template.yml",
-        "hashed_secret": "9d51dabe59aa776bef2909d3689374ebb93ab2be",
-        "is_verified": false,
-        "line_number": 639
       }
     ],
     "test/support/certs.json": [

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -115,7 +115,8 @@
         "filename": "config/jwks-file-static.json",
         "hashed_secret": "ed62b47fd3b50efa5ac26528e55d81092af405f9",
         "is_verified": false,
-        "line_number": 4
+        "line_number": 4,
+        "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
@@ -130,7 +131,8 @@
         "filename": "config/jwks-file-static.json",
         "hashed_secret": "cfed69888acbd1a5a2dc12a093d1e1141af05807",
         "is_verified": false,
-        "line_number": 12
+        "line_number": 12,
+        "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
@@ -145,7 +147,8 @@
         "filename": "config/jwks-file-static.json",
         "hashed_secret": "5ec9a1a2e3f33fdd442f873acc689c75ecb1b60a",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 20,
+        "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
@@ -160,7 +163,8 @@
         "filename": "config/jwks-file-static.json",
         "hashed_secret": "01cfde694c3ae081d9d48c49948f83f862f11039",
         "is_verified": false,
-        "line_number": 28
+        "line_number": 28,
+        "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
@@ -185,7 +189,8 @@
         "filename": "config/jwks-file.json",
         "hashed_secret": "ed62b47fd3b50efa5ac26528e55d81092af405f9",
         "is_verified": false,
-        "line_number": 4
+        "line_number": 4,
+        "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
@@ -200,7 +205,8 @@
         "filename": "config/jwks-file.json",
         "hashed_secret": "cfed69888acbd1a5a2dc12a093d1e1141af05807",
         "is_verified": false,
-        "line_number": 12
+        "line_number": 12,
+        "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
@@ -215,7 +221,8 @@
         "filename": "config/jwks-file.json",
         "hashed_secret": "5ec9a1a2e3f33fdd442f873acc689c75ecb1b60a",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 20,
+        "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
@@ -230,7 +237,8 @@
         "filename": "config/jwks-file.json",
         "hashed_secret": "01cfde694c3ae081d9d48c49948f83f862f11039",
         "is_verified": false,
-        "line_number": 28
+        "line_number": 28,
+        "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
@@ -314,24 +322,6 @@
         "hashed_secret": "14736999d9940728c5294277831a702f7882dece",
         "is_verified": false,
         "line_number": 89
-      }
-    ],
-    "internal/dinosaur/pkg/api/public/api/openapi.yaml": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/dinosaur/pkg/api/public/api/openapi.yaml",
-        "hashed_secret": "5b455797b93de5b6a19633ba22127c8a610f5c1b",
-        "is_verified": false,
-        "line_number": 1594
-      }
-    ],
-    "internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config.go": [
-      {
-        "type": "Secret Keyword",
-        "filename": "internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config.go",
-        "hashed_secret": "be360007ffb63864f206e904bd2360d7ba083128",
-        "is_verified": false,
-        "line_number": 97
       }
     ],
     "pkg/client/iam/client_moq.go": [
@@ -434,7 +424,8 @@
         "filename": "pkg/shared/secrets/secrets_test.go",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 113
+        "line_number": 113,
+        "is_secret": false
       }
     ],
     "templates/envoy-config-configmap.yml": [
@@ -523,17 +514,10 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "9d51dabe59aa776bef2909d3689374ebb93ab2be",
         "is_verified": false,
-        "line_number": 638
+        "line_number": 639
       }
     ],
     "test/support/certs.json": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "test/support/certs.json",
-        "hashed_secret": "99c4dce3baf838620dc33a9589cdca36d05b0be2",
-        "is_verified": false,
-        "line_number": 4
-      },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/support/certs.json",

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0",
+  "version": "1.3.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -113,10 +113,24 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "config/jwks-file-static.json",
+        "hashed_secret": "ed62b47fd3b50efa5ac26528e55d81092af405f9",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "config/jwks-file-static.json",
         "hashed_secret": "551c2aa179bc3c0e2e8176d4b458d077ed358e25",
         "is_verified": false,
         "line_number": 8,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "config/jwks-file-static.json",
+        "hashed_secret": "cfed69888acbd1a5a2dc12a093d1e1141af05807",
+        "is_verified": false,
+        "line_number": 12
       },
       {
         "type": "Base64 High Entropy String",
@@ -129,10 +143,24 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "config/jwks-file-static.json",
+        "hashed_secret": "5ec9a1a2e3f33fdd442f873acc689c75ecb1b60a",
+        "is_verified": false,
+        "line_number": 20
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "config/jwks-file-static.json",
         "hashed_secret": "e23d321e76d1144e48b7f1d05dfd0d5036031003",
         "is_verified": false,
         "line_number": 24,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "config/jwks-file-static.json",
+        "hashed_secret": "01cfde694c3ae081d9d48c49948f83f862f11039",
+        "is_verified": false,
+        "line_number": 28
       },
       {
         "type": "Base64 High Entropy String",
@@ -155,10 +183,24 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "config/jwks-file.json",
+        "hashed_secret": "ed62b47fd3b50efa5ac26528e55d81092af405f9",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "config/jwks-file.json",
         "hashed_secret": "551c2aa179bc3c0e2e8176d4b458d077ed358e25",
         "is_verified": false,
         "line_number": 8,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "config/jwks-file.json",
+        "hashed_secret": "cfed69888acbd1a5a2dc12a093d1e1141af05807",
+        "is_verified": false,
+        "line_number": 12
       },
       {
         "type": "Base64 High Entropy String",
@@ -171,10 +213,24 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "config/jwks-file.json",
+        "hashed_secret": "5ec9a1a2e3f33fdd442f873acc689c75ecb1b60a",
+        "is_verified": false,
+        "line_number": 20
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "config/jwks-file.json",
         "hashed_secret": "e23d321e76d1144e48b7f1d05dfd0d5036031003",
         "is_verified": false,
         "line_number": 24,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "config/jwks-file.json",
+        "hashed_secret": "01cfde694c3ae081d9d48c49948f83f862f11039",
+        "is_verified": false,
+        "line_number": 28
       },
       {
         "type": "Base64 High Entropy String",
@@ -193,6 +249,89 @@
         "is_verified": false,
         "line_number": 1,
         "is_secret": false
+      }
+    ],
+    "dev/env/manifests/shared/03-configmap-config.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
+        "hashed_secret": "13032f402fed753c2248419ea4f69f99931f6dbc",
+        "is_verified": false,
+        "line_number": 52
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
+        "hashed_secret": "30025f80f6e22cdafb85db387d50f90ea884576a",
+        "is_verified": false,
+        "line_number": 52
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
+        "hashed_secret": "355f24fd038bcaf85617abdcaa64af51ed19bbcf",
+        "is_verified": false,
+        "line_number": 52
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
+        "hashed_secret": "3d8a1dcd2c3c765ce35c9a9552d23273cc4ddace",
+        "is_verified": false,
+        "line_number": 52
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
+        "hashed_secret": "4ac7b0522761eba972467942cd5cd7499dd2c361",
+        "is_verified": false,
+        "line_number": 52
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
+        "hashed_secret": "7639ab2a6bcf2ea30a055a99468c9cd844d4c22a",
+        "is_verified": false,
+        "line_number": 52
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
+        "hashed_secret": "b56360daf4793d2a74991a972b34d95bc00fb2da",
+        "is_verified": false,
+        "line_number": 52
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
+        "hashed_secret": "c9a73ef9ee8ce9f38437227801c70bcc6740d1a1",
+        "is_verified": false,
+        "line_number": 52
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
+        "hashed_secret": "14736999d9940728c5294277831a702f7882dece",
+        "is_verified": false,
+        "line_number": 89
+      }
+    ],
+    "internal/dinosaur/pkg/api/public/api/openapi.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/dinosaur/pkg/api/public/api/openapi.yaml",
+        "hashed_secret": "5b455797b93de5b6a19633ba22127c8a610f5c1b",
+        "is_verified": false,
+        "line_number": 1594
+      }
+    ],
+    "internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config.go",
+        "hashed_secret": "be360007ffb63864f206e904bd2360d7ba083128",
+        "is_verified": false,
+        "line_number": 97
       }
     ],
     "pkg/client/iam/client_moq.go": [
@@ -298,7 +437,79 @@
         "line_number": 113
       }
     ],
+    "templates/envoy-config-configmap.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "templates/envoy-config-configmap.yml",
+        "hashed_secret": "9d51dabe59aa776bef2909d3689374ebb93ab2be",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
     "templates/service-template.yml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "templates/service-template.yml",
+        "hashed_secret": "13032f402fed753c2248419ea4f69f99931f6dbc",
+        "is_verified": false,
+        "line_number": 469
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "templates/service-template.yml",
+        "hashed_secret": "30025f80f6e22cdafb85db387d50f90ea884576a",
+        "is_verified": false,
+        "line_number": 469
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "templates/service-template.yml",
+        "hashed_secret": "355f24fd038bcaf85617abdcaa64af51ed19bbcf",
+        "is_verified": false,
+        "line_number": 469
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "templates/service-template.yml",
+        "hashed_secret": "3d8a1dcd2c3c765ce35c9a9552d23273cc4ddace",
+        "is_verified": false,
+        "line_number": 469
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "templates/service-template.yml",
+        "hashed_secret": "4ac7b0522761eba972467942cd5cd7499dd2c361",
+        "is_verified": false,
+        "line_number": 469
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "templates/service-template.yml",
+        "hashed_secret": "7639ab2a6bcf2ea30a055a99468c9cd844d4c22a",
+        "is_verified": false,
+        "line_number": 469
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "templates/service-template.yml",
+        "hashed_secret": "b56360daf4793d2a74991a972b34d95bc00fb2da",
+        "is_verified": false,
+        "line_number": 469
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "templates/service-template.yml",
+        "hashed_secret": "c9a73ef9ee8ce9f38437227801c70bcc6740d1a1",
+        "is_verified": false,
+        "line_number": 469
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "templates/service-template.yml",
+        "hashed_secret": "14736999d9940728c5294277831a702f7882dece",
+        "is_verified": false,
+        "line_number": 506
+      },
       {
         "type": "Secret Keyword",
         "filename": "templates/service-template.yml",
@@ -306,9 +517,23 @@
         "is_verified": false,
         "line_number": 599,
         "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "templates/service-template.yml",
+        "hashed_secret": "9d51dabe59aa776bef2909d3689374ebb93ab2be",
+        "is_verified": false,
+        "line_number": 638
       }
     ],
     "test/support/certs.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "test/support/certs.json",
+        "hashed_secret": "99c4dce3baf838620dc33a9589cdca36d05b0be2",
+        "is_verified": false,
+        "line_number": 4
+      },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/support/certs.json",

--- a/cmd/fleet-manager/main_test.go
+++ b/cmd/fleet-manager/main_test.go
@@ -35,6 +35,5 @@ func TestInjections(t *testing.T) {
 
 	var workerList []workers.Worker
 	env.MustResolve(&workerList)
-	Expect(workerList).To(HaveLen(8))
-
+	Expect(workerList).To(HaveLen(9))
 }

--- a/internal/dinosaur/pkg/api/dbapi/central_request_types.go
+++ b/internal/dinosaur/pkg/api/dbapi/central_request_types.go
@@ -52,6 +52,9 @@ type CentralRequest struct {
 	RoutesCreationID string `json:"routes_creation_id"`
 	// DeletionTimestamp stores the timestamp of the DELETE api call for the resource
 	DeletionTimestamp *time.Time `json:"deletionTimestamp"`
+
+	// All we need to integrate Central with an IdP.
+	AuthConfig
 }
 
 // CentralList ...
@@ -59,6 +62,13 @@ type CentralList []*CentralRequest
 
 // CentralIndex ...
 type CentralIndex map[string]*CentralRequest
+
+// AuthConfig keeps all we need to set up IdP for a Central instance.
+type AuthConfig struct {
+	ClientID     string `json:"idp_client_id"`
+	ClientSecret string `json:"idp_client_secret"`
+	Issuer       string `json:"idp_issuer"`
+}
 
 // Index ...
 func (l CentralList) Index() CentralIndex {

--- a/internal/dinosaur/pkg/api/dbapi/central_request_types.go
+++ b/internal/dinosaur/pkg/api/dbapi/central_request_types.go
@@ -22,7 +22,8 @@ type CentralRequest struct {
 	Owner          string `json:"owner" gorm:"index"` // TODO: ocm owner?
 	OwnerAccountID string `json:"owner_account_id"`
 	OwnerUserID    string `json:"owner_user_id"`
-	// The DNS host (domain) of the Central service
+	// Instance-independent part of the Central's hostname. For example, this
+	// can be `rhacs-dev.com`, `acs-stage.rhcloud.com`, etc.
 	Host           string `json:"host"`
 	OrganisationID string `json:"organisation_id" gorm:"index"`
 	FailedReason   string `json:"failed_reason"`

--- a/internal/dinosaur/pkg/config/central.go
+++ b/internal/dinosaur/pkg/config/central.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"github.com/stackrox/acs-fleet-manager/pkg/shared"
 )
@@ -87,11 +88,11 @@ func (c *CentralConfig) ReadFiles() error {
 	// Check that all parts of static auth config are present.
 	if c.HasStaticAuth() {
 		if c.CentralIDPClientSecret == "" {
-			glog.Warningf("no client_secret specified for static client_id %q;"+
+			return errors.Errorf("no client_secret specified for static client_id %q;"+
 				" auth configuration is either incorrect or insecure", c.CentralIDPClientID)
 		}
 		if c.CentralIDPIssuer == "" {
-			glog.Errorf("no issuer specified for static client_id %q;"+
+			return errors.Errorf("no issuer specified for static client_id %q;"+
 				" auth configuration will likely not work properly", c.CentralIDPClientID)
 		}
 	}

--- a/internal/dinosaur/pkg/config/central.go
+++ b/internal/dinosaur/pkg/config/central.go
@@ -83,6 +83,19 @@ func (c *CentralConfig) ReadFiles() error {
 	} else {
 		glog.Infof("Central's IdP client secret from file %q is missing", c.CentralIDPClientSecretFile)
 	}
+
+	// Check that all parts of static auth config are present.
+	if c.HasStaticAuth() {
+		if c.CentralIDPClientSecret == "" {
+			glog.Warningf("no client_secret specified for static client_id %q;"+
+				" auth configuration is either incorrect or insecure", c.CentralIDPClientID)
+		}
+		if c.CentralIDPIssuer == "" {
+			glog.Errorf("no issuer specified for static client_id %q;"+
+				" auth configuration will likely not work properly", c.CentralIDPClientID)
+		}
+	}
+
 	// TODO(ROX-11289): drop MaxCapacity
 	// MaxCapacity is deprecated and will not be used.
 	// Temporarily set MaxCapacity manually in order to simplify app start.

--- a/internal/dinosaur/pkg/config/central.go
+++ b/internal/dinosaur/pkg/config/central.go
@@ -89,3 +89,12 @@ func (c *CentralConfig) ReadFiles() error {
 	c.MaxCapacity = MaxCapacityConfig{1000}
 	return nil
 }
+
+// HasStaticAuth returns true if the static auth config for Centrals has been
+// specified and false otherwise.
+func (c *CentralConfig) HasStaticAuth() bool {
+	// We don't look at other integral parts of the auth config like
+	// RhSsoIssuer or RhSsoClientSecret. Failure to provide a working auth
+	// configuration should not mask an intent to use static configuration.
+	return c.RhSsoClientID != ""
+}

--- a/internal/dinosaur/pkg/config/central.go
+++ b/internal/dinosaur/pkg/config/central.go
@@ -96,5 +96,5 @@ func (c *CentralConfig) HasStaticAuth() bool {
 	// We don't look at other integral parts of the auth config like
 	// RhSsoIssuer or RhSsoClientSecret. Failure to provide a working auth
 	// configuration should not mask an intent to use static configuration.
-	return c.RhSsoClientID != ""
+	return c.CentralIDPClientID != ""
 }

--- a/internal/dinosaur/pkg/environments/integration.go
+++ b/internal/dinosaur/pkg/environments/integration.go
@@ -45,7 +45,6 @@ func (b IntegrationEnvLoader) Defaults() map[string]string {
 		"dataplane-cluster-scaling-type":      "auto", // need to set this to 'auto' for integration environment as some tests rely on this
 		"central-operator-addon-id":           "managed-central-qe",
 		"fleetshard-addon-id":                 "fleetshard-operator-qe",
-		"central-idp-client-id":               "rhacs-ms-dev",
 	}
 }
 

--- a/internal/dinosaur/pkg/migrations/20220826000000_add_auth_config_to_centrals.go
+++ b/internal/dinosaur/pkg/migrations/20220826000000_add_auth_config_to_centrals.go
@@ -1,0 +1,77 @@
+package migrations
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/stackrox/acs-fleet-manager/pkg/api"
+	"github.com/stackrox/acs-fleet-manager/pkg/db"
+	"gorm.io/gorm"
+)
+
+func addAuthConfigToCentralRequest() *gormigrate.Migration {
+	newColumns := []string{"ClientID", "ClientSecret", "Issuer"}
+
+	type AuthConfig struct {
+		ClientID     string `json:"idp_client_id"`
+		ClientSecret string `json:"idp_client_secret"`
+		Issuer       string `json:"idp_issuer"`
+	}
+
+	type CentralRequest struct {
+		db.Model
+		Region                        string
+		ClusterID                     string
+		CloudProvider                 string
+		MultiAZ                       bool
+		Name                          string
+		Status                        string
+		SubscriptionID                string
+		Owner                         string
+		OwnerAccountID                string
+		OwnerUserID                   string
+		Host                          string
+		OrganisationID                string
+		FailedReason                  string
+		PlacementID                   string
+		Central                       api.JSON
+		Scanner                       api.JSON
+		DesiredCentralVersion         string
+		ActualCentralVersion          string
+		DesiredCentralOperatorVersion string
+		ActualCentralOperatorVersion  string
+		CentralUpgrading              bool
+		CentralOperatorUpgrading      bool
+		InstanceType                  string
+		QuotaType                     string
+		Routes                        api.JSON
+		RoutesCreated                 bool
+		Namespace                     string
+		RoutesCreationID              string
+		DeletionTimestamp             *time.Time
+		AuthConfig
+	}
+
+	return &gormigrate.Migration{
+		ID: "20220826000000",
+		Migrate: func(tx *gorm.DB) error {
+			for _, col := range newColumns {
+				err := tx.Migrator().AddColumn(&CentralRequest{}, col)
+				if err != nil {
+					return fmt.Errorf("adding new column %q: %w", col, err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			for _, col := range newColumns {
+				err := tx.Migrator().DropColumn(&CentralRequest{}, col)
+				if err != nil {
+					return fmt.Errorf("removing column %q: %w", col, err)
+				}
+			}
+			return nil
+		},
+	}
+}

--- a/internal/dinosaur/pkg/migrations/migrations.go
+++ b/internal/dinosaur/pkg/migrations/migrations.go
@@ -31,6 +31,7 @@ var migrations = []*gormigrate.Migration{
 	sampleMigration(),
 	addOwnerUserIDToCentralRequest(),
 	addResourcesToCentralRequest(),
+	addAuthConfigToCentralRequest(),
 }
 
 // New ...

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -65,11 +65,11 @@ func (c *ManagedCentralPresenter) PresentManagedCentral(from *dbapi.CentralReque
 				from.Owner,
 			},
 			Auth: private.ManagedCentralAllOfSpecAuth{
-				ClientSecret: c.centralConfig.CentralIDPClientSecret, // pragma: allowlist secret
-				ClientId:     c.centralConfig.CentralIDPClientID,
+				ClientId:     from.AuthConfig.ClientID,
+				ClientSecret: from.AuthConfig.ClientSecret, // pragma: allowlist secret
 				OwnerOrgId:   from.OrganisationID,
 				OwnerUserId:  from.OwnerUserID,
-				Issuer:       c.centralConfig.CentralIDPIssuer,
+				Issuer:       from.AuthConfig.Issuer,
 			},
 			UiEndpoint: private.ManagedCentralAllOfSpecUiEndpoint{
 				Host: from.GetUIHost(),

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -849,7 +849,7 @@ func (k *dinosaurService) ListCentralsWithoutAuthConfig() ([]*dbapi.CentralReque
 
 	dbConn := k.connectionFactory.New().
 		Where("status IN (?)", status).
-		Where("client_id == ''")
+		Where("client_id LIKE ''")
 
 	var results []*dbapi.CentralRequest
 	if err := dbConn.Find(&results).Error; err != nil {

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -847,14 +847,13 @@ func (k *dinosaurService) ListCentralsWithoutAuthConfig() ([]*dbapi.CentralReque
 		dinosaurConstants.CentralRequestStatusPreparing,
 	}
 
-	dbConn := k.connectionFactory.New()
-	var results []*dbapi.CentralRequest
-	if err := dbConn.
+	dbConn := k.connectionFactory.New().
 		Where("status IN (?)", status).
-		Where("idp_client_id == ''").
-		Scan(&results).
-		Error; err != nil {
-		return nil, errors.NewWithCause(errors.ErrorGeneral, err, "failed to list dinosaur requests")
+		Where("idp_client_id == ''")
+
+	var results []*dbapi.CentralRequest
+	if err := dbConn.Find(&results).Error; err != nil {
+		return nil, errors.NewWithCause(errors.ErrorGeneral, err, "failed to list Central requests")
 	}
 	return results, nil
 }

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -29,8 +29,17 @@ import (
 )
 
 var (
-	dinosaurDeletionStatuses  = []string{dinosaurConstants.CentralRequestStatusDeleting.String(), dinosaurConstants.CentralRequestStatusDeprovision.String()}
-	dinosaurManagedCRStatuses = []string{dinosaurConstants.CentralRequestStatusProvisioning.String(), dinosaurConstants.CentralRequestStatusDeprovision.String(), dinosaurConstants.CentralRequestStatusReady.String(), dinosaurConstants.CentralRequestStatusFailed.String()}
+	dinosaurDeletionStatuses = []string{
+		dinosaurConstants.CentralRequestStatusDeleting.String(),
+		dinosaurConstants.CentralRequestStatusDeprovision.String(),
+	}
+
+	dinosaurManagedCRStatuses = []string{
+		dinosaurConstants.CentralRequestStatusProvisioning.String(),
+		dinosaurConstants.CentralRequestStatusDeprovision.String(),
+		dinosaurConstants.CentralRequestStatusReady.String(),
+		dinosaurConstants.CentralRequestStatusFailed.String(),
+	}
 )
 
 // DinosaurRoutesAction ...

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -847,7 +847,7 @@ func (k *dinosaurService) ListCentralsWithoutAuthConfig() ([]*dbapi.CentralReque
 		dinosaurConstants.CentralRequestStatusPreparing,
 	}
 
-	dbConn := k.connectionFactory.New().
+	dbQuery := k.connectionFactory.New().
 		Where("status IN (?)", status).
 		Where("client_id = ''")
 

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -334,7 +334,7 @@ func (k *dinosaurService) PrepareDinosaurRequest(dinosaurRequest *dbapi.CentralR
 		Meta: api.Meta{
 			ID: dinosaurRequest.ID,
 		},
-		Status:      dinosaurConstants.CentralRequestStatusProvisioning.String(),
+		Status: dinosaurConstants.CentralRequestStatusProvisioning.String(),
 	}
 	if err := k.Update(updatedCentralRequest); err != nil {
 		return errors.NewWithCause(errors.ErrorGeneral, err, "failed to update dinosaur request")

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -849,7 +849,7 @@ func (k *dinosaurService) ListCentralsWithoutAuthConfig() ([]*dbapi.CentralReque
 
 	dbConn := k.connectionFactory.New().
 		Where("status IN (?)", status).
-		Where("idp_client_id == ''")
+		Where("client_id == ''")
 
 	var results []*dbapi.CentralRequest
 	if err := dbConn.Find(&results).Error; err != nil {

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -849,7 +849,7 @@ func (k *dinosaurService) ListCentralsWithoutAuthConfig() ([]*dbapi.CentralReque
 
 	dbConn := k.connectionFactory.New().
 		Where("status IN (?)", status).
-		Where("client_id LIKE ''")
+		Where("client_id = ''")
 
 	var results []*dbapi.CentralRequest
 	if err := dbConn.Find(&results).Error; err != nil {

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -276,7 +276,7 @@ func (k *dinosaurService) RegisterDinosaurJob(dinosaurRequest *dbapi.CentralRequ
 // require blocking operations (deducing namespace or instance hostname). Upon
 // success, CentralRequest is transitioned to 'Preparing' status and might not
 // be fully prepared yet.
-func (k *dinosaurService) AcceptCentralRequest(dinosaurRequest *dbapi.CentralRequest) *errors.ServiceError {
+func (k *dinosaurService) AcceptCentralRequest(centralRequest *dbapi.CentralRequest) *errors.ServiceError {
 	// Set namespace.
 	namespace, formatErr := FormatNamespace(dinosaurRequest.ID)
 	if formatErr != nil {

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -259,7 +259,7 @@ func (k *dinosaurService) RegisterDinosaurJob(dinosaurRequest *dbapi.CentralRequ
 	dinosaurRequest.Status = dinosaurConstants.CentralRequestStatusAccepted.String()
 	dinosaurRequest.SubscriptionID = subscriptionID
 	glog.Infof("Central request %s has been assigned the subscription %s.", dinosaurRequest.ID, subscriptionID)
-	// Persist the QuotaTyoe to be able to dynamically pick the right Quota service implementation even on restarts.
+	// Persist the QuotaType to be able to dynamically pick the right Quota service implementation even on restarts.
 	// A typical usecase is when a dinosaur A is created, at the time of creation the quota-type was ams. At some point in the future
 	// the API is restarted this time changing the --quota-type flag to quota-management-list, when dinosaur A is deleted at this point,
 	// we want to use the correct quota to perform the deletion.

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -842,9 +842,9 @@ func (k *dinosaurService) ListDinosaursWithRoutesNotCreated() ([]*dbapi.CentralR
 func (k *dinosaurService) ListCentralsWithoutAuthConfig() ([]*dbapi.CentralRequest, *errors.ServiceError) {
 	// There is no value in augmenting auth config for central requests beyond
 	// 'Preparing'.
-	status := []dinosaurConstants.DinosaurStatus{
-		dinosaurConstants.DinosaurRequestStatusAccepted,
-		dinosaurConstants.DinosaurRequestStatusPreparing,
+	status := []dinosaurConstants.CentralStatus{
+		dinosaurConstants.CentralRequestStatusAccepted,
+		dinosaurConstants.CentralRequestStatusPreparing,
 	}
 
 	dbConn := k.connectionFactory.New()

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -330,7 +330,7 @@ func (k *dinosaurService) PrepareDinosaurRequest(dinosaurRequest *dbapi.CentralR
 	}
 
 	// Update the fields of the CentralRequest record in the database.
-	updatedDinosaurRequest := &dbapi.CentralRequest{
+	updatedCentralRequest := &dbapi.CentralRequest{
 		Meta: api.Meta{
 			ID: dinosaurRequest.ID,
 		},

--- a/internal/dinosaur/pkg/services/dinosaurservice_moq.go
+++ b/internal/dinosaur/pkg/services/dinosaurservice_moq.go
@@ -34,7 +34,7 @@ var _ DinosaurService = &DinosaurServiceMock{}
 // 			CountByRegionAndInstanceTypeFunc: func() ([]DinosaurRegionCount, error) {
 // 				panic("mock out the CountByRegionAndInstanceType method")
 // 			},
-// 			CountByStatusFunc: func(status []dinosaurConstants.DinosaurStatus) ([]DinosaurStatusCount, error) {
+// 			CountByStatusFunc: func(status []dinosaurConstants.CentralStatus) ([]DinosaurStatusCount, error) {
 // 				panic("mock out the CountByStatus method")
 // 			},
 // 			DeleteFunc: func(centralRequest *dbapi.CentralRequest) *serviceError.ServiceError {
@@ -70,7 +70,7 @@ var _ DinosaurService = &DinosaurServiceMock{}
 // 			ListByClusterIDFunc: func(clusterID string) ([]*dbapi.CentralRequest, *serviceError.ServiceError) {
 // 				panic("mock out the ListByClusterID method")
 // 			},
-// 			ListByStatusFunc: func(status ...dinosaurConstants.DinosaurStatus) ([]*dbapi.CentralRequest, *serviceError.ServiceError) {
+// 			ListByStatusFunc: func(status ...dinosaurConstants.CentralStatus) ([]*dbapi.CentralRequest, *serviceError.ServiceError) {
 // 				panic("mock out the ListByStatus method")
 // 			},
 // 			ListCentralsWithoutAuthConfigFunc: func() ([]*dbapi.CentralRequest, *serviceError.ServiceError) {
@@ -94,7 +94,7 @@ var _ DinosaurService = &DinosaurServiceMock{}
 // 			UpdateFunc: func(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError {
 // 				panic("mock out the Update method")
 // 			},
-// 			UpdateStatusFunc: func(id string, status dinosaurConstants.DinosaurStatus) (bool, *serviceError.ServiceError) {
+// 			UpdateStatusFunc: func(id string, status dinosaurConstants.CentralStatus) (bool, *serviceError.ServiceError) {
 // 				panic("mock out the UpdateStatus method")
 // 			},
 // 			UpdatesFunc: func(dinosaurRequest *dbapi.CentralRequest, values map[string]interface{}) *serviceError.ServiceError {
@@ -120,7 +120,7 @@ type DinosaurServiceMock struct {
 	CountByRegionAndInstanceTypeFunc func() ([]DinosaurRegionCount, error)
 
 	// CountByStatusFunc mocks the CountByStatus method.
-	CountByStatusFunc func(status []dinosaurConstants.DinosaurStatus) ([]DinosaurStatusCount, error)
+	CountByStatusFunc func(status []dinosaurConstants.CentralStatus) ([]DinosaurStatusCount, error)
 
 	// DeleteFunc mocks the Delete method.
 	DeleteFunc func(centralRequest *dbapi.CentralRequest) *serviceError.ServiceError
@@ -156,7 +156,7 @@ type DinosaurServiceMock struct {
 	ListByClusterIDFunc func(clusterID string) ([]*dbapi.CentralRequest, *serviceError.ServiceError)
 
 	// ListByStatusFunc mocks the ListByStatus method.
-	ListByStatusFunc func(status ...dinosaurConstants.DinosaurStatus) ([]*dbapi.CentralRequest, *serviceError.ServiceError)
+	ListByStatusFunc func(status ...dinosaurConstants.CentralStatus) ([]*dbapi.CentralRequest, *serviceError.ServiceError)
 
 	// ListCentralsWithoutAuthConfigFunc mocks the ListCentralsWithoutAuthConfig method.
 	ListCentralsWithoutAuthConfigFunc func() ([]*dbapi.CentralRequest, *serviceError.ServiceError)
@@ -180,7 +180,7 @@ type DinosaurServiceMock struct {
 	UpdateFunc func(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError
 
 	// UpdateStatusFunc mocks the UpdateStatus method.
-	UpdateStatusFunc func(id string, status dinosaurConstants.DinosaurStatus) (bool, *serviceError.ServiceError)
+	UpdateStatusFunc func(id string, status dinosaurConstants.CentralStatus) (bool, *serviceError.ServiceError)
 
 	// UpdatesFunc mocks the Updates method.
 	UpdatesFunc func(dinosaurRequest *dbapi.CentralRequest, values map[string]interface{}) *serviceError.ServiceError
@@ -208,7 +208,7 @@ type DinosaurServiceMock struct {
 		// CountByStatus holds details about calls to the CountByStatus method.
 		CountByStatus []struct {
 			// Status is the status argument value.
-			Status []dinosaurConstants.DinosaurStatus
+			Status []dinosaurConstants.CentralStatus
 		}
 		// Delete holds details about calls to the Delete method.
 		Delete []struct {
@@ -270,7 +270,7 @@ type DinosaurServiceMock struct {
 		// ListByStatus holds details about calls to the ListByStatus method.
 		ListByStatus []struct {
 			// Status is the status argument value.
-			Status []dinosaurConstants.DinosaurStatus
+			Status []dinosaurConstants.CentralStatus
 		}
 		// ListCentralsWithoutAuthConfig holds details about calls to the ListCentralsWithoutAuthConfig method.
 		ListCentralsWithoutAuthConfig []struct {
@@ -308,7 +308,7 @@ type DinosaurServiceMock struct {
 			// ID is the id argument value.
 			ID string
 			// Status is the status argument value.
-			Status dinosaurConstants.DinosaurStatus
+			Status dinosaurConstants.CentralStatus
 		}
 		// Updates holds details about calls to the Updates method.
 		Updates []struct {
@@ -446,12 +446,12 @@ func (mock *DinosaurServiceMock) CountByRegionAndInstanceTypeCalls() []struct {
 }
 
 // CountByStatus calls CountByStatusFunc.
-func (mock *DinosaurServiceMock) CountByStatus(status []dinosaurConstants.DinosaurStatus) ([]DinosaurStatusCount, error) {
+func (mock *DinosaurServiceMock) CountByStatus(status []dinosaurConstants.CentralStatus) ([]DinosaurStatusCount, error) {
 	if mock.CountByStatusFunc == nil {
 		panic("DinosaurServiceMock.CountByStatusFunc: method is nil but DinosaurService.CountByStatus was just called")
 	}
 	callInfo := struct {
-		Status []dinosaurConstants.DinosaurStatus
+		Status []dinosaurConstants.CentralStatus
 	}{
 		Status: status,
 	}
@@ -465,10 +465,10 @@ func (mock *DinosaurServiceMock) CountByStatus(status []dinosaurConstants.Dinosa
 // Check the length with:
 //     len(mockedDinosaurService.CountByStatusCalls())
 func (mock *DinosaurServiceMock) CountByStatusCalls() []struct {
-	Status []dinosaurConstants.DinosaurStatus
+	Status []dinosaurConstants.CentralStatus
 } {
 	var calls []struct {
-		Status []dinosaurConstants.DinosaurStatus
+		Status []dinosaurConstants.CentralStatus
 	}
 	mock.lockCountByStatus.RLock()
 	calls = mock.calls.CountByStatus
@@ -821,12 +821,12 @@ func (mock *DinosaurServiceMock) ListByClusterIDCalls() []struct {
 }
 
 // ListByStatus calls ListByStatusFunc.
-func (mock *DinosaurServiceMock) ListByStatus(status ...dinosaurConstants.DinosaurStatus) ([]*dbapi.CentralRequest, *serviceError.ServiceError) {
+func (mock *DinosaurServiceMock) ListByStatus(status ...dinosaurConstants.CentralStatus) ([]*dbapi.CentralRequest, *serviceError.ServiceError) {
 	if mock.ListByStatusFunc == nil {
 		panic("DinosaurServiceMock.ListByStatusFunc: method is nil but DinosaurService.ListByStatus was just called")
 	}
 	callInfo := struct {
-		Status []dinosaurConstants.DinosaurStatus
+		Status []dinosaurConstants.CentralStatus
 	}{
 		Status: status,
 	}
@@ -840,10 +840,10 @@ func (mock *DinosaurServiceMock) ListByStatus(status ...dinosaurConstants.Dinosa
 // Check the length with:
 //     len(mockedDinosaurService.ListByStatusCalls())
 func (mock *DinosaurServiceMock) ListByStatusCalls() []struct {
-	Status []dinosaurConstants.DinosaurStatus
+	Status []dinosaurConstants.CentralStatus
 } {
 	var calls []struct {
-		Status []dinosaurConstants.DinosaurStatus
+		Status []dinosaurConstants.CentralStatus
 	}
 	mock.lockListByStatus.RLock()
 	calls = mock.calls.ListByStatus
@@ -1058,13 +1058,13 @@ func (mock *DinosaurServiceMock) UpdateCalls() []struct {
 }
 
 // UpdateStatus calls UpdateStatusFunc.
-func (mock *DinosaurServiceMock) UpdateStatus(id string, status dinosaurConstants.DinosaurStatus) (bool, *serviceError.ServiceError) {
+func (mock *DinosaurServiceMock) UpdateStatus(id string, status dinosaurConstants.CentralStatus) (bool, *serviceError.ServiceError) {
 	if mock.UpdateStatusFunc == nil {
 		panic("DinosaurServiceMock.UpdateStatusFunc: method is nil but DinosaurService.UpdateStatus was just called")
 	}
 	callInfo := struct {
 		ID     string
-		Status dinosaurConstants.DinosaurStatus
+		Status dinosaurConstants.CentralStatus
 	}{
 		ID:     id,
 		Status: status,
@@ -1080,11 +1080,11 @@ func (mock *DinosaurServiceMock) UpdateStatus(id string, status dinosaurConstant
 //     len(mockedDinosaurService.UpdateStatusCalls())
 func (mock *DinosaurServiceMock) UpdateStatusCalls() []struct {
 	ID     string
-	Status dinosaurConstants.DinosaurStatus
+	Status dinosaurConstants.CentralStatus
 } {
 	var calls []struct {
 		ID     string
-		Status dinosaurConstants.DinosaurStatus
+		Status dinosaurConstants.CentralStatus
 	}
 	mock.lockUpdateStatus.RLock()
 	calls = mock.calls.UpdateStatus

--- a/internal/dinosaur/pkg/services/dinosaurservice_moq.go
+++ b/internal/dinosaur/pkg/services/dinosaurservice_moq.go
@@ -6,7 +6,7 @@ package services
 import (
 	"context"
 	"github.com/aws/aws-sdk-go/service/route53"
-	constants2 "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
+	dinosaurConstants "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/dinosaurs/types"
 	"github.com/stackrox/acs-fleet-manager/pkg/api"
@@ -25,13 +25,16 @@ var _ DinosaurService = &DinosaurServiceMock{}
 //
 // 		// make and configure a mocked DinosaurService
 // 		mockedDinosaurService := &DinosaurServiceMock{
+// 			AcceptCentralRequestFunc: func(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError {
+// 				panic("mock out the AcceptCentralRequest method")
+// 			},
 // 			ChangeDinosaurCNAMErecordsFunc: func(dinosaurRequest *dbapi.CentralRequest, action DinosaurRoutesAction) (*route53.ChangeResourceRecordSetsOutput, *serviceError.ServiceError) {
 // 				panic("mock out the ChangeDinosaurCNAMErecords method")
 // 			},
 // 			CountByRegionAndInstanceTypeFunc: func() ([]DinosaurRegionCount, error) {
 // 				panic("mock out the CountByRegionAndInstanceType method")
 // 			},
-// 			CountByStatusFunc: func(status []constants2.CentralStatus) ([]DinosaurStatusCount, error) {
+// 			CountByStatusFunc: func(status []dinosaurConstants.DinosaurStatus) ([]DinosaurStatusCount, error) {
 // 				panic("mock out the CountByStatus method")
 // 			},
 // 			DeleteFunc: func(centralRequest *dbapi.CentralRequest) *serviceError.ServiceError {
@@ -67,8 +70,11 @@ var _ DinosaurService = &DinosaurServiceMock{}
 // 			ListByClusterIDFunc: func(clusterID string) ([]*dbapi.CentralRequest, *serviceError.ServiceError) {
 // 				panic("mock out the ListByClusterID method")
 // 			},
-// 			ListByStatusFunc: func(status ...constants2.CentralStatus) ([]*dbapi.CentralRequest, *serviceError.ServiceError) {
+// 			ListByStatusFunc: func(status ...dinosaurConstants.DinosaurStatus) ([]*dbapi.CentralRequest, *serviceError.ServiceError) {
 // 				panic("mock out the ListByStatus method")
+// 			},
+// 			ListCentralsWithoutAuthConfigFunc: func() ([]*dbapi.CentralRequest, *serviceError.ServiceError) {
+// 				panic("mock out the ListCentralsWithoutAuthConfig method")
 // 			},
 // 			ListComponentVersionsFunc: func() ([]DinosaurComponentVersions, error) {
 // 				panic("mock out the ListComponentVersions method")
@@ -88,7 +94,7 @@ var _ DinosaurService = &DinosaurServiceMock{}
 // 			UpdateFunc: func(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError {
 // 				panic("mock out the Update method")
 // 			},
-// 			UpdateStatusFunc: func(id string, status constants2.CentralStatus) (bool, *serviceError.ServiceError) {
+// 			UpdateStatusFunc: func(id string, status dinosaurConstants.DinosaurStatus) (bool, *serviceError.ServiceError) {
 // 				panic("mock out the UpdateStatus method")
 // 			},
 // 			UpdatesFunc: func(dinosaurRequest *dbapi.CentralRequest, values map[string]interface{}) *serviceError.ServiceError {
@@ -104,6 +110,9 @@ var _ DinosaurService = &DinosaurServiceMock{}
 //
 // 	}
 type DinosaurServiceMock struct {
+	// AcceptCentralRequestFunc mocks the AcceptCentralRequest method.
+	AcceptCentralRequestFunc func(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError
+
 	// ChangeDinosaurCNAMErecordsFunc mocks the ChangeDinosaurCNAMErecords method.
 	ChangeDinosaurCNAMErecordsFunc func(dinosaurRequest *dbapi.CentralRequest, action DinosaurRoutesAction) (*route53.ChangeResourceRecordSetsOutput, *serviceError.ServiceError)
 
@@ -111,7 +120,7 @@ type DinosaurServiceMock struct {
 	CountByRegionAndInstanceTypeFunc func() ([]DinosaurRegionCount, error)
 
 	// CountByStatusFunc mocks the CountByStatus method.
-	CountByStatusFunc func(status []constants2.CentralStatus) ([]DinosaurStatusCount, error)
+	CountByStatusFunc func(status []dinosaurConstants.DinosaurStatus) ([]DinosaurStatusCount, error)
 
 	// DeleteFunc mocks the Delete method.
 	DeleteFunc func(centralRequest *dbapi.CentralRequest) *serviceError.ServiceError
@@ -147,7 +156,10 @@ type DinosaurServiceMock struct {
 	ListByClusterIDFunc func(clusterID string) ([]*dbapi.CentralRequest, *serviceError.ServiceError)
 
 	// ListByStatusFunc mocks the ListByStatus method.
-	ListByStatusFunc func(status ...constants2.CentralStatus) ([]*dbapi.CentralRequest, *serviceError.ServiceError)
+	ListByStatusFunc func(status ...dinosaurConstants.DinosaurStatus) ([]*dbapi.CentralRequest, *serviceError.ServiceError)
+
+	// ListCentralsWithoutAuthConfigFunc mocks the ListCentralsWithoutAuthConfig method.
+	ListCentralsWithoutAuthConfigFunc func() ([]*dbapi.CentralRequest, *serviceError.ServiceError)
 
 	// ListComponentVersionsFunc mocks the ListComponentVersions method.
 	ListComponentVersionsFunc func() ([]DinosaurComponentVersions, error)
@@ -168,7 +180,7 @@ type DinosaurServiceMock struct {
 	UpdateFunc func(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError
 
 	// UpdateStatusFunc mocks the UpdateStatus method.
-	UpdateStatusFunc func(id string, status constants2.CentralStatus) (bool, *serviceError.ServiceError)
+	UpdateStatusFunc func(id string, status dinosaurConstants.DinosaurStatus) (bool, *serviceError.ServiceError)
 
 	// UpdatesFunc mocks the Updates method.
 	UpdatesFunc func(dinosaurRequest *dbapi.CentralRequest, values map[string]interface{}) *serviceError.ServiceError
@@ -178,6 +190,11 @@ type DinosaurServiceMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
+		// AcceptCentralRequest holds details about calls to the AcceptCentralRequest method.
+		AcceptCentralRequest []struct {
+			// DinosaurRequest is the dinosaurRequest argument value.
+			DinosaurRequest *dbapi.CentralRequest
+		}
 		// ChangeDinosaurCNAMErecords holds details about calls to the ChangeDinosaurCNAMErecords method.
 		ChangeDinosaurCNAMErecords []struct {
 			// DinosaurRequest is the dinosaurRequest argument value.
@@ -191,7 +208,7 @@ type DinosaurServiceMock struct {
 		// CountByStatus holds details about calls to the CountByStatus method.
 		CountByStatus []struct {
 			// Status is the status argument value.
-			Status []constants2.CentralStatus
+			Status []dinosaurConstants.DinosaurStatus
 		}
 		// Delete holds details about calls to the Delete method.
 		Delete []struct {
@@ -253,7 +270,10 @@ type DinosaurServiceMock struct {
 		// ListByStatus holds details about calls to the ListByStatus method.
 		ListByStatus []struct {
 			// Status is the status argument value.
-			Status []constants2.CentralStatus
+			Status []dinosaurConstants.DinosaurStatus
+		}
+		// ListCentralsWithoutAuthConfig holds details about calls to the ListCentralsWithoutAuthConfig method.
+		ListCentralsWithoutAuthConfig []struct {
 		}
 		// ListComponentVersions holds details about calls to the ListComponentVersions method.
 		ListComponentVersions []struct {
@@ -288,7 +308,7 @@ type DinosaurServiceMock struct {
 			// ID is the id argument value.
 			ID string
 			// Status is the status argument value.
-			Status constants2.CentralStatus
+			Status dinosaurConstants.DinosaurStatus
 		}
 		// Updates holds details about calls to the Updates method.
 		Updates []struct {
@@ -305,6 +325,7 @@ type DinosaurServiceMock struct {
 			DinosaurRequest *dbapi.CentralRequest
 		}
 	}
+	lockAcceptCentralRequest              sync.RWMutex
 	lockChangeDinosaurCNAMErecords        sync.RWMutex
 	lockCountByRegionAndInstanceType      sync.RWMutex
 	lockCountByStatus                     sync.RWMutex
@@ -320,6 +341,7 @@ type DinosaurServiceMock struct {
 	lockList                              sync.RWMutex
 	lockListByClusterID                   sync.RWMutex
 	lockListByStatus                      sync.RWMutex
+	lockListCentralsWithoutAuthConfig     sync.RWMutex
 	lockListComponentVersions             sync.RWMutex
 	lockListDinosaursWithRoutesNotCreated sync.RWMutex
 	lockPrepareDinosaurRequest            sync.RWMutex
@@ -329,6 +351,37 @@ type DinosaurServiceMock struct {
 	lockUpdateStatus                      sync.RWMutex
 	lockUpdates                           sync.RWMutex
 	lockVerifyAndUpdateDinosaurAdmin      sync.RWMutex
+}
+
+// AcceptCentralRequest calls AcceptCentralRequestFunc.
+func (mock *DinosaurServiceMock) AcceptCentralRequest(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError {
+	if mock.AcceptCentralRequestFunc == nil {
+		panic("DinosaurServiceMock.AcceptCentralRequestFunc: method is nil but DinosaurService.AcceptCentralRequest was just called")
+	}
+	callInfo := struct {
+		DinosaurRequest *dbapi.CentralRequest
+	}{
+		DinosaurRequest: dinosaurRequest,
+	}
+	mock.lockAcceptCentralRequest.Lock()
+	mock.calls.AcceptCentralRequest = append(mock.calls.AcceptCentralRequest, callInfo)
+	mock.lockAcceptCentralRequest.Unlock()
+	return mock.AcceptCentralRequestFunc(dinosaurRequest)
+}
+
+// AcceptCentralRequestCalls gets all the calls that were made to AcceptCentralRequest.
+// Check the length with:
+//     len(mockedDinosaurService.AcceptCentralRequestCalls())
+func (mock *DinosaurServiceMock) AcceptCentralRequestCalls() []struct {
+	DinosaurRequest *dbapi.CentralRequest
+} {
+	var calls []struct {
+		DinosaurRequest *dbapi.CentralRequest
+	}
+	mock.lockAcceptCentralRequest.RLock()
+	calls = mock.calls.AcceptCentralRequest
+	mock.lockAcceptCentralRequest.RUnlock()
+	return calls
 }
 
 // ChangeDinosaurCNAMErecords calls ChangeDinosaurCNAMErecordsFunc.
@@ -393,12 +446,12 @@ func (mock *DinosaurServiceMock) CountByRegionAndInstanceTypeCalls() []struct {
 }
 
 // CountByStatus calls CountByStatusFunc.
-func (mock *DinosaurServiceMock) CountByStatus(status []constants2.CentralStatus) ([]DinosaurStatusCount, error) {
+func (mock *DinosaurServiceMock) CountByStatus(status []dinosaurConstants.DinosaurStatus) ([]DinosaurStatusCount, error) {
 	if mock.CountByStatusFunc == nil {
 		panic("DinosaurServiceMock.CountByStatusFunc: method is nil but DinosaurService.CountByStatus was just called")
 	}
 	callInfo := struct {
-		Status []constants2.CentralStatus
+		Status []dinosaurConstants.DinosaurStatus
 	}{
 		Status: status,
 	}
@@ -412,10 +465,10 @@ func (mock *DinosaurServiceMock) CountByStatus(status []constants2.CentralStatus
 // Check the length with:
 //     len(mockedDinosaurService.CountByStatusCalls())
 func (mock *DinosaurServiceMock) CountByStatusCalls() []struct {
-	Status []constants2.CentralStatus
+	Status []dinosaurConstants.DinosaurStatus
 } {
 	var calls []struct {
-		Status []constants2.CentralStatus
+		Status []dinosaurConstants.DinosaurStatus
 	}
 	mock.lockCountByStatus.RLock()
 	calls = mock.calls.CountByStatus
@@ -768,12 +821,12 @@ func (mock *DinosaurServiceMock) ListByClusterIDCalls() []struct {
 }
 
 // ListByStatus calls ListByStatusFunc.
-func (mock *DinosaurServiceMock) ListByStatus(status ...constants2.CentralStatus) ([]*dbapi.CentralRequest, *serviceError.ServiceError) {
+func (mock *DinosaurServiceMock) ListByStatus(status ...dinosaurConstants.DinosaurStatus) ([]*dbapi.CentralRequest, *serviceError.ServiceError) {
 	if mock.ListByStatusFunc == nil {
 		panic("DinosaurServiceMock.ListByStatusFunc: method is nil but DinosaurService.ListByStatus was just called")
 	}
 	callInfo := struct {
-		Status []constants2.CentralStatus
+		Status []dinosaurConstants.DinosaurStatus
 	}{
 		Status: status,
 	}
@@ -787,14 +840,40 @@ func (mock *DinosaurServiceMock) ListByStatus(status ...constants2.CentralStatus
 // Check the length with:
 //     len(mockedDinosaurService.ListByStatusCalls())
 func (mock *DinosaurServiceMock) ListByStatusCalls() []struct {
-	Status []constants2.CentralStatus
+	Status []dinosaurConstants.DinosaurStatus
 } {
 	var calls []struct {
-		Status []constants2.CentralStatus
+		Status []dinosaurConstants.DinosaurStatus
 	}
 	mock.lockListByStatus.RLock()
 	calls = mock.calls.ListByStatus
 	mock.lockListByStatus.RUnlock()
+	return calls
+}
+
+// ListCentralsWithoutAuthConfig calls ListCentralsWithoutAuthConfigFunc.
+func (mock *DinosaurServiceMock) ListCentralsWithoutAuthConfig() ([]*dbapi.CentralRequest, *serviceError.ServiceError) {
+	if mock.ListCentralsWithoutAuthConfigFunc == nil {
+		panic("DinosaurServiceMock.ListCentralsWithoutAuthConfigFunc: method is nil but DinosaurService.ListCentralsWithoutAuthConfig was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockListCentralsWithoutAuthConfig.Lock()
+	mock.calls.ListCentralsWithoutAuthConfig = append(mock.calls.ListCentralsWithoutAuthConfig, callInfo)
+	mock.lockListCentralsWithoutAuthConfig.Unlock()
+	return mock.ListCentralsWithoutAuthConfigFunc()
+}
+
+// ListCentralsWithoutAuthConfigCalls gets all the calls that were made to ListCentralsWithoutAuthConfig.
+// Check the length with:
+//     len(mockedDinosaurService.ListCentralsWithoutAuthConfigCalls())
+func (mock *DinosaurServiceMock) ListCentralsWithoutAuthConfigCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockListCentralsWithoutAuthConfig.RLock()
+	calls = mock.calls.ListCentralsWithoutAuthConfig
+	mock.lockListCentralsWithoutAuthConfig.RUnlock()
 	return calls
 }
 
@@ -979,13 +1058,13 @@ func (mock *DinosaurServiceMock) UpdateCalls() []struct {
 }
 
 // UpdateStatus calls UpdateStatusFunc.
-func (mock *DinosaurServiceMock) UpdateStatus(id string, status constants2.CentralStatus) (bool, *serviceError.ServiceError) {
+func (mock *DinosaurServiceMock) UpdateStatus(id string, status dinosaurConstants.DinosaurStatus) (bool, *serviceError.ServiceError) {
 	if mock.UpdateStatusFunc == nil {
 		panic("DinosaurServiceMock.UpdateStatusFunc: method is nil but DinosaurService.UpdateStatus was just called")
 	}
 	callInfo := struct {
 		ID     string
-		Status constants2.CentralStatus
+		Status dinosaurConstants.DinosaurStatus
 	}{
 		ID:     id,
 		Status: status,
@@ -1001,11 +1080,11 @@ func (mock *DinosaurServiceMock) UpdateStatus(id string, status constants2.Centr
 //     len(mockedDinosaurService.UpdateStatusCalls())
 func (mock *DinosaurServiceMock) UpdateStatusCalls() []struct {
 	ID     string
-	Status constants2.CentralStatus
+	Status dinosaurConstants.DinosaurStatus
 } {
 	var calls []struct {
 		ID     string
-		Status constants2.CentralStatus
+		Status dinosaurConstants.DinosaurStatus
 	}
 	mock.lockUpdateStatus.RLock()
 	calls = mock.calls.UpdateStatus

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/accepted_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/accepted_dinosaurs_mgr.go
@@ -128,7 +128,7 @@ func (k *AcceptedDinosaurManager) reconcileAcceptedDinosaur(dinosaur *dbapi.Cent
 
 	glog.Infof("Central instance with id %s is assigned to cluster with id %s", dinosaur.ID, dinosaur.ClusterID)
 
-	if err = k.dinosaurService.AcceptCentralRequest(dinosaur); err != nil {
+	if err := k.dinosaurService.AcceptCentralRequest(dinosaur); err != nil {
 		return errors.Wrapf(err, "failed to accept Central %s with cluster details", dinosaur.ID)
 	}
 	return nil

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/accepted_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/accepted_dinosaurs_mgr.go
@@ -126,10 +126,10 @@ func (k *AcceptedDinosaurManager) reconcileAcceptedDinosaur(dinosaur *dbapi.Cent
 	}
 	dinosaur.DesiredCentralVersion = selectedDinosaurOperatorVersion.CentralVersions[len(selectedDinosaurOperatorVersion.CentralVersions)-1].Version
 
-	glog.Infof("Dinosaur instance with id %s is assigned to cluster with id %s", dinosaur.ID, dinosaur.ClusterID)
-	dinosaur.Status = constants2.CentralRequestStatusPreparing.String()
-	if err2 := k.dinosaurService.Update(dinosaur); err2 != nil {
-		return errors.Wrapf(err2, "failed to update dinosaur %s with cluster details", dinosaur.ID)
+	glog.Infof("Central instance with id %s is assigned to cluster with id %s", dinosaur.ID, dinosaur.ClusterID)
+
+	if err = k.dinosaurService.AcceptDinosaurRequest(dinosaur); err != nil {
+		return errors.Wrapf(err, "failed to accept Central %s with cluster details", dinosaur.ID)
 	}
 	return nil
 }

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/accepted_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/accepted_dinosaurs_mgr.go
@@ -128,7 +128,7 @@ func (k *AcceptedDinosaurManager) reconcileAcceptedDinosaur(dinosaur *dbapi.Cent
 
 	glog.Infof("Central instance with id %s is assigned to cluster with id %s", dinosaur.ID, dinosaur.ClusterID)
 
-	if err = k.dinosaurService.AcceptDinosaurRequest(dinosaur); err != nil {
+	if err = k.dinosaurService.AcceptCentralRequest(dinosaur); err != nil {
 		return errors.Wrapf(err, "failed to accept Central %s with cluster details", dinosaur.ID)
 	}
 	return nil

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config.go
@@ -1,0 +1,102 @@
+package dinosaurmgrs
+
+import (
+	"github.com/golang/glog"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/config"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/services"
+	"github.com/stackrox/acs-fleet-manager/pkg/workers"
+)
+
+// CentralAuthConfigManager updates CentralRequests with auth configuration.
+type CentralAuthConfigManager struct {
+	workers.BaseWorker
+	centralService services.DinosaurService
+	centralConfig  *config.CentralConfig
+}
+
+var _ workers.Worker = &CentralAuthConfigManager{}
+
+func NewCentralAuthConfigManager(centralService services.DinosaurService, centralConfig *config.CentralConfig) *CentralAuthConfigManager {
+	return &CentralAuthConfigManager{
+		BaseWorker: workers.BaseWorker{
+			ID:         uuid.New().String(),
+			WorkerType: "central_auth_config",
+			Reconciler: workers.Reconciler{},
+		},
+		centralService: centralService,
+		centralConfig:  centralConfig,
+	}
+}
+
+// Start uses base's Start()
+func (k *CentralAuthConfigManager) Start() {
+	k.StartWorker(k)
+}
+
+// Stop uses base's Stop()
+func (k *CentralAuthConfigManager) Stop() {
+	k.StopWorker(k)
+}
+
+// Reconcile fetches all CentralRequests without auth config from the DB and
+// updates them.
+func (k *CentralAuthConfigManager) Reconcile() []error {
+	glog.Infoln("reconciling auth config for Centrals")
+	var errs []error
+
+	centralRequests, listErr := k.centralService.ListDinosaursWithoutAuthConfig()
+	if listErr != nil {
+		errs = append(errs, errors.Wrap(listErr, "failed to list centrals without auth config"))
+	} else {
+		glog.V(5).Infof("%d central(s) need auth config to be added", len(centralRequests))
+	}
+
+	for _, cr := range centralRequests {
+		if err := augmentWithAuthConfig(cr, k.centralConfig); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errs
+}
+
+// augmentWithAuthConfig augments provided CentralRequest with auth config
+// information. For that, it performs all necessary rituals, if any.
+func augmentWithAuthConfig(r *dbapi.CentralRequest, centralConfig *config.CentralConfig) error {
+	glog.V(5).Infof("augmenting Central %q with auth config", r.Meta.ID)
+	// Auth config can either be:
+	//   1) static, i.e., the same for all Centrals,
+	//   2) dynamic, i.e., each Central has its own.
+	// In case of 1), all necessary information should be provided in
+	// CentralConfig. For 2), we need to request a dynamic client from the
+	// RHSSO API.
+
+	// If CentralConfig contains auth info, take it and be done.
+	if centralConfig.RhSsoClientID != "" && centralConfig.RhSsoIssuer != "" {
+		glog.V(7).Infoln("static config found; no dynamic client will be requested from IdP")
+		if centralConfig.RhSsoClientSecret == "" {
+			glog.Warningf("no client_secret specified for static client_id %q;" +
+				" auth configuration is either incorrect or insecure", centralConfig.RhSsoClientID)
+		}
+		if centralConfig.RhSsoIssuer == "" {
+			glog.Errorf("no issuer specified for static client_id %q;" +
+				" auth configuration will likely not work properly", centralConfig.RhSsoClientID)
+		}
+
+		r.AuthConfig.ClientID = centralConfig.RhSsoClientID
+		r.AuthConfig.ClientSecret = centralConfig.RhSsoClientSecret
+		r.AuthConfig.Issuer = centralConfig.RhSsoIssuer
+
+		return nil
+	}
+
+	// Proceed with the dynamic path.
+	glog.V(7).Infoln("no static config found; requesting dynamic client")
+
+	// TODO(alexr): Talk to RHSSO dynamic client API.
+
+	return nil
+}

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config_mgr.go
@@ -65,8 +65,10 @@ func (k *CentralAuthConfigManager) Reconcile() []error {
 
 		var augmentWithAuthConfigF func(r *dbapi.CentralRequest, centralConfig *config.CentralConfig) error
 		if k.centralConfig.HasStaticAuth() {
+			glog.V(7).Infoln("static config found; no dynamic client will be requested the IdP")
 			augmentWithAuthConfigF = augmentWithStaticAuthConfig
 		} else {
+			glog.V(7).Infoln("no static config found; attempting to obtain one from the IdP")
 			augmentWithAuthConfigF = augmentWithDynamicAuthConfig
 		}
 
@@ -75,14 +77,14 @@ func (k *CentralAuthConfigManager) Reconcile() []error {
 		}
 	}
 
+	// TODO(alexr): Call dinosaurService.Update()
+
 	return errs
 }
 
 // augmentWithStaticAuthConfig augments provided CentralRequest with static auth
 // config information, i.e., the same for all Centrals.
 func augmentWithStaticAuthConfig(r *dbapi.CentralRequest, centralConfig *config.CentralConfig) error {
-	glog.V(7).Infoln("static config found; no dynamic client will be requested from IdP")
-
 	// TODO(alexr): Ideally this belongs in a config validation routine.
 	if centralConfig.RhSsoClientSecret == "" {
 		glog.Warningf("no client_secret specified for static client_id %q;" +
@@ -103,8 +105,6 @@ func augmentWithStaticAuthConfig(r *dbapi.CentralRequest, centralConfig *config.
 // augmentWithDynamicAuthConfig performs all necessary rituals to obtain auth
 // configuration via RHSSO API.
 func augmentWithDynamicAuthConfig(_ *dbapi.CentralRequest, _ *config.CentralConfig) error {
-	glog.V(7).Infoln("")
-
 	// TODO(alexr): Talk to RHSSO dynamic client API.
 
 	return errors.New("dynamic auth config is currently not supported")

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config_mgr.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	CentralAuthConfigManagerWorkerType = "central_auth_config"
+	centralAuthConfigManagerWorkerType = "central_auth_config"
 )
 
 // CentralAuthConfigManager updates CentralRequests with auth configuration.
@@ -28,7 +28,7 @@ func NewCentralAuthConfigManager(centralService services.DinosaurService, centra
 	return &CentralAuthConfigManager{
 		BaseWorker: workers.BaseWorker{
 			ID:         uuid.New().String(),
-			WorkerType: CentralAuthConfigManagerWorkerType,
+			WorkerType: centralAuthConfigManagerWorkerType,
 			Reconciler: workers.Reconciler{},
 		},
 		centralService: centralService,

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config_mgr.go
@@ -63,16 +63,15 @@ func (k *CentralAuthConfigManager) Reconcile() []error {
 		// CentralConfig. For 2), we need to request a dynamic client from the
 		// RHSSO API.
 
-		var augmentWithAuthConfigF func(r *dbapi.CentralRequest, centralConfig *config.CentralConfig) error
+		var err error
 		if k.centralConfig.HasStaticAuth() {
 			glog.V(7).Infoln("static config found; no dynamic client will be requested the IdP")
-			augmentWithAuthConfigF = augmentWithStaticAuthConfig
+			err = augmentWithStaticAuthConfig(cr, k.centralConfig)
 		} else {
 			glog.V(7).Infoln("no static config found; attempting to obtain one from the IdP")
-			augmentWithAuthConfigF = augmentWithDynamicAuthConfig
+			err = augmentWithDynamicAuthConfig(cr, k.centralConfig)
 		}
-
-		if err := augmentWithAuthConfigF(cr, k.centralConfig); err != nil {
+		if err != nil {
 			errs = append(errs, errors.Wrap(err, "failed to augment central request with auth config"))
 		}
 

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config_mgr.go
@@ -87,16 +87,6 @@ func (k *CentralAuthConfigManager) Reconcile() []error {
 // augmentWithStaticAuthConfig augments provided CentralRequest with static auth
 // config information, i.e., the same for all Centrals.
 func augmentWithStaticAuthConfig(r *dbapi.CentralRequest, centralConfig *config.CentralConfig) error {
-	// TODO(alexr): Ideally this belongs in a config validation routine.
-	if centralConfig.CentralIDPClientSecret == "" {
-		glog.Warningf("no client_secret specified for static client_id %q;"+
-			" auth configuration is either incorrect or insecure", centralConfig.CentralIDPClientID)
-	}
-	if centralConfig.CentralIDPIssuer == "" {
-		glog.Errorf("no issuer specified for static client_id %q;"+
-			" auth configuration will likely not work properly", centralConfig.CentralIDPClientID)
-	}
-
 	r.AuthConfig.ClientID = centralConfig.CentralIDPClientID
 	r.AuthConfig.ClientSecret = centralConfig.CentralIDPClientSecret //pragma: allowlist secret
 	r.AuthConfig.Issuer = centralConfig.CentralIDPIssuer

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config_mgr.go
@@ -73,11 +73,13 @@ func (k *CentralAuthConfigManager) Reconcile() []error {
 		}
 
 		if err := augmentWithAuthConfigF(cr, k.centralConfig); err != nil {
-			errs = append(errs, err)
+			errs = append(errs, errors.Wrap(err, "failed to augment central request with auth config"))
+		}
+
+		if err := k.centralService.Update(cr); err != nil {
+			errs = append(errs, errors.Wrapf(err, "failed to update central request %s", cr.ID))
 		}
 	}
-
-	// TODO(alexr): Call dinosaurService.Update()
 
 	return errs
 }

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config_mgr.go
@@ -19,6 +19,7 @@ type CentralAuthConfigManager struct {
 
 var _ workers.Worker = &CentralAuthConfigManager{}
 
+// NewCentralAuthConfigManager creates an instance of this worker.
 func NewCentralAuthConfigManager(centralService services.DinosaurService, centralConfig *config.CentralConfig) *CentralAuthConfigManager {
 	return &CentralAuthConfigManager{
 		BaseWorker: workers.BaseWorker{
@@ -87,18 +88,18 @@ func (k *CentralAuthConfigManager) Reconcile() []error {
 // config information, i.e., the same for all Centrals.
 func augmentWithStaticAuthConfig(r *dbapi.CentralRequest, centralConfig *config.CentralConfig) error {
 	// TODO(alexr): Ideally this belongs in a config validation routine.
-	if centralConfig.RhSsoClientSecret == "" {
-		glog.Warningf("no client_secret specified for static client_id %q;" +
-			" auth configuration is either incorrect or insecure", centralConfig.RhSsoClientID)
+	if centralConfig.CentralIDPClientSecret == "" {
+		glog.Warningf("no client_secret specified for static client_id %q;"+
+			" auth configuration is either incorrect or insecure", centralConfig.CentralIDPClientID)
 	}
-	if centralConfig.RhSsoIssuer == "" {
-		glog.Errorf("no issuer specified for static client_id %q;" +
-			" auth configuration will likely not work properly", centralConfig.RhSsoClientID)
+	if centralConfig.CentralIDPIssuer == "" {
+		glog.Errorf("no issuer specified for static client_id %q;"+
+			" auth configuration will likely not work properly", centralConfig.CentralIDPClientID)
 	}
 
-	r.AuthConfig.ClientID = centralConfig.RhSsoClientID
-	r.AuthConfig.ClientSecret = centralConfig.RhSsoClientSecret
-	r.AuthConfig.Issuer = centralConfig.RhSsoIssuer
+	r.AuthConfig.ClientID = centralConfig.CentralIDPClientID
+	r.AuthConfig.ClientSecret = centralConfig.CentralIDPClientSecret //pragma: allowlist secret
+	r.AuthConfig.Issuer = centralConfig.CentralIDPIssuer
 
 	return nil
 }

--- a/internal/dinosaur/providers.go
+++ b/internal/dinosaur/providers.go
@@ -86,6 +86,7 @@ func ServiceProviders() di.Option {
 		di.Provide(dinosaurmgrs.NewProvisioningDinosaurManager, di.As(new(workers.Worker))),
 		di.Provide(dinosaurmgrs.NewReadyDinosaurManager, di.As(new(workers.Worker))),
 		di.Provide(dinosaurmgrs.NewDinosaurCNAMEManager, di.As(new(workers.Worker))),
+		di.Provide(dinosaurmgrs.NewCentralAuthConfigManager, di.As(new(workers.Worker))),
 		di.Provide(presenters.NewManagedCentralPresenter),
 	)
 }


### PR DESCRIPTION
## Description
Prior to this PR, only "static" RHSSO setup for Central is possible, hence `CentralRequest` is augmented right upon being presented to fleetshard. This will not be possible once RHSSO setup becomes more involved, e.g., talking to some API.

In preparation to supporting such involved RHSSO setup, this PR moves augmentation code into a separate "worker", which configures RHSSO in a non-blocking way.

**Note**: it's unclear how to add an E2E test using currently available testing framework. What we probably need to add in follow-up PRs is an ability to query a deployed Central to be able to at least check if an auth provider has been configured as expected (without checking the configuration allows logging in).

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [x] Documentation added if necessary
- [x] CI and all relevant tests are passing
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

Verified in the CI run status transitions of Central request up to Provisioning.
