### PR TITLE
Deploy a non-released operator version with Helm

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/acs-operator.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/acs-operator.yaml
@@ -16,5 +16,19 @@ spec:
   name: rhacs-operator
   source: {{ .Values.acsOperator.source }}
   sourceNamespace: {{ .Values.acsOperator.sourceNamespace }}
-  startingCSV: {{ .Values.acsOperator.startingCSV }}
+  startingCSV: rhacs-operator.{{ .Values.acsOperator.version }}
+---
+{{- if .Values.acsOperator.upstream.use }}
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: {{ .Values.acsOperator.source }}
+  namespace: openshift-marketplace
+spec:
+  displayName: 'RHACS Development'
+  publisher: 'Red Hat ACS'
+  sourceType: grpc
+  image: quay.io/rhacs-eng/stackrox-operator-index:{{ .Values.acsOperator.version }}
+---
+{{- end }}
 {{- end }}

--- a/dp-terraform/helm/rhacs-terraform/templates/acs-operator.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/acs-operator.yaml
@@ -18,7 +18,7 @@ spec:
   sourceNamespace: {{ .Values.acsOperator.sourceNamespace }}
   startingCSV: rhacs-operator.{{ .Values.acsOperator.version }}
 ---
-{{- if .Values.acsOperator.upstream.use }}
+{{- if .Values.acsOperator.upstream }}
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -139,7 +139,7 @@ helm upgrade rhacs-terraform ./ \
   --set observability.observatorium.metricsSecret="${OBSERVABILITY_OBSERVATORIUM_METRICS_SECRET}" \
   --set observability.pagerduty.key="${PAGERDUTY_SERVICE_KEY}"
   # In case you want to deploy an upstream version of the operator, you can uncomment the lines below
-  #--set acsOperator.upstream.use=true \
+  #--set acsOperator.upstream=true \
   #--set acsOperator.source=rhacs-operators \
   # Make sure to set the version of the operator also to a unrelease version, i.e. "v3.72.0-35-gf72be438ec"
 

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -99,6 +99,17 @@ case $ENVIRONMENT in
     ;;
 esac
 
+
+## Uncomment this section if you want to deploy an upstream version of the operator.
+## Update the global pull secret within the dataplane cluster to include the read-only credentials for quay.io/rhacs-eng
+#QUAY_READ_ONLY_USERNAME=$(bw get username "66de0e1f-52fd-470b-ad9b-ae0701339dda")
+#QUAY_READ_ONLY_PASSWORD=$(bw get password "66de0e1f-52fd-470b-ad9b-ae0701339dda")
+#quay_basic_auth=$(echo "${QUAY_READ_ONLY_USERNAME}:${QUAY_READ_ONLY_PASSWORD}")
+#oc get secret/pull-secret -n openshift-config --template='{{index .data ".dockerconfigjson" | base64decode}}' > ./tmp-pull-secret.json
+#oc registry login --registry="quay.io/rhacs-eng" --auth-basic="${quay_basic_auth}" --to=./tmp-pull-secret.json --skip-check
+#oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=./tmp-pull-secret.json
+#rm ./tmp-pull-secret.json
+
 GIT_COMMIT_SHA=$(git rev-parse HEAD)
 GIT_DESCRIBE_TAG=$(git describe --tag)
 
@@ -111,7 +122,7 @@ helm upgrade rhacs-terraform ./ \
   --set acsOperator.enabled=true \
   --set acsOperator.source=redhat-operators \
   --set acsOperator.sourceNamespace=openshift-marketplace \
-  --set acsOperator.startingCSV=rhacs-operator.v3.71.0 \
+  --set acsOperator.version=v3.71.0 \
   --set fleetshardSync.authType="RHSSO" \
   --set fleetshardSync.gitCommitSHA="${GIT_COMMIT_SHA}" \
   --set fleetshardSync.gitDescribeTag="${GIT_DESCRIBE_TAG}" \
@@ -127,6 +138,11 @@ helm upgrade rhacs-terraform ./ \
   --set observability.observatorium.metricsClientId="${OBSERVABILITY_OBSERVATORIUM_METRICS_CLIENT_ID}" \
   --set observability.observatorium.metricsSecret="${OBSERVABILITY_OBSERVATORIUM_METRICS_SECRET}" \
   --set observability.pagerduty.key="${PAGERDUTY_SERVICE_KEY}"
