### PR TITLE
TestEnv: Fix standalone deployment of fleet-manager

### DIFF
--- a/dev/env/manifests/fleet-manager/02-fleet-manager-deployment.yaml
+++ b/dev/env/manifests/fleet-manager/02-fleet-manager-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - command:
             - sh
             - "-c"
-            - "cd /; $FLEET_MANAGER_COMMAND || { sleep 120; false; }"
+            - "cd /; /usr/local/bin/fleet-manager serve --force-leader --api-server-bindaddress=0.0.0.0:8000 --health-check-server-bindaddress=0.0.0.0:8083 --kubeconfig=/secrets/kubeconfig --enable-central-external-certificate=$ENABLE_CENTRAL_EXTERNAL_CERTIFICATE --central-domain-name='$CENTRAL_DOMAIN_NAME' || { sleep 120; false; }"
           image: "$FLEET_MANAGER_IMAGE"
           imagePullPolicy: IfNotPresent
           name: fleet-manager

--- a/dev/env/scripts/up.sh
+++ b/dev/env/scripts/up.sh
@@ -72,7 +72,6 @@ log "Database is ready."
 
 # Deploy MS components.
 log "Deploying fleet-manager"
-export FLEET_MANAGER_COMMAND="/usr/local/bin/fleet-manager serve --force-leader --api-server-bindaddress=0.0.0.0:8000 --health-check-server-bindaddress=0.0.0.0:8083 --kubeconfig=/secrets/kubeconfig --enable-central-external-certificate=$ENABLE_CENTRAL_EXTERNAL_CERTIFICATE --central-domain-name='$CENTRAL_DOMAIN_NAME'"
 apply "${MANIFESTS_DIR}/fleet-manager"
 wait_for_container_to_appear "$ACSMS_NAMESPACE" "application=fleet-manager" "fleet-manager"
 if [[ "$SPAWN_LOGGER" == "true" && -n "${LOG_DIR:-}" ]]; then


### PR DESCRIPTION
## Description

Currently fleet-manager within the TestEnv can only be deployed by using the `up.sh` script. But, this script is doing a lot of initialization and sometimes, during development, it would be sufficient to do quickly do something like:

```
dev/env/scripts/delete dev/env/manifests/fleet-manager/deployment.yaml
make image/build/local
dev/env/scripts/up dev/env/manifests/fleet-manager/deployment.yaml
```

But this flow currently doesn't work anymore, since the deployment YAML references a mandatory variable `FLEET_MANAGER_COMMAND`, which is not initialized as part of the `lib.sh:init` initialization, but only in `up.sh`.

I don't remember the exact rationale behind this, @johannes94 am I overlooking something here?

This PR simply get rids of the variable -- I am assuming that it's value is rather static (and the way it was set up now also did not expose it as being configurable).

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
