### PR TITLE
Fix acquiring lease for central_auth_config worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ cmd/fleet-manager/fleet-manager
 /secrets/sentry.*
 /secrets/redhatsso-service.*
 /secrets/keycloak-service.crt
+/secrets/central.idp*
 
 # cluster details (used for testing)
 /internal/dinosaur/test/integration/test_cluster.json

--- a/internal/dinosaur/pkg/migrations/202209141000_add_central_auth_lease_type.go
+++ b/internal/dinosaur/pkg/migrations/202209141000_add_central_auth_lease_type.go
@@ -1,0 +1,40 @@
+package migrations
+
+// Migrations should NEVER use types from other packages. Types can change
+// and then migrations run on a _new_ database will fail or behave unexpectedly.
+// Instead of importing types, always re-create the type in the migration, as
+// is done here, even though the same type is defined in pkg/api
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/stackrox/acs-fleet-manager/pkg/api"
+	"github.com/stackrox/acs-fleet-manager/pkg/db"
+	"gorm.io/gorm"
+)
+
+const centralAuthLeaseType = "central_auth_config"
+
+// addCentralAuthLease adds a leader lease value for the central_auth_config lease and its
+// worker.
+// It is similar to addLeaderLease.
+func addCentralAuthLease() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "202209141000",
+		Migrate: func(tx *gorm.DB) error {
+			// Set an initial already expired lease for central_auth_config.
+			err := tx.Create(&api.LeaderLease{
+				Expires:   &db.DinosaurAdditionalLeasesExpireTime,
+				LeaseType: centralAuthLeaseType,
+				Leader:    api.NewID(),
+			}).Error
+
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return nil
+		},
+	}
+}

--- a/internal/dinosaur/pkg/migrations/migrations.go
+++ b/internal/dinosaur/pkg/migrations/migrations.go
@@ -32,6 +32,7 @@ var migrations = []*gormigrate.Migration{
 	addOwnerUserIDToCentralRequest(),
 	addResourcesToCentralRequest(),
 	addAuthConfigToCentralRequest(),
+	addCentralAuthLease(),
 }
 
 // New ...


### PR DESCRIPTION
## Description

Witihin [pull/334](https://github.com/stackrox/acs-fleet-manager/pull/334) we've added a new worker type `central_auth_config`, which is responsible later on for creating the dynamic OIDC client for central's auth provider.

When starting the fleet manager, you will receive the following error message within the logs:
```
I0914 03:20:12.406221   24111 leader_election_mgr.go:127] failed to acquire leader lease: expected to find a lease entry, found none for :central_auth_config
```

Diving deeper into the code of leader_election_mgr, we see the following lines that are the culprit of the error ([code 
ref](https://github.com/stackrox/acs-fleet-manager/blob/a0d43f031545373c2fe7c774619260c26decb4fc/pkg/workers/leader_election_mgr.go#L151-L154):
```go
	// we failed to read the current lease, we always expect a single lease to exist, create one so that worker can proceed.
	if len(leaseList) == 0 {
		return nil, errors.Errorf("expected to find a lease entry, found none for :%s", workerType)
	}
```

This error is due to no `LeaderLease` entry being present within the database.
The leader election expects _at least_ one entry to be present within the database.
Looking at [the initial migration that introduced the LeaderLease type](https://github.com/stackrox/acs-fleet-manager/blob/4a473d523afd7c729802473c35b167a92e2ad825/internal/dinosaur/pkg/migrations/20220114114503_add_leader_lease.go) we see that each type a.k.a. worker type got a expired lease entry added within the database.

Mimicking the same behavior, an additional migration has been added that will create such an entry within the database and the leader election will work as expected.

Interestingly, this behavior is not the case for the E2E tests. That's due to setting the `ForceLeader` flag, which will essentially skip the whole acquiring of the lease ([pull/218 introduced this](https://github.com/stackrox/acs-fleet-manager/pull/218)). It might be worthwhile to revert this and have leader election being a part of the E2E tests, as this particular issue could have been detected by them (if there's no obvious reason to disable it, of course).

My suspision is that, if this commit is deployed within stage / prod, the provisioning of any cluster will fail, but that needs to be confirmed by checking the logs of the environments.


## Test manual

```
# Run the database migration
make db/migrate

# Run fleet manager locally
./fleet-manager serve

# Observe within the logs that all leases have been successfully acquired
```
