### PR TITLE
fix memory leak in reconciler map of fleetshard-sync

### DIFF
--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -138,13 +138,13 @@ func (r *Runtime) handleReconcileResult(central private.ManagedCentral, status *
 func (r *Runtime) deleteStaleReconcilers(list *private.ManagedCentralList) {
 	// This map collects all central ids in the current list, it is later used to find and delete all reconcilers of
 	// centrals that are no longer in the GetManagedCentralList
-	centralIds := map[string]bool{}
+	centralIds := map[string]struct{}{}
 	for _, central := range list.Items {
-		centralIds[central.Id] = true
+		centralIds[central.Id] = struct{}{}
 	}
 
 	for key := range r.reconcilers {
-		if !centralIds[key] {
+		if _, hasKey := centralIds[key]; !hasKey {
 			delete(r.reconcilers, key)
 		}
 	}

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -66,10 +66,10 @@ func (c *ManagedCentralPresenter) PresentManagedCentral(from *dbapi.CentralReque
 			},
 			Auth: private.ManagedCentralAllOfSpecAuth{
 				ClientSecret: c.centralConfig.RhSsoClientSecret, // pragma: allowlist secret
-				ClientId:    c.centralConfig.RhSsoClientID,
-				OwnerOrgId:  from.OrganisationID,
-				OwnerUserId: from.OwnerUserID,
-				Issuer:      c.centralConfig.RhSsoIssuer,
+				ClientId:     c.centralConfig.RhSsoClientID,
+				OwnerOrgId:   from.OrganisationID,
+				OwnerUserId:  from.OwnerUserID,
+				Issuer:       c.centralConfig.RhSsoIssuer,
 			},
 			UiEndpoint: private.ManagedCentralAllOfSpecUiEndpoint{
 				Host: from.GetUIHost(),


### PR DESCRIPTION
## Description
fleetshard-sync hold a map in memory with instances of a Reconciler for each central. When a central gets deleted and no longer appears in the response from fleet-manager's API the Reconciler instance is not deleted. This leads to a growing Map of Reconciler instances and potential out of memory issues if many central instances are created and deleted 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Documentation added if necessary
- [x] CI and all relevant tests are passing
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
