### PR TITLE
Add now time to trigger fleetshard re-deployments

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: fleetshard-sync
+    managed-service.rhacs.redhat.com/update-trigger: {{ now }}
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
## Description

The fleetshard deployment was never applied as it always deploys the main image in staging currently.
By adding a timestamp the deployment is always recreated.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

 - Executing helm template