### PR TITLE
set limits greater than requests for admin e2e test

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -354,7 +354,7 @@ var _ = Describe("Central", func() {
 							v1.ResourceMemory.String(): "199M",
 						},
 						Limits: map[string]string{
-							v1.ResourceCPU.String(): "499m",
+							v1.ResourceCPU.String(): "505m",
 						},
 					},
 				},
@@ -365,7 +365,7 @@ var _ = Describe("Central", func() {
 					v1.ResourceMemory: resource.MustParse("199M"),
 				},
 				Limits: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("499m"),
+					v1.ResourceCPU:    resource.MustParse("505m"),
 					v1.ResourceMemory: resource.MustParse("202M"),
 				},
 			}


### PR DESCRIPTION
## Description
The test for updating central resource usage through the admin API, was broken. Requested CPU was higher than the limit CPU after sending the update request. We didn't see the test failing because it only tests that the central CR had it's resource requirements updated. Not that also the deployment created by the operator was updated.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
