### PR TITLE
Make sure Ginkgo CLI dependencies exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ACS fleet-manager repository for the ACS managed service.
 ### Overview
 
 ```
-├── bin                 -- binary output directory   
+├── bin                 -- binary output directory  
 ├── cmd                 -- cmd entry points
 ├── config              -- various fleet-manager configurations
 ├── dashboards          -- grafana dashboards
@@ -79,7 +79,7 @@ This requires some preparations on a cluster:
 # Install git-hooks, for more information see git-hooks.md [1]
 $ make setup/git/hooks
 
-# To generate code and compile binaries run 
+# To generate code and compile binaries run
 $ make all
 
 # To only compile fleet-manager and fleetshard-synchronizer run

--- a/go.mod
+++ b/go.mod
@@ -82,9 +82,11 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/swag v0.21.1 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -128,6 +130,7 @@ require (
 	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220411224347-583f2d630306 // indirect
+	golang.org/x/tools v0.1.12 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220804142021-4e6b2dfa6612 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1215,6 +1215,7 @@ github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfC
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
@@ -1497,6 +1498,7 @@ github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210506205249-923b5ab0fc1a/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/rpmpack v0.0.0-20191226140753-aa36bfddb3a0/go.mod h1:RaTPr0KUf2K7fnZYLNDrr8rxAamWs3iNywJLtQ2AzBg=
@@ -2538,8 +2540,6 @@ github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redhat-developer/app-services-sdk-go v0.10.0 h1:zI0X5FR0NOj6IwBWk3y1TWn0JASEV8qoBPQjzkv8wbQ=
 github.com/redhat-developer/app-services-sdk-go v0.10.0/go.mod h1:enn8Zz6IT0HZYzS6LSttiME2apwnvfVWZnGRS81A4rk=
-github.com/redhat-developer/app-services-sdk-go/serviceaccounts v0.4.0 h1:vQVP520MHG0bIgbeRJD2wmcCXOA1Aik8zdWjhHOiJ4k=
-github.com/redhat-developer/app-services-sdk-go/serviceaccounts v0.4.0/go.mod h1:fTjoxpUyPOWpns7RNHANurfy6gfWdVHvuTJPk1AYbjk=
 github.com/redhat-developer/app-services-sdk-go/serviceaccounts v0.5.0 h1:RLLHQA5Pxf3a5khNYaEqqj22xjIpEh6IUN+sCt4t90o=
 github.com/redhat-developer/app-services-sdk-go/serviceaccounts v0.5.0/go.mod h1:SXhFcIpBh7Qu804KHXrKEQg+5BgSBeoeNq0yuWVskxA=
 github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319/go.mod h1:rhSvwcijY9wfmrBYrfCvapX8/xOTV46NAUjBRgUyJqc=

--- a/openapi/fleet-manager-private-admin.yaml
+++ b/openapi/fleet-manager-private-admin.yaml
@@ -22,7 +22,7 @@ paths:
       operationId: createCentral
       description: |
         Creates a new Central that is owned by the user and organisation authenticated for the request.
-        Each Central has a single owner organisation and a single owner user. 
+        Each Central has a single owner organisation and a single owner user.
         This API allows providing custom resource settings for the new Central instance.
       parameters:
         - in: query

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,8 @@
+//go:build tools
+// +build tools
+
+package main
+
+import (
+  _ "github.com/onsi/ginkgo/v2/ginkgo"
+)


### PR DESCRIPTION
## Description

What worked previously -- executing `go run github.com/onsi/ginkgo/v2/ginkgo` -- doesn't work anymore:

```
$ go run github.com/onsi/ginkgo/v2/ginkgo
../../../../pkg/mod/github.com/onsi/ginkgo/v2@v2.1.4/ginkgo/generators/bootstrap_command.go:9:2: missing go.sum entry for module providing package github.com/go-task/slim-sprig (imported by github.com/onsi/ginkgo/v2/ginkgo/generators); to add:
        go get github.com/onsi/ginkgo/v2/ginkgo/generators@v2.1.4
../../../../pkg/mod/github.com/onsi/ginkgo/v2@v2.1.4/ginkgo/internal/profiles_and_reports.go:12:2: missing go.sum entry for module providing package github.com/google/pprof/profile (imported by github.com/onsi/ginkgo/v2/ginkgo/internal); to add:
        go get github.com/onsi/ginkgo/v2/ginkgo/internal@v2.1.4
$
```

Reading the [Ginkgo documentation](https://onsi.github.io/ginkgo/#recommended-continuous-integration-configuration) again I found this paragraph:

> When running in CI you'll want to make sure that the version of the ginkgo CLI you are using matches the version of Ginkgo in your go.mod file. You can ensure this by invoking the ginkgo command via go run:
> 
> `go run github.com/onsi/ginkgo/v2/ginkgo`
> 
> This alone, however, is often not enough. The Ginkgo CLi includes additional dependencies that aren't part of the Ginkgo library - since your code doesn't import the cli these dependencies probably aren't in your go.sum file. To get around this it is idiomatic Go to introduce a tools.go file. This can go anywhere in your module - for example, Gomega places its tools.go at the top-level. Your tools.go file should look like:
> 
> ```
> //go:build tools
> // +build tools
> 
> package main
> 
> import (
>   _ "github.com/onsi/ginkgo/v2/ginkgo"
> )
> [...]
> ```
> 
> The `//go:build tools` constraint ensures this code is never actually built, however the `_ "github.com/onsi/ginkgo/v2/ginkgo` import statement is enough to convince go mod to include the Ginkgo CLI dependencies in your `go.sum` file.

I have added this `tools.go` and ran `go mod tidy`. Afterwards I was able to execute the Ginkgo CLI again with `go run`.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
