### PR TITLE
Make NO_PROXY value deterministic

### DIFF
--- a/fleetshard/pkg/central/reconciler/proxy.go
+++ b/fleetshard/pkg/central/reconciler/proxy.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -33,6 +34,7 @@ func getProxyEnvVars(namespace string) []corev1.EnvVar {
 			)
 		}
 	}
+	sort.Strings(noProxyTargets) // ensure deterministic output
 	noProxyStr := strings.Join(noProxyTargets, ",")
 	for _, envVarName := range []string{"no_proxy", "NO_PROXY"} {
 		envVars = append(envVars, corev1.EnvVar{

--- a/fleetshard/pkg/central/reconciler/proxy_test.go
+++ b/fleetshard/pkg/central/reconciler/proxy_test.go
@@ -10,8 +10,9 @@ import (
 	"golang.org/x/net/http/httpproxy"
 )
 
+const testNS = `acsms-01`
+
 func TestProxyConfiguration(t *testing.T) {
-	const testNS = `acsms-01`
 	ei := envisolator.NewEnvIsolator(t)
 	defer ei.RestoreAll()
 
@@ -60,5 +61,13 @@ func TestProxyConfiguration(t *testing.T) {
 			continue
 		}
 		assert.Equal(t, expectedProxyURL, proxyURL.String())
+	}
+}
+
+func TestProxyConfiguration_IsDeterministic(t *testing.T) {
+	envVars := getProxyEnvVars(testNS)
+	for i := 0; i < 5; i++ {
+		otherEnvVars := getProxyEnvVars(testNS)
+		assert.Equal(t, envVars, otherEnvVars)
 	}
 }


### PR DESCRIPTION
## Description

Because `NO_PROXY` is assembled by ranging over a map, it might be non-deterministic. This causes the pods to be recreated on every reconcile, which is bad.

Sort the list of `NO_PROXY` targets to ensure a deterministic output.

## Checklist (Definition of Done)
- [x] Unit and integration tests added
- [x] ~Documentation added if necessary~
- [ ] CI and all relevant tests are passing
- [x] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual
Ran unit test