### PR TITLE
ROX-12451: Rename fleet-manager to fleet-manager-credentials vault secret name

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -901,7 +901,7 @@ objects:
           - name: fleet-manager-credentials
             secret:
               # secretName is a vault-secret provider name in the app-interface
-              secretName: fleet-manager # pragma: allowlist secret
+              secretName: fleet-manager-credentials # pragma: allowlist secret
           - name: rhsso-client-secret
             secret:
               # secretName is a vault-secret provider name in the app-interface


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
`fleet-manager-credentials` is more precise name for credentials Vault secret.
`fleet-manager-credentials` [mapping is already created on app-interface](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/acs-fleet-manager/namespaces/acs-fleet-manager-stage.yml#L35)
