### PR TITLE
new cluster placement strategies

### DIFF
--- a/internal/dinosaur/pkg/config/dataplane_cluster_config.go
+++ b/internal/dinosaur/pkg/config/dataplane_cluster_config.go
@@ -30,6 +30,7 @@ type DataplaneClusterConfig struct {
 	// 'none' to disabled scaling all together, useful in testing
 	DataPlaneClusterScalingType string `json:"dataplane_cluster_scaling_type"`
 	DataPlaneClusterConfigFile  string `json:"dataplane_cluster_config_file"`
+	DataPlaneClusterTarget      string `json:"dataplane_cluster_target"`
 	ReadOnlyUserList            userv1.OptionalNames
 	ReadOnlyUserListFile        string
 	// TODO ROX-11294 adjust or drop sre user list
@@ -317,6 +318,7 @@ func (c *DataplaneClusterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.FleetshardOperatorOLMConfig.Namespace, "fleetshard-operator-namespace", c.FleetshardOperatorOLMConfig.Namespace, "fleetshard operator namespace")
 	fs.StringVar(&c.FleetshardOperatorOLMConfig.Package, "fleetshard-operator-package", c.FleetshardOperatorOLMConfig.Package, "fleetshard operator package")
 	fs.StringVar(&c.FleetshardOperatorOLMConfig.SubscriptionChannel, "fleetshard-operator-sub-channel", c.FleetshardOperatorOLMConfig.SubscriptionChannel, "fleetshard operator subscription channel")
+	fs.StringVar(&c.DataPlaneClusterTarget, "dataplane-cluster-target", "", "set placement of centrals to cluster with this id")
 }
 
 // ReadFiles ...

--- a/internal/dinosaur/pkg/config/dataplane_cluster_config.go
+++ b/internal/dinosaur/pkg/config/dataplane_cluster_config.go
@@ -318,7 +318,7 @@ func (c *DataplaneClusterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.FleetshardOperatorOLMConfig.Namespace, "fleetshard-operator-namespace", c.FleetshardOperatorOLMConfig.Namespace, "fleetshard operator namespace")
 	fs.StringVar(&c.FleetshardOperatorOLMConfig.Package, "fleetshard-operator-package", c.FleetshardOperatorOLMConfig.Package, "fleetshard operator package")
 	fs.StringVar(&c.FleetshardOperatorOLMConfig.SubscriptionChannel, "fleetshard-operator-sub-channel", c.FleetshardOperatorOLMConfig.SubscriptionChannel, "fleetshard operator subscription channel")
-	fs.StringVar(&c.DataPlaneClusterTarget, "dataplane-cluster-target", "", "set placement of centrals to cluster with this id")
+	fs.StringVar(&c.DataPlaneClusterTarget, "dataplane-cluster-target", "", "specify cluster by ID on which new centrals should be created")
 }
 
 // ReadFiles ...

