### PR TITLE
ROX-12571: Use explicit egress proxy command to override entrypoint

### DIFF
--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
@@ -38,6 +38,8 @@ spec:
         command:
         - "squid"
         - "-N"
+        - "-f"
+        - "/etc/squid/squid.conf"
         ports:
         - containerPort: 3128
           protocol: TCP

--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
@@ -35,6 +35,9 @@ spec:
       containers:
       - name: egress-proxy
         image: {{ .Values.egressProxy.image }}
+        command:
+        - "squid"
+        - "-N"
         ports:
         - containerPort: 3128
           protocol: TCP


### PR DESCRIPTION
## Description

Specify `command` explicitly for the `egress-proxy` container overrides the entrypoint script. This ensures the egress proxy works with both the `ubuntu/squid` and the `ose-egress-http-proxy` image.

## Checklist (Definition of Done)
- [x] ~Unit and integration tests added~
- [x] ~Documentation added if necessary~
- [ ] CI and all relevant tests are passing
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

- CI
- Tested in "prod"