### PR TITLE
added logic to auto approve rhacs operator installplans

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -125,7 +125,7 @@ helm upgrade rhacs-terraform ./ \
 
 echo "Waiting for unapproved rhacs Operator InstallPlans..."
 for i in $(seq 1 6); do
-  unapprovedInstallPlans=$(oc get installplan -n rhacs -o json | jq '.items[] | select(.spec.approved == true) | select(.spec.clusterServiceVersionNames[] | contains("'$OPERATOR_CSV'")) | [.]')
+  unapprovedInstallPlans=$(oc get installplan -n rhacs -o json | jq '.items[] | select(.spec.approved == false) | select(.spec.clusterServiceVersionNames[] | contains("'$OPERATOR_CSV'")) | [.]')
   if [ ! -z  "$unapprovedInstallPlans" ]
   then
     break


### PR DESCRIPTION
## Description
Since the rhacs operator Subscription is set to Manual approval, we need to approve the initial installation of the ACS Operator. This PR adds some autosensing logic to the terraforming script for data planes to automatically approve InstallPlans created after the helm chart was applied. The InstallPlan is only approved if it matches the desired operator version to prevent from upgrading the operator automatically.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
