### PR TITLE
ROX-12468: Deploy and configure egress proxies for each tenant

### DIFF
--- a/dev/env/manifests/rhacs-operator/marketplace/03-subscription.yaml
+++ b/dev/env/manifests/rhacs-operator/marketplace/03-subscription.yaml
@@ -11,10 +11,4 @@ spec:
   sourceNamespace: openshift-marketplace
   startingCSV: rhacs-operator.v3.70.0
   config:
-    env:
-      # use a test value for NO_PROXY. This will not have any impact
-      # on the services at runtime, but we can test if it gets piped
-      # through correctly.
-      - name: NO_PROXY
-        value: "127.1.2.3/8"
     resources: $RHACS_OPERATOR_RESOURCES

--- a/dev/env/manifests/rhacs-operator/quay/03-subscription.yaml
+++ b/dev/env/manifests/rhacs-operator/quay/03-subscription.yaml
@@ -16,9 +16,4 @@ spec:
         value: "${IMAGE_REGISTRY}"
       - name: ROX_OPERATOR_COLLECTOR_REGISTRY
         value: "${IMAGE_REGISTRY}"
-      # use a test value for NO_PROXY. This will not have any impact
-      # on the services at runtime, but we can test if it gets piped
-      # through correctly.
-      - name: NO_PROXY
-        value: "127.1.2.3/8"
     resources: $RHACS_OPERATOR_RESOURCES

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
 	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -187,6 +190,21 @@ var _ = Describe("Central", func() {
 				return centralStatus(createdCentral, client)
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Equal(constants.CentralRequestStatusReady.String()))
 		})
