### PR TITLE
ROX-12157: Implement augmentWithDynamicAuthConfig

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -280,22 +280,6 @@
         "line_number": 183
       }
     ],
-    "pkg/client/redhatsso/serviceaccounts/client_moq.go": [
-      {
-        "type": "Secret Keyword",
-        "filename": "pkg/client/redhatsso/serviceaccounts/client_moq.go",
-        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
-        "is_verified": false,
-        "line_number": 247
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "pkg/client/redhatsso/serviceaccounts/client_moq.go",
-        "hashed_secret": "cb03097ef5f9f0681164390e055c68f71185fe61",
-        "is_verified": false,
-        "line_number": 248
-      }
-    ],
     "pkg/shared/secrets/secrets_test.go": [
       {
         "type": "Secret Keyword",
@@ -337,5 +321,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-06T12:29:40Z"
+  "generated_at": "2022-10-05T05:17:16Z"
 }

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -851,10 +851,12 @@ func (k *dinosaurService) ListDinosaursWithRoutesNotCreated() ([]*dbapi.CentralR
 }
 
 // ListCentralsWithoutAuthConfig returns all _relevant_ central requests with
-// no auth config.
+// no auth config. For central requests without host set, we cannot compute
+// redirect_uri and hence cannot set up auth config.
 func (k *dinosaurService) ListCentralsWithoutAuthConfig() ([]*dbapi.CentralRequest, *errors.ServiceError) {
 	dbQuery := k.connectionFactory.New().
-		Where("client_id = ''")
+		Where("client_id = ''").
+		Where("host != ''")
 
 	var results []*dbapi.CentralRequest
 	if err := dbQuery.Find(&results).Error; err != nil {


### PR DESCRIPTION
## Description
This PR augments central requests with Central IdP OIDC client data by using dynamic clients API provided to us by CIAM team.

Changes within this PR:
* call to RHSSO dynamic clients API to get OIDC client data
* GetIssuer() method in IAMService to avoid us depending on a config value
* Truncate name according to dynamic clients API limitation
* Limit client creation requests only to centrals with already set `host`


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
0. **Remove orgId check:** https://github.com/stackrox/acs-fleet-manager/blob/667ae5a81952f3508742e905a6f57b502e1fbcd9/fleetshard/pkg/central/reconciler/init_auth.go#L156-L161 
1. Deploy `fleetshard-sync` to OSD cluster with `sso.stage.redhat.com` service account auth:
```
helm -n $NAMESPACE install rhacs-terraform dp-terraform/helm/rhacs-terraform/ \                                                                                                                    
  --set fleetshardSync.authType="RHSSO" \
  --set fleetshardSync.fleetManagerEndpoint=${FLEET_MANAGER_ENDPOINT} \
  --set fleetshardSync.clusterId=${CLUSTER_ID} \
  --set fleetshardSync.image="${FLEET_MANAGER_IMAGE}" \
  --set fleetshardSync.gitCommitSHA="wow" \
  --set fleetshardSync.gitDescribeTag="bowaoo" \
  --set acsOperator.enabled=true \
  --set acsOperator.source="${RHACS_OPERATOR_CATALOG_NAME}" \
  --set logging.enabled=false \
  --set acsOperator.version="v${RHACS_OPERATOR_CATALOG_VERSION}" \
  --set fleetshardSync.redHatSSO.clientId="${CLIENT_ID}" \
  --set fleetshardSync.redHatSSO.clientSecret="${CLIENT_SECRET}" \
  --set fleetshardSync.redHatSSO.endpoint=https://sso.stage.redhat.com \
--set observability.enabled=false
```
In general follow steps here:
https://github.com/stackrox/acs-fleet-manager/blob/main/docs/development/setup-developer-osd-cluster.md
2. Add `orgId` of fleetshardSync token to the list here:
https://github.com/stackrox/acs-fleet-manager/blob/667ae5a81952f3508742e905a6f57b502e1fbcd9/config/fleetshard-authz-org-ids-development.yaml
3. Initialise clientId/clientSecret to call dynamic clients API
```
echo "${DYNAMIC_CLIENT_ID}" > secrets/redhatsso-service.clientId
echo "${DYNAMIC_CLIENT_ID}" > secrets/redhatsso-service.clientSecret
```
4. Deploy local fleet-manager `OCM_TOKEN=$(ocm token) ./fleet-manager serve --redhat-sso-base-url="https://sso.stage.redhat.com" --dataplane-cluster-config-file "./${CLUSTER_ID}.yaml"`
6.  Create central
7. Add central `reencrypt` route to `/etc/hosts`: https://github.com/stackrox/acs-fleet-manager/blob/main/docs/development/test-locally-route-hosts.md
8. `sudo oc -n ${CENTRAL_NAMESPACE} port-forward pod/${CENTRAL_POD}  443:8443`
9. Access Stackrox in browser via `https://${CENTRAL_REENCRYPT_PATH}`. Use account in `sso.stage.redhat.com` to log in with `Red Hat SSO (stage)`

