### PR TITLE
Avoid RHSSO in Central auth config for clarity

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -304,7 +304,7 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "4e199b4a1c40b497a95fcd1cd896351733849949",
         "is_verified": false,
-        "line_number": 596,
+        "line_number": 595,
         "is_secret": false
       }
     ],
@@ -329,5 +329,5 @@
       }
     ]
   },
-  "generated_at": "2022-08-11T14:42:07Z"
+  "generated_at": "2022-09-09T13:53:44Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ help:
 	@echo "make deploy/project              deploy the service via templates to an openshift cluster"
 	@echo "make undeploy                    remove the service deployments from an openshift cluster"
 	@echo "make redhatsso/setup             setup sso clientId & clientSecret"
-	@echo "make centralidp/setup            setup Central's RHSSO clientSecret"
+	@echo "make centralidp/setup            setup Central's static auth config (client_secret)"
 	@echo "make openapi/spec/validate       validate OpenAPI spec using spectral"
 	@echo "$(fake)"
 .PHONY: help

--- a/docs/legacy/feature-flags.md
+++ b/docs/legacy/feature-flags.md
@@ -34,10 +34,18 @@ This lists the feature flags and their sub-configurations to enable/disable and 
 - **enable-central-external-certificate**: Enables custom Central TLS certificate.
     - `central-tls-cert-file` [Required]: The path to the file containing the Central TLS certificate (default: `'secrets/central-tls.crt'`).
     - `central-tls-key-file` [Required]: The path to the file containing the Central TLS private key (default: `'secrets/central-tls.key'`).
-- **enable-evaluator-instance**: Enable the creation of one central evaluator instances per user  
-- **rhsso-client-id**: RHSSO client ID to pass to Central's auth config to set up RHSSO IdP
-- **rhsso-client-secret-file**: File containing RHSSO client secret to pass to Central's auth config to set up RHSSO IdP
-- **rhsso-issuer**: RHSSO issuer to pass to Central's auth config to set up RHSSO IdP
+- **enable-evaluator-instance**: Enable the creation of one central evaluator instances per user
+
+- **central-idp-***: A collection of flags describing _static_ auth config for Central.
+  If set, every Central will have the **same** IdP config which is likely not what you
+  want for production. If not set, the IdP API will be queried for dynamic configuration.
+    - **central-idp-client-id**: OIDC client_id to pass to Central's auth config to set
+      up its IdP integration.
+    - **central-idp-client-secret-file**: File containing OIDC client_secret to pass to
+      Central's auth config to set up its IdP integration.
+    - **central-idp-issuer**: OIDC issuer URL to pass to Central's auth config to set up
+      its IdP integration.
+
 - **quota-type**: Sets the quota service to be used for access control when requesting Central instances (options: `ams` or `quota-management-list`, default: `quota-management-list`).
     > For more information on the quota service implementation, see the [quota service architecture](./architecture/quota-service-implementation) architecture documentation.
     - If this is set to `quota-management-list`, quotas will be managed via the quota management list configuration.

--- a/internal/dinosaur/pkg/config/central.go
+++ b/internal/dinosaur/pkg/config/central.go
@@ -28,10 +28,10 @@ type CentralConfig struct {
 	Quota           *CentralQuotaConfig    `json:"central_quota"`
 
 	// Central's IdP static configuration (optional).
-	CentralIdPClientID         string `json:"central_idp_client_id"`
-	CentralIdPClientSecret     string `json:"central_idp_client_secret"`
-	CentralIdPClientSecretFile string `json:"central_idp_client_secret_file"`
-	CentralIdPIssuer           string `json:"central_idp_issuer"`
+	CentralIDPClientID         string `json:"central_idp_client_id"`
+	CentralIDPClientSecret     string `json:"central_idp_client_secret"`
+	CentralIDPClientSecretFile string `json:"central_idp_client_secret_file"`
+	CentralIDPIssuer           string `json:"central_idp_issuer"`
 }
 
 // NewCentralConfig ...
