### PR TITLE
Use controller-runtime client in `IsRoutesResourceEnabled` function

### DIFF
--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -64,7 +65,7 @@ var _ = BeforeSuite(func() {
 	k8sClient = k8s.CreateClientOrDie()
 	routeService = k8s.NewRouteService(k8sClient)
 	var err error
-	routesEnabled, err = k8s.IsRoutesResourceEnabled()
+	routesEnabled, err = k8s.IsRoutesResourceEnabled(context.TODO(), k8sClient)
 	Expect(err).ToNot(HaveOccurred())
 
 	var accessKey, secretKey string

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -65,7 +64,7 @@ var _ = BeforeSuite(func() {
 	k8sClient = k8s.CreateClientOrDie()
 	routeService = k8s.NewRouteService(k8sClient)
 	var err error
-	routesEnabled, err = k8s.IsRoutesResourceEnabled(context.TODO(), k8sClient)
+	routesEnabled, err = k8s.IsRoutesResourceEnabled(k8sClient)
 	Expect(err).ToNot(HaveOccurred())
 
 	var accessKey, secretKey string

--- a/fleetshard/pkg/k8s/client.go
+++ b/fleetshard/pkg/k8s/client.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"github.com/golang/glog"
 	openshiftOperatorV1 "github.com/openshift/api/operator/v1"
 	openshiftRouteV1 "github.com/openshift/api/route/v1"
@@ -44,7 +43,7 @@ func CreateClientOrDie() ctrlClient.Client {
 }
 
 // IsRoutesResourceEnabled checks if routes resource are available on the cluster.
-func IsRoutesResourceEnabled(ctx context.Context, client ctrlClient.Client) (bool, error) {
+func IsRoutesResourceEnabled(client ctrlClient.Client) (bool, error) {
 	_, err := client.RESTMapper().ResourceFor(routesGVK)
 	if err != nil {
 		return false, nil

--- a/fleetshard/pkg/k8s/client_test.go
+++ b/fleetshard/pkg/k8s/client_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,14 +23,14 @@ func TestIsRoutesResourceEnabled(t *testing.T) {
 	fakeClient := testutils.NewFakeClientBuilder(t).
 		WithRESTMapper(mapper).
 		Build()
-	enabled, err := IsRoutesResourceEnabled(context.TODO(), fakeClient)
+	enabled, err := IsRoutesResourceEnabled(fakeClient)
 	require.NoError(t, err)
 	assert.True(t, enabled)
 }
 
 func TestIsRoutesResourceEnabledShouldReturnFalse(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().Build()
-	enabled, err := IsRoutesResourceEnabled(context.TODO(), fakeClient)
+	enabled, err := IsRoutesResourceEnabled(fakeClient)
 	require.NoError(t, err)
 	assert.False(t, enabled)
 }

--- a/fleetshard/pkg/k8s/client_test.go
+++ b/fleetshard/pkg/k8s/client_test.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"context"
-	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -10,7 +9,8 @@ import (
 )
 
 func TestIsRoutesResourceEnabled(t *testing.T) {
-	fakeClient := testutils.NewFakeClientBuilder(t).Build()
+	//fakeClient := testutils.NewFakeClientBuilder(t).Build()
+	fakeClient := CreateClientOrDie()
 	enabled, err := IsRoutesResourceEnabled(context.TODO(), fakeClient)
 	require.NoError(t, err)
 	assert.True(t, enabled)

--- a/fleetshard/pkg/k8s/client_test.go
+++ b/fleetshard/pkg/k8s/client_test.go
@@ -1,13 +1,14 @@
 package k8s
 
 import (
+	"testing"
+
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 type restScope struct{}

--- a/fleetshard/pkg/k8s/client_test.go
+++ b/fleetshard/pkg/k8s/client_test.go
@@ -2,15 +2,28 @@ package k8s
 
 import (
 	"context"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"testing"
 )
 
+type restScope struct{}
+
+func (r *restScope) Name() meta.RESTScopeName {
+	return "namespace/name"
+}
+
 func TestIsRoutesResourceEnabled(t *testing.T) {
-	//fakeClient := testutils.NewFakeClientBuilder(t).Build()
-	fakeClient := CreateClientOrDie()
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{routesGVK.GroupVersion()})
+	mapper.Add(schema.GroupVersionKind{Group: routesGVK.Group, Version: routesGVK.Version, Kind: "Route"}, &restScope{})
+
+	fakeClient := testutils.NewFakeClientBuilder(t).
+		WithRESTMapper(mapper).
+		Build()
 	enabled, err := IsRoutesResourceEnabled(context.TODO(), fakeClient)
 	require.NoError(t, err)
 	assert.True(t, enabled)

--- a/fleetshard/pkg/k8s/client_test.go
+++ b/fleetshard/pkg/k8s/client_test.go
@@ -1,0 +1,24 @@
+package k8s
+
+import (
+	"context"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func TestIsRoutesResourceEnabled(t *testing.T) {
+	fakeClient := testutils.NewFakeClientBuilder(t).Build()
+	enabled, err := IsRoutesResourceEnabled(context.TODO(), fakeClient)
+	require.NoError(t, err)
+	assert.True(t, enabled)
+}
+
+func TestIsRoutesResourceEnabledShouldReturnFalse(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().Build()
+	enabled, err := IsRoutesResourceEnabled(context.TODO(), fakeClient)
+	require.NoError(t, err)
+	assert.False(t, enabled)
+}

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -172,7 +172,7 @@ func (r *Runtime) deleteStaleReconcilers(list *private.ManagedCentralList) {
 }
 
 func (r *Runtime) routesAvailable() bool {
-	available, err := k8s.IsRoutesResourceEnabled(context.Background(), r.k8sClient)
+	available, err := k8s.IsRoutesResourceEnabled(r.k8sClient)
 	if err != nil {
 		glog.Errorf("Skip checking OpenShift routes availability due to an error: %v", err)
 		return true // make an optimistic assumption that routes can be created despite the error

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -86,7 +86,7 @@ func (r *Runtime) Start() error {
 	glog.Info("fleetshard runtime started")
 	glog.Infof("Auth provider initialisation enabled: %v", r.config.CreateAuthProvider)
 
-	routesAvailable := routesAvailable()
+	routesAvailable := r.routesAvailable()
 
 	reconcilerOpts := centralReconciler.CentralReconcilerOptions{
 		UseRoutes:         routesAvailable,
@@ -171,8 +171,8 @@ func (r *Runtime) deleteStaleReconcilers(list *private.ManagedCentralList) {
 	}
 }
 
-func routesAvailable() bool {
-	available, err := k8s.IsRoutesResourceEnabled()
+func (r *Runtime) routesAvailable() bool {
+	available, err := k8s.IsRoutesResourceEnabled(context.Background(), r.k8sClient)
 	if err != nil {
 		glog.Errorf("Skip checking OpenShift routes availability due to an error: %v", err)
 		return true // make an optimistic assumption that routes can be created despite the error


### PR DESCRIPTION
## Description

Use the controller-runtime client instead of the default kubernetes clientset.

 - Client is now injected 
 - Client can be tested
 - Client is not created hardcoded

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Documentation added if necessary
- [x] CI and all relevant tests are passing
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

 - CI
 - Automated tests (unit)
 - Manual testing on k8s 
   - run `fleet-manager` and `fleetshard-sync` on the same cluster
   - Install openshift-router with `make install/openshift-router`
   - Create Central instance
   - Routes should be created
 