### PR TITLE
ROX-12179: Immutable auth provider and groups

### DIFF
--- a/fleetshard/pkg/central/reconciler/init_auth.go
+++ b/fleetshard/pkg/central/reconciler/init_auth.go
@@ -30,6 +30,9 @@ var (
 			return &storage.Group{
 				Props: &storage.GroupProperties{
 					AuthProviderId: providerId,
+					Traits: &storage.Traits{
+						MutabilityMode: storage.Traits_ALLOW_MUTATE_FORCED,
+					},
 				},
 				RoleName: "None",
 			}
@@ -40,6 +43,9 @@ var (
 					AuthProviderId: providerId,
 					Key:            "userid",
 					Value:          auth.OwnerUserId,
+					Traits: &storage.Traits{
+						MutabilityMode: storage.Traits_ALLOW_MUTATE_FORCED,
+					},
 				},
 				RoleName: "Admin",
 			}
@@ -50,6 +56,9 @@ var (
 					AuthProviderId: providerId,
 					Key:            "groups",
 					Value:          "org_admin",
+					Traits: &storage.Traits{
+						MutabilityMode: storage.Traits_ALLOW_MUTATE_FORCED,
+					},
 				},
 				RoleName: "Admin",
 			}
@@ -152,6 +161,9 @@ func createAuthProviderRequest(central private.ManagedCentral) *storage.AuthProv
 				AttributeKey:   "orgid",
 				AttributeValue: central.Spec.Auth.OwnerOrgId,
 			},
+		},
+		Traits: &storage.Traits{
+			MutabilityMode: storage.Traits_ALLOW_MUTATE_FORCED,
 		},
 	}
 	return request


### PR DESCRIPTION
## Description
Following up on https://issues.redhat.com/browse/ROX-11017 to make auth provider and groups created by `fleetshard-sync` immutable

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
None
