### PR TITLE
Add CENTRAL_RHSSO_CLIENT_ID variable to service-template.yml

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -304,7 +304,7 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "4e199b4a1c40b497a95fcd1cd896351733849949",
         "is_verified": false,
-        "line_number": 599,
+        "line_number": 603,
         "is_secret": false
       }
     ],
@@ -329,5 +329,5 @@
       }
     ]
   },
-  "generated_at": "2022-09-12T10:12:04Z"
+  "generated_at": "2022-09-12T17:39:32Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -701,14 +701,14 @@ deploy/service: DATAPLANE_CLUSTER_SCALING_TYPE ?= "manual"
 deploy/service: CENTRAL_OPERATOR_OPERATOR_ADDON_ID ?= "managed-central-qe"
 deploy/service: FLEETSHARD_ADDON_ID ?= "fleetshard-operator-qe"
 deploy/service: CENTRAL_IDP_ISSUER ?= "https://sso.stage.redhat.com/auth/realms/redhat-external"
-deploy/service: CENTRAL_RHSSO_CLIENT_ID ?= "rhacs-ms-dev"
+deploy/service: CENTRAL_IDP_CLIENT_ID ?= "rhacs-ms-dev"
 deploy/service: deploy/envoy deploy/route
 	@if test -z "$(IMAGE_TAG)"; then echo "IMAGE_TAG was not specified"; exit 1; fi
 	@time timeout --foreground 3m bash -c "until oc get routes -n $(NAMESPACE) | grep -q fleet-manager; do echo 'waiting for fleet-manager route to be created'; sleep 1; done"
 	@oc process -f ./templates/service-template.yml \
 		-p ENVIRONMENT="$(FLEET_MANAGER_ENV)" \
 		-p CENTRAL_IDP_ISSUER="$(CENTRAL_IDP_ISSUER)" \
-		-p CENTRAL_RHSSO_CLIENT_ID="$(CENTRAL_RHSSO_CLIENT_ID)" \
+		-p CENTRAL_IDP_CLIENT_ID="$(CENTRAL_IDP_CLIENT_ID)" \
 		-p IMAGE_REGISTRY=$(IMAGE_REGISTRY) \
 		-p IMAGE_REPOSITORY=$(IMAGE_REPOSITORY) \
 		-p IMAGE_TAG=$(IMAGE_TAG) \

--- a/Makefile
+++ b/Makefile
@@ -701,12 +701,14 @@ deploy/service: DATAPLANE_CLUSTER_SCALING_TYPE ?= "manual"
 deploy/service: CENTRAL_OPERATOR_OPERATOR_ADDON_ID ?= "managed-central-qe"
 deploy/service: FLEETSHARD_ADDON_ID ?= "fleetshard-operator-qe"
 deploy/service: CENTRAL_IDP_ISSUER ?= "https://sso.stage.redhat.com/auth/realms/redhat-external"
+deploy/service: CENTRAL_RHSSO_CLIENT_ID ?= "rhacs-ms-dev"
 deploy/service: deploy/envoy deploy/route
 	@if test -z "$(IMAGE_TAG)"; then echo "IMAGE_TAG was not specified"; exit 1; fi
 	@time timeout --foreground 3m bash -c "until oc get routes -n $(NAMESPACE) | grep -q fleet-manager; do echo 'waiting for fleet-manager route to be created'; sleep 1; done"
 	@oc process -f ./templates/service-template.yml \
 		-p ENVIRONMENT="$(FLEET_MANAGER_ENV)" \
 		-p CENTRAL_IDP_ISSUER="$(CENTRAL_IDP_ISSUER)" \
+		-p CENTRAL_RHSSO_CLIENT_ID="$(CENTRAL_RHSSO_CLIENT_ID)" \
 		-p IMAGE_REGISTRY=$(IMAGE_REGISTRY) \
 		-p IMAGE_REPOSITORY=$(IMAGE_REPOSITORY) \
 		-p IMAGE_TAG=$(IMAGE_TAG) \

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -19,6 +19,10 @@ parameters:
   description: Which ACS Service Fleet Manager environment to use for this deployment
   value: production
 
+- name: CENTRAL_RHSSO_CLIENT_ID
+  displayName: Central Red Hat SSO client id
+  description: Which OIDC client id to use to connect to Red Hat SSO from Central
+
 - name: CENTRAL_IDP_ISSUER
   displayName: Central's IdP issuer
   description: OIDC issuer URL to pass to Central's auth config

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -20,8 +20,8 @@ parameters:
   value: production
 
 - name: CENTRAL_IDP_CLIENT_ID
-  displayName: Central Red Hat SSO client id
-  description: Which OIDC client id to use to connect to Red Hat SSO from Central
+  displayName: Central's IdP client ID
+  description: OIDC client ID to pass to Central's auth config
 
 - name: CENTRAL_IDP_ISSUER
   displayName: Central's IdP issuer

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -1068,6 +1068,7 @@ objects:
             - --aws-route53-access-key-file=/secrets/fleet-manager-credentials/aws.route53accesskey
             - --aws-route53-secret-access-key-file=/secrets/fleet-manager-credentials/aws.route53secretaccesskey
             - --central-idp-client-secret-file=/secrets/fleet-manager-credentials/central.idp-client-secret
+            - --central-idp-client-id=${CENTRAL_RHSSO_CLIENT_ID}
             - --observatorium-debug=${ENABLE_OBSERVATORIUM_DEBUG}
             - --observatorium-ignore-ssl=${OBSERVATORIUM_INSECURE}
             - --observatorium-timeout=${OBSERVATORIUM_TIMEOUT}

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -19,7 +19,7 @@ parameters:
   description: Which ACS Service Fleet Manager environment to use for this deployment
   value: production
 
-- name: CENTRAL_RHSSO_CLIENT_ID
+- name: CENTRAL_IDP_CLIENT_ID
   displayName: Central Red Hat SSO client id
   description: Which OIDC client id to use to connect to Red Hat SSO from Central
 
@@ -1068,7 +1068,7 @@ objects:
             - --aws-route53-access-key-file=/secrets/fleet-manager-credentials/aws.route53accesskey
             - --aws-route53-secret-access-key-file=/secrets/fleet-manager-credentials/aws.route53secretaccesskey
             - --central-idp-client-secret-file=/secrets/fleet-manager-credentials/central.idp-client-secret
-            - --central-idp-client-id=${CENTRAL_RHSSO_CLIENT_ID}
+            - --central-idp-client-id=${CENTRAL_IDP_CLIENT_ID}
             - --observatorium-debug=${ENABLE_OBSERVATORIUM_DEBUG}
             - --observatorium-ignore-ssl=${OBSERVATORIUM_INSECURE}
             - --observatorium-timeout=${OBSERVATORIUM_TIMEOUT}


### PR DESCRIPTION
## Description
This change is created to help us choose the correct clientId in [app-interface](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/acs-fleet-manager/cicd/saas.yaml) repo.

 This PR should not be merged until `CENTRAL_RHSSO_CLIENT_ID` variable is set up in app-interface repo, otherwise staging and prod will provide incorrect auth provider in Central creation.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
-
