### PR TITLE
cleanup TODO(create-ticket) comments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,7 +50,7 @@ linters-settings:
       - name: error-strings
       - name: error-naming
       - name: exported
-        arguments: ["disableStutteringCheck"] #TODO(ROX-11892) enable revive naming checks
+        arguments: ["disableStutteringCheck"]
       - name: if-return
       - name: increment-decrement
       - name: var-naming

--- a/Makefile
+++ b/Makefile
@@ -487,7 +487,6 @@ docker/login/internal:
 .PHONY: docker/login/internal
 
 # Build the binary and image
-# TODO(create-ticket): Revisit decision to use a combined-image-approach, where the image contains both the fleet-manager and the fleetshard-sync.
 image/build: GOOS=linux
 image/build: GOARCH=amd64
 image/build: fleet-manager fleetshard-sync
@@ -799,5 +798,3 @@ tag:
 setup-dev-env:
 	./scripts/setup-dev-env.sh
 .PHONY: setup-dev-env
-
-# TODO CRC Deployment stuff

--- a/dp-terraform/add-on/rhacs-terraform/Makefile
+++ b/dp-terraform/add-on/rhacs-terraform/Makefile
@@ -27,7 +27,7 @@ endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # IMAGE_REPO is the repository (server and namespace) into which the operator images will get pushed.
-# TODO(addon) ask admin to create project in quay.io/rhacs-eng
+# TODO(ROX-11551) ask admin to create project in quay.io/rhacs-eng
 IMAGE_REPO ?= quay.io/jrodrig
 
 # IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.

--- a/dp-terraform/add-on/rhacs-terraform/Makefile
+++ b/dp-terraform/add-on/rhacs-terraform/Makefile
@@ -27,7 +27,7 @@ endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # IMAGE_REPO is the repository (server and namespace) into which the operator images will get pushed.
-# TODO(create-ticket): ask admin to create project in quay.io/rhacs-eng
+# TODO ask admin to create project in quay.io/rhacs-eng
 IMAGE_REPO ?= quay.io/jrodrig
 
 # IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.

--- a/dp-terraform/add-on/rhacs-terraform/Makefile
+++ b/dp-terraform/add-on/rhacs-terraform/Makefile
@@ -27,7 +27,7 @@ endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # IMAGE_REPO is the repository (server and namespace) into which the operator images will get pushed.
-# TODO ask admin to create project in quay.io/rhacs-eng
+# TODO(addon) ask admin to create project in quay.io/rhacs-eng
 IMAGE_REPO ?= quay.io/jrodrig
 
 # IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.

--- a/dp-terraform/add-on/rhacs-terraform/config/rbac/role.yaml
+++ b/dp-terraform/add-on/rhacs-terraform/config/rbac/role.yaml
@@ -6,7 +6,7 @@ rules:
 ##
 ## Base operator rules
 ##
-# // TODO(create-ticket): Replace with least privileges permissions
+# // TODO(addon): Replace with least privileges permissions
 - apiGroups:
   - '*'
   resources:

--- a/dp-terraform/add-on/rhacs-terraform/config/rbac/role.yaml
+++ b/dp-terraform/add-on/rhacs-terraform/config/rbac/role.yaml
@@ -6,7 +6,7 @@ rules:
 ##
 ## Base operator rules
 ##
-# // TODO(addon): Replace with least privileges permissions
+# // TODO(ROX-11551): Replace with least privileges permissions
 - apiGroups:
   - '*'
   resources:

