### PR TITLE
Test Env: Update yq to get rid of annoying deprecation warnings.

### DIFF
--- a/.openshift-ci/build-root/Dockerfile
+++ b/.openshift-ci/build-root/Dockerfile
@@ -36,31 +36,41 @@ RUN rm -f /etc/yum.repos.d/* && { \
 
 RUN dnf update -y && dnf -y install make which git gettext jq gcc
 
-RUN curl -L --retry 10 --silent --show-error --fail -o /tmp/go1.17.12.linux-amd64.tar.gz \
-    https://go.dev/dl/go1.17.12.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf /tmp/go1.17.12.linux-amd64.tar.gz && \
-    rm -f /tmp/go1.17.12.linux-amd64.tar.gz
+ARG GO_VERSION=1.17.12
+RUN curl -L --retry 10 --silent --show-error --fail -o /tmp/go.linux-amd64.tar.gz \
+    "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \
+    tar -C /usr/local -xzf /tmp/go.linux-amd64.tar.gz && \
+    rm -f /tmp/go.linux-amd64.tar.gz
 ENV PATH="/usr/local/go/bin:${PATH}"
 
-RUN curl -L --retry 10 --silent --show-error --fail -o "/usr/local/bin/yq" \
-    https://github.com/mikefarah/yq/releases/download/v4.2.0/yq_linux_amd64 && \
-    chmod +x /usr/local/bin/yq
+ARG YQ_VERSION=4.27.5
+RUN curl -L --retry 10 --silent --show-error --fail -o /tmp/yq_linux_amd64.tar.gz \
+    "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64.tar.gz" && \
+    tar -xzf /tmp/yq_linux_amd64.tar.gz ./yq_linux_amd64 && \
+    mv yq_linux_amd64 /usr/local/bin/yq && \
+    chmod +x /usr/local/bin/yq && \
+    rm /tmp/yq_linux_amd64.tar.gz
 
-RUN curl -L --retry 10 --silent --show-error --fail -O https://nodejs.org/dist/v16.15.1/node-v16.15.1-linux-x64.tar.gz && \
+ARG NODE_VERSION=16.15.1
+RUN curl -L --retry 10 --silent --show-error --fail -o /tmp/node-linux-x64.tar.gz \
+    "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz" && \
     mkdir -p /usr/local/lib/nodejs && \
-    tar -xzf node-v16.15.1-linux-x64.tar.gz -C /usr/local/lib/nodejs && \
-    rm node-v16.15.1-linux-x64.tar.gz
-ENV PATH="/usr/local/lib/nodejs/node-v16.15.1-linux-x64/bin:${PATH}"
+    tar -xzf /tmp/node-linux-x64.tar.gz -C /usr/local/lib/nodejs && \
+    rm /tmp/node-linux-x64.tar.gz
+ENV PATH="/usr/local/lib/nodejs/node-v${NODE_VERSION}-linux-x64/bin:${PATH}"
 
+ARG STERN_VERSION="1.11.0"
 RUN curl -L --retry 10 --silent --show-error --fail -o "/usr/local/bin/stern" \
-    https://github.com/wercker/stern/releases/download/1.11.0/stern_linux_amd64 && \
+    "https://github.com/wercker/stern/releases/download/${STERN_VERSION}/stern_linux_amd64" && \
     chmod +x /usr/local/bin/stern
 
-RUN curl -L --retry 10 --silent --show-error --fail -O https://github.com/gotestyourself/gotestsum/releases/download/v1.8.1/gotestsum_1.8.1_linux_amd64.tar.gz && \
-    tar -xzvf gotestsum_1.8.1_linux_amd64.tar.gz gotestsum && \
+ARG GOTESTSUM_VERSION=1.8.1
+RUN curl -L --retry 10 --silent --show-error --fail -o /tmp/gotestsum_linux_amd64.tar.gz \
+    "https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz" && \
+    tar -xzvf /tmp/gotestsum_linux_amd64.tar.gz gotestsum && \
     mv gotestsum /usr/local/bin && \
     chmod +x /usr/local/bin/gotestsum && \
-    rm gotestsum_1.8.1_linux_amd64.tar.gz
+    rm /tmp/gotestsum_linux_amd64.tar.gz
 
 RUN mkdir -p /stackrox/crds && \
     curl -L --retry 10 --silent --show-error --fail -o /stackrox/crds/platform.stackrox.io_centrals.yaml \
@@ -68,8 +78,9 @@ RUN mkdir -p /stackrox/crds && \
     curl -L --retry 10 --silent --show-error --fail -o /stackrox/crds/platform.stackrox.io_securedclusters.yaml \
     https://raw.githubusercontent.com/stackrox/stackrox/release/3.70.x/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
 
+ARG OCM_VERSION=0.1.64
 RUN curl -L --retry 10 --silent --show-error --fail -o "/usr/local/bin/ocm" \
-    https://github.com/openshift-online/ocm-cli/releases/download/v0.1.64/ocm-linux-amd64 && \
+    "https://github.com/openshift-online/ocm-cli/releases/download/v${OCM_VERSION}/ocm-linux-amd64" && \
     chmod +x /usr/local/bin/ocm
 
 ARG GOPATH=/go

--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -236,13 +236,13 @@ wait_for_default_service_account() {
 assemble_kubeconfig() {
     kubeconf=$($KUBECTL config view --minify=true --raw=true 2>/dev/null)
     CONTEXT_NAME=$(echo "$kubeconf" | yq e .current-context -)
-    CONTEXT="$(echo "$kubeconf" | yq e ".contexts[] | select(.name == \"${CONTEXT_NAME}\")" -j - | jq -c)"
+    CONTEXT="$(echo "$kubeconf" | yq e ".contexts[] | select(.name == \"${CONTEXT_NAME}\")" -o=json - | jq -c)"
     USER_NAME=$(echo "$CONTEXT" | jq -r .context.user -)
     CLUSTER_NAME=$(echo "$CONTEXT" | jq -r .context.cluster -)
-    CLUSTER=$(echo "$kubeconf" | yq e ".clusters[] | select(.name == \"${CLUSTER_NAME}\")" -j - | jq -c)
+    CLUSTER=$(echo "$kubeconf" | yq e ".clusters[] | select(.name == \"${CLUSTER_NAME}\")" -o=json - | jq -c)
     NEW_CONTEXT_NAME="$CLUSTER_NAME"
     CONTEXT=$(echo "$CONTEXT" | jq ".name = \"$NEW_CONTEXT_NAME\"" -c -)
-    KUBEUSER="$(echo "$kubeconf" | yq e ".users[] | select(.name == \"${USER_NAME}\")" -j - | jq -c)"
+    KUBEUSER="$(echo "$kubeconf" | yq e ".users[] | select(.name == \"${USER_NAME}\")" -o=json - | jq -c)"
 
     if [[ "$KUBECONF_CLUSTER_SERVER_OVERRIDE" == "true" ]]; then
         local server


### PR DESCRIPTION
## Description

Update yq in root Dockerfile (also: turn version numbers into ARGs to separate them from the Dockerfile RUN commands).
Use the newer invocation style for yq, getting rid of warnings like: Flag --tojson has been deprecated, please use -o=json instead.

CI e2e run should fail, since the change in `yq` is already taking effect but the build-root Dockerfile is taken from the main branch.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