--- a/internal/dinosaur/pkg/migrations/20220916000000_add_skip_scheduling_to_clusters.go
+++ b/internal/dinosaur/pkg/migrations/20220916000000_add_skip_scheduling_to_clusters.go
@@ -1,0 +1,54 @@
+package migrations
+
+// Migrations should NEVER use types from other packages. Types can change
+// and then migrations run on a _new_ database will fail or behave unexpectedly.
+// Instead of importing types, always re-create the type in the migration, as
+// is done here, even though the same type is defined in pkg/api
+
+import (
+	"fmt"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/stackrox/acs-fleet-manager/pkg/api"
+	"github.com/stackrox/acs-fleet-manager/pkg/db"
+	"gorm.io/gorm"
+)
+
+func addSkipSchedulingToClusters() *gormigrate.Migration {
+	type Cluster struct {
+		db.Model
+		CloudProvider                    string   `json:"cloud_provider"`
+		ClusterID                        string   `json:"cluster_id" gorm:"uniqueIndex:uix_clusters_cluster_id"`
+		ExternalID                       string   `json:"external_id"`
+		MultiAZ                          bool     `json:"multi_az"`
+		Region                           string   `json:"region"`
+		Status                           string   `json:"status" gorm:"index"`
+		StatusDetails                    string   `json:"status_details" gorm:"-"`
+		IdentityProviderID               string   `json:"identity_provider_id"`
+		ClusterDNS                       string   `json:"cluster_dns"`
+		ProviderType                     string   `json:"provider_type"`
+		ProviderSpec                     string   `json:"provider_spec"`
+		ClusterSpec                      string   `json:"cluster_spec"`
+		AvailableCentralOperatorVersions api.JSON `json:"available_central_operator_versions"`
+		SupportedInstanceType            string   `json:"supported_instance_type"`
+		SkipScheduling                   bool     `json:"skip_scheduling" gorm:"default:false"`
+	}
+
+	return &gormigrate.Migration{
+		ID: "20220916000000",
+		Migrate: func(tx *gorm.DB) error {
+			err := tx.AutoMigrate(&Cluster{})
+			if err != nil {
+				return fmt.Errorf("migrating 20220114114501: %w", err)
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			err := tx.Migrator().DropTable(&Cluster{})
+			if err != nil {
+				return fmt.Errorf("rolling back 20220114114501: %w", err)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/dinosaur/pkg/migrations/20220916000000_add_skip_scheduling_to_clusters.go
+++ b/internal/dinosaur/pkg/migrations/20220916000000_add_skip_scheduling_to_clusters.go
@@ -39,14 +39,14 @@ func addSkipSchedulingToClusters() *gormigrate.Migration {
 		Migrate: func(tx *gorm.DB) error {
 			err := tx.AutoMigrate(&Cluster{})
 			if err != nil {
-				return fmt.Errorf("migrating 20220114114501: %w", err)
+				return fmt.Errorf("migrating 20220916000000: %w", err)
 			}
 			return nil
 		},
 		Rollback: func(tx *gorm.DB) error {
-			err := tx.Migrator().DropTable(&Cluster{})
+			err := tx.Migrator().DropColumn(&Cluster{}, "SkipScheduling")
 			if err != nil {
-				return fmt.Errorf("rolling back 20220114114501: %w", err)
+				return fmt.Errorf("rolling back 20220916000000: %w", err)
 			}
 			return nil
 		},

--- a/internal/dinosaur/pkg/migrations/migrations.go
+++ b/internal/dinosaur/pkg/migrations/migrations.go
@@ -33,6 +33,7 @@ var migrations = []*gormigrate.Migration{
 	addResourcesToCentralRequest(),
 	addAuthConfigToCentralRequest(),
 	addCentralAuthLease(),
+	addSkipSchedulingToClusters(),
 }
 
 // New ...

--- a/internal/dinosaur/pkg/services/cluster_placement_strategy.go
+++ b/internal/dinosaur/pkg/services/cluster_placement_strategy.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/config"
@@ -20,29 +21,33 @@ type ClusterPlacementStrategy interface {
 // placement configuration. An appropriate ClusterPlacementStrategy implementation
 // is returned based on the received parameters content
 func NewClusterPlacementStrategy(clusterService ClusterService, dataplaneClusterConfig *config.DataplaneClusterConfig) ClusterPlacementStrategy {
-	var clusterSelection ClusterPlacementStrategy = FirstDBClusterPlacementStrategy{
-		clusterService: clusterService,
+	var clusterSelection ClusterPlacementStrategy
+	if dataplaneClusterConfig.DataPlaneClusterTarget != "" {
+		clusterSelection = TargetClusterPlacementStrategy{
+			targetClusterID: dataplaneClusterConfig.DataPlaneClusterTarget,
+			clusterService:  clusterService}
+	} else {
+		clusterSelection = DefaultClusterPlacementStrategy{
+			clusterService: clusterService,
+		}
 	}
 
 	return clusterSelection
 }
 
 // TODO(create-ticket): Revisit placement strategy before going live.
-var _ ClusterPlacementStrategy = (*FirstDBClusterPlacementStrategy)(nil)
+var _ ClusterPlacementStrategy = (*DefaultClusterPlacementStrategy)(nil)
 
-// FirstDBClusterPlacementStrategy ...
-type FirstDBClusterPlacementStrategy struct {
+// DefaultClusterPlacementStrategy ...
+type DefaultClusterPlacementStrategy struct {
 	clusterService ClusterService
 }
 
 // FindCluster ...
-func (d FirstDBClusterPlacementStrategy) FindCluster(dinosaur *dbapi.CentralRequest) (*api.Cluster, error) {
-	clusters, err := d.clusterService.FindAllClusters(FindClusterCriteria{})
+func (d DefaultClusterPlacementStrategy) FindCluster(dinosaur *dbapi.CentralRequest) (*api.Cluster, error) {
+	clusters, err := findAllClusters(d.clusterService)
 	if err != nil {
 		return nil, err
-	}
-	if len(clusters) == 0 {
-		return nil, errors.New("no cluster was found")
 	}
 
 	for _, cluster := range clusters {
@@ -52,4 +57,40 @@ func (d FirstDBClusterPlacementStrategy) FindCluster(dinosaur *dbapi.CentralRequ
 	}
 
 	return nil, errors.New("no schedulable cluster found")
+}
+
+var _ ClusterPlacementStrategy = TargetClusterPlacementStrategy{}
+
+// TargetClusterPlacementStrategy implements the ClusterPlacementStrategy to always return the same cluster
+type TargetClusterPlacementStrategy struct {
+	targetClusterID string
+	clusterService  ClusterService
+}
+
+// FindCluster returns the target cluster of the placement strategy if found in the cluster list
+func (f TargetClusterPlacementStrategy) FindCluster(central *dbapi.CentralRequest) (*api.Cluster, error) {
+	clusters, err := findAllClusters(f.clusterService)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, cluster := range clusters {
+		if cluster.ID == f.targetClusterID {
+			return cluster, nil
+		}
+	}
+
+	return nil, fmt.Errorf("target cluster: %v not found in cluster list", f.targetClusterID)
+}
+
+func findAllClusters(c ClusterService) ([]*api.Cluster, error) {
+	clusters, err := c.FindAllClusters(FindClusterCriteria{})
+	if err != nil {
+		return nil, err
+	}
+	if len(clusters) == 0 {
+		return nil, errors.New("no cluster was found")
+	}
+
+	return clusters, nil
 }

--- a/internal/dinosaur/pkg/services/cluster_placement_strategy.go
+++ b/internal/dinosaur/pkg/services/cluster_placement_strategy.go
@@ -44,5 +44,12 @@ func (d FirstDBClusterPlacementStrategy) FindCluster(dinosaur *dbapi.CentralRequ
 	if len(clusters) == 0 {
 		return nil, errors.New("no cluster was found")
 	}
-	return clusters[0], nil
+
+	for _, cluster := range clusters {
+		if cluster.Status == api.ClusterReady && !cluster.SkipScheduling {
+			return cluster, nil
+		}
+	}
+
+	return nil, errors.New("no schedulable cluster found")
 }

--- a/internal/dinosaur/pkg/services/cluster_placement_strategy.go
+++ b/internal/dinosaur/pkg/services/cluster_placement_strategy.go
@@ -45,16 +45,18 @@ type FirstReadyPlacementStrategy struct {
 
 // FindCluster ...
 func (d FirstReadyPlacementStrategy) FindCluster(dinosaur *dbapi.CentralRequest) (*api.Cluster, error) {
-	clusters, err := d.clusterService.FindAllClusters(FindClusterCriteria{SkipScheduling: false, Status: api.ClusterReady})
+	clusters, err := d.clusterService.FindAllClusters(FindClusterCriteria{Status: api.ClusterReady})
 	if err != nil {
 		return nil, err
 	}
 
-	if len(clusters) == 0 {
-		return nil, errors.New("no schedulable cluster found")
+	for _, c := range clusters {
+		if !c.SkipScheduling {
+			return c, nil
+		}
 	}
 
-	return clusters[0], nil
+	return nil, errors.New("no schedulable cluster found")
 }
 
 var _ ClusterPlacementStrategy = TargetClusterPlacementStrategy{}

--- a/internal/dinosaur/pkg/services/cluster_placement_strategy_test.go
+++ b/internal/dinosaur/pkg/services/cluster_placement_strategy_test.go
@@ -1,0 +1,47 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlacementStrategyType(t *testing.T) {
+
+	tt := []struct {
+		description          string
+		createClusterService func() ClusterService
+		dataPlaneConfig      *config.DataplaneClusterConfig
+		expectedType         interface{}
+	}{
+		{
+			description: "DefaultClusterPlacementStrategy",
+			createClusterService: func() ClusterService {
+				return &ClusterServiceMock{}
+			},
+			dataPlaneConfig: &config.DataplaneClusterConfig{
+				DataPlaneClusterTarget: "",
+			},
+			expectedType: DefaultClusterPlacementStrategy{},
+		},
+		{
+			description: "TargetClusterPlacementStrategy",
+			createClusterService: func() ClusterService {
+				return &ClusterServiceMock{}
+			},
+			dataPlaneConfig: &config.DataplaneClusterConfig{
+				DataPlaneClusterTarget: "test-cluster-id",
+			},
+			expectedType: TargetClusterPlacementStrategy{},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.description, func(t *testing.T) {
+			strategy := NewClusterPlacementStrategy(tc.createClusterService(), tc.dataPlaneConfig)
+
+			require.IsType(t, tc.expectedType, strategy)
+		})
+	}
+}

--- a/internal/dinosaur/pkg/services/cluster_placement_strategy_test.go
+++ b/internal/dinosaur/pkg/services/cluster_placement_strategy_test.go
@@ -23,7 +23,7 @@ func TestPlacementStrategyType(t *testing.T) {
 			dataPlaneConfig: &config.DataplaneClusterConfig{
 				DataPlaneClusterTarget: "",
 			},
-			expectedType: DefaultClusterPlacementStrategy{},
+			expectedType: FirstReadyPlacementStrategy{},
 		},
 		{
 			description: "TargetClusterPlacementStrategy",

--- a/internal/dinosaur/pkg/services/clusters.go
+++ b/internal/dinosaur/pkg/services/clusters.go
@@ -262,6 +262,7 @@ type FindClusterCriteria struct {
 	MultiAZ               bool
 	Status                api.ClusterStatus
 	SupportedInstanceType string
+	SkipScheduling        bool
 }
 
 // FindCluster ...
@@ -271,10 +272,11 @@ func (c clusterService) FindCluster(criteria FindClusterCriteria) (*api.Cluster,
 	var cluster api.Cluster
 
 	clusterDetails := &api.Cluster{
-		CloudProvider: criteria.Provider,
-		Region:        criteria.Region,
-		MultiAZ:       criteria.MultiAZ,
-		Status:        criteria.Status,
+		CloudProvider:  criteria.Provider,
+		Region:         criteria.Region,
+		MultiAZ:        criteria.MultiAZ,
+		Status:         criteria.Status,
+		SkipScheduling: criteria.SkipScheduling,
 	}
 
 	// filter by supported instance type

--- a/internal/dinosaur/pkg/services/clusters.go
+++ b/internal/dinosaur/pkg/services/clusters.go
@@ -262,7 +262,6 @@ type FindClusterCriteria struct {
 	MultiAZ               bool
 	Status                api.ClusterStatus
 	SupportedInstanceType string
-	SkipScheduling        bool
 }
 
 // FindCluster ...
@@ -272,11 +271,10 @@ func (c clusterService) FindCluster(criteria FindClusterCriteria) (*api.Cluster,
 	var cluster api.Cluster
 
 	clusterDetails := &api.Cluster{
-		CloudProvider:  criteria.Provider,
-		Region:         criteria.Region,
-		MultiAZ:        criteria.MultiAZ,
-		Status:         criteria.Status,
-		SkipScheduling: criteria.SkipScheduling,
+		CloudProvider: criteria.Provider,
+		Region:        criteria.Region,
+		MultiAZ:       criteria.MultiAZ,
+		Status:        criteria.Status,
 	}
 
 	// filter by supported instance type

--- a/internal/dinosaur/pkg/services/clusterservice_moq.go
+++ b/internal/dinosaur/pkg/services/clusterservice_moq.go
@@ -98,6 +98,9 @@ var _ ClusterService = &ClusterServiceMock{}
 // 			UpdateFunc: func(cluster api.Cluster) *serviceError.ServiceError {
 // 				panic("mock out the Update method")
 // 			},
+// 			UpdateMultiClusterSkipSchedulingFunc: func(clusterIds []string, skipScheduling bool) *serviceError.ServiceError {
+// 				panic("mock out the UpdateMultiClusterSkipScheduling method")
+// 			},
 // 			UpdateMultiClusterStatusFunc: func(clusterIds []string, status api.ClusterStatus) *serviceError.ServiceError {
 // 				panic("mock out the UpdateMultiClusterStatus method")
 // 			},
@@ -188,6 +191,9 @@ type ClusterServiceMock struct {
 
 	// UpdateFunc mocks the Update method.
 	UpdateFunc func(cluster api.Cluster) *serviceError.ServiceError
+
+	// UpdateMultiClusterSkipSchedulingFunc mocks the UpdateMultiClusterSkipScheduling method.
+	UpdateMultiClusterSkipSchedulingFunc func(clusterIds []string, skipScheduling bool) *serviceError.ServiceError
 
 	// UpdateMultiClusterStatusFunc mocks the UpdateMultiClusterStatus method.
 	UpdateMultiClusterStatusFunc func(clusterIds []string, status api.ClusterStatus) *serviceError.ServiceError
@@ -345,6 +351,13 @@ type ClusterServiceMock struct {
 			// Cluster is the cluster argument value.
 			Cluster api.Cluster
 		}
+		// UpdateMultiClusterSkipScheduling holds details about calls to the UpdateMultiClusterSkipScheduling method.
+		UpdateMultiClusterSkipScheduling []struct {
+			// ClusterIds is the clusterIds argument value.
+			ClusterIds []string
+			// SkipScheduling is the skipScheduling argument value.
+			SkipScheduling bool
+		}
 		// UpdateMultiClusterStatus holds details about calls to the UpdateMultiClusterStatus method.
 		UpdateMultiClusterStatus []struct {
 			// ClusterIds is the clusterIds argument value.
@@ -386,6 +399,7 @@ type ClusterServiceMock struct {
 	lockScaleUpComputeNodes                 sync.RWMutex
 	lockSetComputeNodes                     sync.RWMutex
 	lockUpdate                              sync.RWMutex
+	lockUpdateMultiClusterSkipScheduling    sync.RWMutex
 	lockUpdateMultiClusterStatus            sync.RWMutex
 	lockUpdateStatus                        sync.RWMutex
 }
@@ -1228,6 +1242,41 @@ func (mock *ClusterServiceMock) UpdateCalls() []struct {
 	mock.lockUpdate.RLock()
 	calls = mock.calls.Update
 	mock.lockUpdate.RUnlock()
+	return calls
+}
+
+// UpdateMultiClusterSkipScheduling calls UpdateMultiClusterSkipSchedulingFunc.
+func (mock *ClusterServiceMock) UpdateMultiClusterSkipScheduling(clusterIds []string, skipScheduling bool) *serviceError.ServiceError {
+	if mock.UpdateMultiClusterSkipSchedulingFunc == nil {
+		panic("ClusterServiceMock.UpdateMultiClusterSkipSchedulingFunc: method is nil but ClusterService.UpdateMultiClusterSkipScheduling was just called")
+	}
+	callInfo := struct {
+		ClusterIds     []string
+		SkipScheduling bool
+	}{
+		ClusterIds:     clusterIds,
+		SkipScheduling: skipScheduling,
+	}
+	mock.lockUpdateMultiClusterSkipScheduling.Lock()
+	mock.calls.UpdateMultiClusterSkipScheduling = append(mock.calls.UpdateMultiClusterSkipScheduling, callInfo)
+	mock.lockUpdateMultiClusterSkipScheduling.Unlock()
+	return mock.UpdateMultiClusterSkipSchedulingFunc(clusterIds, skipScheduling)
+}
+
+// UpdateMultiClusterSkipSchedulingCalls gets all the calls that were made to UpdateMultiClusterSkipScheduling.
+// Check the length with:
+//     len(mockedClusterService.UpdateMultiClusterSkipSchedulingCalls())
+func (mock *ClusterServiceMock) UpdateMultiClusterSkipSchedulingCalls() []struct {
+	ClusterIds     []string
+	SkipScheduling bool
+} {
+	var calls []struct {
+		ClusterIds     []string
+		SkipScheduling bool
+	}
+	mock.lockUpdateMultiClusterSkipScheduling.RLock()
+	calls = mock.calls.UpdateMultiClusterSkipScheduling
+	mock.lockUpdateMultiClusterSkipScheduling.RUnlock()
 	return calls
 }
 

--- a/internal/dinosaur/pkg/workers/clusters_mgr.go
+++ b/internal/dinosaur/pkg/workers/clusters_mgr.go
@@ -375,15 +375,16 @@ func (c *ClusterManager) reconcileDeprovisioningCluster(cluster *api.Cluster) er
 
 func (c *ClusterManager) reconcileCleanupCluster(cluster api.Cluster) error {
 	glog.Infof("Removing Dataplane cluster %s fleetshard service account", cluster.ClusterID)
-	serviceAcountRemovalErr := c.FleetshardOperatorAddon.RemoveServiceAccount(cluster)
-	if serviceAcountRemovalErr != nil {
-		return errors.Wrapf(serviceAcountRemovalErr, "Failed to removed Dataplance cluster %s fleetshard service account", cluster.ClusterID)
-	}
+	// TODO(addon): reactivate this, if required for cluster terraforming by fleet-manager
+	// serviceAcountRemovalErr := c.FleetshardOperatorAddon.RemoveServiceAccount(cluster)
+	// if serviceAcountRemovalErr != nil {
+	// 	return errors.Wrapf(serviceAcountRemovalErr, "Failed to removed Dataplance cluster %s fleetshard service account", cluster.ClusterID)
+	// }
 
 	glog.Infof("Soft deleting the Dataplane cluster %s from the database", cluster.ClusterID)
 	deleteError := c.ClusterService.DeleteByClusterID(cluster.ClusterID)
 	if deleteError != nil {
-		return errors.Wrapf(deleteError, "Failed to soft delete Dataplance cluster %s from the database", cluster.ClusterID)
+		return errors.Wrapf(deleteError, "Failed to soft delete Dataplane cluster %s from the database", cluster.ClusterID)
 	}
 	return nil
 }

--- a/internal/dinosaur/pkg/workers/clusters_mgr.go
+++ b/internal/dinosaur/pkg/workers/clusters_mgr.go
@@ -673,6 +673,8 @@ func (c *ClusterManager) reconcileClusterWithManualConfig() []error {
 		newCluster.ProviderType = manualCluster.ProviderType
 		newCluster.ClusterDNS = manualCluster.ClusterDNS
 		newCluster.SupportedInstanceType = manualCluster.SupportedInstanceType
+		newCluster.SkipScheduling = false
+
 		if err := cluster.SetAvailableCentralOperatorVersions(manualCluster.AvailableCentralOperatorVersions); err != nil {
 			return []error{errors.Wrapf(err, "Failed to update operator versions for manual cluster %s with config file", manualCluster.ClusterID)}
 		}

--- a/pkg/api/cluster_types.go
+++ b/pkg/api/cluster_types.go
@@ -154,6 +154,7 @@ type Cluster struct {
 	StatusDetails      string        `json:"status_details" gorm:"-"`
 	IdentityProviderID string        `json:"identity_provider_id"`
 	ClusterDNS         string        `json:"cluster_dns"`
+	SkipScheduling     bool          `json:"skip_scheduling"`
 	// the provider type for the cluster, e.g. OCM, AWS, GCP, Standalone etc
 	ProviderType ClusterProviderType `json:"provider_type"`
 	// store the provider-specific information that can be used to managed the openshift/k8s cluster


### PR DESCRIPTION
## Description
Implemented 2 cluster placement strategies for central:

- DefaultClusterPlacementStrategy
  - first cluster in Ready state that has SkipScheduling set to false for central
  - is enabled by default
- TargetClusterPlacementStrategy
  - allows to specify a command line flag `-dataplane-cluster-target`, if that flag is set centrals are placed 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