@@ -43,8 +43,8 @@ func NewCentralConfig() *CentralConfig {
 		CentralDomainName:                "rhacs-dev.com",
 		CentralLifespan:                  NewCentralLifespanConfig(),
 		Quota:                            NewCentralQuotaConfig(),
-		CentralIdPClientSecretFile:       "secrets/central.idp-client-secret", //pragma: allowlist secret
-		CentralIdPIssuer:                 "https://sso.redhat.com/auth/realms/redhat-external",
+		CentralIDPClientSecretFile:       "secrets/central.idp-client-secret", //pragma: allowlist secret
+		CentralIDPIssuer:                 "https://sso.redhat.com/auth/realms/redhat-external",
 	}
 }
 
@@ -59,9 +59,9 @@ func (c *CentralConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.Quota.Type, "quota-type", c.Quota.Type, "The type of the quota service to be used. The available options are: 'ams' for AMS backed implementation and 'quota-management-list' for quota list backed implementation (default).")
 	fs.BoolVar(&c.Quota.AllowEvaluatorInstance, "allow-evaluator-instance", c.Quota.AllowEvaluatorInstance, "Allow the creation of central evaluator instances")
 
-	fs.StringVar(&c.CentralIdPClientID, "central-idp-client-id", c.CentralIdPClientID, "OIDC client_id to pass to Central's auth config")
-	fs.StringVar(&c.CentralIdPClientSecretFile, "central-idp-client-secret-file", c.CentralIdPClientSecretFile, "File containing OIDC client_secret to pass to Central's auth config")
-	fs.StringVar(&c.CentralIdPIssuer, "central-idp-issuer", c.CentralIdPIssuer, "OIDC issuer URL to pass to Central's auth config")
+	fs.StringVar(&c.CentralIDPClientID, "central-idp-client-id", c.CentralIDPClientID, "OIDC client_id to pass to Central's auth config")
+	fs.StringVar(&c.CentralIDPClientSecretFile, "central-idp-client-secret-file", c.CentralIDPClientSecretFile, "File containing OIDC client_secret to pass to Central's auth config")
+	fs.StringVar(&c.CentralIDPIssuer, "central-idp-issuer", c.CentralIDPIssuer, "OIDC issuer URL to pass to Central's auth config")
 }
 
 // ReadFiles ...
@@ -74,14 +74,14 @@ func (c *CentralConfig) ReadFiles() error {
 	if err != nil {
 		return fmt.Errorf("reading TLS key file: %w", err)
 	}
-	err = shared.ReadFileValueString(c.CentralIdPClientSecretFile, &c.CentralIdPClientSecret)
+	err = shared.ReadFileValueString(c.CentralIDPClientSecretFile, &c.CentralIDPClientSecret)
 	if err != nil {
 		return fmt.Errorf("reading Central's IdP client secret file: %w", err)
 	}
-	if c.CentralIdPClientSecret != "" {
+	if c.CentralIDPClientSecret != "" {
 		glog.Info("Central's IdP client secret is configured")
 	} else {
-		glog.Infof("Central's IdP client secret from file %q is missing", c.CentralIdPClientSecretFile)
+		glog.Infof("Central's IdP client secret from file %q is missing", c.CentralIDPClientSecretFile)
 	}
 	// TODO(ROX-11289): drop MaxCapacity
 	// MaxCapacity is deprecated and will not be used.

--- a/internal/dinosaur/pkg/environments/development.go
+++ b/internal/dinosaur/pkg/environments/development.go
@@ -35,8 +35,8 @@ func NewDevelopmentEnvLoader() environments.EnvLoader {
 		"additional-sso-issuers-file":                     "config/additional-sso-issuers.yaml",
 		"jwks-file":                                       "config/jwks-file-static.json",
 		"fleetshard-authz-config-file":                    "config/fleetshard-authz-org-ids-development.yaml",
-		"rhsso-client-id":                                 "rhacs-ms-dev",
-		"rhsso-issuer":                                    "https://sso.stage.redhat.com/auth/realms/redhat-external",
+		"central-idp-client-id":                           "rhacs-ms-dev",
+		"central-idp-issuer":                              "https://sso.stage.redhat.com/auth/realms/redhat-external",
 		"admin-authz-config-file":                         "config/admin-authz-roles-dev.yaml",
 	}
 }

--- a/internal/dinosaur/pkg/environments/integration.go
+++ b/internal/dinosaur/pkg/environments/integration.go
@@ -45,7 +45,7 @@ func (b IntegrationEnvLoader) Defaults() map[string]string {
 		"dataplane-cluster-scaling-type":      "auto", // need to set this to 'auto' for integration environment as some tests rely on this
 		"central-operator-addon-id":           "managed-central-qe",
 		"fleetshard-addon-id":                 "fleetshard-operator-qe",
-		"rhsso-client-id":                     "rhacs-ms-dev",
+		"central-idp-client-id":               "rhacs-ms-dev",
 	}
 }
 