+
+		It("should spin up an egress proxy with two healthy replicas", func() {
+			Eventually(func() error {
+				var egressProxyDeployment appsv1.Deployment
+				key := ctrlClient.ObjectKey{Namespace: namespaceName, Name: "egress-proxy"}
+				if err := k8sClient.Get(context.TODO(), key, &egressProxyDeployment); err != nil {
+					return err
+				}
+				if egressProxyDeployment.Status.ReadyReplicas < 2 {
+					return errors.New("less than 2 ready replicas for egress-proxy available")
+				}
+				return nil
+			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Succeed())
+		})
+
 		// TODO(ROX-11368): Add test to eventually reach ready state
 		// TODO(ROX-11368): create test to check that Central and Scanner are healthy
 		// TODO(ROX-11368): Create test to check Central is correctly exposed
@@ -207,6 +225,14 @@ var _ = Describe("Central", func() {
 				err := k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: centralName, Namespace: centralName}, central)
 				return apiErrors.IsNotFound(err)
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(BeTrue())
+		})
+
+		It("should delete the egress proxy", func() {
+			Eventually(func() error {
+				var egressProxyDeployment appsv1.Deployment
+				key := ctrlClient.ObjectKey{Namespace: namespaceName, Name: "egress-proxy"}
+				return k8sClient.Get(context.TODO(), key, &egressProxyDeployment)
+			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Satisfy(apiErrors.IsNotFound))
 		})
 
 		It("should remove central namespace", func() {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"time"
 
+	"sigs.k8s.io/yaml"
+
 	appsv1 "k8s.io/api/apps/v1"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -198,7 +200,8 @@ var _ = Describe("Central", func() {
 					return err
 				}
 				if egressProxyDeployment.Status.ReadyReplicas < 2 {
-					return fmt.Errorf("egress proxy only has %d/%d ready replicas (and %d unavailable ones), expected 2", egressProxyDeployment.Status.ReadyReplicas, egressProxyDeployment.Status.Replicas, egressProxyDeployment.Status.UnavailableReplicas)
+					statusBytes, _ := yaml.Marshal(&egressProxyDeployment.Status)
+					return fmt.Errorf("egress proxy only has %d/%d ready replicas (and %d unavailable ones), expected 2. full status: %s", egressProxyDeployment.Status.ReadyReplicas, egressProxyDeployment.Status.Replicas, egressProxyDeployment.Status.UnavailableReplicas, statusBytes)
 				}
 				return nil
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Succeed())

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -199,7 +198,7 @@ var _ = Describe("Central", func() {
 					return err
 				}
 				if egressProxyDeployment.Status.ReadyReplicas < 2 {
-					return errors.New("less than 2 ready replicas for egress-proxy available")
+					return fmt.Errorf("egress proxy only has %d/%d ready replicas (and %d unavailable ones), expected 2", egressProxyDeployment.Status.ReadyReplicas, egressProxyDeployment.Status.Replicas, egressProxyDeployment.Status.UnavailableReplicas)
 				}
 				return nil
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Succeed())

--- a/fleetshard/pkg/central/charts/data/tenant-resources/config/squid.conf
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/config/squid.conf
@@ -1,0 +1,58 @@
+# Squid proxy configuration
+#
+# This file configures Squid as an egress proxy that
+# (a) only accepts traffic from the local network
+# (b) does not allow outgoing traffic to the local network (but to all other destinations)
+
+acl localnet src 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
+acl localnet src 10.0.0.0/8		# RFC 1918 local private network (LAN)
+acl localnet src 100.64.0.0/10		# RFC 6598 shared address space (CGN)
+acl localnet src 169.254.0.0/16 	# RFC 3927 link-local (directly plugged) machines
+acl localnet src 172.16.0.0/12		# RFC 1918 local private network (LAN)
+acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
+acl localnet src fc00::/7       	# RFC 4193 local private network range
+acl localnet src fe80::/10      	# RFC 4291 link-local (directly plugged) machines
+
+acl to_localnet dst 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
+acl to_localnet dst 10.0.0.0/8		# RFC 1918 local private network (LAN)
+acl to_localnet dst 100.64.0.0/10		# RFC 6598 shared address space (CGN)
+acl to_localnet dst 169.254.0.0/16 	# RFC 3927 link-local (directly plugged) machines
+acl to_localnet dst 172.16.0.0/12		# RFC 1918 local private network (LAN)
+acl to_localnet dst 192.168.0.0/16		# RFC 1918 local private network (LAN)
+acl to_localnet dst fc00::/7       	# RFC 4193 local private network range
+acl to_localnet dst fe80::/10      	# RFC 4291 link-local (directly plugged) machines
+
+acl CONNECT method CONNECT
+
+# Forbid all access to localhost and local networks, either directly or via CONNECT
+http_access deny to_localnet
+http_access deny to_localhost
+http_access deny CONNECT to_localnet
+http_access deny CONNECT to_localhost
+
+# Only allow cachemgr access from localhost
+http_access allow localhost manager
+http_access deny manager
+
+# Allow access from the lcoal network
+http_access allow localnet
+http_access allow localhost
+
+# Allow access to non-local destinations
+http_access allow !to_localnet
+http_access allow !to_localhost
+http_access allow CONNECT !to_localnet
+http_access allow CONNECT !to_localhost
+
+# Catch-all rule for anything else
+http_access deny all
+
+# Serve on standard port 3128
+http_port 3128
+
+# Disable caching and most logging
+cache deny all
+access_log none all
+debug_options ALL,0
+
+shutdown_lifetime 0

--- a/fleetshard/pkg/central/charts/data/tenant-resources/config/squid.conf
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/config/squid.conf
@@ -52,7 +52,8 @@ http_port 3128
 
 # Disable caching and most logging
 cache deny all
+cache_log /dev/null
 access_log none all
 debug_options ALL,0
-
+pid_filename none
 shutdown_lifetime 0

--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
@@ -35,8 +35,8 @@ spec:
       containers:
       - name: egress-proxy
         image: {{ .Values.egressProxy.image }}
-        containerPorts:
-        - port: 3128
+        ports:
+        - containerPort: 3128
           protocol: TCP
           name: egress-proxy
         volumeMounts:
@@ -90,5 +90,6 @@ spec:
     - podSelector:
         matchLabels:
           app: scanner
-    port: 3128
-    protocol: TCP
+    ports:
+    - port: 3128
+      protocol: TCP

--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
@@ -1,0 +1,94 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: egress-proxy-config
+  labels:
+    app.kubernetes.io/component: egress-proxy
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    {{- include "annotations" . | nindent 4 }}
+data:
+  squid.conf: |
+    {{- .Files.Get "config/squid.conf" | nindent 4 }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: egress-proxy
+  labels:
+    app.kubernetes.io/component: egress-proxy
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    {{- include "annotations" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.egressProxy.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: egress-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: egress-proxy
+      annotations:
+        config-hash: {{ .Files.Get "config/squid.conf" | sha256sum | quote }}
+    spec:
+      containers:
+      - name: egress-proxy
+        image: {{ .Values.egressProxy.image }}
+        containerPorts:
+        - port: 3128
+          protocol: TCP
+          name: egress-proxy
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/squid/squid.conf
+          subPath: squid.conf
+          readOnly: true
+      volumes:
+      - name: config-volume
+        configMap:
+          name: egress-proxy-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: egress-proxy
+  labels:
+    app.kubernetes.io/component: egress-proxy
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    {{- include "annotations" . | nindent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/component: egress-proxy
+  ports:
+  - port: 3128
+    protocol: TCP
+    targetPort: 3128
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-proxy
+  labels:
+    app.kubernetes.io/component: egress-proxy
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    {{- include "annotations" . | nindent 4 }}
+spec:
+  policyTypes:
+  - Ingress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: egress-proxy
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: central
+    - podSelector:
+        matchLabels:
+          app: scanner
+    port: 3128
+    protocol: TCP

--- a/fleetshard/pkg/central/charts/data/tenant-resources/values.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/values.yaml
@@ -1,2 +1,7 @@
+
+egressProxy:
+  image: ubuntu/squid:5.2-22.04_beta
+  replicas: 2
+
 labels: {}
 annotations: {}

--- a/fleetshard/pkg/central/reconciler/proxy.go
+++ b/fleetshard/pkg/central/reconciler/proxy.go
@@ -1,0 +1,45 @@
+package reconciler
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func getProxyEnvVars(namespace string) []corev1.EnvVar {
+	var envVars []corev1.EnvVar
+	proxyURL := fmt.Sprintf("http://egress-proxy.%s.svc:3128", namespace)
+	// Use both upper- and lowercase env var names for maximum compatibility.
+	for _, envVarName := range []string{"http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY", "all_proxy", "ALL_PROXY"} {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  envVarName,
+			Value: proxyURL,
+		})
+	}
+
+	directServicesAndPorts := map[string][]int{
+		"central":    {443},
+		"scanner":    {8080, 8443},
+		"scanner-db": {5432},
+	}
+	var noProxyTargets []string
+	for svcName, ports := range directServicesAndPorts {
+		for _, port := range ports {
+			noProxyTargets = append(noProxyTargets,
+				fmt.Sprintf("%s:%d", svcName, port),
+				fmt.Sprintf("%s.%s:%d", svcName, namespace, port),
+				fmt.Sprintf("%s.%s.svc:%d", svcName, namespace, port),
+			)
+		}
+	}
+	noProxyStr := strings.Join(noProxyTargets, ",")
+	for _, envVarName := range []string{"no_proxy", "NO_PROXY"} {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  envVarName,
+			Value: noProxyStr,
+		})
+	}
+
+	return envVars
+}

--- a/fleetshard/pkg/central/reconciler/proxy_test.go
+++ b/fleetshard/pkg/central/reconciler/proxy_test.go
@@ -1,0 +1,64 @@
+package reconciler
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stackrox/rox/pkg/testutils/envisolator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http/httpproxy"
+)
+
+func TestProxyConfiguration(t *testing.T) {
+	const testNS = `acsms-01`
+	ei := envisolator.NewEnvIsolator(t)
+	defer ei.RestoreAll()
+
+	for _, envVar := range getProxyEnvVars(testNS) {
+		ei.Setenv(envVar.Name, envVar.Value)
+	}
+
+	proxyFunc := httpproxy.FromEnvironment().ProxyFunc()
+
+	noProxyURLs := []string{
+		"https://central",
+		"https://central.acsms-01",
+		"https://central.acsms-01.svc",
+		"https://central.acsms-01.svc:443",
+		"https://scanner-db.acsms-01.svc:5432",
+		"https://scanner:8443",
+		"https://scanner.acsms-01:8080",
+	}
+
+	for _, u := range noProxyURLs {
+		parsedURL, err := url.Parse(u)
+		require.NoError(t, err)
+
+		proxyURL, err := proxyFunc(parsedURL)
+		require.NoError(t, err)
+		assert.Nilf(t, proxyURL, "expected URL %s to not be proxied, got: %s", u, proxyURL)
+	}
+
+	proxiedURLs := []string{
+		"https://www.example.com",
+		"https://www.example.com:8443",
+		"http://example.com",
+		"http://example.com:8080",
+		"https://central.acsms-01.svc:8443",
+		"https://scanner.acsms-01.svc",
+	}
+	const expectedProxyURL = "http://egress-proxy.acsms-01.svc:3128"
+
+	for _, u := range proxiedURLs {
+		parsedURL, err := url.Parse(u)
+		require.NoError(t, err)
+
+		proxyURL, err := proxyFunc(parsedURL)
+		require.NoError(t, err)
+		if !assert.NotNilf(t, proxyURL, "expected URL %s to be proxied", u) {
+			continue
+		}
+		assert.Equal(t, expectedProxyURL, proxyURL.String())
+	}
+}

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -92,6 +92,9 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		return nil, errors.Wrap(err, "converting Scanner DB resources")
 	}
 
+	// Set proxy configuration
+	envVars := getProxyEnvVars(remoteCentralNamespace)
+
 	central := &v1alpha1.Central{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      remoteCentralName,
@@ -125,6 +128,9 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 				Monitoring: &v1alpha1.Monitoring{
 					ExposeEndpoint: &monitoringExposeEndpointEnabled,
 				},
+			},
+			Customize: &v1alpha1.CustomizeSpec{
+				EnvVars: envVars,
 			},
 		},
 	}

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -126,10 +126,9 @@ func TestReconcileLastHashNotUpdatedOnError(t *testing.T) {
 	}, centralDeploymentObject()).Build()
 
 	r := CentralReconciler{
-		status:         pointer.Int32(0),
-		client:         fakeClient,
-		central:        private.ManagedCentral{},
-		resourcesChart: resourcesChart,
+		status:  pointer.Int32(0),
+		client:  fakeClient,
+		central: private.ManagedCentral{},
 	}
 
 	_, err := r.Reconcile(context.TODO(), simpleManagedCentral)

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
 	v1 "k8s.io/api/core/v1"
 
