### PR TITLE
Delete leftover namespaces in down script

### DIFF
--- a/dev/env/scripts/down.sh
+++ b/dev/env/scripts/down.sh
@@ -18,7 +18,7 @@ delete "${MANIFESTS_DIR}/fleetshard-sync" || true
 central_namespaces=$($KUBECTL get namespace -o jsonpath='{range .items[?(@.status.phase == "Active")]}{.metadata.name}{"\n"}{end}' | grep '^rhacs-.*$')
 
 for namespace in $central_namespaces; do
-    kubectl delete namespace "$namespace" &
+    $KUBECTL delete namespace "$namespace" &
 done
 log "Waiting for leftover RHACS namespaces to be deleted... "
 for p in $(jobs -pr); do

--- a/dev/env/scripts/down.sh
+++ b/dev/env/scripts/down.sh
@@ -14,3 +14,13 @@ port-forwarding stop db 5432 || true
 delete "${MANIFESTS_DIR}/db" || true
 delete "${MANIFESTS_DIR}/fleet-manager" || true
 delete "${MANIFESTS_DIR}/fleetshard-sync" || true
+
+central_namespaces=$($KUBECTL get namespace -o jsonpath='{range .items[?(@.status.phase == "Active")]}{.metadata.name}{"\n"}{end}' | grep '^rhacs-.*$')
+
+for namespace in $central_namespaces; do
+    kubectl delete namespace "$namespace" &
+done
+log "Waiting for leftover RHACS namespaces to be deleted... "
+for p in $(jobs -pr); do
+    wait "$p"
+done

--- a/dev/env/scripts/down.sh
+++ b/dev/env/scripts/down.sh
@@ -15,7 +15,7 @@ delete "${MANIFESTS_DIR}/db" || true
 delete "${MANIFESTS_DIR}/fleet-manager" || true
 delete "${MANIFESTS_DIR}/fleetshard-sync" || true
 
-central_namespaces=$($KUBECTL get namespace -o jsonpath='{range .items[?(@.status.phase == "Active")]}{.metadata.name}{"\n"}{end}' | grep '^rhacs-.*$')
+central_namespaces=$($KUBECTL get namespace -o jsonpath='{range .items[?(@.status.phase == "Active")]}{.metadata.name}{"\n"}{end}' | grep '^rhacs-.*$' || true)
 
 for namespace in $central_namespaces; do
     $KUBECTL delete namespace "$namespace" &


### PR DESCRIPTION
## Description

When debugging issues in the e2e test suite it happens easily that we have to cleanup leftovers. In my opinion it makes sense to integrate this into `down.sh`.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
