### PR TITLE
ROX-12743: Provide fleet-manager endpoint for manually deleting tenants in the database

### DIFF
--- a/e2e/admin_client_api.go
+++ b/e2e/admin_client_api.go
@@ -128,3 +128,17 @@ func (c *Client) UpdateCentral(id string, updateReq private.CentralUpdateRequest
 	}
 	return result, nil
 }
+
+// DbDeleteCentral deletes the Central denoted by the provided ID within fleet-manager's database.
+func (c *Client) DbDeleteCentral(id string) error {
+	resp, err := c.newRequest(http.MethodDelete, fmt.Sprintf("%s/dinosaurs/db/%s", c.adminAPIEndpoint, id), nil)
+	if err != nil {
+		return err
+	}
+
+	err = c.unmarshalResponse(resp, nil)
+	if err != nil {
+		return errors.Wrapf(err, "deleting central %q in database", id)
+	}
+	return nil
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -9,10 +9,6 @@ import (
 	"os"
 	"time"
 
-	"sigs.k8s.io/yaml"
-
-	appsv1 "k8s.io/api/apps/v1"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	openshiftRouteV1 "github.com/openshift/api/route/v1"
@@ -25,10 +21,13 @@ import (
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/converters"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/services"
 	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
-	v1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 )
 
 func newCentralName() string {
@@ -110,7 +109,7 @@ var _ = Describe("Central", func() {
 		// and that is not accessible from a value `*public.CentralRequest`
 		It("should create central namespace", func() {
 			Eventually(func() error {
-				ns := &v1.Namespace{}
+				ns := &corev1.Namespace{}
 				return k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: namespaceName}, ns)
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Succeed())
 		})
@@ -239,7 +238,7 @@ var _ = Describe("Central", func() {
 
 		It("should remove central namespace", func() {
 			Eventually(func() bool {
-				ns := &v1.Namespace{}
+				ns := &corev1.Namespace{}
 				err := k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: namespaceName}, ns)
 				return apiErrors.IsNotFound(err)
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(BeTrue())
@@ -267,12 +266,12 @@ var _ = Describe("Central", func() {
 
 		centralResources := public.ResourceRequirements{
 			Requests: map[string]string{
-				v1.ResourceCPU.String():    "501m",
-				v1.ResourceMemory.String(): "201M",
+				corev1.ResourceCPU.String():    "501m",
+				corev1.ResourceMemory.String(): "201M",
 			},
 			Limits: map[string]string{
-				v1.ResourceCPU.String():    "502m",
-				v1.ResourceMemory.String(): "202M",
+				corev1.ResourceCPU.String():    "502m",
+				corev1.ResourceMemory.String(): "202M",
 			},
 		}
 		centralSpec := public.CentralSpec{
@@ -280,12 +279,12 @@ var _ = Describe("Central", func() {
 		}
 		scannerResources := public.ResourceRequirements{
 			Requests: map[string]string{
-				v1.ResourceCPU.String():    "301m",
-				v1.ResourceMemory.String(): "151M",
+				corev1.ResourceCPU.String():    "301m",
+				corev1.ResourceMemory.String(): "151M",
 			},
 			Limits: map[string]string{
-				v1.ResourceCPU.String():    "302m",
-				v1.ResourceMemory.String(): "152M",
+				corev1.ResourceCPU.String():    "302m",
+				corev1.ResourceMemory.String(): "152M",
 			},
 		}
 		scannerScaling := public.ScannerSpecAnalyzerScaling{
@@ -351,33 +350,33 @@ var _ = Describe("Central", func() {
 				Central: private.CentralSpec{
 					Resources: private.ResourceRequirements{
 						Requests: map[string]string{
-							v1.ResourceMemory.String(): "199M",
+							corev1.ResourceMemory.String(): "199M",
 						},
 						Limits: map[string]string{
-							v1.ResourceCPU.String(): "505m",
+							corev1.ResourceCPU.String(): "505m",
 						},
 					},
 				},
 			}
-			newCentralResources := v1.ResourceRequirements{
-				Requests: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("501m"),
-					v1.ResourceMemory: resource.MustParse("199M"),
+			newCentralResources := corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("501m"),
+					corev1.ResourceMemory: resource.MustParse("199M"),
 				},
-				Limits: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("505m"),
-					v1.ResourceMemory: resource.MustParse("202M"),
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("505m"),
+					corev1.ResourceMemory: resource.MustParse("202M"),
 				},
 			}
 
 			_, err = adminClient.UpdateCentral(centralID, updateReq)
 			Expect(err).ToNot(HaveOccurred())
-			Eventually(func() v1.ResourceRequirements {
+			Eventually(func() corev1.ResourceRequirements {
 				central := &v1alpha1.Central{}
 				err := k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: centralName, Namespace: namespaceName}, central)
 				Expect(err).ToNot(HaveOccurred())
 				if central.Spec.Central == nil || central.Spec.Central.Resources == nil {
-					return v1.ResourceRequirements{}
+					return corev1.ResourceRequirements{}
 				}
 				return *central.Spec.Central.Resources
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Equal(newCentralResources))
@@ -409,7 +408,7 @@ var _ = Describe("Central", func() {
 
 		It("should remove central namespace", func() {
 			Eventually(func() bool {
-				ns := &v1.Namespace{}
+				ns := &corev1.Namespace{}
 				err := k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: namespaceName}, ns)
 				return apiErrors.IsNotFound(err)
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(BeTrue())
@@ -429,6 +428,87 @@ var _ = Describe("Central", func() {
 				Should(BeEmpty(), "Started at %s", time.Now())
 		})
 
+	})
+
+	Describe("should be deployed and can be force-deleted", func() {
+		var err error
+
+		centralName := newCentralName()
+		request := public.CentralRequestPayload{
+			Name:          centralName,
+			MultiAz:       true,
+			CloudProvider: dpCloudProvider,
+			Region:        dpRegion,
+		}
+
+		var createdCentral *public.CentralRequest
+		var namespaceName string
+		It("created a central", func() {
+			createdCentral, err = client.CreateCentral(request)
+			GinkgoWriter.Printf("createdCentral = %+v\n", *createdCentral)
+			Expect(err).To(BeNil())
+			namespaceName, err = services.FormatNamespace(createdCentral.Id)
+			Expect(err).To(BeNil())
+			Expect(constants.CentralRequestStatusAccepted.String()).To(Equal(createdCentral.Status))
+
+			Eventually(func() error {
+				_, err := client.GetCentral(createdCentral.Id)
+				return err
+			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(BeNil())
+		})
+
+		It("should transition central's state to ready", func() {
+			Eventually(func() string {
+				return centralStatus(createdCentral, client)
+			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Equal(constants.CentralRequestStatusReady.String()))
+		})
+
+		It("should be deletable in the control-plane database", func() {
+			err = adminClient.DbDeleteCentral(createdCentral.Id)
+			Expect(err).To(Succeed())
+			err = adminClient.DbDeleteCentral(createdCentral.Id)
+			Expect(err).To(HaveOccurred())
+			central, err := client.GetCentral(createdCentral.Id)
+			Expect(central).To(BeNil())
+			Expect(err).To(HaveOccurred())
+		})
+
+		// Cleaning up on data-plane side because we have skipped the regular deletion workflow taking care of this.
+		It("can be cleaned up manually", func() {
+			// (1) Delete the Central CR.
+			centralRef := &v1alpha1.Central{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      centralName,
+					Namespace: namespaceName,
+				},
+			}
+			GinkgoWriter.Printf("centralRef = %+v\n", *centralRef)
+			err = k8sClient.Delete(context.Background(), centralRef)
+			Expect(err).ToNot(HaveOccurred())
+
+			// (2) Delete the namespace and everything in it.
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespaceName,
+				},
+			}
+			err = k8sClient.Delete(context.Background(), namespace)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should delete external DNS entries", func() {
+			if !dnsEnabled {
+				Skip(skipDNSMsg)
+			}
+
+			central := getCentral(createdCentral, client)
+			dnsRecordsLoader := dns.NewRecordsLoader(route53Client, central)
+
+			Eventually(dnsRecordsLoader.LoadDNSRecords).
+				WithTimeout(waitTimeout).
+				WithPolling(defaultPolling).
+				Should(BeEmpty(), "Started at %s", time.Now())
+		})
 	})
 })
 

--- a/internal/dinosaur/pkg/api/admin/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/admin/private/api/openapi.yaml
@@ -376,6 +376,46 @@ paths:
       security:
       - Bearer: []
       summary: Update a Central instance by ID
+  /api/rhacs/v1/admin/db/centrals/{id}:
+    delete:
+      operationId: deleteDbCentralById
+      parameters:
+      - description: The ID of record
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Central deleted by ID
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Auth token is invalid
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: User is not authorised to access the service
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: No Central found with the specified ID
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unexpected error occurred
+      security:
+      - Bearer: []
+      summary: Delete a Central directly in the Database by ID
 components:
   schemas:
     Central:

--- a/internal/dinosaur/pkg/api/admin/private/api_default.go
+++ b/internal/dinosaur/pkg/api/admin/private/api_default.go
@@ -284,6 +284,111 @@ func (a *DefaultApiService) DeleteCentralById(ctx _context.Context, id string, a
 }
 
 /*
+DeleteDbCentralById Delete a Central directly in the Database by ID
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param id The ID of record
+*/
+func (a *DefaultApiService) DeleteDbCentralById(ctx _context.Context, id string) (*_nethttp.Response, error) {
+	var (
+		localVarHTTPMethod   = _nethttp.MethodDelete
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/api/rhacs/v1/admin/db/centrals/{id}"
+	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", _neturl.QueryEscape(parameterToString(id, "")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 401 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 403 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 404 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 500 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
+
+/*
 GetCentralById Return the details of Central instance by ID
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param id The ID of record

--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -160,6 +160,21 @@ func (h adminDinosaurHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	handlers.HandleDelete(w, r, cfg, http.StatusAccepted)
 }
 
+// DbDelete ...
+func (h adminDinosaurHandler) DbDelete(w http.ResponseWriter, r *http.Request) {
+	cfg := &handlers.HandlerConfig{
+		Action: func() (i interface{}, serviceError *errors.ServiceError) {
+			id := mux.Vars(r)["id"]
+			ctx := r.Context()
+
+			err := h.service.DbDelete(ctx, id)
+			return nil, err
+		},
+	}
+
+	handlers.HandleDelete(w, r, cfg, http.StatusOK)
+}
+
 func updateResourcesList(to *corev1.ResourceList, from map[string]string) error {
 	newResourceList := to.DeepCopy()
 	for name, qty := range from {

--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -166,7 +166,6 @@ func (h adminDinosaurHandler) DbDelete(w http.ResponseWriter, r *http.Request) {
 		Action: func() (i interface{}, serviceError *errors.ServiceError) {
 			id := mux.Vars(r)["id"]
 			ctx := r.Context()
-
 			err := h.service.DbDelete(ctx, id)
 			return nil, err
 		},

--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -160,13 +160,19 @@ func (h adminDinosaurHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	handlers.HandleDelete(w, r, cfg, http.StatusAccepted)
 }
 
-// DbDelete ...
+// DbDelete implements the endpoint for force-deleting Central tenants in the database in emergency situations requiring manual recovery
+// from an inconsistent state.
 func (h adminDinosaurHandler) DbDelete(w http.ResponseWriter, r *http.Request) {
 	cfg := &handlers.HandlerConfig{
 		Action: func() (i interface{}, serviceError *errors.ServiceError) {
 			id := mux.Vars(r)["id"]
 			ctx := r.Context()
-			err := h.service.DbDelete(ctx, id)
+			centralRequest, err := h.service.Get(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+
+			err = h.service.Delete(centralRequest, true)
 			return nil, err
 		},
 	}

--- a/internal/dinosaur/pkg/routes/route_loader.go
+++ b/internal/dinosaur/pkg/routes/route_loader.go
@@ -218,7 +218,11 @@ func (s *options) buildAPIBaseRouter(mainRouter *mux.Router, basePath string, op
 	adminRouter.Use(auth.NewRolesAuhzMiddleware(s.AdminRoleAuthZConfig).RequireRolesForMethods(errors.ErrorNotFound))
 	adminRouter.Use(auth.NewAuditLogMiddleware().AuditLog(errors.ErrorNotFound))
 	adminDinosaursRouter := adminRouter.PathPrefix("/dinosaurs").Subrouter()
+
 	adminDbCentralsRouter := adminDinosaursRouter.PathPrefix("/db").Subrouter()
+	adminDbCentralsRouter.HandleFunc("/{id}", adminDinosaurHandler.DbDelete).
+		Name(logger.NewLogEvent("admin-db-delete-central", "[admin] delete central by id").ToString()).
+		Methods(http.MethodDelete)
 
 	adminDinosaursRouter.HandleFunc("", adminDinosaurHandler.List).
 		Name(logger.NewLogEvent("admin-list-dinosaurs", "[admin] list all dinosaurs").ToString()).
@@ -232,10 +236,6 @@ func (s *options) buildAPIBaseRouter(mainRouter *mux.Router, basePath string, op
 	adminDinosaursRouter.HandleFunc("/{id}", adminDinosaurHandler.Update).
 		Name(logger.NewLogEvent("admin-update-dinosaur", "[admin] update dinosaur by id").ToString()).
 		Methods(http.MethodPatch)
-
-	adminDbCentralsRouter.HandleFunc("/{id}", adminDinosaurHandler.DbDelete).
-		Name(logger.NewLogEvent("admin-db-delete-central", "[admin] delete central by id").ToString()).
-		Methods(http.MethodDelete)
 
 	adminCreateRouter := adminDinosaursRouter.NewRoute().Subrouter()
 	adminCreateRouter.HandleFunc("", adminDinosaurHandler.Create).Methods(http.MethodPost)

--- a/internal/dinosaur/pkg/routes/route_loader.go
+++ b/internal/dinosaur/pkg/routes/route_loader.go
@@ -218,6 +218,7 @@ func (s *options) buildAPIBaseRouter(mainRouter *mux.Router, basePath string, op
 	adminRouter.Use(auth.NewRolesAuhzMiddleware(s.AdminRoleAuthZConfig).RequireRolesForMethods(errors.ErrorNotFound))
 	adminRouter.Use(auth.NewAuditLogMiddleware().AuditLog(errors.ErrorNotFound))
 	adminDinosaursRouter := adminRouter.PathPrefix("/dinosaurs").Subrouter()
+	adminDbCentralsRouter := adminDinosaursRouter.PathPrefix("/db").Subrouter()
 
 	adminDinosaursRouter.HandleFunc("", adminDinosaurHandler.List).
 		Name(logger.NewLogEvent("admin-list-dinosaurs", "[admin] list all dinosaurs").ToString()).
@@ -231,6 +232,10 @@ func (s *options) buildAPIBaseRouter(mainRouter *mux.Router, basePath string, op
 	adminDinosaursRouter.HandleFunc("/{id}", adminDinosaurHandler.Update).
 		Name(logger.NewLogEvent("admin-update-dinosaur", "[admin] update dinosaur by id").ToString()).
 		Methods(http.MethodPatch)
+
+	adminDbCentralsRouter.HandleFunc("/{id}", adminDinosaurHandler.DbDelete).
+		Name(logger.NewLogEvent("admin-db-delete-central", "[admin] delete central by id").ToString()).
+		Methods(http.MethodDelete)
 
 	adminCreateRouter := adminDinosaursRouter.NewRoute().Subrouter()
 	adminCreateRouter.HandleFunc("", adminDinosaurHandler.Create).Methods(http.MethodPost)

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -76,8 +76,7 @@ type DinosaurService interface {
 	GetByID(id string) (*dbapi.CentralRequest, *errors.ServiceError)
 	// Delete cleans up all dependencies for a Dinosaur request and soft deletes the Dinosaur Request record from the database.
 	// The Dinosaur Request in the database will be updated with a deleted_at timestamp.
-	Delete(*dbapi.CentralRequest) *errors.ServiceError
-	DbDelete(ctx context.Context, id string) *errors.ServiceError
+	Delete(centralRequest *dbapi.CentralRequest, force bool) *errors.ServiceError
 	List(ctx context.Context, listArgs *services.ListArguments) (dbapi.CentralList, *api.PagingMeta, *errors.ServiceError)
 	ListByClusterID(clusterID string) ([]*dbapi.CentralRequest, *errors.ServiceError)
 	RegisterDinosaurJob(dinosaurRequest *dbapi.CentralRequest) *errors.ServiceError
@@ -518,30 +517,43 @@ func (k *dinosaurService) DeprovisionExpiredDinosaurs(dinosaurAgeInHours int) *e
 	return nil
 }
 
-// Delete ...
-func (k *dinosaurService) Delete(dinosaurRequest *dbapi.CentralRequest) *errors.ServiceError {
+// Delete a CentralRequest from the database.
+// The implementation uses soft-deletion (via GORM).
+// If the force flag is true, then any errors prior to the final deletion of the CentralRequest will be logged as warnings
+// but do not interrupt the deletion flow.
+func (k *dinosaurService) Delete(centralRequest *dbapi.CentralRequest, force bool) *errors.ServiceError {
 	dbConn := k.connectionFactory.New()
 
 	// if the we don't have the clusterID we can only delete the row from the database
-	if dinosaurRequest.ClusterID != "" {
-		routes, err := dinosaurRequest.GetRoutes()
+	if centralRequest.ClusterID != "" {
+		routes, err := centralRequest.GetRoutes()
 		if err != nil {
 			return errors.NewWithCause(errors.ErrorGeneral, err, "failed to get routes")
 		}
 		// Only delete the routes when they are set
 		if routes != nil && k.dinosaurConfig.EnableCentralExternalCertificate {
-			_, err := k.ChangeDinosaurCNAMErecords(dinosaurRequest, DinosaurRoutesActionDelete)
+			_, err := k.ChangeDinosaurCNAMErecords(centralRequest, DinosaurRoutesActionDelete)
 			if err != nil {
-				return err
+				if force {
+					glog.Warningf("Failed to delete CNAME records for Central tenant %q: %v", centralRequest.ID, err)
+					glog.Warning("Continuing with deletion of Central tenant because force-deletion is specified")
+				} else {
+					return err
+				}
 			}
+			glog.Infof("Successfully deleted CNAME records for Central tenant %q", centralRequest.ID)
 		}
 	}
 
 	// soft delete the dinosaur request
-	if err := dbConn.Delete(dinosaurRequest).Error; err != nil {
-		return errors.NewWithCause(errors.ErrorGeneral, err, "unable to delete central request with id %s", dinosaurRequest.ID)
+	if err := dbConn.Delete(centralRequest).Error; err != nil {
+		return errors.NewWithCause(errors.ErrorGeneral, err, "unable to delete central request with id %s", centralRequest.ID)
 	}
 
+	glog.Infof("Successfully deleted Central tenant %q in the database.", centralRequest.ID)
+	if force {
+		glog.Infof("Make sure any other resources belonging to the Central tenant %q are manually deleted.", centralRequest.ID)
+	}
 	metrics.IncreaseCentralTotalOperationsCountMetric(dinosaurConstants.CentralOperationDelete)
 	metrics.IncreaseCentralSuccessOperationsCountMetric(dinosaurConstants.CentralOperationDelete)
 
@@ -894,27 +906,4 @@ func buildResourceRecordChange(recordName string, clusterIngress string, action 
 	}
 
 	return resourceRecordChange
-}
-
-// DbDelete deletes a Central request from the database.
-// This is an administrative escape hatch for manually recovering from an inconsistent control-/data-plane state.
-func (k *dinosaurService) DbDelete(ctx context.Context, id string) *errors.ServiceError {
-	if id == "" {
-		return errors.Validation("id is undefined")
-	}
-
-	if !auth.GetIsAdminFromContext(ctx) {
-		return errors.Unauthorized("administrator access only")
-	}
-
-	var centralRequest dbapi.CentralRequest
-	centralRequest.ID = id
-	dbConn := k.connectionFactory.New()
-	if err := dbConn.Delete(&centralRequest).Error; err != nil {
-		return errors.NewWithCause(errors.ErrorGeneral, err, "unable to delete central request with id %q", centralRequest.ID)
-	}
-
-	glog.Infof("Successfully force-deleted CentralRequest %q in database. Make sure any other resources belonging to this Central tenant are manually deleted.", centralRequest.ID)
-
-	return nil
 }

--- a/internal/dinosaur/pkg/services/dinosaurservice_moq.go
+++ b/internal/dinosaur/pkg/services/dinosaurservice_moq.go
@@ -37,10 +37,7 @@ var _ DinosaurService = &DinosaurServiceMock{}
 // 			CountByStatusFunc: func(status []dinosaurConstants.CentralStatus) ([]DinosaurStatusCount, error) {
 // 				panic("mock out the CountByStatus method")
 // 			},
-// 			DbDeleteFunc: func(ctx context.Context, id string) *serviceError.ServiceError {
-// 				panic("mock out the DbDelete method")
-// 			},
-// 			DeleteFunc: func(centralRequest *dbapi.CentralRequest) *serviceError.ServiceError {
+// 			DeleteFunc: func(centralRequest *dbapi.CentralRequest, force bool) *serviceError.ServiceError {
 // 				panic("mock out the Delete method")
 // 			},
 // 			DeprovisionDinosaurForUsersFunc: func(users []string) *serviceError.ServiceError {
@@ -125,11 +122,8 @@ type DinosaurServiceMock struct {
 	// CountByStatusFunc mocks the CountByStatus method.
 	CountByStatusFunc func(status []dinosaurConstants.CentralStatus) ([]DinosaurStatusCount, error)
 
-	// DbDeleteFunc mocks the DbDelete method.
-	DbDeleteFunc func(ctx context.Context, id string) *serviceError.ServiceError
-
 	// DeleteFunc mocks the Delete method.
-	DeleteFunc func(centralRequest *dbapi.CentralRequest) *serviceError.ServiceError
+	DeleteFunc func(centralRequest *dbapi.CentralRequest, force bool) *serviceError.ServiceError
 
 	// DeprovisionDinosaurForUsersFunc mocks the DeprovisionDinosaurForUsers method.
 	DeprovisionDinosaurForUsersFunc func(users []string) *serviceError.ServiceError
@@ -216,17 +210,12 @@ type DinosaurServiceMock struct {
 			// Status is the status argument value.
 			Status []dinosaurConstants.CentralStatus
 		}
-		// DbDelete holds details about calls to the DbDelete method.
-		DbDelete []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// ID is the id argument value.
-			ID string
-		}
 		// Delete holds details about calls to the Delete method.
 		Delete []struct {
 			// CentralRequest is the centralRequest argument value.
 			CentralRequest *dbapi.CentralRequest
+			// Force is the force argument value.
+			Force bool
 		}
 		// DeprovisionDinosaurForUsers holds details about calls to the DeprovisionDinosaurForUsers method.
 		DeprovisionDinosaurForUsers []struct {
@@ -342,7 +331,6 @@ type DinosaurServiceMock struct {
 	lockChangeDinosaurCNAMErecords        sync.RWMutex
 	lockCountByRegionAndInstanceType      sync.RWMutex
 	lockCountByStatus                     sync.RWMutex
-	lockDbDelete                          sync.RWMutex
 	lockDelete                            sync.RWMutex
 	lockDeprovisionDinosaurForUsers       sync.RWMutex
 	lockDeprovisionExpiredDinosaurs       sync.RWMutex
@@ -490,55 +478,22 @@ func (mock *DinosaurServiceMock) CountByStatusCalls() []struct {
 	return calls
 }
 
-// DbDelete calls DbDeleteFunc.
-func (mock *DinosaurServiceMock) DbDelete(ctx context.Context, id string) *serviceError.ServiceError {
-	if mock.DbDeleteFunc == nil {
-		panic("DinosaurServiceMock.DbDeleteFunc: method is nil but DinosaurService.DbDelete was just called")
-	}
-	callInfo := struct {
-		Ctx context.Context
-		ID  string
-	}{
-		Ctx: ctx,
-		ID:  id,
-	}
-	mock.lockDbDelete.Lock()
-	mock.calls.DbDelete = append(mock.calls.DbDelete, callInfo)
-	mock.lockDbDelete.Unlock()
-	return mock.DbDeleteFunc(ctx, id)
-}
-
-// DbDeleteCalls gets all the calls that were made to DbDelete.
-// Check the length with:
-//     len(mockedDinosaurService.DbDeleteCalls())
-func (mock *DinosaurServiceMock) DbDeleteCalls() []struct {
-	Ctx context.Context
-	ID  string
-} {
-	var calls []struct {
-		Ctx context.Context
-		ID  string
-	}
-	mock.lockDbDelete.RLock()
-	calls = mock.calls.DbDelete
-	mock.lockDbDelete.RUnlock()
-	return calls
-}
-
 // Delete calls DeleteFunc.
-func (mock *DinosaurServiceMock) Delete(centralRequest *dbapi.CentralRequest) *serviceError.ServiceError {
+func (mock *DinosaurServiceMock) Delete(centralRequest *dbapi.CentralRequest, force bool) *serviceError.ServiceError {
 	if mock.DeleteFunc == nil {
 		panic("DinosaurServiceMock.DeleteFunc: method is nil but DinosaurService.Delete was just called")
 	}
 	callInfo := struct {
 		CentralRequest *dbapi.CentralRequest
+		Force          bool
 	}{
 		CentralRequest: centralRequest,
+		Force:          force,
 	}
 	mock.lockDelete.Lock()
 	mock.calls.Delete = append(mock.calls.Delete, callInfo)
 	mock.lockDelete.Unlock()
-	return mock.DeleteFunc(centralRequest)
+	return mock.DeleteFunc(centralRequest, force)
 }
 
 // DeleteCalls gets all the calls that were made to Delete.
@@ -546,9 +501,11 @@ func (mock *DinosaurServiceMock) Delete(centralRequest *dbapi.CentralRequest) *s
 //     len(mockedDinosaurService.DeleteCalls())
 func (mock *DinosaurServiceMock) DeleteCalls() []struct {
 	CentralRequest *dbapi.CentralRequest
+	Force          bool
 } {
 	var calls []struct {
 		CentralRequest *dbapi.CentralRequest
+		Force          bool
 	}
 	mock.lockDelete.RLock()
 	calls = mock.calls.Delete

--- a/internal/dinosaur/pkg/services/dinosaurservice_moq.go
+++ b/internal/dinosaur/pkg/services/dinosaurservice_moq.go
@@ -37,6 +37,9 @@ var _ DinosaurService = &DinosaurServiceMock{}
 // 			CountByStatusFunc: func(status []dinosaurConstants.CentralStatus) ([]DinosaurStatusCount, error) {
 // 				panic("mock out the CountByStatus method")
 // 			},
+// 			DbDeleteFunc: func(ctx context.Context, id string) *serviceError.ServiceError {
+// 				panic("mock out the DbDelete method")
+// 			},
 // 			DeleteFunc: func(centralRequest *dbapi.CentralRequest) *serviceError.ServiceError {
 // 				panic("mock out the Delete method")
 // 			},
@@ -121,6 +124,9 @@ type DinosaurServiceMock struct {
 
 	// CountByStatusFunc mocks the CountByStatus method.
 	CountByStatusFunc func(status []dinosaurConstants.CentralStatus) ([]DinosaurStatusCount, error)
+
+	// DbDeleteFunc mocks the DbDelete method.
+	DbDeleteFunc func(ctx context.Context, id string) *serviceError.ServiceError
 
 	// DeleteFunc mocks the Delete method.
 	DeleteFunc func(centralRequest *dbapi.CentralRequest) *serviceError.ServiceError
@@ -209,6 +215,13 @@ type DinosaurServiceMock struct {
 		CountByStatus []struct {
 			// Status is the status argument value.
 			Status []dinosaurConstants.CentralStatus
+		}
+		// DbDelete holds details about calls to the DbDelete method.
+		DbDelete []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ID is the id argument value.
+			ID string
 		}
 		// Delete holds details about calls to the Delete method.
 		Delete []struct {
@@ -329,6 +342,7 @@ type DinosaurServiceMock struct {
 	lockChangeDinosaurCNAMErecords        sync.RWMutex
 	lockCountByRegionAndInstanceType      sync.RWMutex
 	lockCountByStatus                     sync.RWMutex
+	lockDbDelete                          sync.RWMutex
 	lockDelete                            sync.RWMutex
 	lockDeprovisionDinosaurForUsers       sync.RWMutex
 	lockDeprovisionExpiredDinosaurs       sync.RWMutex
@@ -473,6 +487,41 @@ func (mock *DinosaurServiceMock) CountByStatusCalls() []struct {
 	mock.lockCountByStatus.RLock()
 	calls = mock.calls.CountByStatus
 	mock.lockCountByStatus.RUnlock()
+	return calls
+}
+
+// DbDelete calls DbDeleteFunc.
+func (mock *DinosaurServiceMock) DbDelete(ctx context.Context, id string) *serviceError.ServiceError {
+	if mock.DbDeleteFunc == nil {
+		panic("DinosaurServiceMock.DbDeleteFunc: method is nil but DinosaurService.DbDelete was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		ID  string
+	}{
+		Ctx: ctx,
+		ID:  id,
+	}
+	mock.lockDbDelete.Lock()
+	mock.calls.DbDelete = append(mock.calls.DbDelete, callInfo)
+	mock.lockDbDelete.Unlock()
+	return mock.DbDeleteFunc(ctx, id)
+}
+
+// DbDeleteCalls gets all the calls that were made to DbDelete.
+// Check the length with:
+//     len(mockedDinosaurService.DbDeleteCalls())
+func (mock *DinosaurServiceMock) DbDeleteCalls() []struct {
+	Ctx context.Context
+	ID  string
+} {
+	var calls []struct {
+		Ctx context.Context
+		ID  string
+	}
+	mock.lockDbDelete.RLock()
+	calls = mock.calls.DbDelete
+	mock.lockDbDelete.RUnlock()
 	return calls
 }
 

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/deleting_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/deleting_dinosaurs_mgr.go
@@ -104,7 +104,7 @@ func (k *DeletingDinosaurManager) reconcileDeletingDinosaurs(dinosaur *dbapi.Cen
 		return errors.Wrapf(err, "failed to delete subscription id %s for central %s", dinosaur.SubscriptionID, dinosaur.ID)
 	}
 
-	if err := k.dinosaurService.Delete(dinosaur); err != nil {
+	if err := k.dinosaurService.Delete(dinosaur, false); err != nil {
 		return errors.Wrapf(err, "failed to delete central %s", dinosaur.ID)
 	}
 	return nil

--- a/openapi/fleet-manager-private-admin.yaml
+++ b/openapi/fleet-manager-private-admin.yaml
@@ -259,6 +259,41 @@ paths:
             application/json:
               schema:
                 $ref: 'fleet-manager.yaml#/components/schemas/Error'
+  '/api/rhacs/v1/admin/db/centrals/{id}':
+    delete:
+      summary: Delete a Central directly in the Database by ID
+      parameters:
+        - $ref: "fleet-manager.yaml#/components/parameters/id"
+      security:
+        - Bearer: [ ]
+      operationId: deleteDbCentralById
+      responses:
+        "200":
+          description: Central deleted by ID
+        "401":
+          description: Auth token is invalid
+          content:
+            application/json:
+              schema:
+                $ref: 'fleet-manager.yaml#/components/schemas/Error'
+        "403":
+          description: User is not authorised to access the service
+          content:
+            application/json:
+              schema:
+                $ref: 'fleet-manager.yaml#/components/schemas/Error'
+        "404":
+          description: No Central found with the specified ID
+          content:
+            application/json:
+              schema:
+                $ref: 'fleet-manager.yaml#/components/schemas/Error'
+        "500":
+          description: Unexpected error occurred
+          content:
+            application/json:
+              schema:
+                $ref: 'fleet-manager.yaml#/components/schemas/Error'
 
 components:
   schemas:


### PR DESCRIPTION
## Description

See https://issues.redhat.com/browse/ROX-12743. This PR implements a new DELETE endpoint as `/api/rhacs/v1/admin/dinosaurs/db/{CENTRAL ID}`.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] ~~Documentation added if necessary~~
- [ ] CI and all relevant tests are passing
- [x] ~~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
