### PR TITLE
Support setting FLEET_MANAGER_IMAGE to a simply image tag instead of a complete image reference

### DIFF
--- a/dev/env/scripts/up.sh
+++ b/dev/env/scripts/up.sh
@@ -22,6 +22,12 @@ EOF
 KUBE_CONFIG=$(assemble_kubeconfig | yq e . -j - | jq -c . -)
 export KUBE_CONFIG
 
+if [[ "$FLEET_MANAGER_IMAGE" =~ ^[0-9a-z.-]+$ ]]; then
+    log "FLEET_MANAGER_IMAGE='${FLEET_MANAGER_IMAGE}' looks like an image tag. Setting:"
+    FLEET_MANAGER_IMAGE="quay.io/rhacs-eng/fleet-manager:${FLEET_MANAGER_IMAGE}"
+    log "FLEET_MANAGER_IMAGE='${FLEET_MANAGER_IMAGE}'"
+fi
+
 if [[ ! ("$CLUSTER_TYPE" == "openshift-ci" || "$CLUSTER_TYPE" == "infra-openshift") ]]; then
     # We are deploying locally. Locally we support Quay images and freshly built images.
     if [[ "$FLEET_MANAGER_IMAGE" =~ ^fleet-manager:.* ]]; then


### PR DESCRIPTION
## Description

Default to `quay.io/rhacs-eng/fleet-manager` repo, when `FLEET_MANAGER_IMAGE` does not seem to be a full image reference.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