--- a/internal/dinosaur/pkg/environments/stage.go
+++ b/internal/dinosaur/pkg/environments/stage.go
@@ -17,8 +17,8 @@ func NewStageEnvLoader() environments.EnvLoader {
 		"additional-sso-issuers-file":         "config/additional-sso-issuers.yaml",
 		"jwks-file":                           "config/jwks-file-static.json",
 		"fleetshard-authz-config-file":        "config/fleetshard-authz-org-ids-development.yaml",
-		"rhsso-client-id":                     "rhacs-ms-dev",
-		"rhsso-issuer":                        "https://sso.stage.redhat.com/auth/realms/redhat-external",
+		"central-idp-client-id":               "rhacs-ms-dev",
+		"central-idp-issuer":                  "https://sso.stage.redhat.com/auth/realms/redhat-external",
 		"admin-authz-config-file":             "config/admin-authz-roles-dev.yaml",
 	}
 }

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -65,11 +65,11 @@ func (c *ManagedCentralPresenter) PresentManagedCentral(from *dbapi.CentralReque
 				from.Owner,
 			},
 			Auth: private.ManagedCentralAllOfSpecAuth{
-				ClientSecret: c.centralConfig.CentralIdPClientSecret, // pragma: allowlist secret
-				ClientId:     c.centralConfig.CentralIdPClientID,
+				ClientSecret: c.centralConfig.CentralIDPClientSecret, // pragma: allowlist secret
+				ClientId:     c.centralConfig.CentralIDPClientID,
 				OwnerOrgId:   from.OrganisationID,
 				OwnerUserId:  from.OwnerUserID,
-				Issuer:       c.centralConfig.CentralIdPIssuer,
+				Issuer:       c.centralConfig.CentralIDPIssuer,
 			},
 			UiEndpoint: private.ManagedCentralAllOfSpecUiEndpoint{
 				Host: from.GetUIHost(),

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -65,11 +65,11 @@ func (c *ManagedCentralPresenter) PresentManagedCentral(from *dbapi.CentralReque
 				from.Owner,
 			},
 			Auth: private.ManagedCentralAllOfSpecAuth{
-				ClientSecret: c.centralConfig.RhSsoClientSecret, // pragma: allowlist secret
-				ClientId:     c.centralConfig.RhSsoClientID,
+				ClientSecret: c.centralConfig.CentralIdPClientSecret, // pragma: allowlist secret
+				ClientId:     c.centralConfig.CentralIdPClientID,
 				OwnerOrgId:   from.OrganisationID,
 				OwnerUserId:  from.OwnerUserID,
-				Issuer:       c.centralConfig.RhSsoIssuer,
+				Issuer:       c.centralConfig.CentralIdPIssuer,
 			},
 			UiEndpoint: private.ManagedCentralAllOfSpecUiEndpoint{
 				Host: from.GetUIHost(),

--- a/templates/secrets-template.yml
+++ b/templates/secrets-template.yml
@@ -29,6 +29,9 @@ parameters:
   description: Password for the database user.
   value: TheBlurstOfTimes
 
+- name: CENTRAL_IDP_CLIENT_SECRET
+  description: Client secret to pass to Central's auth config to set up its IdP integration.
+
 - name: OCM_SERVICE_CLIENT_ID
   description: Client id used to interact with other UHC services
 
@@ -114,6 +117,7 @@ objects:
   metadata:
     name: fleet-manager
   stringData:
+    central.idp-client-secret: "${CENTRAL_IDP_CLIENT_SECRET}"
     ocm-service.clientId: ${OCM_SERVICE_CLIENT_ID}
     ocm-service.clientSecret: ${OCM_SERVICE_CLIENT_SECRET}
     ocm-service.token: ${OCM_SERVICE_TOKEN}

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -1059,7 +1059,7 @@ objects:
             - --aws-secret-access-key-file=/secrets/service/aws.secretaccesskey
             - --aws-route53-access-key-file=/secrets/fleet-manager-credentials/aws.route53accesskey
             - --aws-route53-secret-access-key-file=/secrets/fleet-manager-credentials/aws.route53secretaccesskey
-            - --central-idp-client-secret-file=/secrets/service/central.idp-client-secret
+            - --central-idp-client-secret-file=/secrets/fleet-manager-credentials/central.idp-client-secret
             - --observatorium-debug=${ENABLE_OBSERVATORIUM_DEBUG}
             - --observatorium-ignore-ssl=${OBSERVATORIUM_INSECURE}
             - --observatorium-timeout=${OBSERVATORIUM_TIMEOUT}

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -592,6 +592,7 @@ objects:
     metadata:
       name: fake-fleet-manager-secret
     data:
+      central.idp-client-secret: badger
       ocm-service.clientId: badger
       ocm-service.clientSecret: badger
       ocm-service.token: badger
@@ -902,10 +903,6 @@ objects:
             secret:
               # secretName is a vault-secret provider name in the app-interface
               secretName: fleet-manager-credentials # pragma: allowlist secret
-          - name: rhsso-client-secret
-            secret:
-              # secretName is a vault-secret provider name in the app-interface
-              secretName: fleet-manager-central-rhsso-client-secret # pragma: allowlist secret
           - name: tls
             secret:
               secretName: fleet-manager-tls # pragma: allowlist secret
@@ -995,8 +992,6 @@ objects:
               mountPath: /secrets/fleet-manager-credentials
             - name: tls
               mountPath: /secrets/tls
-            - name: rhsso-client-secret
-              mountPath: /secrets/rhsso-client-secret
             - name: service
               mountPath: /secrets/service
             - name: dataplane-certificate
@@ -1064,7 +1059,7 @@ objects:
             - --aws-secret-access-key-file=/secrets/service/aws.secretaccesskey
             - --aws-route53-access-key-file=/secrets/fleet-manager-credentials/aws.route53accesskey
             - --aws-route53-secret-access-key-file=/secrets/fleet-manager-credentials/aws.route53secretaccesskey
-            - --rhsso-client-secret-file=/secrets/rhsso-client-secret/clientSecret
+            - --central-idp-client-secret-file=/secrets/service/central.idp-client-secret
             - --observatorium-debug=${ENABLE_OBSERVATORIUM_DEBUG}
             - --observatorium-ignore-ssl=${OBSERVATORIUM_INSECURE}
             - --observatorium-timeout=${OBSERVATORIUM_TIMEOUT}


### PR DESCRIPTION
## Description
Fleet manager config has several knobs mentioning "sso", "client secret", or alike in their names:
* `--observability-red-hat-sso-logs-client-id-file`
* `--redhat-sso-client-secret-file`
* `--ocm-client-secret-file`
* `--rhsso-client-secret-file`

`--redhat-sso-client-secret-file` and `--rhsso-client-secret-file` look particularly confusing. To avoid that, this PR aims to rename the latter (and those from the same `--rhsso-*` family) to `--central-idp-client-secret-file` (`--central-idp-*`).

Also mount entry for `rhsso-client-secret` in "templates/service-template.yml" is replaced by a different location ([stage Vault](https://vault.devshift.net/ui/vault/secrets/app-interface/show/acs-fleet-manager/stage/service/credentials) has been updated accordingly).

## Checklist (Definition of Done)
- [ ] ~Unit and integration tests added~
- [x] Documentation added if necessary
- [x] CI and all relevant tests are passing
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

CI run.