### PR TITLE
Work around docker.io outages

### DIFF
--- a/dev/env/scripts/bootstrap.sh
+++ b/dev/env/scripts/bootstrap.sh
@@ -125,19 +125,23 @@ fi
 
 if is_local_cluster "$CLUSTER_TYPE"; then
     if [[ ("$INSTALL_OPERATOR" == "true" && "$OPERATOR_SOURCE" == "quay") || "$FLEET_MANAGER_IMAGE" =~ ^quay.io/ ]]; then
-        log "Logging into Quay image registry"
-        $DOCKER login quay.io -u "$QUAY_USER" --password-stdin <<EOF
+        if docker_logged_in "quay.io"; then
+            log "Looks like we are already logged into Quay"
+        else
+            log "Logging into Quay image registry"
+            $DOCKER login quay.io -u "$QUAY_USER" --password-stdin <<EOF
 $QUAY_TOKEN
 EOF
+        fi
     fi
 
     log "Preloading images into ${CLUSTER_TYPE} cluster..."
-    $DOCKER pull "postgres:13"
+    docker_pull "postgres:13"
     if [[ "$INSTALL_OPERATOR" == "true" ]]; then
         # Preload images required by Central installation.
-        $DOCKER pull "${IMAGE_REGISTRY}/scanner:${SCANNER_VERSION}"
-        $DOCKER pull "${IMAGE_REGISTRY}/scanner-db:${SCANNER_VERSION}"
-        $DOCKER pull "${IMAGE_REGISTRY}/main:${CENTRAL_VERSION}"
+        docker_pull "${IMAGE_REGISTRY}/scanner:${SCANNER_VERSION}"
+        docker_pull "${IMAGE_REGISTRY}/scanner-db:${SCANNER_VERSION}"
+        docker_pull "${IMAGE_REGISTRY}/main:${CENTRAL_VERSION}"
     fi
     log "Images preloaded"
 fi

--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -276,3 +276,31 @@ is_local_cluster() {
         return 1
     fi
 }
+
+_docker_images=""
+
+docker_pull() {
+    local image_ref="${1:-}"
+    if [[ -z "${_docker_images}" ]]; then
+        _docker_images=$($DOCKER images --format '{{.Repository}}:{{.Tag}}')
+    fi
+    if echo "${_docker_images}" | grep -q "^${image_ref}$"; then
+        log "Skipping pulling of image ${image_ref}, as it is already there"
+    else
+        log "Pulling image ${image_ref}"
+        $DOCKER pull "$image_ref"
+    fi
+}
+
+docker_logged_in() {
+    local registry="${1:-}"
+    if [[ -z "$registry" ]]; then
+        log "docker_logged_in() called with empty registry argument"
+        return 1
+    fi
+    if jq -ec ".auths[\"${registry}\"]" <"$DOCKER_CONFIG/config.json" >/dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
+}

--- a/dev/env/scripts/up.sh
+++ b/dev/env/scripts/up.sh
@@ -39,7 +39,7 @@ if [[ ! ("$CLUSTER_TYPE" == "openshift-ci" || "$CLUSTER_TYPE" == "infra-openshif
         fi
     else
         log "Trying to pull image '${FLEET_MANAGER_IMAGE}'..."
-        $DOCKER pull "$FLEET_MANAGER_IMAGE"
+        docker_pull "$FLEET_MANAGER_IMAGE"
     fi
 
     # Verify that the image is there.


### PR DESCRIPTION
## Description

Yesterday I wanted to setup a test environment for testing purposes, but `docker.io` was having stability issues. Since the test env scripts unconditionally try to `docker login` and `docker pull`, I was blocked by the `docker.io` outage.

With these modifications the test environment setting up skips `docker login` and `docker pull` if not necessary.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
