### PR TITLE
remove trailing slash for FM_ENDPOINT in prod dp terraforming

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -72,7 +72,7 @@ case $ENVIRONMENT in
     fi
     CLUSTER_ID=$(ocm list cluster "${CLUSTER_NAME}" --no-headers --columns="ID")
 
-    FM_ENDPOINT="https://syqugpy2fa29zqc.api.openshift.com/"
+    FM_ENDPOINT="https://syqugpy2fa29zqc.api.openshift.com"
 
     ensure_bitwarden_session_exists
     # Note: the Red Hat SSO client as of 2022-09-02 is the same between stage and prod.


### PR DESCRIPTION
## Description
Status updates in Prod were failing because of the trailing slash in the FM_ENDPOINT config.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