+  # In case you want to deploy an upstream version of the operator, you can uncomment the lines below
+  #--set acsOperator.upstream.use=true \
+  #--set acsOperator.source=rhacs-operators \
+  # Make sure to set the version of the operator also to a unrelease version, i.e. "v3.72.0-35-gf72be438ec"
+
 
 # To uninstall an existing release:
 # helm uninstall rhacs-terraform --namespace rhacs

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -38,8 +38,7 @@ acsOperator:
   sourceNamespace: openshift-marketplace
   version: v3.70.0
   # This setting specifies whether to use a upstream operator to test unreleased versions of ACS.
-  upstream:
-    use: false
+  upstream: false
 
 # See available parameters in charts/observability/values.yaml
 # - enabled flag is used to completely enable/disable observability sub-chart

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -36,7 +36,10 @@ acsOperator:
   enabled: false
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: rhacs-operator.v3.70.0
+  version: v3.70.0
+  # This setting specifies whether to use a upstream operator to test unreleased versions of ACS.
+  upstream:
+    use: false
 
 # See available parameters in charts/observability/values.yaml
 # - enabled flag is used to completely enable/disable observability sub-chart


### PR DESCRIPTION
## Description

This adds preparation to deploy an upstream version of the operator to a dataplane cluster using the `dp-terraform/helm/terraform-cluster.sh` script.

It's not set in stone whether we want to do it _exactly_ in this way, but at the very least this works in a rough state and we can remove it once we have found a better way to deploy the operator.

In detail, the following has been done based on [the existing documentation of adding an upstream operator](https://github.com/stackrox/acs-fleet-manager/blob/main/docs/development/setup-developer-osd-cluster.md#prepare-cluster-for-rhacs-operator):
- Add scripts for adding the pull secret for `quay.io/rhacs-eng` to the global pull secret of the OSD cluster (using the credentials within BitWarden).
- Expose a new helm setting `acsOperator.upstream.use`.
- If `acsOperator.upstream.use` create a new Catalog source using the operator index image within `quay.io/rhacs-eng`.

The code within the `terraform-cluster.sh` is commented out for now, since we don't plan to use it immediately. 
Once we decide to use upstream images (and don't have another way to do so), we can uncomment them and commit them, as this is currently the workflow within the deployment / terraforming of clusters.

## Test manual


```
# Create a dataplane cluster following the instructions within [this documentation](https://github.com/stackrox/acs-fleet-manager/blob/main/docs/development/setup-developer-osd-cluster.md#prepare-cluster-for-rhacs-operator)
# (Note: skip deploying the catalog source, instead after the cluster is provisioned and the IdP is created, go straight for the helm installation)

# For the helm installation, use the following to terraform the cluster
helm upgrade --install rhacs-terraform \
  --namespace "${NAMESPACE}" \
  --set fleetshardSync.authType="STATIC_TOKEN" \
  --set fleetshardSync.image="${FLEET_MANAGER_IMAGE}" \
  --set fleetshardSync.fleetManagerEndpoint="${FLEET_MANAGER_ENDPOINT}" \
  --set fleetshardSync.staticToken="${STATIC_TOKEN}" \
  --set fleetshardSync.clusterId="${CLUSTER_ID}" \
  --set acsOperator.enabled=true \
  --set acsOperator.upstream.use=true \
  --set acsOperator.source="rhacs-operators" \
  --set acsOperator.version="v3.72.0-35-gf72be438ec" \
  --set logging.enabled=false \
  --set observability.enabled=false ./dp-terraform/helm/rhacs-terraform

# The install plan is currently configured as "Manual", so you have to approve it.

# After approval, fleetshard-sync and the rhacs-operator-manager should show up in the namespace you have chosen
oc get pods -n "${NAMESPACE}"

# Create a central using the following curl script, verify that the provisioning succeeds:
curl -X POST -H "Authorization: Bearer ${STATIC_TOKEN}" "http://localhost:8000/api/rhacs/v1/centrals?async=true" -d "{\"name\":\"test-central\",\"cloud_provider\":\"aws\",\"region\":\"us-east-1\",\"multi_az\":true}"
```