+	networkingv1 "k8s.io/api/networking/v1"
+
 	openshiftRouteV1 "github.com/openshift/api/route/v1"
 	"github.com/pkg/errors"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/testutils"
@@ -126,9 +128,10 @@ func TestReconcileLastHashNotUpdatedOnError(t *testing.T) {
 	}, centralDeploymentObject()).Build()
 
 	r := CentralReconciler{
-		status:  pointer.Int32(0),
-		client:  fakeClient,
-		central: private.ManagedCentral{},
+		status:         pointer.Int32(0),
+		client:         fakeClient,
+		central:        private.ManagedCentral{},
+		resourcesChart: resourcesChart,
 	}
 
 	_, err := r.Reconcile(context.TODO(), simpleManagedCentral)
@@ -331,6 +334,49 @@ func TestChartResourcesAreAddedAndRemoved(t *testing.T) {
 
 	err = fakeClient.Get(context.TODO(), dummySvcKey, &dummySvc)
 	assert.True(t, k8sErrors.IsNotFound(err))
+}
+
+func TestEgressProxyIsDeployed(t *testing.T) {
+	fakeClient := testutils.NewFakeClientBuilder(t).Build()
+	r := NewCentralReconciler(fakeClient, private.ManagedCentral{}, true, false)
+
+	_, err := r.Reconcile(context.TODO(), simpleManagedCentral)
+	require.NoError(t, err)
+
+	expectedObjs := []client.Object{
+		&v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: simpleManagedCentral.Metadata.Namespace,
+				Name:      "egress-proxy-config",
+			},
+		},
+		&v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: simpleManagedCentral.Metadata.Namespace,
+				Name:      "egress-proxy",
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: simpleManagedCentral.Metadata.Namespace,
+				Name:      "egress-proxy",
+			},
+		},
+		&networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: simpleManagedCentral.Metadata.Namespace,
+				Name:      "egress-proxy",
+			},
+		},
+	}
+
+	for _, expectedObj := range expectedObjs {
+		actualObj := expectedObj.DeepCopyObject().(client.Object)
+		if !assert.NoError(t, fakeClient.Get(context.TODO(), client.ObjectKeyFromObject(expectedObj), actualObj)) {
+			continue
+		}
+		assert.Equal(t, k8s.ManagedByFleetshardValue, actualObj.GetLabels()[k8s.ManagedByLabelKey])
+	}
 }
 
 func TestNoRoutesSentWhenOneNotCreated(t *testing.T) {

--- a/fleetshard/pkg/testutils/k8s.go
+++ b/fleetshard/pkg/testutils/k8s.go
@@ -78,7 +78,6 @@ func NewFakeClientBuilder(t *testing.T, objects ...ctrlClient.Object) *fake.Clie
 // NewFakeClientWithTracker returns a new fake client and a ReconcileTracker to mock k8s responses
 func NewFakeClientWithTracker(t *testing.T) (ctrlClient.WithWatch, *ReconcileTracker) {
 	scheme := NewScheme(t)
-
 	tracker := NewReconcileTracker(scheme)
 	client := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -90,8 +89,6 @@ func NewFakeClientWithTracker(t *testing.T) (ctrlClient.WithWatch, *ReconcileTra
 // NewScheme returns a new scheme instance used for fleetshard testing
 func NewScheme(t *testing.T) *runtime.Scheme {
 	scheme := runtime.NewScheme()
-
-	require.NoError(t, coreV1.AddToScheme(scheme))
 	require.NoError(t, platform.AddToScheme(scheme))
 	require.NoError(t, clientgoscheme.AddToScheme(scheme))
 	require.NoError(t, openshiftRouteV1.Install(scheme))

--- a/fleetshard/pkg/testutils/k8s.go
+++ b/fleetshard/pkg/testutils/k8s.go
@@ -78,6 +78,7 @@ func NewFakeClientBuilder(t *testing.T, objects ...ctrlClient.Object) *fake.Clie
 // NewFakeClientWithTracker returns a new fake client and a ReconcileTracker to mock k8s responses
 func NewFakeClientWithTracker(t *testing.T) (ctrlClient.WithWatch, *ReconcileTracker) {
 	scheme := NewScheme(t)
+
 	tracker := NewReconcileTracker(scheme)
 	client := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -89,6 +90,8 @@ func NewFakeClientWithTracker(t *testing.T) (ctrlClient.WithWatch, *ReconcileTra
 // NewScheme returns a new scheme instance used for fleetshard testing
 func NewScheme(t *testing.T) *runtime.Scheme {
 	scheme := runtime.NewScheme()
+
+	require.NoError(t, coreV1.AddToScheme(scheme))
 	require.NoError(t, platform.AddToScheme(scheme))
 	require.NoError(t, clientgoscheme.AddToScheme(scheme))
 	require.NoError(t, openshiftRouteV1.Install(scheme))


### PR DESCRIPTION
## Description

This creates 2 replicas of a squid web proxy as egress proxies alongside Central, as described in the [design doc](https://docs.google.com/document/d/1LJwDx8P-Xx9mpmej__QWqUrbjJh_gtGJbKiMFvAoA1w/edit#heading=h.1h3ev6pf6wey).


## Checklist (Definition of Done)
- [x] Unit and integration tests added
- [x] ~Documentation added if necessary~
- [x] CI and all relevant tests are passing ([successful e2e run](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_acs-fleet-manager/362/pull-ci-stackrox-acs-fleet-manager-main-e2e/1566810315943841792))
- [x] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

- Deployed manually
- E2E test added and verified that it passes.