### PR TITLE
ROX-11614: Pass pagerduty key value to helm

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -53,6 +53,7 @@ case $ENVIRONMENT in
         jq --arg OBSERVABILITY_OBSERVATORIUM_METRICS_CLIENT_ID "${OBSERVABILITY_OBSERVATORIUM_METRICS_CLIENT_ID}" \
             '.fields[] | select(.name | contains($OBSERVABILITY_OBSERVATORIUM_METRICS_CLIENT_ID)) | .value' --raw-output
     )
+    PAGERDUTY_SERVICE_KEY=$(bw get item "3615347e-1dde-46b5-b2e3-af0300a049fa" | jq '.fields[] | select(.name | contains("Integration Key")) | .value' --raw-output)
     ;;
 
   prod)
@@ -91,7 +92,8 @@ helm upgrade rhacs-terraform ./ \
   --set observability.github.repository=https://api.github.com/repos/stackrox/rhacs-observability-resources/contents \
   --set observability.gateway=https://observatorium-mst.api.stage.openshift.com \
   --set observability.observatorium.metricsClientId="${OBSERVABILITY_OBSERVATORIUM_METRICS_CLIENT_ID}" \
-  --set observability.observatorium.metricsSecret="${OBSERVABILITY_OBSERVATORIUM_METRICS_SECRET}"
+  --set observability.observatorium.metricsSecret="${OBSERVABILITY_OBSERVATORIUM_METRICS_SECRET}" \
+  --set observability.pagerduty.key="${PAGERDUTY_SERVICE_KEY}"
 
 # To uninstall an existing release:
 # helm uninstall rhacs-terraform --namespace rhacs


### PR DESCRIPTION
## Description

Fetch PagerDuty integration key from BitWarden and pass it to helm.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~Unit and integration tests added~
- [ ] ~Documentation added if necessary~
- [ ] ~CI and all relevant tests are passing~
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Tested locally by running the `terraform_cluster.sh`.