### PR TITLE
[terraforming] Explicit `rhacs-fleetshard` namespace instead of `rhacs`

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -107,7 +107,7 @@ esac
 helm upgrade rhacs-terraform ./ \
   --install \
   --debug \
-  --namespace rhacs \
+  --namespace rhacs-fleetshard \
   --create-namespace \
   --set acsOperator.enabled=true \
   --set acsOperator.source=rhacs-operators \


### PR DESCRIPTION
## Description

This PR changes the `rhacs` namespace to `rhacs-terraform` to better identify the fleetshard namespace.
I propose this change before going into service preview to have a better naming and exploration.

@ebensh @stehessel @kurlov How big is the impact to make this change? For example I am thinking of alerting, secrets etc.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

 - /
