### PR TITLE
ROX-12406: add more metrics to fleetshard-sync

### DIFF
--- a/fleetshard/pkg/fleetmanager/client.go
+++ b/fleetshard/pkg/fleetmanager/client.go
@@ -145,10 +145,10 @@ func (c *Client) newRequest(method string, url string, body io.Reader) (*http.Re
 		return nil, fmt.Errorf("adding authentication information to request: %w", err)
 	}
 
-	fleetshardmetrics.MetricsInstance().IncrementFleetManagerRequests()
+	fleetshardmetrics.MetricsInstance().IncFleetManagerRequests()
 	resp, err := c.client.Do(r)
 	if err != nil {
-		fleetshardmetrics.MetricsInstance().IncrementFleetManagerRequestErrors()
+		fleetshardmetrics.MetricsInstance().IncFleetManagerRequestErrors()
 		return nil, fmt.Errorf("executing HTTP request: %w", err)
 	}
 	return resp, nil
@@ -177,7 +177,7 @@ func (c *Client) unmarshalResponse(resp *http.Response, v interface{}) error {
 
 	// Unmarshal error
 	if into.Kind == "Error" || into.Kind == "error" {
-		fleetshardmetrics.MetricsInstance().IncrementFleetManagerRequestErrors()
+		fleetshardmetrics.MetricsInstance().IncFleetManagerRequestErrors()
 		apiError := compat.Error{}
 		err = json.Unmarshal(data, &apiError)
 		if err != nil {

--- a/fleetshard/pkg/fleetshardmetrics/metrics.go
+++ b/fleetshard/pkg/fleetshardmetrics/metrics.go
@@ -16,10 +16,12 @@ var (
 // Metrics holds the prometheus.Collector instances for fleetshard-sync's custom metrics
 // and provides methods to interact with them.
 type Metrics struct {
-	fleetManagerRequests       prometheus.Counter
-	fleetManagerRequestErrors  prometheus.Counter
-	centralReconcilations      prometheus.Counter
-	centralReconcilationErrors prometheus.Counter
+	fleetManagerRequests        prometheus.Counter
+	fleetManagerRequestErrors   prometheus.Counter
+	centralReconcilations       prometheus.Counter
+	centralReconcilationErrors  prometheus.Counter
+	activeCentralReconcilations prometheus.Gauge
+	totalCentrals               prometheus.Gauge
 }
 
 // Register registers the metrics with the given prometheus.Registerer
@@ -28,26 +30,43 @@ func (m *Metrics) Register(r prometheus.Registerer) {
 	r.MustRegister(m.fleetManagerRequests)
 	r.MustRegister(m.centralReconcilations)
 	r.MustRegister(m.centralReconcilationErrors)
+	r.MustRegister(m.activeCentralReconcilations)
+	r.MustRegister(m.totalCentrals)
 }
 
-// IncrementFleetManagerRequests increments the metric counter for fleet-manager requests
-func (m *Metrics) IncrementFleetManagerRequests() {
+// IncFleetManagerRequests increments the metric counter for fleet-manager requests
+func (m *Metrics) IncFleetManagerRequests() {
 	m.fleetManagerRequests.Inc()
 }
 
-// IncrementFleetManagerRequestErrors increments the metric counter for fleet-manager request errors
-func (m *Metrics) IncrementFleetManagerRequestErrors() {
+// IncFleetManagerRequestErrors increments the metric counter for fleet-manager request errors
+func (m *Metrics) IncFleetManagerRequestErrors() {
 	m.fleetManagerRequestErrors.Inc()
 }
 
-// IncrementCentralReconcilations increments the metric counter for central reconcilations errors
-func (m *Metrics) IncrementCentralReconcilations() {
+// IncCentralReconcilations increments the metric counter for central reconcilations errors
+func (m *Metrics) IncCentralReconcilations() {
 	m.centralReconcilations.Inc()
 }
 
-// IncrementCentralReconcilationErrors increments the metric counter for central reconcilation errors
-func (m *Metrics) IncrementCentralReconcilationErrors() {
+// IncCentralReconcilationErrors increments the metric counter for central reconcilation errors
+func (m *Metrics) IncCentralReconcilationErrors() {
 	m.centralReconcilationErrors.Inc()
+}
+
+// SetTotalCentrals sets the metric for total centrals to the given value
+func (m *Metrics) SetTotalCentrals(v float64) {
+	m.totalCentrals.Set(v)
+}
+
+// IncActiveCentralReconcilations increments the metric gauge for active central reconcilations
+func (m *Metrics) IncActiveCentralReconcilations() {
+	m.activeCentralReconcilations.Inc()
+}
+
+// DecActiveCentralReconcilations decrements the metric gauge for active central reconcilations
+func (m *Metrics) DecActiveCentralReconcilations() {
+	m.activeCentralReconcilations.Dec()
 }
 
 // MetricsInstance return the global Singleton instance for Metrics
@@ -77,6 +96,14 @@ func newMetrics() *Metrics {
 		centralReconcilationErrors: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: metricsPrefix + "total_central_reconcilation_errors",
 			Help: "The total number of failed central reconcilations",
+		}),
+		activeCentralReconcilations: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: metricsPrefix + "active_central_reconcilations",
+			Help: "The number of currently running central reconcilations",
+		}),
+		totalCentrals: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: metricsPrefix + "total_centrals",
+			Help: "The total number of centrals monitored by fleetshard-sync",
 		}),
 	}
 }

--- a/fleetshard/pkg/fleetshardmetrics/metrics.go
+++ b/fleetshard/pkg/fleetshardmetrics/metrics.go
@@ -16,14 +16,18 @@ var (
 // Metrics holds the prometheus.Collector instances for fleetshard-sync's custom metrics
 // and provides methods to interact with them.
 type Metrics struct {
-	fleetManagerRequests      prometheus.Counter
-	fleetManagerRequestErrors prometheus.Counter
+	fleetManagerRequests       prometheus.Counter
+	fleetManagerRequestErrors  prometheus.Counter
+	centralReconcilations      prometheus.Counter
+	centralReconcilationErrors prometheus.Counter
 }
 
 // Register registers the metrics with the given prometheus.Registerer
 func (m *Metrics) Register(r prometheus.Registerer) {
 	r.MustRegister(m.fleetManagerRequestErrors)
 	r.MustRegister(m.fleetManagerRequests)
+	r.MustRegister(m.centralReconcilations)
+	r.MustRegister(m.centralReconcilationErrors)
 }
 
 // IncrementFleetManagerRequests increments the metric counter for fleet-manager requests
@@ -34,6 +38,16 @@ func (m *Metrics) IncrementFleetManagerRequests() {
 // IncrementFleetManagerRequestErrors increments the metric counter for fleet-manager request errors
 func (m *Metrics) IncrementFleetManagerRequestErrors() {
 	m.fleetManagerRequestErrors.Inc()
+}
+
+// IncrementCentralReconcilations increments the metric counter for central reconcilations errors
+func (m *Metrics) IncrementCentralReconcilations() {
+	m.centralReconcilations.Inc()
+}
+
+// IncrementCentralReconcilationErrors increments the metric counter for central reconcilation errors
+func (m *Metrics) IncrementCentralReconcilationErrors() {
+	m.centralReconcilationErrors.Inc()
 }
 
 // MetricsInstance return the global Singleton instance for Metrics
@@ -55,6 +69,14 @@ func newMetrics() *Metrics {
 		fleetManagerRequestErrors: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: metricsPrefix + "total_fleet_manager_request_errors",
 			Help: "The total number of request errors for requests send to fleet-manager",
+		}),
+		centralReconcilations: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: metricsPrefix + "total_central_reconcilations",
+			Help: "The total number of central reconcilations started",
+		}),
+		centralReconcilationErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: metricsPrefix + "total_central_reconcilation_errors",
+			Help: "The total number of failed central reconcilations",
 		}),
 	}
 }

