### PR TITLE
ROX-12076: probe service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,8 @@ verify: check-gopath openapi/validate
 		./pkg/... \
 		./internal/... \
 		./test/... \
-		./fleetshard/...
+		./fleetshard/... \
+		./probe/...
 .PHONY: verify
 
 # Runs linter against go files and .y(a)ml files in the templates directory
@@ -284,7 +285,8 @@ lint: golangci-lint specinstall
 		./pkg/... \
 		./internal/... \
 		./test/... \
-		./fleetshard/...
+		./fleetshard/... \
+		./probe/...
 
 	spectral lint templates/*.yml templates/*.yaml --ignore-unknown-format --ruleset .validate-templates.yaml
 .PHONY: lint
@@ -300,7 +302,11 @@ fleetshard-sync:
 	GOOS="$(GOOS)" GOARCH="$(GOARCH)" $(GO) build $(GOARGS) -o fleetshard-sync ./fleetshard
 .PHONY: fleetshard-sync
 
-binary: fleet-manager fleetshard-sync
+probe:
+	GOOS="$(GOOS)" GOARCH="$(GOARCH)" $(GO) build $(GOARGS) -o probe/bin ./probe
+.PHONY: probe
+
+binary: fleet-manager fleetshard-sync probe
 .PHONY: binary
 
 # Install
@@ -309,7 +315,7 @@ install: verify lint
 .PHONY: install
 
 clean:
-	rm -f fleet-manager fleetshard-sync
+	rm -f fleet-manager fleetshard-sync probe
 .PHONY: clean
 
 # Runs the unit tests.

--- a/dp-terraform/add-on/rhacs-terraform/api/v1alpha1/terraform_types.go
+++ b/dp-terraform/add-on/rhacs-terraform/api/v1alpha1/terraform_types.go
@@ -7,14 +7,14 @@ import (
 type Terraform struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec TerraformSpec `json:"spec,omitempty"`
-	Status TerraformStatus `json:"status,omitempty"`
+	Spec              TerraformSpec   `json:"spec,omitempty"`
+	Status            TerraformStatus `json:"status,omitempty"`
 }
 
 type TerraformSpec struct {
 	FleetshardSync *FleetshardSyncSpec `json:"fleetshardSync,omitempty"`
-	AcsOperator *AcsOperatorSpec `json:"acsOperator,omitempty"`
-	Observability *ObservabilitySpec `json:"observability,omitempty"`
+	AcsOperator    *AcsOperatorSpec    `json:"acsOperator,omitempty"`
+	Observability  *ObservabilitySpec  `json:"observability,omitempty"`
 }
 
 type TerraformStatus struct {
@@ -22,35 +22,35 @@ type TerraformStatus struct {
 }
 
 type FleetshardSyncSpec struct {
-	OcmToken string `json:"ocmToken,omitempty"`
-	FleetManagerEndpoint string `json:"fleetManagerEndpoint,omitempty"`
-	ClusterId string `json:"clusterId,omitempty"`
-	RedHatSSO *RedHatSSOSpec `json:"redHatSSO,omitempty"`
+	OcmToken             string         `json:"ocmToken,omitempty"`
+	FleetManagerEndpoint string         `json:"fleetManagerEndpoint,omitempty"`
+	ClusterId            string         `json:"clusterId,omitempty"`
+	RedHatSSO            *RedHatSSOSpec `json:"redHatSSO,omitempty"`
 }
 
 type RedHatSSOSpec struct {
-	ClientId string `json:"clientId,omitempty"`
+	ClientId     string `json:"clientId,omitempty"`
 	ClientSecret string `json:"clientSecret,omitempty"`
 }
 
 type AcsOperatorSpec struct {
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled     bool   `json:"enabled,omitempty"`
 	StartingCSV string `json:"startingCSV,omitempty"`
 }
 
 type ObservabilitySpec struct {
-	Enabled bool `json:"enabled,omitempty"`
-	Github *GithubSpec `json:"github,omitempty"`
+	Enabled       bool               `json:"enabled,omitempty"`
+	Github        *GithubSpec        `json:"github,omitempty"`
 	Observatorium *ObservatoriumSpec `json:"observatorium,omitempty"`
 }
 
 type GithubSpec struct {
 	AccessToken string `json:"accessToken,omitempty"`
-	Repository string `json:"repository,omitempty"`
+	Repository  string `json:"repository,omitempty"`
 }
 
 type ObservatoriumSpec struct {
-	Gateway string `json:"gateway,omitempty"`
+	Gateway         string `json:"gateway,omitempty"`
 	MetricsClientId string `json:"metricsClientId,omitempty"`
-	MetricsSecret string `json:"metricsSecret,omitempty"`
+	MetricsSecret   string `json:"metricsSecret,omitempty"`
 }

--- a/probe/Dockerfile
+++ b/probe/Dockerfile
@@ -1,0 +1,13 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+
+COPY bin/probe /usr/local/bin/
+
+EXPOSE 7070
+
+ENTRYPOINT ["/usr/local/bin/probe", "start"]
+
+LABEL name="probe" \
+    vendor="Red Hat" \
+    version="0.0.1" \
+    summary="Blackbox monitoring probe for ACS Fleet Manager" \
+    description="Blackbox monitoring probe for the Red Hat Advanced Cluster Security Fleet Manager"

--- a/probe/README.md
+++ b/probe/README.md
@@ -1,6 +1,6 @@
 # External probe
 
-The probe service enables blackbox monitoring for fleet manaer. During each
+The probe service enables blackbox monitoring for fleet manager. During each
 probe run, it attempts to
 
 1. create a Central instance and ensure it is in `ready` state.

--- a/probe/README.md
+++ b/probe/README.md
@@ -1,0 +1,50 @@
+# External probe
+
+The probe service enables blackbox monitoring for fleet manaer. During each
+probe run, it attempts to
+
+1. create a Central instance and ensure it is in `ready` state.
+2. verify that the Central instance is of type `standard` and that the Central UI is reachable.
+3. deprovision the Central.
+
+Requests against fleet manager are authenticated by a Red Hat SSO service account.
+
+The probe service may run as a one-shot command (`probe run`), in which case a single probe
+is executed. If the probe aborts or fails, the service exits with exit code 1. In
+addition, the probe service may run in a continuous loop (`probe start`), in which case
+probe runs are executed in an endless loop. Prometheus metrics capture the results of the probes.
+
+The probe service implements graceful shutdown, which means upon receiving an interrupt signal, it
+attempts to clean up remainig resources.
+
+## Quickstart
+
+Execute all commands from git root directory.
+
+1. Set up a dataplane configuration file in `./$CLUSTER_ID.yaml`.
+2. Create a service account for the probe service via the [OpenShift console](https://console.redhat.com/application-services/service-accounts).
+3. Assign quota to the service account via the [quota list](../config/quota-management-list-configuration.yaml).
+4. Start fleet manager
+
+```
+$ /fleet-manager serve --dataplane-cluster-config-file "./$CLUSTER_ID.yaml"
+```
+
+5. Set environment variables
+
+```
+export RHSSO_SERVICE_ACCOUNT_CLIENT_ID=<service-account-client-id>
+export RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET=<service-account-client-secret>
+```
+
+6. Start the probe service and run a single probe
+
+```
+$ ./probe/bin/probe run
+```
+
+or run a endless loop of probes
+
+```
+$ ./probe/bin/probe start
+```

--- a/probe/config/config.go
+++ b/probe/config/config.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"time"
+
+	"github.com/stackrox/rox/pkg/errorhelpers"
+
+	"github.com/caarlos0/env/v6"
+	"github.com/pkg/errors"
+)
+
+// Config contains this application's runtime configuration.
+type Config struct {
+	DataCloudProvider    string        `env:"DATA_PLANE_CLOUD_PROVIDER" envDefault:"aws"`
+	DataPlaneRegion      string        `env:"DATA_PLANE_REGION" envDefault:"us-east-1"`
+	FleetManagerEndpoint string        `env:"FLEET_MANAGER_ENDPOINT" envDefault:"http://127.0.0.1:8000"`
+	MetricsAddress       string        `env:"FLEETSHARD_METRICS_ADDRESS" envDefault:":7070"`
+	RHSSOClientID        string        `env:"RHSSO_SERVICE_ACCOUNT_CLIENT_ID"`
+	RHSSOClientSecret    string        `env:"RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET"`
+	RHSSOEndpoint        string        `env:"RHSSO_ENDPOINT" envDefault:"https://sso.redhat.com"`
+	RHSSORealm           string        `env:"RHSSO_REALM" envDefault:"redhat-external"`
+	RuntimePollPeriod    time.Duration `env:"RUNTIME_POLL_PERIOD" envDefault:"5s"`
+	RuntimePollTimeout   time.Duration `env:"RUNTIME_POLL_TIMEOUT" envDefault:"5m"`
+	RuntimeRunTimeout    time.Duration `env:"RUNTIME_RUN_TIMEOUT" envDefault:"15m"`
+	RuntimeRunWaitPeriod time.Duration `env:"RUNTIME_RUN_WAIT_PERIOD" envDefault:"30s"`
+}
+
+// GetConfig retrieves the current runtime configuration from the environment and returns it.
+func GetConfig() (*Config, error) {
+	c := Config{}
+	var configErrors errorhelpers.ErrorList
+
+	if err := env.Parse(&c); err != nil {
+		return nil, errors.Wrapf(err, "Unable to parse runtime configuration from environment.")
+	}
+	if c.RHSSOClientID == "" {
+		configErrors.AddError(errors.New("RHSSO_SERVICE_ACCOUNT_CLIENT_ID unset in the environment"))
+	}
+	if c.RHSSOClientSecret == "" {
+		configErrors.AddError(errors.New("RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET unset in the environment"))
+	}
+	cfgErr := configErrors.ToError()
+	if cfgErr != nil {
+		return nil, errors.Wrap(cfgErr, "Unexpected configuration settings.")
+	}
+	return &c, nil
+}

--- a/probe/config/config_test.go
+++ b/probe/config/config_test.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSingleton_Success(t *testing.T) {
+	t.Setenv("FLEET_MANAGER_ENDPOINT", "http://127.0.0.1:8888")
+	t.Setenv("RHSSO_SERVICE_ACCOUNT_CLIENT_ID", "dummy")
+	t.Setenv("RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET", "dummy")
+
+	cfg, err := GetConfig()
+
+	require.NoError(t, err)
+	assert.Equal(t, cfg.FleetManagerEndpoint, "http://127.0.0.1:8888")
+	assert.Equal(t, cfg.MetricsAddress, ":7070")
+	assert.Equal(t, cfg.RuntimePollPeriod, 5*time.Second)
+}
+
+func TestSingleton_Failure(t *testing.T) {
+	t.Setenv("RHSSO_SERVICE_ACCOUNT_CLIENT_ID", "")
+	t.Setenv("RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET", "")
+
+	cfg, err := GetConfig()
+
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+}

--- a/probe/main.go
+++ b/probe/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"flag"
+	"os"
+
+	"github.com/golang/glog"
+	"github.com/stackrox/acs-fleet-manager/probe/pkg/cmd"
+)
+
+func main() {
+	// This is needed to make `glog` believe that the flags have already been parsed, otherwise
+	// every log messages is prefixed by an error message stating the the flags haven't been
+	// parsed.
+	_ = flag.CommandLine.Parse([]string{})
+
+	// Always log to stderr by default, required for glog.
+	if err := flag.Set("logtostderr", "true"); err != nil {
+		glog.Info("Unable to set logtostderr to true.")
+	}
+
+	var exitCode int
+	defer func() { os.Exit(exitCode) }()
+
+	cmd := cmd.Command()
+	if err := cmd.Execute(); err != nil {
+		exitCode = 1
+	}
+}

--- a/probe/pkg/cmd/cmd.go
+++ b/probe/pkg/cmd/cmd.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"net/http"
+	"os"
+	"os/signal"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/stackrox/acs-fleet-manager/probe/config"
+	"github.com/stackrox/acs-fleet-manager/probe/pkg/fleetmanager"
+	"github.com/stackrox/acs-fleet-manager/probe/pkg/metrics"
+	"github.com/stackrox/acs-fleet-manager/probe/pkg/runtime"
+	"golang.org/x/sys/unix"
+)
+
+// Command builds the root CLI command.
+func Command() *cobra.Command {
+	c := &cobra.Command{
+		SilenceUsage: true,
+		Use:          os.Args[0],
+		Long:         "Probe is a service that verifies the availability of ACS fleet manager.",
+	}
+	c.AddCommand(
+		startCommand(),
+		runCommand(),
+	)
+	return c
+}
+
+func startCommand() *cobra.Command {
+	c := &cobra.Command{
+		SilenceUsage: true,
+		Use:          "start",
+		Short:        "Start a continuous loop of probe runs.",
+		Long:         "Start a continuous loop of probe runs.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return executeProbe(true, cmd, args)
+		},
+	}
+	return c
+}
+
+func runCommand() *cobra.Command {
+	c := &cobra.Command{
+		SilenceUsage: true,
+		Use:          "run",
+		Short:        "Run a single probe run.",
+		Long:         "Run a single probe run.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return executeProbe(false, cmd, args)
+		},
+	}
+	return c
+}
+
+func executeProbe(loop bool, cmd *cobra.Command, args []string) error {
+	glog.Infof("Probe service has been started.")
+
+	config, err := config.GetConfig()
+	if err != nil {
+		return errors.Wrap(err, "Failed to load configuration")
+	}
+
+	metricsServer := metrics.NewMetricsServer(config.MetricsAddress)
+	defer cleanupMetricsServer(metricsServer)
+	go func() {
+		if err := metricsServer.ListenAndServe(); err != nil {
+			glog.Errorf("Failed to serve metrics: %v", err)
+		}
+	}()
+
+	fleetManagerClient, err := fleetmanager.New(config)
+	if err != nil {
+		return errors.Wrap(err, "Failed to initialize probe")
+	}
+	runtime, err := runtime.New(config, fleetManagerClient)
+	if err != nil {
+		return errors.Wrap(err, "Failed to initialize probe")
+	}
+	defer cleanupRuntime(runtime)
+
+	// TODO: Add server for liveness and readiness probes here.
+
+	isErr := make(chan bool, 1)
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, os.Interrupt, unix.SIGTERM)
+
+	go runtime.Run(isErr, sigs, loop)
+
+	sig := <-sigs
+	if sig != nil {
+		glog.Infof("Caught %s signal.", sig)
+		isErr <- true
+	}
+	glog.Info("Probe service has been stopped.")
+
+	returnErr := <-isErr
+	if returnErr {
+		return errors.New("Probe service failed. Exiting with status code 1.")
+	}
+	return nil
+}
+
+func cleanupRuntime(runtime *runtime.Runtime) {
+	err := runtime.Stop()
+	if err != nil {
+		glog.Errorf("Failed to close runtime: %v", err)
+	}
+}
+
+func cleanupMetricsServer(metricsServer *http.Server) {
+	if err := metricsServer.Close(); err != nil {
+		glog.Errorf("Failed to close metrics server: %v", err)
+	}
+}

--- a/probe/pkg/fleetmanager/client.go
+++ b/probe/pkg/fleetmanager/client.go
@@ -1,0 +1,46 @@
+package fleetmanager
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/public"
+	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
+	"github.com/stackrox/acs-fleet-manager/probe/config"
+)
+
+const (
+	authType = "RHSSO"
+	// StandardInstanceType denotes an instance with quota.
+	StandardInstanceType = "standard"
+)
+
+// Client is an interface for the fleetmanager client.
+type Client interface {
+	CreateCentral(context.Context, bool, public.CentralRequestPayload) (public.CentralRequest, *http.Response, error)
+	DeleteCentralById(context.Context, string, bool) (*http.Response, error)
+	GetCentralById(context.Context, string) (public.CentralRequest, *http.Response, error)
+}
+
+// New creates a new fleet manager client.
+func New(config *config.Config) (Client, error) {
+	auth, err := fleetmanager.NewAuth(authType, fleetmanager.Option{
+		Sso: fleetmanager.RHSSOOption{
+			ClientID:     config.RHSSOClientID,
+			ClientSecret: config.RHSSOClientSecret, // pragma: allowlist secret
+			Realm:        config.RHSSORealm,
+			Endpoint:     config.RHSSOEndpoint,
+		},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create fleet manager authentication")
+	}
+
+	client, err := fleetmanager.NewClient(config.FleetManagerEndpoint, auth, fleetmanager.WithUserAgent("probe-service"))
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create fleet manager client")
+	}
+
+	return client.PublicAPI(), nil
+}

--- a/probe/pkg/fleetmanager/client_mock.go
+++ b/probe/pkg/fleetmanager/client_mock.go
@@ -1,0 +1,108 @@
+package fleetmanager
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/public"
+)
+
+// CreateCentralResponse is returned by the client for the central creation endpoint.
+type CreateCentralResponse struct {
+	Request  public.CentralRequest
+	Response *http.Response
+	Err      error
+}
+
+// DeleteCentralByIDResponse is returned by the client for the central deletion endpoint.
+type DeleteCentralByIDResponse struct {
+	Response *http.Response
+	Err      error
+}
+
+// GetCentralByIDResponse is returned by the client for the central get endpoint.
+type GetCentralByIDResponse struct {
+	Request  public.CentralRequest
+	Response *http.Response
+	Err      error
+}
+
+// MockClient is a fake client used for unit testing against fleet manager.
+type MockClient struct {
+	createCentralResponses     []*CreateCentralResponse
+	deleteCentralByIDResponses []*DeleteCentralByIDResponse
+	getCentralByIDResponses    []*GetCentralByIDResponse
+}
+
+// NewMock returns a new mock client.
+func NewMock() (*MockClient, error) {
+	return &MockClient{}, nil
+}
+
+// AddCreateCentralResponse adds a response to the CreateCentral endpoint.
+func (c *MockClient) AddCreateCentralResponse(response *CreateCentralResponse) {
+	c.createCentralResponses = append(c.createCentralResponses, response)
+}
+
+// AddDeleteCentralByIDResponse adds a response to the DeleteCentralById endpoint.
+func (c *MockClient) AddDeleteCentralByIDResponse(response *DeleteCentralByIDResponse) {
+	c.deleteCentralByIDResponses = append(c.deleteCentralByIDResponses, response)
+}
+
+// AddGetCentralByIDResponse adds a response to the GetCentralByIdResponse endpoint.
+func (c *MockClient) AddGetCentralByIDResponse(response *GetCentralByIDResponse) {
+	c.getCentralByIDResponses = append(c.getCentralByIDResponses, response)
+}
+
+// ClearResponses deletes all stored responses.
+func (c *MockClient) ClearResponses(response *GetCentralByIDResponse) {
+	c.createCentralResponses = nil
+	c.deleteCentralByIDResponses = nil
+	c.getCentralByIDResponses = nil
+}
+
+// CreateCentral mocks a Central creation request.
+func (c *MockClient) CreateCentral(ctx context.Context, async bool, payload public.CentralRequestPayload) (public.CentralRequest, *http.Response, error) {
+	if len(c.createCentralResponses) == 0 {
+		return public.CentralRequest{}, nil, nil
+	}
+	request := c.createCentralResponses[0].Request
+	response := c.createCentralResponses[0].Response
+	err := c.createCentralResponses[0].Err
+
+	if len(c.createCentralResponses) > 0 {
+		c.createCentralResponses = c.createCentralResponses[1:]
+	}
+	return request, response, err
+}
+
+// DeleteCentralById mocks a Central deletion request.
+//nolint:revive
+func (c *MockClient) DeleteCentralById(ctx context.Context, id string, async bool) (*http.Response, error) {
+	if len(c.deleteCentralByIDResponses) == 0 {
+		return nil, nil
+	}
+	response := c.deleteCentralByIDResponses[0].Response
+	err := c.deleteCentralByIDResponses[0].Err
+
+	if len(c.deleteCentralByIDResponses) > 0 {
+		c.deleteCentralByIDResponses = c.deleteCentralByIDResponses[1:]
+	}
+	return response, err
+}
+
+// GetCentralById mocks a Central get request.
+//nolint:revive
+func (c *MockClient) GetCentralById(ctx context.Context, id string) (public.CentralRequest, *http.Response, error) {
+	if len(c.getCentralByIDResponses) == 0 {
+		return public.CentralRequest{}, nil, nil
+	}
+	request := c.getCentralByIDResponses[0].Request
+	response := c.getCentralByIDResponses[0].Response
+	err := c.getCentralByIDResponses[0].Err
+
+	if len(c.getCentralByIDResponses) > 0 {
+		c.getCentralByIDResponses = c.getCentralByIDResponses[1:]
+	}
+	return request, response, err
+}

--- a/probe/pkg/fleetmanager/responses_mock.go
+++ b/probe/pkg/fleetmanager/responses_mock.go
@@ -1,0 +1,64 @@
+package fleetmanager
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/public"
+)
+
+func makeHTTPResponse(statusCode int) *http.Response {
+	json := `{}`
+	r := ioutil.NopCloser(bytes.NewReader([]byte(json)))
+	response := &http.Response{
+		StatusCode: statusCode,
+		Body:       r,
+	}
+	return response
+}
+
+// Predefined responses.
+var (
+	CreateCentralResponseAccepted = &CreateCentralResponse{
+		Response: makeHTTPResponse(http.StatusAccepted),
+	}
+	CreateCentralResponseStatusServerError = &CreateCentralResponse{
+		Response: makeHTTPResponse(http.StatusInternalServerError),
+	}
+	CreateCentralResponseError = &CreateCentralResponse{
+		Response: makeHTTPResponse(http.StatusAccepted),
+		Err:      errors.New("Failed response"),
+	}
+
+	DeleteCentralByIDResponseAccepted          = &DeleteCentralByIDResponse{Response: makeHTTPResponse(http.StatusAccepted)}
+	DeleteCentralByIDResponseStatusServerError = &DeleteCentralByIDResponse{Response: makeHTTPResponse(http.StatusInternalServerError)}
+	DeleteCentralByIDResponseError             = &DeleteCentralByIDResponse{
+		Response: makeHTTPResponse(http.StatusAccepted),
+		Err:      errors.New("Failed response"),
+	}
+
+	GetCentralByIDResponseAccepted = &GetCentralByIDResponse{
+		Request:  public.CentralRequest{InstanceType: StandardInstanceType, Status: constants.CentralRequestStatusAccepted.String()},
+		Response: makeHTTPResponse(http.StatusOK),
+	}
+	GetCentralByIDResponseReady = &GetCentralByIDResponse{
+		Request:  public.CentralRequest{InstanceType: StandardInstanceType, Status: constants.CentralRequestStatusReady.String()},
+		Response: makeHTTPResponse(http.StatusOK),
+	}
+	GetCentralByIDResponseDeprovision = &GetCentralByIDResponse{
+		Request:  public.CentralRequest{InstanceType: StandardInstanceType, Status: constants.CentralRequestStatusDeprovision.String()},
+		Response: makeHTTPResponse(http.StatusOK),
+	}
+	GetCentralByIDResponseStatusServerError = &GetCentralByIDResponse{
+		Request:  public.CentralRequest{InstanceType: StandardInstanceType, Status: constants.CentralRequestStatusAccepted.String()},
+		Response: makeHTTPResponse(http.StatusInternalServerError),
+	}
+	GetCentralByIDResponseError = &GetCentralByIDResponse{
+		Request:  public.CentralRequest{InstanceType: StandardInstanceType, Status: constants.CentralRequestStatusDeprovision.String()},
+		Response: makeHTTPResponse(http.StatusOK),
+		Err:      errors.New("Failed response"),
+	}
+)

--- a/probe/pkg/httpclient/client.go
+++ b/probe/pkg/httpclient/client.go
@@ -1,0 +1,20 @@
+package httpclient
+
+import (
+	"net/http"
+	"time"
+)
+
+// HTTPClient is a http client used to ping the Central UI.
+var HTTPClient Client
+
+// Client is a http client interface.
+type Client interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+func init() {
+	HTTPClient = &http.Client{
+		Timeout: 5 * time.Second,
+	}
+}

--- a/probe/pkg/httpclient/client_mock.go
+++ b/probe/pkg/httpclient/client_mock.go
@@ -1,0 +1,22 @@
+package httpclient
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+)
+
+// MockClient is a fake http client for unit testing.
+type MockClient struct {
+	StatusCode int
+}
+
+// Do mock a http call and always returns a response with the given status code.
+func (m *MockClient) Do(req *http.Request) (*http.Response, error) {
+	json := ``
+	r := ioutil.NopCloser(bytes.NewReader([]byte(json)))
+	return &http.Response{
+		StatusCode: m.StatusCode,
+		Body:       r,
+	}, nil
+}

--- a/probe/pkg/metrics/metrics.go
+++ b/probe/pkg/metrics/metrics.go
@@ -1,0 +1,121 @@
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	prometheusNamespace = "acs"
+	prometheusSubsystem = "probe"
+)
+
+var (
+	metrics *Metrics
+	once    sync.Once
+)
+
+// Metrics holds the prometheus.Collector instances for the probe's custom metrics
+// and provides methods to interact with them.
+type Metrics struct {
+	startedRuns            prometheus.Counter
+	successfulRuns         prometheus.Counter
+	failedRuns             prometheus.Counter
+	lastSuccessTimestamp   prometheus.Gauge
+	lastFailureTimestamp   prometheus.Gauge
+	totalDurationHistogram prometheus.Histogram
+}
+
+// Register registers the metrics with the given prometheus.Registerer.
+func (m *Metrics) Register(r prometheus.Registerer) {
+	r.MustRegister(m.startedRuns)
+	r.MustRegister(m.successfulRuns)
+	r.MustRegister(m.failedRuns)
+	r.MustRegister(m.totalDurationHistogram)
+	r.MustRegister(m.lastFailureTimestamp)
+	r.MustRegister(m.lastSuccessTimestamp)
+}
+
+// IncStartedRuns increments the metric counter for started probe runs.
+func (m *Metrics) IncStartedRuns() {
+	m.startedRuns.Inc()
+}
+
+// IncSuccessfulRuns increments the metric counter for successful probe runs.
+func (m *Metrics) IncSuccessfulRuns() {
+	m.successfulRuns.Inc()
+}
+
+// IncFailedRuns increments the metric counter for failed probe runs.
+func (m *Metrics) IncFailedRuns() {
+	m.failedRuns.Inc()
+}
+
+// SetLastSuccessTimestamp sets timestamp for the last successful probe run.
+func (m *Metrics) SetLastSuccessTimestamp() {
+	m.lastSuccessTimestamp.SetToCurrentTime()
+}
+
+// SetLastFailureTimestamp sets timestamp for the last failed probe run.
+func (m *Metrics) SetLastFailureTimestamp() {
+	m.lastFailureTimestamp.SetToCurrentTime()
+}
+
+// ObserveTotalDuration sets the total duration gauge for probe runs.
+func (m *Metrics) ObserveTotalDuration(duration time.Duration) {
+	m.totalDurationHistogram.Observe(duration.Seconds())
+}
+
+// MetricsInstance return the global Singleton instance for Metrics
+func MetricsInstance() *Metrics {
+	once.Do(initMetricsInstance)
+	return metrics
+}
+
+func initMetricsInstance() {
+	metrics = newMetrics()
+}
+
+func newMetrics() *Metrics {
+	return &Metrics{
+		startedRuns: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: prometheusNamespace,
+			Subsystem: prometheusSubsystem,
+			Name:      "started_runs",
+			Help:      "The number of started probe runs.",
+		}),
+		successfulRuns: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: prometheusNamespace,
+			Subsystem: prometheusSubsystem,
+			Name:      "successful_runs",
+			Help:      "The number of successful probe runs.",
+		}),
+		failedRuns: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: prometheusNamespace,
+			Subsystem: prometheusSubsystem,
+			Name:      "failed_runs",
+			Help:      "The number of failed probe runs.",
+		}),
+		lastSuccessTimestamp: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: prometheusNamespace,
+			Subsystem: prometheusSubsystem,
+			Name:      "last_success_timestamp",
+			Help:      "The Unix timestamp of the last successful probe run.",
+		}),
+		lastFailureTimestamp: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: prometheusNamespace,
+			Subsystem: prometheusSubsystem,
+			Name:      "last_failure_timestamp",
+			Help:      "The Unix timestamp of the last failed probe run.",
+		}),
+		totalDurationHistogram: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: prometheusNamespace,
+			Subsystem: prometheusSubsystem,
+			Name:      "total_duration_seconds",
+			Help:      "The total run duration in seconds.",
+			Buckets:   prometheus.ExponentialBuckets(10, 2, 8),
+		}),
+	}
+}

--- a/probe/pkg/metrics/metrics_test.go
+++ b/probe/pkg/metrics/metrics_test.go
@@ -1,0 +1,124 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCounterIncrements(t *testing.T) {
+	const expectedIncrement = 1.0
+
+	tt := []struct {
+		metricName        string
+		callIncrementFunc func(m *Metrics)
+	}{
+		{
+			metricName: "acs_probe_started_runs",
+			callIncrementFunc: func(m *Metrics) {
+				m.IncStartedRuns()
+			},
+		},
+		{
+			metricName: "acs_probe_successful_runs",
+			callIncrementFunc: func(m *Metrics) {
+				m.IncSuccessfulRuns()
+			},
+		},
+		{
+			metricName: "acs_probe_failed_runs",
+			callIncrementFunc: func(m *Metrics) {
+				m.IncFailedRuns()
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.metricName, func(t *testing.T) {
+			m := newMetrics()
+			tc.callIncrementFunc(m)
+
+			metrics := serveMetrics(t, m)
+			targetMetric := requireMetric(t, metrics, tc.metricName)
+
+			// Test that the metrics value is 1 after calling the incrementFunc
+			value := targetMetric.Metric[0].GetCounter().GetValue()
+			assert.Equalf(t, expectedIncrement, value, "expected metric: %s to have value: %v", tc.metricName, expectedIncrement)
+		})
+	}
+}
+
+func TestTimestampGauges(t *testing.T) {
+	tt := []struct {
+		metricName       string
+		setTimestampFunc func(m *Metrics)
+	}{
+		{
+			metricName: "acs_probe_last_success_timestamp",
+			setTimestampFunc: func(m *Metrics) {
+				m.SetLastSuccessTimestamp()
+			},
+		},
+		{
+			metricName: "acs_probe_last_failure_timestamp",
+			setTimestampFunc: func(m *Metrics) {
+				m.SetLastFailureTimestamp()
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.metricName, func(t *testing.T) {
+			m := newMetrics()
+			lowerBound := time.Now().Unix()
+			tc.setTimestampFunc(m)
+
+			metrics := serveMetrics(t, m)
+			targetMetric := requireMetric(t, metrics, tc.metricName)
+
+			value := int64(targetMetric.Metric[0].GetGauge().GetValue())
+			assert.GreaterOrEqualf(t, value, lowerBound, "expected metric: %s to have a value greater than %v", tc.metricName, lowerBound)
+		})
+	}
+}
+
+func TestHistograms(t *testing.T) {
+	tt := []struct {
+		metricName  string
+		observeFunc func(m *Metrics)
+	}{
+		{
+			metricName: "acs_probe_total_duration_seconds",
+			observeFunc: func(m *Metrics) {
+				m.ObserveTotalDuration(5 * time.Minute)
+				m.ObserveTotalDuration(3 * time.Minute)
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.metricName, func(t *testing.T) {
+			m := newMetrics()
+			expectedCount := uint64(2)
+			expectedSum := 480.0
+			tc.observeFunc(m)
+
+			metrics := serveMetrics(t, m)
+			targetMetric := requireMetric(t, metrics, tc.metricName)
+
+			count := targetMetric.Metric[0].GetHistogram().GetSampleCount()
+			sum := targetMetric.Metric[0].GetHistogram().GetSampleSum()
+			assert.Equalf(t, expectedCount, count, "expected metric: %s to have a count of %v", tc.metricName, expectedCount)
+			assert.Equalf(t, expectedSum, sum, "expected metric: %s to have a sum of %v", tc.metricName, expectedSum)
+		})
+	}
+}
+
+func requireMetric(t *testing.T, metrics metricResponse, metricName string) *io_prometheus_client.MetricFamily {
+	targetMetric, hasKey := metrics[metricName]
+	require.Truef(t, hasKey, "expected metrics to contain %s but it did not: %v", metricName, metrics)
+	return targetMetric
+}

--- a/probe/pkg/metrics/server.go
+++ b/probe/pkg/metrics/server.go
@@ -1,0 +1,27 @@
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// NewMetricsServer returns the metrics server
+func NewMetricsServer(address string) *http.Server {
+	return newMetricsServer(address, MetricsInstance())
+}
+
+func newMetricsServer(address string, customMetrics *Metrics) *http.Server {
+	registry := prometheus.NewRegistry()
+	// Register default metrics to use a dedicated registry instead of prometheus.DefaultRegistry
+	// this makes it easier to isolate metric state when unit testing this package
+	registry.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
+	registry.MustRegister(prometheus.NewGoCollector())
+	customMetrics.Register(registry)
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+
+	return &http.Server{Addr: address, Handler: mux}
+}

--- a/probe/pkg/metrics/server_test.go
+++ b/probe/pkg/metrics/server_test.go
@@ -1,0 +1,57 @@
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type metricResponse map[string]*io_prometheus_client.MetricFamily
+
+func TestMetricsServerCorrectAddress(t *testing.T) {
+	server := NewMetricsServer(":8081")
+	assert.Equal(t, ":8081", server.Addr)
+}
+
+func TestMetricsServerServesDefaultMetrics(t *testing.T) {
+	metrics := serveMetrics(t, newMetrics())
+	_, hasKey := metrics["go_memstats_alloc_bytes"]
+	assert.Truef(t, hasKey, "expected metrics to contain go default metrics but it did not: %v", metrics)
+}
+
+func TestMetricsServerServesCustomMetrics(t *testing.T) {
+	metrics := serveMetrics(t, newMetrics())
+
+	expectedKeys := []string{
+		"acs_probe_started_runs",
+		"acs_probe_successful_runs",
+		"acs_probe_failed_runs",
+		"acs_probe_last_success_timestamp",
+		"acs_probe_last_failure_timestamp",
+		"acs_probe_total_duration_seconds",
+	}
+
+	for _, key := range expectedKeys {
+		assert.Containsf(t, metrics, key, "expected metrics to contain %s but it did not: %v", key, metrics)
+	}
+}
+
+func serveMetrics(t *testing.T, customMetrics *Metrics) metricResponse {
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodGet, "/metrics", nil)
+	require.NoError(t, err, "failed creating metrics requests")
+
+	server := newMetricsServer(":8081", customMetrics)
+	server.Handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, "status code should be OK")
+
+	promParser := expfmt.TextParser{}
+	metrics, err := promParser.TextToMetricFamilies(rec.Body)
+	require.NoError(t, err, "failed parsing metrics file")
+	return metrics
+}

--- a/probe/pkg/runtime/runtime.go
+++ b/probe/pkg/runtime/runtime.go
@@ -1,0 +1,249 @@
+package runtime
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/public"
+	"github.com/stackrox/acs-fleet-manager/probe/config"
+	"github.com/stackrox/acs-fleet-manager/probe/pkg/fleetmanager"
+	"github.com/stackrox/acs-fleet-manager/probe/pkg/httpclient"
+	"github.com/stackrox/acs-fleet-manager/probe/pkg/metrics"
+)
+
+// Runtime performs a probe run against fleet manager.
+type Runtime struct {
+	config             *config.Config
+	fleetManagerClient fleetmanager.Client
+	request            *public.CentralRequestPayload
+	centralState       *public.CentralRequest
+}
+
+// New creates a new runtime.
+func New(config *config.Config, fleetManagerClient fleetmanager.Client) (*Runtime, error) {
+	centralName, err := newCentralName()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create runtime")
+	}
+
+	request := &public.CentralRequestPayload{
+		Name:          centralName,
+		MultiAz:       true,
+		CloudProvider: config.DataCloudProvider,
+		Region:        config.DataPlaneRegion,
+	}
+
+	return &Runtime{
+		config:             config,
+		fleetManagerClient: fleetManagerClient,
+		request:            request,
+	}, nil
+}
+
+// Run sets up time outs and metrics, and then executes either a single probe run
+// or a continuous loop of probe runs.
+func (r *Runtime) Run(isErr chan bool, sigs chan os.Signal, loop bool) {
+	for {
+		ctxTimeout, cancel := context.WithTimeout(context.Background(), r.config.RuntimeRunTimeout)
+		defer cancel()
+		isDone := make(chan bool, 1)
+
+		go func() {
+			metrics.MetricsInstance().IncStartedRuns()
+			err := r.probeCentral(ctxTimeout)
+			if err != nil {
+				metrics.MetricsInstance().IncFailedRuns()
+				metrics.MetricsInstance().SetLastFailureTimestamp()
+				glog.Error(err)
+			} else {
+				metrics.MetricsInstance().IncSuccessfulRuns()
+				metrics.MetricsInstance().SetLastSuccessTimestamp()
+			}
+			isDone <- true
+		}()
+
+		select {
+		case <-ctxTimeout.Done():
+			glog.Errorf("Probe run timed out: %v", ctxTimeout.Err())
+			metrics.MetricsInstance().IncFailedRuns()
+			if loop {
+				time.Sleep(r.config.RuntimeRunWaitPeriod)
+				continue
+			} else {
+				isErr <- true
+				close(sigs)
+				return
+			}
+		case <-isDone:
+			if loop {
+				time.Sleep(r.config.RuntimeRunWaitPeriod)
+				continue
+			} else {
+				isErr <- false
+				close(sigs)
+				return
+			}
+		}
+	}
+}
+
+// probeCentral represents a single probe run.
+func (r *Runtime) probeCentral(ctx context.Context) error {
+	defer totalDurationTimer()()
+
+	err := r.createCentral(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = r.verifyCentral(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = r.deleteCentral(ctx)
+	return err
+}
+
+// Stop the probe run.
+// TODO: Add write ahead log to clean up after ungraceful restarts.
+func (r *Runtime) Stop() error {
+	if r.centralState == nil {
+		return nil
+	}
+	ctx := context.Background()
+	_, err := r.fleetManagerClient.DeleteCentralById(ctx, r.centralState.Id, true)
+	if err != nil {
+		return errors.Wrapf(err, "Clean up: Deletion of Central instance %s failed", r.centralState.Id)
+	}
+	glog.Infof("Clean up: Deletion of Central instance %s requested.", r.centralState.Id)
+	return nil
+}
+
+// totalDurationTimer returns a function that measures the elapsed time between the
+// call to the timer and the call to the returned function. The result is tracked
+// as a Prometheus metric.
+func totalDurationTimer() func() {
+	start := time.Now()
+	return func() {
+		metrics.MetricsInstance().ObserveTotalDuration(time.Since(start))
+	}
+}
+
+// Create a Central and verify that it transitioned to 'ready' state.
+func (r *Runtime) createCentral(ctx context.Context) error {
+	central, response, err := r.fleetManagerClient.CreateCentral(ctx, true, *r.request)
+	glog.Infof("Creation of Central instance requested.")
+	if err != nil {
+		return errors.Wrap(err, "Creation of Central instance failed")
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusAccepted {
+		return errors.Errorf("Creation request to Central instance was not accepted: %s.", response.Status)
+	}
+
+	r.centralState = &central
+	err = r.ensureCentralState(constants.CentralRequestStatusReady.String())
+	return err
+}
+
+// Verify that the Central instance has the expected properties and that the
+// Central UI is reachable.
+func (r *Runtime) verifyCentral(ctx context.Context) error {
+	if r.centralState.InstanceType != fleetmanager.StandardInstanceType {
+		return errors.Errorf("Central has wrong instance type. Expected %s, got %s.", fleetmanager.StandardInstanceType, r.centralState.InstanceType)
+	}
+
+	err := r.pingURL(r.centralState.CentralUIURL)
+	return err
+}
+
+func (r *Runtime) pingURL(url string) error {
+	request, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to create request for Central UI %s", r.centralState.Id)
+	}
+	response, err := httpclient.HTTPClient.Do(request)
+	if err != nil {
+		return errors.Wrapf(err, "Central UI of instance %s not reachable", r.centralState.Id)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return errors.Errorf("Central UI %s did not respond with status OK. Got: %s", r.centralState.Id, response.Status)
+	}
+	return nil
+}
+
+// Delete the Central instance and verify that it transitioned to 'deprovision' state.
+func (r *Runtime) deleteCentral(ctx context.Context) error {
+	response, err := r.fleetManagerClient.DeleteCentralById(ctx, r.centralState.Id, true)
+	glog.Infof("Deletion of Central instance %s requested.", r.centralState.Id)
+	if err != nil {
+		return errors.Wrapf(err, "Deletion of Central instance %s failed", r.centralState.Id)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusAccepted {
+		return errors.Errorf("Deletion request to Central instance %s was not accepted: %s.", r.centralState.Id, response.Status)
+	}
+
+	err = r.ensureCentralState(constants.CentralRequestStatusDeprovision.String())
+	return err
+}
+
+func newCentralName() (string, error) {
+	rnd := make([]byte, 8)
+	_, err := rand.Read(rnd)
+	if err != nil {
+		return "", errors.Wrapf(err, "Reading random bytes for unique central name")
+	}
+	rndString := hex.EncodeToString(rnd)
+
+	return fmt.Sprintf("probe-%s", rndString), nil
+}
+
+func (r *Runtime) ensureCentralState(targetState string) error {
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), r.config.RuntimePollTimeout)
+	defer cancel()
+
+	isDone := make(chan bool, 1)
+
+	go r.pollCentral(ctxTimeout, isDone, targetState)
+
+	select {
+	case <-ctxTimeout.Done():
+		return errors.Wrapf(ctxTimeout.Err(), "Central instance %s did not reach %s state", r.centralState.Id, targetState)
+	case <-isDone:
+		return nil
+	}
+}
+
+func (r *Runtime) pollCentral(ctx context.Context, isDone chan bool, targetState string) error {
+	for {
+		central, response, err := r.fleetManagerClient.GetCentralById(ctx, r.centralState.Id)
+		if err != nil {
+			glog.Warningf("Central instance %s not reachable: %s.", r.centralState.Id, err.Error())
+			continue
+		}
+		defer response.Body.Close()
+		if response.StatusCode != http.StatusOK {
+			glog.Warningf("Central instance %s did not respond with status OK: %s.", r.centralState.Id, response.Status)
+			continue
+		}
+
+		r.centralState = &central
+		if r.centralState.Status == targetState {
+			glog.Infof("Central instance %s is in `%s` state.", r.centralState.Id, targetState)
+			isDone <- true
+			return nil
+		}
+		time.Sleep(r.config.RuntimePollPeriod)
+	}
+}

--- a/probe/pkg/runtime/runtime_test.go
+++ b/probe/pkg/runtime/runtime_test.go
@@ -1,0 +1,211 @@
+package runtime
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stackrox/acs-fleet-manager/probe/config"
+	"github.com/stackrox/acs-fleet-manager/probe/pkg/fleetmanager"
+	"github.com/stackrox/acs-fleet-manager/probe/pkg/httpclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testConfig = &config.Config{
+	RuntimePollPeriod:    1 * time.Second,
+	RuntimePollTimeout:   10 * time.Second,
+	RuntimeRunTimeout:    10 * time.Second,
+	RuntimeRunWaitPeriod: 1 * time.Second,
+}
+
+func TestRuntimeProbeCentral(t *testing.T) {
+	tt := []struct {
+		testName     string
+		responseFunc func(*fleetmanager.MockClient)
+		wantErr      bool
+		errContains  string
+	}{
+		{
+			testName: "testProbeCentralHappyPath",
+			responseFunc: func(client *fleetmanager.MockClient) {
+				client.AddCreateCentralResponse(fleetmanager.CreateCentralResponseAccepted)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseReady)
+				client.AddDeleteCentralByIDResponse(fleetmanager.DeleteCentralByIDResponseAccepted)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseDeprovision)
+
+				httpclient.HTTPClient = &httpclient.MockClient{StatusCode: http.StatusOK}
+			},
+			wantErr: false,
+		},
+		{
+			testName: "testProbeCentralCreateStatusServerError",
+			responseFunc: func(client *fleetmanager.MockClient) {
+				client.AddCreateCentralResponse(fleetmanager.CreateCentralResponseStatusServerError)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseReady)
+				client.AddDeleteCentralByIDResponse(fleetmanager.DeleteCentralByIDResponseAccepted)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseDeprovision)
+
+				httpclient.HTTPClient = &httpclient.MockClient{StatusCode: http.StatusOK}
+			},
+			wantErr:     true,
+			errContains: "Creation request to Central instance was not accepted",
+		},
+		{
+			testName: "testProbeCentralCreateCentralError",
+			responseFunc: func(client *fleetmanager.MockClient) {
+				client.AddCreateCentralResponse(fleetmanager.CreateCentralResponseError)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseReady)
+				client.AddDeleteCentralByIDResponse(fleetmanager.DeleteCentralByIDResponseAccepted)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseDeprovision)
+
+				httpclient.HTTPClient = &httpclient.MockClient{StatusCode: http.StatusOK}
+			},
+			wantErr:     true,
+			errContains: "Creation of Central instance failed: Failed response",
+		},
+		{
+			testName: "testProbeCentralPollingDoesNotRespondOK",
+			responseFunc: func(client *fleetmanager.MockClient) {
+				client.AddCreateCentralResponse(fleetmanager.CreateCentralResponseAccepted)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseReady)
+				client.AddDeleteCentralByIDResponse(fleetmanager.DeleteCentralByIDResponseAccepted)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseDeprovision)
+
+				httpclient.HTTPClient = &httpclient.MockClient{StatusCode: http.StatusInternalServerError}
+			},
+			wantErr:     true,
+			errContains: "Central UI  did not respond with status OK. Got:",
+		},
+		{
+			testName: "testProbeCentralGetCentralStatusServerErrorIsRetried",
+			responseFunc: func(client *fleetmanager.MockClient) {
+				client.AddCreateCentralResponse(fleetmanager.CreateCentralResponseAccepted)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseStatusServerError)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseReady)
+				client.AddDeleteCentralByIDResponse(fleetmanager.DeleteCentralByIDResponseAccepted)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseDeprovision)
+
+				httpclient.HTTPClient = &httpclient.MockClient{StatusCode: http.StatusOK}
+			},
+			wantErr: false,
+		},
+		{
+			testName: "testProbeCentralGetCentralErrorIsRetried",
+			responseFunc: func(client *fleetmanager.MockClient) {
+				client.AddCreateCentralResponse(fleetmanager.CreateCentralResponseAccepted)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseError)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseReady)
+				client.AddDeleteCentralByIDResponse(fleetmanager.DeleteCentralByIDResponseAccepted)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseDeprovision)
+
+				httpclient.HTTPClient = &httpclient.MockClient{StatusCode: http.StatusOK}
+			},
+			wantErr: false,
+		},
+		{
+			testName: "testProbeCentralDeleteCentralError",
+			responseFunc: func(client *fleetmanager.MockClient) {
+				client.AddCreateCentralResponse(fleetmanager.CreateCentralResponseAccepted)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseReady)
+				client.AddDeleteCentralByIDResponse(fleetmanager.DeleteCentralByIDResponseError)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseDeprovision)
+
+				httpclient.HTTPClient = &httpclient.MockClient{StatusCode: http.StatusOK}
+			},
+			wantErr:     true,
+			errContains: "Deletion of Central instance  failed: Failed response",
+		},
+		{
+			testName: "testProbeCentralDeleteCentralStatusServerError",
+			responseFunc: func(client *fleetmanager.MockClient) {
+				client.AddCreateCentralResponse(fleetmanager.CreateCentralResponseAccepted)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseReady)
+				client.AddDeleteCentralByIDResponse(fleetmanager.DeleteCentralByIDResponseStatusServerError)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseDeprovision)
+
+				httpclient.HTTPClient = &httpclient.MockClient{StatusCode: http.StatusOK}
+			},
+			wantErr:     true,
+			errContains: "Deletion request to Central instance  was not accepted",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.testName, func(t *testing.T) {
+			client, err := fleetmanager.NewMock()
+			require.NoError(t, err, "Failed to create fleet manager client.")
+			tc.responseFunc(client)
+			runtime, err := New(testConfig, client)
+			require.NoError(t, err, "Failed to create runtime.")
+
+			ctx := context.Background()
+			err = runtime.probeCentral(ctx)
+
+			if tc.wantErr {
+				require.ErrorContains(t, err, tc.errContains, "Expected an error during probe run.")
+			} else {
+				require.NoError(t, err, "Failed to run probe.")
+			}
+		})
+	}
+}
+
+func TestRuntimeTimeout(t *testing.T) {
+	tt := []struct {
+		testName     string
+		responseFunc func(*fleetmanager.MockClient)
+		wantErr      bool
+	}{
+		{
+			testName: "testProbeCentralRunTimesOut",
+			responseFunc: func(client *fleetmanager.MockClient) {
+				testConfig.RuntimeRunTimeout = 0
+
+				client.AddCreateCentralResponse(fleetmanager.CreateCentralResponseAccepted)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseReady)
+				client.AddDeleteCentralByIDResponse(fleetmanager.DeleteCentralByIDResponseAccepted)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseDeprovision)
+
+				httpclient.HTTPClient = &httpclient.MockClient{StatusCode: http.StatusOK}
+			},
+			wantErr: true,
+		},
+		{
+			testName: "testProbeCentralPollingTimesOut",
+			responseFunc: func(client *fleetmanager.MockClient) {
+				testConfig.RuntimePollTimeout = 0
+
+				client.AddCreateCentralResponse(fleetmanager.CreateCentralResponseAccepted)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseReady)
+				client.AddDeleteCentralByIDResponse(fleetmanager.DeleteCentralByIDResponseAccepted)
+				client.AddGetCentralByIDResponse(fleetmanager.GetCentralByIDResponseDeprovision)
+
+				httpclient.HTTPClient = &httpclient.MockClient{StatusCode: http.StatusOK}
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.testName, func(t *testing.T) {
+			client, err := fleetmanager.NewMock()
+			require.NoError(t, err, "Failed to create fleet manager client.")
+			tc.responseFunc(client)
+			runtime, err := New(testConfig, client)
+			require.NoError(t, err, "Failed to create runtime.")
+
+			isErr := make(chan bool, 1)
+			sigs := make(chan os.Signal, 1)
+			runtime.Run(isErr, sigs, false)
+
+			if tc.wantErr {
+				assert.True(t, <-isErr, "Expected an error during probe run.")
+			} else {
+				assert.False(t, <-isErr, "Did not expect an error during probe run.")
+			}
+		})
+	}
+}

--- a/tools.go
+++ b/tools.go
@@ -4,5 +4,5 @@
 package main
 
 import (
-  _ "github.com/onsi/ginkgo/v2/ginkgo"
+	_ "github.com/onsi/ginkgo/v2/ginkgo"
 )


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

### Summary

Design doc: https://docs.google.com/document/d/1Vk-r97VokbhsHnZKcb8nAJO0M55NO9W0xtx0AQTavhA/edit

The probe service enables blackbox monitoring for fleet manaer. During each
probe run, it attempts to

1. create a Central instance and ensure it is in `ready` state.
2. verify that the Central instance is of type `standard` and that the Central UI is reachable.
3. deprovision the Central.

Requests against fleet manager are authenticated by a Red Hat SSO service account.

The probe service may run as a one-shot command (`probe run`), in which case a single probe
is executed. If the probe aborts or fails, the service exits with exit code 1. In
addition, the probe service may run in a continuous loop (`probe start`), in which case
probe runs are executed in an endless loop. Prometheus metrics capture the results of the probes.

The probe service implements graceful shutdown, which means upon receiving an interrupt signal, it
attempts to clean up remaining resources.

### Testing

The primary unit testing is done via a custom mocked fleet manager client (see `probe/pkg/fleetmanager/client_mock.go`). I felt this was simpler than a mock directly on http level via https://pkg.go.dev/net/http/httptest.

### TODOs / follow ups:

* Deployment
  - We need to deploy the probe service to a long running cluster, such that it may probe the stage/prod fleet manager deployed in the control plane. The current plan is to deploy the probe service to our data plane clusters for two reasons: a) It is outside of the control plane network. b) We have easy control over the monitoring setup. c) Deployment is easy via Helm.
* Liveness and readiness endpoints.
* Write-ahead log for requested Central instances to clean up in the event of an ungraceful shutdown.


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Documentation added if necessary
- [x] CI and all relevant tests are passing
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Tested probe service with local fleet manager and OSD data plane cluster.