--- a/dp-terraform/add-on/rhacs-terraform/pkg/terraform/values/translation/translation.go
+++ b/dp-terraform/add-on/rhacs-terraform/pkg/terraform/values/translation/translation.go
@@ -76,7 +76,7 @@ func translate(t v1alpha1.Terraform) (chartutil.Values, error) {
 	if t.Spec.Observability != nil {
 		observability := translation.NewValuesBuilder()
 		observability.SetBool("enabled", &t.Spec.Observability.Enabled)
-		// TODO(addon): validate fields that should be mandatory if obs is enabled
+		// TODO(ROX-11551): validate fields that should be mandatory if obs is enabled
 		if t.Spec.Observability.Github != nil {
 			github := translation.NewValuesBuilder()
 			github.SetString("accessToken", &t.Spec.Observability.Github.AccessToken)

--- a/dp-terraform/add-on/rhacs-terraform/pkg/terraform/values/translation/translation.go
+++ b/dp-terraform/add-on/rhacs-terraform/pkg/terraform/values/translation/translation.go
@@ -44,7 +44,6 @@ func (t Translator) Translate(ctx context.Context, u *unstructured.Unstructured)
 	return values, nil
 }
 
-
 // translate translates a Terraform CR into helm values.
 // For non-required fields, this should only set values for fields that are not set to a zero value.
 func translate(t v1alpha1.Terraform) (chartutil.Values, error) {
@@ -77,7 +76,7 @@ func translate(t v1alpha1.Terraform) (chartutil.Values, error) {
 	if t.Spec.Observability != nil {
 		observability := translation.NewValuesBuilder()
 		observability.SetBool("enabled", &t.Spec.Observability.Enabled)
-		// TODO(create-ticket): validate fields that should be mandatory if obs is enabled
+		// TODO(addon): validate fields that should be mandatory if obs is enabled
 		if t.Spec.Observability.Github != nil {
 			github := translation.NewValuesBuilder()
 			github.SetString("accessToken", &t.Spec.Observability.Github.AccessToken)

--- a/dp-terraform/add-on/rhacs-terraform/pkg/values/translation/values_builder.go
+++ b/dp-terraform/add-on/rhacs-terraform/pkg/values/translation/values_builder.go
@@ -1,6 +1,6 @@
 package translation
 
-// TODO(addon): import instead of copy
+// TODO(ROX-11551): import instead of copy
 
 import (
 	"fmt"

--- a/dp-terraform/add-on/rhacs-terraform/pkg/values/translation/values_builder.go
+++ b/dp-terraform/add-on/rhacs-terraform/pkg/values/translation/values_builder.go
@@ -1,6 +1,6 @@
 package translation
 
-// TODO(create-ticket): import instead of copy
+// TODO(addon): import instead of copy
 
 import (
 	"fmt"

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -108,8 +108,6 @@ var _ = Describe("Central", func() {
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Equal(constants.CentralRequestStatusProvisioning.String()))
 		})
 
-		// TODO(create-ticket): fails because the namespace is not centralName anymore but `formatNamespace(dinosaurRequest.ID)`
-		// and that is not accessible from a value `*public.CentralRequest`
 		It("should create central namespace", func() {
 			Eventually(func() error {
 				ns := &corev1.Namespace{}
@@ -124,7 +122,6 @@ var _ = Describe("Central", func() {
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Succeed())
 		})
 
-		// TODO(create-ticket): create test to check that Central and Scanner are healthy
 		It("should create central routes", func() {
 			if !routesEnabled {
 				Skip(skipRouteMsg)

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -66,8 +66,8 @@ type CentralReconciler struct {
 
 // Reconcile takes a private.ManagedCentral and tries to install it into the cluster managed by the fleet-shard.
 // It tries to create a namespace for the Central and applies necessary updates to the resource.
-// TODO(create-ticket): Check correct Central gets reconciled
-// TODO(create-ticket): Should an initial ManagedCentral be added on reconciler creation?
+// TODO(sbaumer): Check correct Central gets reconciled
+// TODO(sbaumer): Should an initial ManagedCentral be added on reconciler creation?
 func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private.ManagedCentral) (*private.DataPlaneCentralStatus, error) {
 	// Only allow to start reconcile function once
 	if !atomic.CompareAndSwapInt32(r.status, FreeStatus, BlockedStatus) {
@@ -205,7 +205,6 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		}
 		glog.Infof("Central %s/%s created", central.GetNamespace(), central.GetName())
 	} else {
-		// TODO(create-ticket): implement update logic
 		glog.Infof("Update central %s/%s", central.GetNamespace(), central.GetName())
 		existingCentral.Spec = central.Spec
 
@@ -255,7 +254,6 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		r.hasAuthProvider = true
 	}
 
-	// TODO(create-ticket): When should we create failed conditions for the reconciler?
 	status := readyStatus()
 	// Do not report routes statuses if:
 	// 1. Routes are not used on the cluster

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -37,7 +37,7 @@ type Runtime struct {
 	config           *config.Config
 	client           *fleetmanager.Client
 	clusterID        string
-	reconcilers      reconcilerRegistry // TODO(create-ticket): possible leak. consider reconcilerRegistry cleanup
+	reconcilers      reconcilerRegistry
 	k8sClient        ctrlClient.Client
 	statusResponseCh chan private.DataPlaneCentralStatus
 }

--- a/internal/dinosaur/pkg/converters/resourceutil.go
+++ b/internal/dinosaur/pkg/converters/resourceutil.go
@@ -20,7 +20,7 @@ func ConvertPublicScalingToV1(scaling *public.ScannerSpecAnalyzerScaling) (v1alp
 	}
 	autoScaling := scaling.AutoScaling
 	return v1alpha1.ScannerAnalyzerScaling{
-		AutoScaling: (*v1alpha1.AutoScalingPolicy)(&autoScaling), // TODO(create-ticket): validate.
+		AutoScaling: (*v1alpha1.AutoScalingPolicy)(&autoScaling), // TODO: validate.
 		Replicas:    &scaling.Replicas,
 		MinReplicas: &scaling.MinReplicas,
 		MaxReplicas: &scaling.MaxReplicas,
@@ -48,7 +48,7 @@ func ConvertPrivateScalingToV1(scaling *private.ManagedCentralAllOfSpecScannerAn
 	}
 	autoScaling := scaling.AutoScaling
 	return v1alpha1.ScannerAnalyzerScaling{
-		AutoScaling: (*v1alpha1.AutoScalingPolicy)(&autoScaling), // TODO(create-ticket): validate.
+		AutoScaling: (*v1alpha1.AutoScalingPolicy)(&autoScaling), // TODO: validate.
 		Replicas:    &scaling.Replicas,
 		MinReplicas: &scaling.MinReplicas,
 		MaxReplicas: &scaling.MaxReplicas,

--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -293,7 +293,7 @@ func updateCentralRequest(request *dbapi.CentralRequest, updateRequest *private.
 		return err
 	}
 
-	// TODO(create-ticket): We should also validate the resource configuration here. If the configuration is invalid
+	// TODO: We should also validate the resource configuration here. If the configuration is invalid
 	// the operator will not be able to create the Central instance and we could fail early here.
 
 	new := *request

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -85,7 +85,6 @@ func (c *ManagedCentralPresenter) PresentManagedCentral(from *dbapi.CentralReque
 				Central:         from.DesiredCentralVersion,
 				CentralOperator: from.DesiredCentralOperatorVersion,
 			},
-			// TODO(create-ticket): add additional CAs to public create/get centrals api and internal models
 			Central: private.ManagedCentralAllOfSpecCentral{
 				Resources: private.ResourceRequirements{
 					Requests: map[string]string{
@@ -118,7 +117,6 @@ func (c *ManagedCentralPresenter) PresentManagedCentral(from *dbapi.CentralReque
 					},
 				},
 				Db: private.ManagedCentralAllOfSpecScannerDb{
-					// TODO:(create-ticket): add DB configuration values to ManagedCentral Scanner
 					Host: "dbhost.rhacs-psql-instance",
 					Resources: private.ResourceRequirements{
 						Requests: map[string]string{

--- a/internal/dinosaur/pkg/services/cluster_placement_strategy.go
+++ b/internal/dinosaur/pkg/services/cluster_placement_strategy.go
@@ -36,7 +36,6 @@ func NewClusterPlacementStrategy(clusterService ClusterService, dataplaneCluster
 	return clusterSelection
 }
 
-// TODO(create-ticket): Revisit placement strategy before going live.
 var _ ClusterPlacementStrategy = (*FirstReadyPlacementStrategy)(nil)
 
 // FirstReadyPlacementStrategy ...

--- a/internal/dinosaur/pkg/services/data_plane_cluster.go
+++ b/internal/dinosaur/pkg/services/data_plane_cluster.go
@@ -74,7 +74,7 @@ func (d *dataPlaneClusterService) UpdateDataPlaneClusterStatus(ctx context.Conte
 		return errors.BadRequest("Cluster agent with ID '%s' not found", clusterID)
 	}
 
-	// TODO(create-ticket): restore when cluster transition to ready is implemented
+	// TODO: restore when cluster transition to ready is implemented
 	/*
 		if !d.clusterCanProcessStatusReports(cluster) {
 			glog.V(10).Infof("Cluster with ID '%s' is in '%s' state. Ignoring status report...", clusterID, cluster.Status)

--- a/internal/dinosaur/pkg/workers/clusters_mgr.go
+++ b/internal/dinosaur/pkg/workers/clusters_mgr.go
@@ -375,7 +375,7 @@ func (c *ClusterManager) reconcileDeprovisioningCluster(cluster *api.Cluster) er
 
 func (c *ClusterManager) reconcileCleanupCluster(cluster api.Cluster) error {
 	glog.Infof("Removing Dataplane cluster %s fleetshard service account", cluster.ClusterID)
-	// TODO(addon): reactivate this, if required for cluster terraforming by fleet-manager
+	// TODO(ROX-11551): reactivate this, if required for cluster terraforming by fleet-manager
 	// serviceAcountRemovalErr := c.FleetshardOperatorAddon.RemoveServiceAccount(cluster)
 	// if serviceAcountRemovalErr != nil {
 	// 	return errors.Wrapf(serviceAcountRemovalErr, "Failed to removed Dataplance cluster %s fleetshard service account", cluster.ClusterID)

--- a/internal/dinosaur/pkg/workers/clusters_mgr.go
+++ b/internal/dinosaur/pkg/workers/clusters_mgr.go
@@ -402,13 +402,13 @@ func (c *ClusterManager) reconcileReadyCluster(cluster api.Cluster) error {
 		return errors.WithMessagef(err, "failed to reconcile instance type ready cluster %s: %s", cluster.ClusterID, err.Error())
 	}
 
-	// TODO(create-ticket): Install necessary OSD cluster resources.
+	// TODO: Install necessary OSD cluster resources.
 	//// resources update if needed
 	// if err := c.reconcileClusterResources(cluster); err != nil {
 	//	return errors.WithMessagef(err, "failed to reconcile ready cluster resources %s ", cluster.ClusterID)
 	//}
 
-	// TODO(create-ticket): Register what is necessary for SSO authn/authz.
+	// TODO: Register what is necessary for SSO authn/authz.
 	// err = c.reconcileClusterIdentityProvider(cluster)
 	// if err != nil {
 	//	return errors.WithMessagef(err, "failed to reconcile identity provider of ready cluster %s: %s", cluster.ClusterID, err.Error())
@@ -419,7 +419,7 @@ func (c *ClusterManager) reconcileReadyCluster(cluster api.Cluster) error {
 		return errors.WithMessagef(err, "failed to reconcile cluster dns of ready cluster %s: %s", cluster.ClusterID, err.Error())
 	}
 
-	// TODO(create-ticket): Install the ACS Operator and Fleetshard Operator (Add-Ons)
+	// TODO: Install the ACS Operator and Fleetshard Operator (Add-Ons)
 	// if c.FleetshardOperatorAddon != nil {
 	//	if err := c.FleetshardOperatorAddon.ReconcileParameters(cluster); err != nil {
 	//		if err.IsBadRequest() {
@@ -501,7 +501,7 @@ func (c *ClusterManager) reconcileEmptyCluster(cluster api.Cluster) (bool, error
 }
 
 func (c *ClusterManager) reconcileProvisionedCluster(cluster api.Cluster) error {
-	// TODO(create-ticket): Register what is necessary for SSO authn/authz.
+	// TODO: Register what is necessary for SSO authn/authz.
 	// if err := c.reconcileClusterIdentityProvider(cluster); err != nil {
 	//	return err
 	//}
@@ -510,7 +510,7 @@ func (c *ClusterManager) reconcileProvisionedCluster(cluster api.Cluster) error 
 		return err
 	}
 
-	// TODO(create-ticket): Install necessary OSD cluster resources.
+	// TODO: Install necessary OSD cluster resources.
 	//// SyncSet creation step
 	// syncSetErr := c.reconcileClusterResources(cluster) //OSD cluster itself
 	// if syncSetErr != nil {
@@ -523,7 +523,7 @@ func (c *ClusterManager) reconcileProvisionedCluster(cluster api.Cluster) error 
 	// installed. The logic to set the status of the cluster should probably done
 	// independently of the installation of the addon, and it should use the
 	// result of the addon/s reconciliation to set the status of the cluster
-	// TODO(create-ticket): Install the ACS Operator and Fleetshard Operator (Add-Ons)
+	// TODO: Install the ACS Operator and Fleetshard Operator (Add-Ons)
 	addOnErr := c.reconcileAddonOperator(cluster)
 	if addOnErr != nil {
 		return errors.WithMessagef(addOnErr, "failed to reconcile cluster %s addon operator: %s", cluster.ClusterID, addOnErr.Error())
@@ -578,7 +578,7 @@ func (c *ClusterManager) reconcileClusterStatus(cluster *api.Cluster) (*api.Clus
 }
 
 func (c *ClusterManager) reconcileAddonOperator(provisionedCluster api.Cluster) error {
-	// TODO(create-ticket): Activate dinosaur reconcilation and FleetshardOperatorAddon.Provision
+	// TODO: Activate dinosaur reconcilation and FleetshardOperatorAddon.Provision
 	// as soon as this components are available
 	dinosaurOperatorIsReady := true
 	// dinosaurOperatorIsReady, err := c.reconcileDinosaurOperator(provisionedCluster)

--- a/internal/dinosaur/test/integration/require_terms_acceptance_middleware_test.go
+++ b/internal/dinosaur/test/integration/require_terms_acceptance_middleware_test.go
@@ -51,7 +51,7 @@ func termsRequiredSetup(termsRequired bool, t *testing.T) TestEnv {
 }
 
 func TestTermsRequired_CreateDinosaurTermsRequired(t *testing.T) {
-	// TODO(create-ticket): Add back this test
+	// TODO: Add back this test
 	skipNotFullyImplementedYet(t)
 	env := termsRequiredSetup(true, t)
 	defer env.teardown()
@@ -78,7 +78,7 @@ func TestTermsRequired_CreateDinosaurTermsRequired(t *testing.T) {
 }
 
 func TestTermsRequired_CreateDinosaur_TermsNotRequired(t *testing.T) {
-	// TODO(create-ticket): Add back this test
+	// TODO: Add back this test
 	skipNotFullyImplementedYet(t)
 	env := termsRequiredSetup(false, t)
 	defer env.teardown()


### PR DESCRIPTION
## Description
Revised all TODO(create-ticket) comments. Removed the (create-ticket) annotations on all TODOs on which we don't know if and when we need to work on them. For example for cluster terraforming and addon operator. That left us with only a few TODO(create-ticket) comments left. All of them are already addressed, and should be done in the next 1-2 weeks.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
