### PR TITLE
Use RHACS operator version with memory leak fix

### DIFF
--- a/dev/env/defaults/00-defaults.env
+++ b/dev/env/defaults/00-defaults.env
@@ -10,7 +10,7 @@ export CLUSTER_ID_DEFAULT="1234567890abcdef1234567890abcdef"
 export CLUSTER_DNS_DEFAULT="cluster.local"
 
 export IMAGE_REGISTRY_DEFAULT="quay.io/rhacs-eng"
-STACKROX_VERSION_TAG="3.70.0-nightly-20220707"
+STACKROX_VERSION_TAG="3.72.0-nightly-20220909"
 export STACKROX_OPERATOR_VERSION_DEFAULT="${STACKROX_VERSION_TAG}"
 export CENTRAL_VERSION_DEFAULT=$(echo "$STACKROX_VERSION_TAG" | sed -e 's/0-nightly/x-nightly/;')
 export SCANNER_VERSION_DEFAULT="2.25.1" # This one matches the above operator version tag.

--- a/dev/env/defaults/cluster-type-infra-openshift/00-openshift.env
+++ b/dev/env/defaults/cluster-type-infra-openshift/00-openshift.env
@@ -1,0 +1,1 @@
+../cluster-type-openshift/env

--- a/dev/env/defaults/cluster-type-infra-openshift/env
+++ b/dev/env/defaults/cluster-type-infra-openshift/env
@@ -1,8 +1,4 @@
-export OPENSHIFT_MARKETPLACE_DEFAULT="true"
-export KUBECTL_DEFAULT="oc"
-export OPERATOR_SOURCE_DEFAULT="marketplace"
-export INSTALL_OLM_DEFAULT="false"
-export ENABLE_FM_PORT_FORWARDING_DEFAULT="true"
+export SPAWN_LOGGER_DEFAULT="true"
 export FLEET_MANAGER_RESOURCES_DEFAULT='{"requests":{"cpu":"400m","memory":"1000Mi"},"limits":{"cpu":"400m","memory":"1000Mi"}}'
 export FLEETSHARD_SYNC_RESOURCES_DEFAULT='{"requests":{"cpu":"400m","memory":"1000Mi"},"limits":{"cpu":"400m","memory":"1000Mi"}}'
 export DB_RESOURCES_DEFAULT='{"requests":{"cpu":"400m","memory":"1000Mi"},"limits":{"cpu":"400m","memory":"1000Mi"}}'

--- a/dev/env/defaults/cluster-type-openshift/env
+++ b/dev/env/defaults/cluster-type-openshift/env
@@ -1,4 +1,4 @@
-export OPENSHIFT_MARKETPLACE_DEFAULT="true"
+export OPENSHIFT_MARKETPLACE_DEFAULT="false"
 export KUBECTL_DEFAULT="oc"
 export OPERATOR_SOURCE_DEFAULT="quay"  # TODO: revert to marketplace once memory leak fix is shipped
 export INSTALL_OLM_DEFAULT="false"
@@ -6,3 +6,5 @@ export ENABLE_FM_PORT_FORWARDING_DEFAULT="true"
 CLUSTER_DNS_DEFAULT=$(try_kubectl get -n "openshift-ingress-operator" ingresscontrollers default -o=jsonpath='{.status.domain}' --ignore-not-found)
 export CLUSTER_DNS_DEFAULT
 export INSTALL_OPENSHIFT_ROUTER_DEFAULT="false"
+export INHERIT_IMAGEPULLSECRETS_DEFAULT="true" # pragma: allowlist secret
+export INSTALL_OPERATOR_DEFAULT="true"

--- a/dev/env/defaults/cluster-type-openshift/env
+++ b/dev/env/defaults/cluster-type-openshift/env
@@ -1,6 +1,6 @@
 export OPENSHIFT_MARKETPLACE_DEFAULT="true"
 export KUBECTL_DEFAULT="oc"
-export OPERATOR_SOURCE_DEFAULT="marketplace"
+export OPERATOR_SOURCE_DEFAULT="quay"  # TODO: revert to marketplace once memory leak fix is shipped
 export INSTALL_OLM_DEFAULT="false"
 export ENABLE_FM_PORT_FORWARDING_DEFAULT="true"
 CLUSTER_DNS_DEFAULT=$(try_kubectl get -n "openshift-ingress-operator" ingresscontrollers default -o=jsonpath='{.status.domain}' --ignore-not-found)

--- a/dev/env/scripts/bootstrap.sh
+++ b/dev/env/scripts/bootstrap.sh
@@ -92,8 +92,10 @@ if [[ "$INSTALL_OPERATOR" == "true" ]]; then
             # operatorhubio catalog is ready, which is why an additional delay has been added.
             echo "Waiting for CatalogSource to include rhacs-operator..."
             while true; do
-                $KUBECTL -n "$STACKROX_OPERATOR_NAMESPACE" get packagemanifests.packages.operators.coreos.com -o json |
-                    jq -r '.items[].metadata.name' | grep -q '^rhacs-operator$' && break
+                if $KUBECTL -n "$STACKROX_OPERATOR_NAMESPACE" get packagemanifests.packages.operators.coreos.com -o json |
+                    jq -cer '.items[] | select(.metadata.labels.catalog == "stackrox-operator-test-index" and .metadata.name == "rhacs-operator") | isempty(.) | not' >/dev/null; then
+                    break
+                fi
                 sleep 1
             done
 


### PR DESCRIPTION
## Description

This changes the operator version (for quay, not marketplace) to a version that includes the memory leak fix, hopefully resulting in fewer CI flakes. Temporarily switching to quay as a source for CI, because there isn't a version with the fix on Marketplace yet.

## Checklist (Definition of Done)
- [x] ~Unit and integration tests added~
- [x] ~Documentation added if necessary~
- [ ] CI and all relevant tests are passing
- [x] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

N/A