### PR TITLE
Propagate Central's RH SSO config to fleet manager

### DIFF
--- a/dev/env/manifests/fleet-manager/01-fleet-manager-secrets.yaml
+++ b/dev/env/manifests/fleet-manager/01-fleet-manager-secrets.yaml
@@ -4,6 +4,9 @@ metadata:
   name: fleet-manager
   namespace: "$ACSMS_NAMESPACE"
 stringData:
+  central.idp-client-id: "${CENTRAL_IDP_CLIENT_ID}"
+  central.idp-client-secret: "${CENTRAL_IDP_CLIENT_SECRET}"
+  central.idp-issuer: "${CENTRAL_IDP_ISSUER}"
   db.host: "${DATABASE_HOST}"
   db.name: "${DATABASE_NAME}"
   db.port: "${DATABASE_PORT}"

--- a/internal/dinosaur/pkg/config/central.go
+++ b/internal/dinosaur/pkg/config/central.go
@@ -42,7 +42,9 @@ func NewCentralConfig() *CentralConfig {
 		CentralDomainName:                "rhacs-dev.com",
 		CentralLifespan:                  NewCentralLifespanConfig(),
 		Quota:                            NewCentralQuotaConfig(),
-		RhSsoIssuer:                      "https://sso.redhat.com/auth/realms/redhat-external",
+		RhSsoClientID:                    "secrets/central.idp-client-id",
+		RhSsoClientSecret:                "secrets/central.idp-client-secret",
+		RhSsoIssuer:                      "secrets/central.idp-issuer",
 	}
 }
 


### PR DESCRIPTION
## Description
Ensure Central's RH SSO config is propagated to fleet manager in E2E tests.

Three respective secrets have been added to https://vault.ci.openshift.org/ui/vault/secrets/kv/show/selfservice/rhacs-ms-e2e-tests/credentials.

## Checklist (Definition of Done)
- [ ] ~Unit and integration tests added~
- [ ] ~Documentation added if necessary~
- [ ] CI and all relevant tests are passing
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

TODO(alexr): Look at CI output to see if the secret is being read.
