### PR TITLE
Change prod fleet-manager endpoint URL to use API gateway

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -72,7 +72,7 @@ case $ENVIRONMENT in
     fi
     CLUSTER_ID=$(ocm list cluster "${CLUSTER_NAME}" --no-headers --columns="ID")
 
-    FM_ENDPOINT="https://syqugpy2fa29zqc.api.openshift.com"
+    FM_ENDPOINT="https://api.openshift.com"
 
     ensure_bitwarden_session_exists
     # Note: the Red Hat SSO client as of 2022-09-02 is the same between stage and prod.


### PR DESCRIPTION
## Description

This PR changes Prod Fleet-Manager endpoint to use API gateway URL.

## Checklist (Definition of Done)
- ~[ ] Unit and integration tests added~
- ~[ ] Documentation added if necessary~
- [ ] CI and all relevant tests are passing
- ~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

We have tested that API exists and it's accessable. You can run the following command:
```
curl --header "Authorization: Bearer $(ocm token)" https://api.openshift.com/api/rhacs/v1/centrals --silent | jq
```

If everything works can really be tested after production is re-terraformed.

