### PR TITLE
ROX-12182: Set managed service annotation on central CR

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -37,6 +37,8 @@ const (
 	revisionAnnotationKey = "rhacs.redhat.com/revision"
 
 	helmReleaseName = "tenant-resources"
+
+	managedServicesAnnotation = "platform.stackrox.io/managed-services"
 )
 
 // CentralReconcilerOptions are the static options for creating a reconciler.
@@ -105,9 +107,10 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 
 	central := &v1alpha1.Central{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      remoteCentralName,
-			Namespace: remoteCentralNamespace,
-			Labels:    map[string]string{k8s.ManagedByLabelKey: k8s.ManagedByFleetshardValue},
+			Name:        remoteCentralName,
+			Namespace:   remoteCentralNamespace,
+			Labels:      map[string]string{k8s.ManagedByLabelKey: k8s.ManagedByFleetshardValue},
+			Annotations: map[string]string{managedServicesAnnotation: "true"},
 		},
 		Spec: v1alpha1.CentralSpec{
 			Central: &v1alpha1.CentralComponentSpec{

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -194,7 +194,10 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	}
 
 	if !centralExists {
-		central.Annotations = map[string]string{revisionAnnotationKey: "1"}
+		if central.GetAnnotations() == nil {
+			central.Annotations = map[string]string{}
+		}
+		central.GetAnnotations()[revisionAnnotationKey] = "1"
 
 		glog.Infof("Creating central %s/%s", central.GetNamespace(), central.GetName())
 		if err := r.client.Create(ctx, central); err != nil {

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -85,6 +85,7 @@ func TestReconcileCreate(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, centralName, central.GetName())
 	assert.Equal(t, "1", central.GetAnnotations()[revisionAnnotationKey])
+	assert.Equal(t, "true", central.GetAnnotations()[managedServicesAnnotation])
 	assert.Equal(t, true, *central.Spec.Central.Exposure.Route.Enabled)
 
 	route := &openshiftRouteV1.Route{}


### PR DESCRIPTION
## Description

This is a follow-up from [pull/3024](https://github.com/stackrox/stackrox/pull/3024) which introduced a new setting within the helm chart speficially for managed services: `._rox.env.managedServices`.

The operator will set this setting to true if the annoation `platform.stackrox.io/managed-services` is set to true on the central CR.

This will lead to the following:
- OpenShift Auth will be disabled (we don't want customers to get information about the infrastructure their managed central is running on).
- the ROX_MANAGED_CENTRAL variable will be set within central. This leads to certain features being disabled (i.e. basic password login will not be shown within UI and other administrative features will be removed).

## Test manual

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration

# Start fleet manager + fleetshard sync with the usual flags
./fleet-manager serve && ./fleetshard-sync

# Start the operator
make install run

# Create a central and verify on the created instance the following:
#  k describe pod central -> verify the environment variable ROX_MANAGED_CENTRAL is set
```