--- a/fleetshard/pkg/fleetshardmetrics/metrics_test.go
+++ b/fleetshard/pkg/fleetshardmetrics/metrics_test.go
@@ -26,6 +26,18 @@ func TestMetricIncrements(t *testing.T) {
 				m.IncrementFleetManagerRequestErrors()
 			},
 		},
+		{
+			metricName: "total_central_reconcilations",
+			callIncrementFunc: func(m *Metrics) {
+				m.IncrementCentralReconcilations()
+			},
+		},
+		{
+			metricName: "total_central_reconcilation_errors",
+			callIncrementFunc: func(m *Metrics) {
+				m.IncrementCentralReconcilationErrors()
+			},
+		},
 	}
 
 	for _, tc := range tt {

--- a/fleetshard/pkg/fleetshardmetrics/metrics_test.go
+++ b/fleetshard/pkg/fleetshardmetrics/metrics_test.go
@@ -3,11 +3,12 @@ package fleetshardmetrics
 import (
 	"testing"
 
+	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestMetricIncrements(t *testing.T) {
+func TestCounterIncrements(t *testing.T) {
 	const expectedIncrement = 1.0
 
 	tt := []struct {
@@ -17,25 +18,25 @@ func TestMetricIncrements(t *testing.T) {
 		{
 			metricName: "total_fleet_manager_requests",
 			callIncrementFunc: func(m *Metrics) {
-				m.IncrementFleetManagerRequests()
+				m.IncFleetManagerRequests()
 			},
 		},
 		{
 			metricName: "total_fleet_manager_request_errors",
 			callIncrementFunc: func(m *Metrics) {
-				m.IncrementFleetManagerRequestErrors()
+				m.IncFleetManagerRequestErrors()
 			},
 		},
 		{
 			metricName: "total_central_reconcilations",
 			callIncrementFunc: func(m *Metrics) {
-				m.IncrementCentralReconcilations()
+				m.IncCentralReconcilations()
 			},
 		},
 		{
 			metricName: "total_central_reconcilation_errors",
 			callIncrementFunc: func(m *Metrics) {
-				m.IncrementCentralReconcilationErrors()
+				m.IncCentralReconcilationErrors()
 			},
 		},
 	}
@@ -46,12 +47,49 @@ func TestMetricIncrements(t *testing.T) {
 			tc.callIncrementFunc(m)
 
 			metrics := serveMetrics(t, m)
-			targetMetric, hasKey := metrics[metricsPrefix+tc.metricName]
-			require.Truef(t, hasKey, "expected metrics to contain %s but it did not: %v", tc.metricName, metrics)
+			targetMetric := requireMetric(t, metrics, metricsPrefix+tc.metricName)
 
 			// Test that the metrics value is 1 after calling the incrementFunc
 			value := targetMetric.Metric[0].Counter.Value
 			assert.Equalf(t, expectedIncrement, *value, "expected metric: %s to have value: %v", tc.metricName, expectedIncrement)
 		})
 	}
+}
+
+func TestTotalCentrals(t *testing.T) {
+	m := newMetrics()
+	metricName := metricsPrefix + "total_centrals"
+	expectedValue := 37.0
+
+	m.SetTotalCentrals(expectedValue)
+	metrics := serveMetrics(t, m)
+
+	targetMetric := requireMetric(t, metrics, metricName)
+	value := targetMetric.Metric[0].Gauge.Value
+	assert.Equalf(t, 37.0, *value, "expected metric: %s to have value: %v", metricName, expectedValue)
+}
+
+func TestActiveCentralReconcilations(t *testing.T) {
+	m := newMetrics()
+	metricName := metricsPrefix + "active_central_reconcilations"
+
+	m.IncActiveCentralReconcilations()
+	metrics := serveMetrics(t, m)
+
+	targetMetric := requireMetric(t, metrics, metricName)
+	value := targetMetric.Metric[0].Gauge.Value
+	assert.Equalf(t, 1.0, *value, "expected metric: %s to have value: %v", metricName, 1.0)
+
+	m.DecActiveCentralReconcilations()
+	metrics = serveMetrics(t, m)
+
+	targetMetric = requireMetric(t, metrics, metricName)
+	value = targetMetric.Metric[0].Gauge.Value
+	assert.Equalf(t, 0.0, *value, "expected metric: %s to have value: %v", metricName, 0.0)
+}
+
+func requireMetric(t *testing.T, metrics metricResponse, metricName string) *io_prometheus_client.MetricFamily {
+	targetMetric, hasKey := metrics[metricName]
+	require.Truef(t, hasKey, "expected metrics to contain %s but it did not: %v", metricName, metrics)
+	return targetMetric
 }

--- a/fleetshard/pkg/fleetshardmetrics/server_test.go
+++ b/fleetshard/pkg/fleetshardmetrics/server_test.go
@@ -32,6 +32,8 @@ func TestMetricsServerServesCustomMetrics(t *testing.T) {
 		"total_fleet_manager_request_errors",
 		"total_central_reconcilations",
 		"total_central_reconcilation_errors",
+		"active_central_reconcilations",
+		"total_centrals",
 	}
 
 	for _, key := range expectedKeys {

--- a/fleetshard/pkg/fleetshardmetrics/server_test.go
+++ b/fleetshard/pkg/fleetshardmetrics/server_test.go
@@ -30,6 +30,8 @@ func TestMetricsServerServesCustomMetrics(t *testing.T) {
 	expectedKeys := []string{
 		"total_fleet_manager_requests",
 		"total_fleet_manager_request_errors",
+		"total_central_reconcilations",
+		"total_central_reconcilation_errors",
 	}
 
 	for _, key := range expectedKeys {


### PR DESCRIPTION
## Description
Added more metrics to the initial implementation of the metrics server for fleetshard-sync component.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
