### PR TITLE
Fail if CENTRAL_IDP_CLIENT_SECRET is not set

### DIFF
--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -86,6 +86,10 @@ init() {
         source "$env_file"
     done
 
+    if [[ -z "${CENTRAL_IDP_CLIENT_SECRET}" ]]; then
+      die "Error: CENTRAL_IDP_CLIENT_SECRET not set. Please make sure that it is initialized properly."
+    done
+
     export KUBECTL=${KUBECTL:-$KUBECTL_DEFAULT}
     export ACSMS_NAMESPACE="${ACSMS_NAMESPACE:-$ACSMS_NAMESPACE_DEFAULT}"
     export CLUSTER_ID=${CLUSTER_ID:-$CLUSTER_ID_DEFAULT}

--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -86,7 +86,7 @@ init() {
         source "$env_file"
     done
 
-    if [[ -z "${CENTRAL_IDP_CLIENT_SECRET}" ]]; then
+    if [[ -z "${CENTRAL_IDP_CLIENT_SECRET:-}" ]]; then
       die "Error: CENTRAL_IDP_CLIENT_SECRET not set. Please make sure that it is initialized properly."
     done
 

--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -88,7 +88,7 @@ init() {
 
     if [[ -z "${CENTRAL_IDP_CLIENT_SECRET:-}" ]]; then
       die "Error: CENTRAL_IDP_CLIENT_SECRET not set. Please make sure that it is initialized properly."
-    done
+    fi
 
     export KUBECTL=${KUBECTL:-$KUBECTL_DEFAULT}
     export ACSMS_NAMESPACE="${ACSMS_NAMESPACE:-$ACSMS_NAMESPACE_DEFAULT}"


### PR DESCRIPTION
## Description

QoL change that will ensure we error out within the `init` function that is called when running `.openshift-ci/tests/e2e-test.sh` if `CENTRAL_IDP_CLIENT_SECRET` is not set.

If the variable is not set, central will be unable to start.
