### PR TITLE
Improve setup development OSD docs

### DIFF
--- a/docs/development/setup-developer-osd-cluster.md
+++ b/docs/development/setup-developer-osd-cluster.md
@@ -17,19 +17,19 @@ Additionally, you will also require `quay.io` credentials.
 
 All commands should be executed in root directory of `stackrox/acs-fleet-manager` project.
 
-### Create OSD Cluster
+### Create development OSD Cluster
 
-1. Create OSD Cluster with `ocm`
+1. Create development OSD Cluster with `ocm`
 
 Export name for your cluster. Prefix it with your initials or something similar to avoid name collisions. i.e. `mt-osd-1307`
 ```
 export OSD_CLUSTER_NAME="<your cluster name>"
 ```
 
-For staging OSD cluster, you should login to staging platform. You should use `rhacs-managed-service-dev` account. To retrieve token required to login via `ocm` command,
-you have to go to: https://console.redhat.com/openshift/token/show# - login there as `rhacs-managed-service-dev`. You can find login credentials in BitWarden.
+To create development OSD cluster in OCM staging platform, you should login to staging platform. You should use `rhacs-managed-service-dev` account. To retrieve token required to login via `ocm` command,
+you have to go to: https://console.redhat.com/openshift/token/show# - login there as `rhacs-managed-service-dev`. You can find `rhacs-managed-service-dev` login credentials in BitWarden.
 
-The `ocm` command is aware of differences and defining `--url staging` is all what is required in order to login to staging platform.
+The `ocm` command is aware of differences and defining `--url staging` is all what is required in order to login to OCM staging platform.
 ```
 ocm login --url staging --token="<your token from OpenShift console UI - console.redhat.com>
 ```
@@ -332,7 +332,7 @@ After that, you can open the following URL in your browser: https://stage.foo.re
 
 **Note:** Since staging External RedHat SSO is used for authentication, you may have to create your personal account.
 
-### Extend OSD cluster lifetime to 7 days
+### Extend development OSD cluster lifetime to 7 days
 
 By default, staging cluster will be up for 2 days. You can extend it to 7 days. To do that, execute the following command for MacOS:
 ```

--- a/docs/development/setup-developer-osd-cluster.md
+++ b/docs/development/setup-developer-osd-cluster.md
@@ -26,7 +26,10 @@ Export name for your cluster. Prefix it with your initials or something similar 
 export OSD_CLUSTER_NAME="<your cluster name>"
 ```
 
-For staging OSD cluster, you should login to staging platform. You should use `rhacs-managed-service-dev` account. The `ocm` command is aware of differences and defining `--url staging` all what is required in order to login to staging platform.
+For staging OSD cluster, you should login to staging platform. You should use `rhacs-managed-service-dev` account. To retrieve token required to login via `ocm` command,
+you have to go to: https://console.redhat.com/openshift/token/show# - login there as `rhacs-managed-service-dev`. You can find login credentials in BitWarden.
+
+The `ocm` command is aware of differences and defining `--url staging` is all what is required in order to login to staging platform.
 ```
 ocm login --url staging --token="<your token from OpenShift console UI - console.redhat.com>
 ```
@@ -54,7 +57,7 @@ ocm create cluster \
   --region "${AWS_REGION}" \
   --multi-az \
   --compute-machine-type "m5a.xlarge" \
-  --version "4.10.20" \
+  --version "4.11.2" \
   "${OSD_CLUSTER_NAME}"
 ```
 
@@ -75,6 +78,7 @@ If you need password for UI login, be sure to store it somewhere.
 ```
 export OSD_ADMIN_USER="osd-admin"
 export OSD_ADMIN_PASS=$(date | md5)
+echo $OSD_ADMIN_PASS > ./tmp-osd-admin-pass.txt
 
 echo "{\"htpasswd\":{\"password\":\"${OSD_ADMIN_PASS}\",\"username\":\"${OSD_ADMIN_USER}\"},\"login\":true,\"mapping_method\":\"add\",\"name\":\"osd-htpasswd\",\"type\":\"HTPasswdIdentityProvider\"}" > ./tmp-osd-htpasswd-body.txt
 ocm post "/api/clusters_mgmt/v1/clusters/${CLUSTER_ID}/identity_providers" --body ./tmp-osd-htpasswd-body.txt
@@ -94,7 +98,7 @@ If login step fails, it can be the case that previously created auth provider an
 
 4. Export defaults
 ```
-export RHACS_OPERATOR_CATALOG_VERSION="3.70.1"
+export RHACS_OPERATOR_CATALOG_VERSION="3.71.0"
 export RHACS_OPERATOR_CATALOG_NAME="redhat-operators"
 ```
 
@@ -161,7 +165,7 @@ You should be able to see `rhacs-operators` pod running.
 export STATIC_TOKEN=$(bw get item "64173bbc-d9fb-4d4a-b397-aec20171b025" | jq '.fields[] | select(.name | contains("JWT")) | .value' --raw-output)
 
 export FLEET_MANAGER_IMAGE=quay.io/app-sre/acs-fleet-manager:main
-export STARTING_CSV="rhacs-operator.v3.70.1"
+export STARTING_CSV="rhacs-operator.v${RHACS_OPERATOR_CATALOG_VERSION}"
 ```
 
 9. Prepare namespace
@@ -183,7 +187,6 @@ GOARCH=amd64 GOOS=linux CGO_ENABLED=0 make image/build/push/internal
 11. (Optional local fleet synchronizer build) Get Fleet Manager image name
 ```
 export FLEET_MANAGER_IMAGE=$(oc get route default-route -n openshift-image-registry -o jsonpath="{.spec.host}")/${NAMESPACE}/fleet-manager:${IMAGE_TAG}
-export STARTING_CSV="rhacs-operator.v${RHACS_OPERATOR_CATALOG_VERSION}"
 ```
 
 12. Terraform cluster


### PR DESCRIPTION
## Description

This PR is adding a few small improvements to documentation for the setup of a development OSD cluster.

The following things are changed:
- improved step for login via `ocm` command to help with fetching of token
- bumped version of Central operator and improved that only one place is required to be updated in the future
- bumped OSD version to 4.11
- added persisting admin password to a local file. Can be useful if someone closes the shell with env var.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~[ ] Unit and integration tests added~
- [x] Documentation added if necessary
- [x] CI and all relevant tests are passing
- ~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

I didn't test it directly, but this was a list of improvements collected on a few occasions where I helped other team members to set up their env.
