### PR TITLE
ROX-12499 - Fix operator subscription to `redhat-operators`

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -99,10 +99,6 @@ case $ENVIRONMENT in
     ;;
 esac
 
-# To use ACS Operator from the OpenShift Marketplace:
-#   --set acsOperator.source=redhat-operators
-#   --set acsOperator.sourceNamespace=openshift-marketplace
-
 # helm template ... to debug changes
 helm upgrade rhacs-terraform ./ \
   --install \
@@ -110,7 +106,8 @@ helm upgrade rhacs-terraform ./ \
   --namespace rhacs \
   --create-namespace \
   --set acsOperator.enabled=true \
-  --set acsOperator.source=rhacs-operators \
+  --set acsOperator.source=redhat-operators \
+  --set acsOperator.sourceNamespace=openshift-marketplace \
   --set acsOperator.startingCSV=rhacs-operator.v3.71.0 \
   --set fleetshardSync.authType="RHSSO" \
   --set fleetshardSync.clusterId=${CLUSTER_ID} \


### PR DESCRIPTION
## Description

The operator subscription was not installed successfully because the catalog source was `rhacs-operators` instead of `redhat-operators`.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

 - Manual provisioning