### PR TITLE
expose fleetshard-sync metrics port with name monitoring

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -39,6 +39,9 @@ spec:
           value: {{ .Values.fleetshardSync.staticToken }}
         - name: EGRESS_PROXY_IMAGE
           value: {{ .Values.fleetshardSync.egressProxy.image | quote }}
+        ports:
+        - name: monitoring
+          containerPort: 8080
       {{- if and .Values.fleetshardSync.redHatSSO.clientId .Values.fleetshardSync.redHatSSO.clientSecret (eq .Values.fleetshardSync.authType "RHSSO") }}
         volumeMounts:
           - mountPath: /run/secrets/rhsso-token


### PR DESCRIPTION
## Description
Explicitly expose the metrics port for fleetshard-sync in the deployment description with name "monitoring". This way prometheus should be able to scrape the endpoint.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Documentation added if necessary
- [x] CI and all relevant tests are passing
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
