### PR TITLE
[ROX-12667] Fix annotation format of date type

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: fleetshard-sync
-    managed-service.rhacs.redhat.com/update-trigger: {{ now }}
+    managed-service.rhacs.redhat.com/update-trigger: {{ now | date "2006-01-02_15-04-05" | quote }}
     managed-service.rhacs.redhat.com/git-commit-sha: {{ .Values.fleetshardSync.gitCommitSHA }}
     managed-service.rhacs.redhat.com/git-describe-tag: {{ .Values.fleetshardSync.gitDescribeTag }}
 spec:


### PR DESCRIPTION
## Description

We had an issue with the date format for the annotation field. Some characters are not allowed.

This is the error that we got during the re-terraforming process.
```
upgrade.go:434: [debug] warning: Upgrade "rhacs-terraform" failed: cannot patch "fleetshard-sync" with kind Deployment: Deployment.apps "fleetshard-sync" is invalid: metadata.labels: Invalid value: "2022-09-15 18:45:36.325388 +0200 CEST m=+7.175811783": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
Error: UPGRADE FAILED: cannot patch "fleetshard-sync" with kind Deployment: Deployment.apps "fleetshard-sync" is invalid: metadata.labels: Invalid value: "2022-09-15 18:45:36.325388 +0200 CEST m=+7.175811783": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
helm.go:84: [debug] cannot patch "fleetshard-sync" with kind Deployment: Deployment.apps "fleetshard-sync" is invalid: metadata.labels: Invalid value: "2022-09-15 18:45:36.325388 +0200 CEST m=+7.175811783": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```

This PR just fixes the issue with formatting, but we should change this. One proposal is described in a comment: https://issues.redhat.com/browse/ROX-12667

With this change output will be like this:
```
managed-service.rhacs.redhat.com/update-trigger: "2022-09-19_14-14-13"
```

## Checklist (Definition of Done)
- ~[ ] Unit and integration tests added~
- ~[ ] Documentation added if necessary~
- [x] CI and all relevant tests are passing
- ~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

I have tested with the `helm template`. You can run the following command and check the result.
```
helm template rhacs-terraform --debug \
  --namespace "test" \
  --set acsOperator.enabled=falsa \
  --set logging.enabled=false \
  --set observability.enabled=false ./dp-terraform/helm/rhacs-terraform | grep update-trigger
```
