### PR TITLE
Fix OpenShift router deployment for k8s clusters

### DIFF
--- a/scripts/openshift-router.sh
+++ b/scripts/openshift-router.sh
@@ -4,10 +4,10 @@ set -eo pipefail
 
 SCRIPT_DIR=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 
-ROUTER_RBAC_YAML="https://raw.githubusercontent.com/openshift/router/master/deploy/router_rbac.yaml"
-ROUTER_CRD_YAML="https://raw.githubusercontent.com/openshift/api/master/route/v1/route.crd.yaml"
-ROUTER_DEPLOYMENT_YAML="https://raw.githubusercontent.com/openshift/router/master/deploy/router.yaml"
-APPS_OPENSHIFT_CRD_YAML="$SCRIPT_DIR/../dev/env/manifests/openshift-router/01-apps-openshift-dummy.crd.yaml"
+ROUTER_RBAC_YAML="https://raw.githubusercontent.com/openshift/router/release-4.11/deploy/router_rbac.yaml"
+ROUTER_CRD_YAML="https://raw.githubusercontent.com/openshift/router/release-4.11/deploy/route_crd.yaml"
+ROUTER_DEPLOYMENT_YAML="https://raw.githubusercontent.com/openshift/router/release-4.11/deploy/router.yaml"
+APPS_OPENSHIFT_CRD_YAML="$SCRIPT_DIR/../dev/env/manifests/openshift-router/00-apps-openshift-dummy.crd.yaml"
 HOSTCTL_PROFILE="acs"
 KUBECTL=${KUBECTL:-kubectl}
 


### PR DESCRIPTION
## Description

This pull request fixes the openshift route deployment. The YAML manifests are pinned to the latest version, now our pin to 4.11.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

 - Manual testing running `make deploy/openshift-router`
