### PR TITLE
ROX-12742: rename "dinosaur" to "central" in error messages and logs

### DIFF
--- a/internal/dinosaur/pkg/cmd/cloudprovider/regionlist.go
+++ b/internal/dinosaur/pkg/cmd/cloudprovider/regionlist.go
@@ -24,7 +24,7 @@ func NewRegionsListCommand(env *environments.Env) *cobra.Command {
 		},
 	}
 	cmd.Flags().String(FlagID, "aws", "Cloud provider id")
-	cmd.Flags().String(FlagInstanceType, "", "Dinosaur instance type to filter the regions by")
+	cmd.Flags().String(FlagInstanceType, "", "Central instance type to filter the regions by")
 	return cmd
 }
 

--- a/internal/dinosaur/pkg/cmd/observatorium/get.go
+++ b/internal/dinosaur/pkg/cmd/observatorium/get.go
@@ -12,14 +12,14 @@ import (
 func NewRunGetStateCommand(env *environments.Env) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get-state",
-		Short: "Fetch dinosaur state metric from Prometheus",
+		Short: "Fetch central state metric from Prometheus",
 		Run: func(cmd *cobra.Command, args []string) {
 			runGethResourceStateMetrics(env, cmd, args)
 		},
 	}
 
-	cmd.Flags().String(FlagName, "", "Dinosaur name")
-	cmd.Flags().String(FlagNameSpace, "", "Dinosaur namepace")
+	cmd.Flags().String(FlagName, "", "Central name")
+	cmd.Flags().String(FlagNameSpace, "", "Central namepace")
 
 	return cmd
 }
@@ -37,9 +37,9 @@ func runGethResourceStateMetrics(env *environments.Env, cmd *cobra.Command, _arg
 		return
 	}
 	if len(dinosaurState.State) > 0 {
-		glog.Infof("dinosaur state is %s ", dinosaurState.State)
+		glog.Infof("central state is %s ", dinosaurState.State)
 	} else {
-		glog.Infof("dinosaur state not found for paramerters %s %s ", name, namespace)
+		glog.Infof("central state not found for paramerters %s %s ", name, namespace)
 	}
 
 }

--- a/internal/dinosaur/pkg/cmd/observatorium/query.go
+++ b/internal/dinosaur/pkg/cmd/observatorium/query.go
@@ -21,12 +21,12 @@ import (
 func NewRunMetricsQueryCommand(env *environments.Env) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "query",
-		Short: "Get metrics with query instant by dinosaur id from Observatorium",
+		Short: "Get metrics with query instant by central id from Observatorium",
 		Run: func(cmd *cobra.Command, args []string) {
 			runGetMetricsByInstantQuery(env, cmd, args)
 		},
 	}
-	cmd.Flags().String(FlagID, "", "Dinosaur id")
+	cmd.Flags().String(FlagID, "", "Central id")
 	cmd.Flags().String(FlagOwner, "", "Username")
 
 	return cmd

--- a/internal/dinosaur/pkg/cmd/observatorium/query_range.go
+++ b/internal/dinosaur/pkg/cmd/observatorium/query_range.go
@@ -21,12 +21,12 @@ import (
 func NewRunMetricsQueryRangeCommand(env *environments.Env) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "query_range",
-		Short: "Get metrics with timeseries query range by dinosaur id from Observatorium",
+		Short: "Get metrics with timeseries query range by central id from Observatorium",
 		Run: func(cmd *cobra.Command, args []string) {
 			runGetMetricsByRangeQuery(env, cmd, args)
 		},
 	}
-	cmd.Flags().String(FlagID, "", "Dinosaur id")
+	cmd.Flags().String(FlagID, "", "Central id")
 	cmd.Flags().String(FlagOwner, "", "Username")
 
 	return cmd

--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -108,7 +108,7 @@ func (h adminDinosaurHandler) List(w http.ResponseWriter, r *http.Request) {
 			listArgs := coreServices.NewListArguments(r.URL.Query())
 
 			if err := listArgs.Validate(); err != nil {
-				return nil, errors.NewWithCause(errors.ErrorMalformedRequest, err, "Unable to list dinosaur requests: %s", err.Error())
+				return nil, errors.NewWithCause(errors.ErrorMalformedRequest, err, "Unable to list central requests: %s", err.Error())
 			}
 
 			dinosaurRequests, paging, err := h.service.List(ctx, listArgs)
@@ -117,7 +117,7 @@ func (h adminDinosaurHandler) List(w http.ResponseWriter, r *http.Request) {
 			}
 
 			dinosaurRequestList := private.CentralList{
-				Kind:  "DinosaurList",
+				Kind:  "CentralList",
 				Page:  int32(paging.Page),
 				Size:  int32(paging.Size),
 				Total: int32(paging.Total),
@@ -146,7 +146,7 @@ func (h adminDinosaurHandler) List(w http.ResponseWriter, r *http.Request) {
 func (h adminDinosaurHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	cfg := &handlers.HandlerConfig{
 		Validate: []handlers.Validate{
-			handlers.ValidateAsyncEnabled(r, "deleting dinosaur requests"),
+			handlers.ValidateAsyncEnabled(r, "deleting central requests"),
 		},
 		Action: func() (i interface{}, serviceError *errors.ServiceError) {
 			id := mux.Vars(r)["id"]

--- a/internal/dinosaur/pkg/handlers/metrics.go
+++ b/internal/dinosaur/pkg/handlers/metrics.go
@@ -39,7 +39,7 @@ func (h metricsHandler) FederateMetrics(w http.ResponseWriter, r *http.Request) 
 	if dinosaurID == "" {
 		shared.HandleError(r, w, &errors.ServiceError{
 			Code:     errors.ErrorBadRequest,
-			Reason:   "missing path parameter: dinosaur id",
+			Reason:   "missing path parameter: central id",
 			HTTPCode: http.StatusBadRequest,
 		})
 		return

--- a/internal/dinosaur/pkg/handlers/service_status.go
+++ b/internal/dinosaur/pkg/handlers/service_status.go
@@ -41,7 +41,7 @@ func (h serviceStatusHandler) Get(w http.ResponseWriter, r *http.Request) {
 			if accessControlListConfig.EnableDenyList {
 				userIsDenied := accessControlListConfig.DenyList.IsUserDenied(username)
 				if userIsDenied {
-					glog.V(5).Infof("User %s is denied to access the service. Setting dinosaur maximum capacity to 'true'", username)
+					glog.V(5).Infof("User %s is denied to access the service. Setting central maximum capacity to 'true'", username)
 					return presenters.PresentServiceStatus(true, false), nil
 				}
 			}

--- a/internal/dinosaur/pkg/handlers/validation_test.go
+++ b/internal/dinosaur/pkg/handlers/validation_test.go
@@ -55,7 +55,7 @@ func Test_Validation_validateDinosaurClusterNameIsUnique(t *testing.T) {
 			},
 			want: &errors.ServiceError{
 				HTTPCode: http.StatusConflict,
-				Reason:   "Dinosaur cluster name is already used",
+				Reason:   "Central cluster name is already used",
 				Code:     36,
 			},
 		},

--- a/internal/dinosaur/pkg/services/clusters.go
+++ b/internal/dinosaur/pkg/services/clusters.go
@@ -702,7 +702,7 @@ func (c clusterService) InstallDinosaurOperator(cluster *api.Cluster) (bool, *ap
 	}
 	ready, err := p.InstallDinosaurOperator(buildClusterSpec(cluster))
 	if err != nil {
-		return ready, apiErrors.NewWithCause(apiErrors.ErrorGeneral, err, "failed to install dinosaur for cluster %s", cluster.ClusterID)
+		return ready, apiErrors.NewWithCause(apiErrors.ErrorGeneral, err, "failed to install central for cluster %s", cluster.ClusterID)
 	}
 	return ready, nil
 }

--- a/internal/dinosaur/pkg/services/data_plane_cluster.go
+++ b/internal/dinosaur/pkg/services/data_plane_cluster.go
@@ -118,7 +118,7 @@ func (d *dataPlaneClusterService) setClusterStatus(cluster *api.Cluster, status 
 		if err != nil {
 			return fmt.Errorf("updating central operator versions: %w", err)
 		}
-		glog.Infof("Updating Dinosaur operator available versions for cluster ID '%s'. From versions '%v' to versions '%v'\n",
+		glog.Infof("Updating Central operator available versions for cluster ID '%s'. From versions '%v' to versions '%v'\n",
 			cluster.ClusterID, prevAvailableDinosaurOperatorVersions, status.AvailableDinosaurOperatorVersions)
 		svcErr := d.ClusterService.Update(*cluster)
 		if svcErr != nil {

--- a/internal/dinosaur/pkg/services/data_plane_dinosaur.go
+++ b/internal/dinosaur/pkg/services/data_plane_dinosaur.go
@@ -21,14 +21,16 @@ import (
 type dinosaurStatus string
 
 const (
-	statusInstalling         dinosaurStatus = "installing"
-	statusReady              dinosaurStatus = "ready"
-	statusError              dinosaurStatus = "error"
-	statusRejected           dinosaurStatus = "rejected"
-	statusDeleted            dinosaurStatus = "deleted"
-	statusUnknown            dinosaurStatus = "unknown"
-	dinosaurOperatorUpdating string         = "DinosaurOperatorUpdating"
-	dinosaurUpdating         string         = "DinosaurUpdating"
+	statusInstalling dinosaurStatus = "installing"
+	statusReady      dinosaurStatus = "ready"
+	statusError      dinosaurStatus = "error"
+	statusRejected   dinosaurStatus = "rejected"
+	statusDeleted    dinosaurStatus = "deleted"
+	statusUnknown    dinosaurStatus = "unknown"
+
+	// TODO: Renaming these dinosaurs will require a DB migration step
+	dinosaurOperatorUpdating string = "DinosaurOperatorUpdating"
+	dinosaurUpdating         string = "DinosaurUpdating"
 )
 
 // DataPlaneDinosaurService ...

--- a/internal/dinosaur/pkg/services/data_plane_dinosaur.go
+++ b/internal/dinosaur/pkg/services/data_plane_dinosaur.go
@@ -27,8 +27,8 @@ const (
 	statusRejected           dinosaurStatus = "rejected"
 	statusDeleted            dinosaurStatus = "deleted"
 	statusUnknown            dinosaurStatus = "unknown"
-	dinosaurOperatorUpdating string         = "CentralOperatorUpdating"
-	dinosaurUpdating         string         = "CentralUpdating"
+	dinosaurOperatorUpdating string         = "DinosaurOperatorUpdating"
+	dinosaurUpdating         string         = "DinosaurUpdating"
 )
 
 // DataPlaneDinosaurService ...

--- a/internal/dinosaur/pkg/services/data_plane_dinosaur.go
+++ b/internal/dinosaur/pkg/services/data_plane_dinosaur.go
@@ -27,8 +27,8 @@ const (
 	statusRejected           dinosaurStatus = "rejected"
 	statusDeleted            dinosaurStatus = "deleted"
 	statusUnknown            dinosaurStatus = "unknown"
-	dinosaurOperatorUpdating string         = "DinosaurOperatorUpdating"
-	dinosaurUpdating         string         = "DinosaurUpdating"
+	dinosaurOperatorUpdating string         = "CentralOperatorUpdating"
+	dinosaurUpdating         string         = "CentralUpdating"
 )
 
 // DataPlaneDinosaurService ...
@@ -65,11 +65,11 @@ func (d *dataPlaneDinosaurService) UpdateDataPlaneDinosaurService(ctx context.Co
 	for _, ks := range status {
 		dinosaur, getErr := d.dinosaurService.GetByID(ks.CentralClusterID)
 		if getErr != nil {
-			glog.Error(errors.Wrapf(getErr, "failed to get dinosaur cluster by id %s", ks.CentralClusterID))
+			glog.Error(errors.Wrapf(getErr, "failed to get central cluster by id %s", ks.CentralClusterID))
 			continue
 		}
 		if dinosaur.ClusterID != clusterID {
-			log.Warningf("clusterId for dinosaur cluster %s does not match clusterId. dinosaur clusterId = %s :: clusterId = %s", dinosaur.ID, dinosaur.ClusterID, clusterID)
+			log.Warningf("clusterId for central cluster %s does not match clusterId. central clusterId = %s :: clusterId = %s", dinosaur.ID, dinosaur.ClusterID, clusterID)
 			continue
 		}
 		var e *serviceError.ServiceError
@@ -91,17 +91,17 @@ func (d *dataPlaneDinosaurService) UpdateDataPlaneDinosaurService(ctx context.Co
 		case statusRejected:
 			e = d.reassignDinosaurCluster(dinosaur)
 		case statusUnknown:
-			log.Infof("dinosaur cluster %s status is unknown", ks.CentralClusterID)
+			log.Infof("central cluster %s status is unknown", ks.CentralClusterID)
 		default:
-			log.V(5).Infof("dinosaur cluster %s is still installing", ks.CentralClusterID)
+			log.V(5).Infof("central cluster %s is still installing", ks.CentralClusterID)
 		}
 		if e != nil {
-			log.Error(errors.Wrapf(e, "Error updating dinosaur %s status", ks.CentralClusterID))
+			log.Error(errors.Wrapf(e, "Error updating central %s status", ks.CentralClusterID))
 		}
 
 		e = d.setDinosaurRequestVersionFields(dinosaur, ks)
 		if e != nil {
-			log.Error(errors.Wrapf(e, "Error updating dinosaur '%s' version fields", ks.CentralClusterID))
+			log.Error(errors.Wrapf(e, "Error updating central '%s' version fields", ks.CentralClusterID))
 		}
 	}
 
@@ -110,10 +110,10 @@ func (d *dataPlaneDinosaurService) UpdateDataPlaneDinosaurService(ctx context.Co
 
 func (d *dataPlaneDinosaurService) setDinosaurClusterReady(dinosaur *dbapi.CentralRequest) *serviceError.ServiceError {
 	if !dinosaur.RoutesCreated {
-		logger.Logger.V(10).Infof("routes for dinosaur %s are not created", dinosaur.ID)
+		logger.Logger.V(10).Infof("routes for central %s are not created", dinosaur.ID)
 		return nil
 	}
-	logger.Logger.Infof("routes for dinosaur %s are created", dinosaur.ID)
+	logger.Logger.Infof("routes for central %s are created", dinosaur.ID)
 
 	// only send metrics data if the current dinosaur request is in "provisioning" status as this is the only case we want to report
 	shouldSendMetric, err := d.checkDinosaurRequestCurrentStatus(dinosaur, constants2.CentralRequestStatusProvisioning)
@@ -123,7 +123,7 @@ func (d *dataPlaneDinosaurService) setDinosaurClusterReady(dinosaur *dbapi.Centr
 
 	err = d.dinosaurService.Updates(dinosaur, map[string]interface{}{"failed_reason": "", "status": constants2.CentralRequestStatusReady.String()})
 	if err != nil {
-		return serviceError.NewWithCause(err.Code, err, "failed to update status %s for dinosaur cluster %s", constants2.CentralRequestStatusReady, dinosaur.ID)
+		return serviceError.NewWithCause(err.Code, err, "failed to update status %s for central cluster %s", constants2.CentralRequestStatusReady, dinosaur.ID)
 	}
 	if shouldSendMetric {
 		metrics.UpdateCentralRequestsStatusSinceCreatedMetric(constants2.CentralRequestStatusReady, dinosaur.ID, dinosaur.ClusterID, time.Since(dinosaur.CreatedAt))
@@ -138,14 +138,14 @@ func (d *dataPlaneDinosaurService) setDinosaurRequestVersionFields(dinosaur *dba
 	needsUpdate := false
 	prevActualDinosaurVersion := status.CentralVersion
 	if status.CentralVersion != "" && status.CentralVersion != dinosaur.ActualCentralVersion {
-		logger.Logger.Infof("Updating Dinosaur version for Dinosaur ID '%s' from '%s' to '%s'", dinosaur.ID, prevActualDinosaurVersion, status.CentralVersion)
+		logger.Logger.Infof("Updating Central version for Central ID '%s' from '%s' to '%s'", dinosaur.ID, prevActualDinosaurVersion, status.CentralVersion)
 		dinosaur.ActualCentralVersion = status.CentralVersion
 		needsUpdate = true
 	}
 
 	prevActualDinosaurOperatorVersion := status.CentralOperatorVersion
 	if status.CentralOperatorVersion != "" && status.CentralOperatorVersion != dinosaur.ActualCentralOperatorVersion {
-		logger.Logger.Infof("Updating Dinosaur operator version for Dinosaur ID '%s' from '%s' to '%s'", dinosaur.ID, prevActualDinosaurOperatorVersion, status.CentralOperatorVersion)
+		logger.Logger.Infof("Updating Central operator version for Central ID '%s' from '%s' to '%s'", dinosaur.ID, prevActualDinosaurOperatorVersion, status.CentralOperatorVersion)
 		dinosaur.ActualCentralOperatorVersion = status.CentralOperatorVersion
 		needsUpdate = true
 	}
@@ -157,12 +157,12 @@ func (d *dataPlaneDinosaurService) setDinosaurRequestVersionFields(dinosaur *dba
 		prevDinosaurOperatorUpgrading := dinosaur.CentralOperatorUpgrading
 		dinosaurOperatorUpdatingReasonIsSet := readyCondition.Reason == dinosaurOperatorUpdating
 		if dinosaurOperatorUpdatingReasonIsSet && !prevDinosaurOperatorUpgrading {
-			logger.Logger.Infof("Dinosaur operator version for Dinosaur ID '%s' upgrade state changed from %t to %t", dinosaur.ID, prevDinosaurOperatorUpgrading, dinosaurOperatorUpdatingReasonIsSet)
+			logger.Logger.Infof("Central operator version for Central ID '%s' upgrade state changed from %t to %t", dinosaur.ID, prevDinosaurOperatorUpgrading, dinosaurOperatorUpdatingReasonIsSet)
 			dinosaur.CentralOperatorUpgrading = true
 			needsUpdate = true
 		}
 		if !dinosaurOperatorUpdatingReasonIsSet && prevDinosaurOperatorUpgrading {
-			logger.Logger.Infof("Dinosaur operator version for Dinosaur ID '%s' upgrade state changed from %t to %t", dinosaur.ID, prevDinosaurOperatorUpgrading, dinosaurOperatorUpdatingReasonIsSet)
+			logger.Logger.Infof("Central operator version for Central ID '%s' upgrade state changed from %t to %t", dinosaur.ID, prevDinosaurOperatorUpgrading, dinosaurOperatorUpdatingReasonIsSet)
 			dinosaur.CentralOperatorUpgrading = false
 			needsUpdate = true
 		}
@@ -170,12 +170,12 @@ func (d *dataPlaneDinosaurService) setDinosaurRequestVersionFields(dinosaur *dba
 		prevDinosaurUpgrading := dinosaur.CentralUpgrading
 		dinosaurUpdatingReasonIsSet := readyCondition.Reason == dinosaurUpdating
 		if dinosaurUpdatingReasonIsSet && !prevDinosaurUpgrading {
-			logger.Logger.Infof("Dinosaur version for Dinosaur ID '%s' upgrade state changed from %t to %t", dinosaur.ID, prevDinosaurUpgrading, dinosaurUpdatingReasonIsSet)
+			logger.Logger.Infof("Central version for Central ID '%s' upgrade state changed from %t to %t", dinosaur.ID, prevDinosaurUpgrading, dinosaurUpdatingReasonIsSet)
 			dinosaur.CentralUpgrading = true
 			needsUpdate = true
 		}
 		if !dinosaurUpdatingReasonIsSet && prevDinosaurUpgrading {
-			logger.Logger.Infof("Dinosaur version for Dinosaur ID '%s' upgrade state changed from %t to %t", dinosaur.ID, prevDinosaurUpgrading, dinosaurUpdatingReasonIsSet)
+			logger.Logger.Infof("Central version for Central ID '%s' upgrade state changed from %t to %t", dinosaur.ID, prevDinosaurUpgrading, dinosaurUpdatingReasonIsSet)
 			dinosaur.CentralUpgrading = false
 			needsUpdate = true
 		}
@@ -191,7 +191,7 @@ func (d *dataPlaneDinosaurService) setDinosaurRequestVersionFields(dinosaur *dba
 		}
 
 		if err := d.dinosaurService.Updates(dinosaur, versionFields); err != nil {
-			return serviceError.NewWithCause(err.Code, err, "failed to update actual version fields for dinosaur cluster %s", dinosaur.ID)
+			return serviceError.NewWithCause(err.Code, err, "failed to update actual version fields for central cluster %s", dinosaur.ID)
 		}
 	}
 
@@ -211,16 +211,16 @@ func (d *dataPlaneDinosaurService) setDinosaurClusterFailed(dinosaur *dbapi.Cent
 	}
 
 	dinosaur.Status = string(constants2.CentralRequestStatusFailed)
-	dinosaur.FailedReason = fmt.Sprintf("Dinosaur reported as failed: '%s'", errMessage)
+	dinosaur.FailedReason = fmt.Sprintf("Central reported as failed: '%s'", errMessage)
 	err = d.dinosaurService.Update(dinosaur)
 	if err != nil {
-		return serviceError.NewWithCause(err.Code, err, "failed to update dinosaur cluster to %s status for dinosaur cluster %s", constants2.CentralRequestStatusFailed, dinosaur.ID)
+		return serviceError.NewWithCause(err.Code, err, "failed to update central cluster to %s status for central cluster %s", constants2.CentralRequestStatusFailed, dinosaur.ID)
 	}
 	if shouldSendMetric {
 		metrics.UpdateCentralRequestsStatusSinceCreatedMetric(constants2.CentralRequestStatusFailed, dinosaur.ID, dinosaur.ClusterID, time.Since(dinosaur.CreatedAt))
 		metrics.IncreaseCentralTotalOperationsCountMetric(constants2.CentralOperationCreate)
 	}
-	logger.Logger.Errorf("Dinosaur status for Dinosaur ID '%s' in ClusterID '%s' reported as failed by Fleet Shard Operator: '%s'", dinosaur.ID, dinosaur.ClusterID, errMessage)
+	logger.Logger.Errorf("Central status for Central ID '%s' in ClusterID '%s' reported as failed by Fleet Shard Operator: '%s'", dinosaur.ID, dinosaur.ClusterID, errMessage)
 
 	return nil
 }
@@ -229,7 +229,7 @@ func (d *dataPlaneDinosaurService) setDinosaurClusterDeleting(dinosaur *dbapi.Ce
 	// If the Dinosaur cluster is deleted from the data plane cluster, we will make it as "deleting" in db and the reconcilier will ensure it is cleaned up properly
 	if ok, updateErr := d.dinosaurService.UpdateStatus(dinosaur.ID, constants2.CentralRequestStatusDeleting); ok {
 		if updateErr != nil {
-			return serviceError.NewWithCause(updateErr.Code, updateErr, "failed to update status %s for dinosaur cluster %s", constants2.CentralRequestStatusDeleting, dinosaur.ID)
+			return serviceError.NewWithCause(updateErr.Code, updateErr, "failed to update status %s for central cluster %s", constants2.CentralRequestStatusDeleting, dinosaur.ID)
 		}
 		metrics.UpdateCentralRequestsStatusSinceCreatedMetric(constants2.CentralRequestStatusDeleting, dinosaur.ID, dinosaur.ClusterID, time.Since(dinosaur.CreatedAt))
 	}
@@ -247,7 +247,7 @@ func (d *dataPlaneDinosaurService) reassignDinosaurCluster(dinosaur *dbapi.Centr
 		}
 		metrics.UpdateCentralRequestsStatusSinceCreatedMetric(constants2.CentralRequestStatusProvisioning, dinosaur.ID, dinosaur.ClusterID, time.Since(dinosaur.CreatedAt))
 	} else {
-		logger.Logger.Infof("dinosaur cluster %s is rejected and current status is %s", dinosaur.ID, dinosaur.Status)
+		logger.Logger.Infof("central cluster %s is rejected and current status is %s", dinosaur.ID, dinosaur.Status)
 	}
 
 	return nil
@@ -290,10 +290,10 @@ func (d *dataPlaneDinosaurService) checkDinosaurRequestCurrentStatus(dinosaur *d
 
 func (d *dataPlaneDinosaurService) persistDinosaurRoutes(dinosaur *dbapi.CentralRequest, dinosaurStatus *dbapi.DataPlaneCentralStatus, cluster *api.Cluster) *serviceError.ServiceError {
 	if dinosaur.Routes != nil {
-		logger.Logger.V(10).Infof("skip persisting routes for Dinosaur %s as they are already stored", dinosaur.ID)
+		logger.Logger.V(10).Infof("skip persisting routes for Central %s as they are already stored", dinosaur.ID)
 		return nil
 	}
-	logger.Logger.Infof("store routes information for dinosaur %s", dinosaur.ID)
+	logger.Logger.Infof("store routes information for central %s", dinosaur.ID)
 	clusterDNS, err := d.clusterService.GetClusterDNS(cluster.ClusterID)
 	if err != nil {
 		return serviceError.NewWithCause(err.Code, err, "failed to get DNS entry for cluster %s", cluster.ClusterID)
@@ -306,11 +306,11 @@ func (d *dataPlaneDinosaurService) persistDinosaurRoutes(dinosaur *dbapi.Central
 	}
 
 	if err := dinosaur.SetRoutes(routesInRequest); err != nil {
-		return serviceError.NewWithCause(serviceError.ErrorGeneral, err, "failed to set routes for dinosaur %s", dinosaur.ID)
+		return serviceError.NewWithCause(serviceError.ErrorGeneral, err, "failed to set routes for central %s", dinosaur.ID)
 	}
 
 	if err := d.dinosaurService.Update(dinosaur); err != nil {
-		return serviceError.NewWithCause(err.Code, err, "failed to update routes for dinosaur cluster %s", dinosaur.ID)
+		return serviceError.NewWithCause(err.Code, err, "failed to update routes for central cluster %s", dinosaur.ID)
 	}
 	return nil
 }

--- a/internal/dinosaur/pkg/services/observatorium_service.go
+++ b/internal/dinosaur/pkg/services/observatorium_service.go
@@ -35,7 +35,7 @@ type ObservatoriumService interface {
 func (obs observatoriumService) GetDinosaurState(name string, namespaceName string) (observatorium.DinosaurState, error) {
 	state, err := obs.observatorium.Service.GetDinosaurState(name, namespaceName)
 	if err != nil {
-		return state, fmt.Errorf("getting dinosaur state for %q in namespace %q: %w", name, namespaceName, err)
+		return state, fmt.Errorf("getting central state for %q in namespace %q: %w", name, namespaceName, err)
 	}
 	return state, nil
 }

--- a/internal/dinosaur/pkg/workers/clusters_mgr.go
+++ b/internal/dinosaur/pkg/workers/clusters_mgr.go
@@ -185,7 +185,7 @@ func (c *ClusterManager) processMetrics() []error {
 	}
 
 	if err := c.setDinosaurPerClusterCountMetrics(); err != nil {
-		return []error{errors.Wrapf(err, "failed to set dinosaur per cluster count metrics")}
+		return []error{errors.Wrapf(err, "failed to set central per cluster count metrics")}
 	}
 
 	c.setClusterStatusMaxCapacityMetrics()
@@ -609,7 +609,7 @@ func (c *ClusterManager) reconcileDinosaurOperator(provisionedCluster api.Cluste
 	if err != nil {
 		return false, err
 	}
-	glog.V(5).Infof("ready status of dinosaur operator installation on cluster %s is %t", provisionedCluster.ClusterID, ready)
+	glog.V(5).Infof("ready status of central operator installation on cluster %s is %t", provisionedCluster.ClusterID, ready)
 	return ready, nil
 }
 
@@ -698,13 +698,13 @@ func (c *ClusterManager) reconcileClusterWithManualConfig() []error {
 
 	dinosaurInstanceCount, err := c.ClusterService.FindDinosaurInstanceCount(excessClusterIds)
 	if err != nil {
-		return []error{errors.Wrapf(err, "Failed to find dinosaur count a cluster: %s", excessClusterIds)}
+		return []error{errors.Wrapf(err, "Failed to find central count a cluster: %s", excessClusterIds)}
 	}
 
 	var idsOfClustersToDeprovision []string
 	for _, c := range dinosaurInstanceCount {
 		if c.Count > 0 {
-			glog.Infof("Excess cluster %s is not going to be deleted because it has %d dinosaur.", c.Clusterid, c.Count)
+			glog.Infof("Excess cluster %s is not going to be deleted because it has %d central.", c.Clusterid, c.Count)
 		} else {
 			glog.Infof("Excess cluster is going to be deleted %s", c.Clusterid)
 			idsOfClustersToDeprovision = append(idsOfClustersToDeprovision, c.Clusterid)

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/deleting_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/deleting_dinosaurs_mgr.go
@@ -48,7 +48,7 @@ func (k *DeletingDinosaurManager) Stop() {
 
 // Reconcile ...
 func (k *DeletingDinosaurManager) Reconcile() []error {
-	glog.Infoln("reconciling deleting dinosaurs")
+	glog.Infoln("reconciling deleting centrals")
 	var encounteredErrors []error
 
 	// handle deleting dinosaur requests
@@ -59,21 +59,21 @@ func (k *DeletingDinosaurManager) Reconcile() []error {
 	deletingDinosaurs, serviceErr := k.dinosaurService.ListByStatus(constants2.CentralRequestStatusDeleting)
 	originalTotalDinosaurInDeleting := len(deletingDinosaurs)
 	if serviceErr != nil {
-		encounteredErrors = append(encounteredErrors, errors.Wrap(serviceErr, "failed to list deleting dinosaur requests"))
+		encounteredErrors = append(encounteredErrors, errors.Wrap(serviceErr, "failed to list deleting central requests"))
 	} else {
-		glog.Infof("%s dinosaurs count = %d", constants2.CentralRequestStatusDeleting.String(), originalTotalDinosaurInDeleting)
+		glog.Infof("%s centrals count = %d", constants2.CentralRequestStatusDeleting.String(), originalTotalDinosaurInDeleting)
 	}
 
 	// We also want to remove Dinosaurs that are set to deprovisioning but have not been provisioned on a data plane cluster
 	deprovisioningDinosaurs, serviceErr := k.dinosaurService.ListByStatus(constants2.CentralRequestStatusDeprovision)
 	if serviceErr != nil {
-		encounteredErrors = append(encounteredErrors, errors.Wrap(serviceErr, "failed to list dinosaur deprovisioning requests"))
+		encounteredErrors = append(encounteredErrors, errors.Wrap(serviceErr, "failed to list central deprovisioning requests"))
 	} else {
-		glog.Infof("%s dinosaurs count = %d", constants2.CentralRequestStatusDeprovision.String(), len(deprovisioningDinosaurs))
+		glog.Infof("%s centrals count = %d", constants2.CentralRequestStatusDeprovision.String(), len(deprovisioningDinosaurs))
 	}
 
 	for _, deprovisioningDinosaur := range deprovisioningDinosaurs {
-		glog.V(10).Infof("deprovision dinosaur id = %s", deprovisioningDinosaur.ID)
+		glog.V(10).Infof("deprovision central id = %s", deprovisioningDinosaur.ID)
 		// TODO check if a deprovisioningDinosaur can be deleted and add it to deletingDinosaurs array
 		// deletingDinosaurs = append(deletingDinosaurs, deprovisioningDinosaur)
 		if deprovisioningDinosaur.Host == "" {
@@ -81,12 +81,12 @@ func (k *DeletingDinosaurManager) Reconcile() []error {
 		}
 	}
 
-	glog.Infof("An additional of dinosaurs count = %d which are marked for removal before being provisioned will also be deleted", len(deletingDinosaurs)-originalTotalDinosaurInDeleting)
+	glog.Infof("An additional of centrals count = %d which are marked for removal before being provisioned will also be deleted", len(deletingDinosaurs)-originalTotalDinosaurInDeleting)
 
 	for _, dinosaur := range deletingDinosaurs {
-		glog.V(10).Infof("deleting dinosaur id = %s", dinosaur.ID)
+		glog.V(10).Infof("deleting central id = %s", dinosaur.ID)
 		if err := k.reconcileDeletingDinosaurs(dinosaur); err != nil {
-			encounteredErrors = append(encounteredErrors, errors.Wrapf(err, "failed to reconcile deleting dinosaur request %s", dinosaur.ID))
+			encounteredErrors = append(encounteredErrors, errors.Wrapf(err, "failed to reconcile deleting central request %s", dinosaur.ID))
 			continue
 		}
 	}
@@ -101,11 +101,11 @@ func (k *DeletingDinosaurManager) reconcileDeletingDinosaurs(dinosaur *dbapi.Cen
 	}
 	err := quotaService.DeleteQuota(dinosaur.SubscriptionID)
 	if err != nil {
-		return errors.Wrapf(err, "failed to delete subscription id %s for dinosaur %s", dinosaur.SubscriptionID, dinosaur.ID)
+		return errors.Wrapf(err, "failed to delete subscription id %s for central %s", dinosaur.SubscriptionID, dinosaur.ID)
 	}
 
 	if err := k.dinosaurService.Delete(dinosaur); err != nil {
-		return errors.Wrapf(err, "failed to delete dinosaur %s", dinosaur.ID)
+		return errors.Wrapf(err, "failed to delete central %s", dinosaur.ID)
 	}
 	return nil
 }

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_mgr.go
@@ -58,7 +58,7 @@ func (k *DinosaurManager) Stop() {
 
 // Reconcile ...
 func (k *DinosaurManager) Reconcile() []error {
-	glog.Infoln("reconciling dinosaurs")
+	glog.Infoln("reconciling centrals")
 	var encounteredErrors []error
 
 	// record the metrics at the beginning of the reconcile loop as some of the states like "accepted"
@@ -76,10 +76,10 @@ func (k *DinosaurManager) Reconcile() []error {
 	// delete dinosaurs of denied owners
 	accessControlListConfig := k.accessControlListConfig
 	if accessControlListConfig.EnableDenyList {
-		glog.Infoln("reconciling denied dinosaur owners")
+		glog.Infoln("reconciling denied central owners")
 		dinosaurDeprovisioningForDeniedOwnersErr := k.reconcileDeniedDinosaurOwners(accessControlListConfig.DenyList)
 		if dinosaurDeprovisioningForDeniedOwnersErr != nil {
-			wrappedError := errors.Wrapf(dinosaurDeprovisioningForDeniedOwnersErr, "Failed to deprovision dinosaur for denied owners %s", accessControlListConfig.DenyList)
+			wrappedError := errors.Wrapf(dinosaurDeprovisioningForDeniedOwnersErr, "Failed to deprovision central for denied owners %s", accessControlListConfig.DenyList)
 			encounteredErrors = append(encounteredErrors, wrappedError)
 		}
 	}
@@ -87,10 +87,10 @@ func (k *DinosaurManager) Reconcile() []error {
 	// cleaning up expired dinosaurs
 	dinosaurConfig := k.dinosaurConfig
 	if dinosaurConfig.CentralLifespan.EnableDeletionOfExpiredCentral {
-		glog.Infoln("deprovisioning expired dinosaurs")
+		glog.Infoln("deprovisioning expired centrals")
 		expiredDinosaursError := k.dinosaurService.DeprovisionExpiredDinosaurs(dinosaurConfig.CentralLifespan.CentralLifespanInHours)
 		if expiredDinosaursError != nil {
-			wrappedError := errors.Wrap(expiredDinosaursError, "failed to deprovision expired Dinosaur instances")
+			wrappedError := errors.Wrap(expiredDinosaursError, "failed to deprovision expired Central instances")
 			encounteredErrors = append(encounteredErrors, wrappedError)
 		}
 	}
@@ -109,7 +109,7 @@ func (k *DinosaurManager) reconcileDeniedDinosaurOwners(deniedUsers acl.DeniedUs
 func (k *DinosaurManager) setDinosaurStatusCountMetric() []error {
 	counters, err := k.dinosaurService.CountByStatus(dinosaurMetricsStatuses)
 	if err != nil {
-		return []error{errors.Wrap(err, "failed to count Dinosaurs by status")}
+		return []error{errors.Wrap(err, "failed to count Centrals by status")}
 	}
 
 	for _, c := range counters {
@@ -122,7 +122,7 @@ func (k *DinosaurManager) setDinosaurStatusCountMetric() []error {
 func (k *DinosaurManager) setClusterStatusCapacityUsedMetric() []error {
 	regions, err := k.dinosaurService.CountByRegionAndInstanceType()
 	if err != nil {
-		return []error{errors.Wrap(err, "failed to count Dinosaurs by region")}
+		return []error{errors.Wrap(err, "failed to count Centrals by region")}
 	}
 
 	for _, region := range regions {

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_routes_cname_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_routes_cname_mgr.go
@@ -43,20 +43,20 @@ func (k *DinosaurRoutesCNAMEManager) Stop() {
 
 // Reconcile ...
 func (k *DinosaurRoutesCNAMEManager) Reconcile() []error {
-	glog.Infoln("reconciling DNS for dinosaurs")
+	glog.Infoln("reconciling DNS for centrals")
 	var errs []error
 
 	dinosaurs, listErr := k.dinosaurService.ListDinosaursWithRoutesNotCreated()
 	if listErr != nil {
-		errs = append(errs, errors.Wrap(listErr, "failed to list dinosaurs whose routes are not created"))
+		errs = append(errs, errors.Wrap(listErr, "failed to list centrals whose routes are not created"))
 	} else {
-		glog.Infof("dinosaurs need routes created count = %d", len(dinosaurs))
+		glog.Infof("centrals need routes created count = %d", len(dinosaurs))
 	}
 
 	for _, dinosaur := range dinosaurs {
 		if k.dinosaurConfig.EnableCentralExternalCertificate {
 			if dinosaur.RoutesCreationID == "" {
-				glog.Infof("creating CNAME records for dinosaur %s", dinosaur.ID)
+				glog.Infof("creating CNAME records for central %s", dinosaur.ID)
 
 				changeOutput, err := k.dinosaurService.ChangeDinosaurCNAMErecords(dinosaur, services.DinosaurRoutesActionCreate)
 
@@ -76,7 +76,7 @@ func (k *DinosaurRoutesCNAMEManager) Reconcile() []error {
 				dinosaur.RoutesCreated = *recordStatus.Status == "INSYNC"
 			}
 		} else {
-			glog.Infof("external certificate is disabled, skip CNAME creation for Dinosaur %s", dinosaur.ID)
+			glog.Infof("external certificate is disabled, skip CNAME creation for Central %s", dinosaur.ID)
 			dinosaur.RoutesCreated = true
 		}
 

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/provisioning_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/provisioning_dinosaurs_mgr.go
@@ -46,7 +46,7 @@ func (k *ProvisioningDinosaurManager) Stop() {
 
 // Reconcile ...
 func (k *ProvisioningDinosaurManager) Reconcile() []error {
-	glog.Infoln("reconciling dinosaurs")
+	glog.Infoln("reconciling centrals")
 	var encounteredErrors []error
 
 	// handle provisioning dinosaurs state
@@ -55,12 +55,12 @@ func (k *ProvisioningDinosaurManager) Reconcile() []error {
 	// We only need to update the metrics here.
 	provisioningDinosaurs, serviceErr := k.dinosaurService.ListByStatus(constants2.CentralRequestStatusProvisioning)
 	if serviceErr != nil {
-		encounteredErrors = append(encounteredErrors, errors.Wrap(serviceErr, "failed to list provisioning dinosaurs"))
+		encounteredErrors = append(encounteredErrors, errors.Wrap(serviceErr, "failed to list provisioning centrals"))
 	} else {
-		glog.Infof("provisioning dinosaurs count = %d", len(provisioningDinosaurs))
+		glog.Infof("provisioning centrals count = %d", len(provisioningDinosaurs))
 	}
 	for _, dinosaur := range provisioningDinosaurs {
-		glog.V(10).Infof("provisioning dinosaur id = %s", dinosaur.ID)
+		glog.V(10).Infof("provisioning central id = %s", dinosaur.ID)
 		metrics.UpdateCentralRequestsStatusSinceCreatedMetric(constants2.CentralRequestStatusProvisioning, dinosaur.ID, dinosaur.ClusterID, time.Since(dinosaur.CreatedAt))
 		// TODO implement additional reconcilation logic for provisioning dinosaurs
 	}

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/ready_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/ready_dinosaurs_mgr.go
@@ -45,19 +45,19 @@ func (k *ReadyDinosaurManager) Stop() {
 
 // Reconcile ...
 func (k *ReadyDinosaurManager) Reconcile() []error {
-	glog.Infoln("reconciling ready dinosaurs")
+	glog.Infoln("reconciling ready centrals")
 
 	var encounteredErrors []error
 
 	readyDinosaurs, serviceErr := k.dinosaurService.ListByStatus(constants2.CentralRequestStatusReady)
 	if serviceErr != nil {
-		encounteredErrors = append(encounteredErrors, errors.Wrap(serviceErr, "failed to list ready dinosaurs"))
+		encounteredErrors = append(encounteredErrors, errors.Wrap(serviceErr, "failed to list ready centrals"))
 	} else {
-		glog.Infof("ready dinosaurs count = %d", len(readyDinosaurs))
+		glog.Infof("ready centrals count = %d", len(readyDinosaurs))
 	}
 
 	for _, dinosaur := range readyDinosaurs {
-		glog.V(10).Infof("ready dinosaur id = %s", dinosaur.ID)
+		glog.V(10).Infof("ready central id = %s", dinosaur.ID)
 		// TODO implement reconciliation logic for ready dinosaurs
 	}
 

--- a/internal/dinosaur/test/common/dinosaur_pollers.go
+++ b/internal/dinosaur/test/common/dinosaur_pollers.go
@@ -26,9 +26,9 @@ func WaitForNumberOfDinosaurToBeGivenCount(ctx context.Context, db *db.Connectio
 		IntervalAndTimeout(defaultPollInterval, defaultDinosaurPollTimeout).
 		RetryLogFunction(func(retry int, maxRetry int) string {
 			if currentCount == -1 {
-				return fmt.Sprintf("Waiting for dinosaurs count to become %d", count)
+				return fmt.Sprintf("Waiting for centrals count to become %d", count)
 			}
-			return fmt.Sprintf("Waiting for dinosaurs count to become %d (current %d)", count, currentCount)
+			return fmt.Sprintf("Waiting for centrals count to become %d (current %d)", count, currentCount)
 		}).
 		OnRetry(func(attempt int, maxRetries int) (done bool, err error) {
 			list, _, err := client.DefaultApi.GetCentrals(ctx, nil)
@@ -41,7 +41,7 @@ func WaitForNumberOfDinosaurToBeGivenCount(ctx context.Context, db *db.Connectio
 		Build().Poll()
 
 	if err != nil {
-		return fmt.Errorf("waiting for number of dinosaurs: %w", err)
+		return fmt.Errorf("waiting for number of centrals: %w", err)
 	}
 	return nil
 }
@@ -54,21 +54,21 @@ func WaitForDinosaurCreateToBeAccepted(ctx context.Context, db *db.ConnectionFac
 		IntervalAndTimeout(defaultPollInterval, defaultDinosaurPollTimeout).
 		RetryLogFunction(func(retry int, maxRetry int) string {
 			if currentStatus == "" {
-				return "Waiting for dinosaur creation to be accepted"
+				return "Waiting for central creation to be accepted"
 			}
-			return fmt.Sprintf("Waiting for dinosaur creation to be accepted (current status %s)", currentStatus)
+			return fmt.Sprintf("Waiting for central creation to be accepted (current status %s)", currentStatus)
 		}).
 		OnRetry(func(attempt int, maxRetries int) (done bool, err error) {
 			dinosaur, resp, err = client.DefaultApi.CreateCentral(ctx, true, k)
 			if err != nil {
-				return true, fmt.Errorf("waiting for dinosaur creation to be accepted: %w", err)
+				return true, fmt.Errorf("waiting for central creation to be accepted: %w", err)
 			}
 			return resp.StatusCode == http.StatusAccepted, nil
 		}).
 		Build().Poll()
 
 	if err != nil {
-		return dinosaur, resp, fmt.Errorf("waiting for dinosaur creation to be accepted: %w", err)
+		return dinosaur, resp, fmt.Errorf("waiting for central creation to be accepted: %w", err)
 	}
 	return dinosaur, resp, nil
 
@@ -84,14 +84,14 @@ func WaitForDinosaurToReachStatus(ctx context.Context, db *db.ConnectionFactory,
 		IntervalAndTimeout(1*time.Second, defaultDinosaurReadyTimeout).
 		RetryLogFunction(func(retry int, maxRetry int) string {
 			if currentStatus == "" {
-				return fmt.Sprintf("Waiting for dinosaur '%s' to reach status '%s'", dinosaurID, status.String())
+				return fmt.Sprintf("Waiting for central '%s' to reach status '%s'", dinosaurID, status.String())
 			}
-			return fmt.Sprintf("Waiting for dinosaur '%s' to reach status '%s' (current status %s)", dinosaurID, status.String(), currentStatus)
+			return fmt.Sprintf("Waiting for central '%s' to reach status '%s' (current status %s)", dinosaurID, status.String(), currentStatus)
 		}).
 		OnRetry(func(attempt int, maxRetries int) (done bool, err error) {
 			dinosaur, _, err = client.DefaultApi.GetCentralById(ctx, dinosaurID)
 			if err != nil {
-				return true, fmt.Errorf("waiting for dinosaur to reach status: %w", err)
+				return true, fmt.Errorf("waiting for central to reach status: %w", err)
 			}
 
 			switch dinosaur.Status {
@@ -100,7 +100,7 @@ func WaitForDinosaurToReachStatus(ctx context.Context, db *db.ConnectionFactory,
 			case constants2.CentralRequestStatusDeprovision.String():
 				fallthrough
 			case constants2.CentralRequestStatusDeleting.String():
-				return false, errors.Errorf("Waiting for dinosaur '%s' to reach status '%s', but status '%s' has been reached instead", dinosaurID, status.String(), dinosaur.Status)
+				return false, errors.Errorf("Waiting for central '%s' to reach status '%s', but status '%s' has been reached instead", dinosaurID, status.String(), dinosaur.Status)
 			}
 
 			currentStatus = dinosaur.Status
@@ -109,7 +109,7 @@ func WaitForDinosaurToReachStatus(ctx context.Context, db *db.ConnectionFactory,
 		Build().Poll()
 
 	if err != nil {
-		return dinosaur, fmt.Errorf("waiting for dinosaur to reach status: %w", err)
+		return dinosaur, fmt.Errorf("waiting for central to reach status: %w", err)
 	}
 	return dinosaur, nil
 }
@@ -118,7 +118,7 @@ func WaitForDinosaurToReachStatus(ctx context.Context, db *db.ConnectionFactory,
 func WaitForDinosaurToBeDeleted(ctx context.Context, db *db.ConnectionFactory, client *public.APIClient, dinosaurID string) error {
 	err := NewPollerBuilder(db).
 		IntervalAndTimeout(defaultPollInterval, defaultDinosaurReadyTimeout).
-		RetryLogMessagef("Waiting for dinosaur '%s' to be deleted", dinosaurID).
+		RetryLogMessagef("Waiting for central '%s' to be deleted", dinosaurID).
 		OnRetry(func(attempt int, maxRetries int) (done bool, err error) {
 			if _, _, err := client.DefaultApi.GetCentralById(ctx, dinosaurID); err != nil {
 				if err.Error() == "404 Not Found" {
@@ -132,7 +132,7 @@ func WaitForDinosaurToBeDeleted(ctx context.Context, db *db.ConnectionFactory, c
 		Build().Poll()
 
 	if err != nil {
-		return fmt.Errorf("waiting for dinosaur to be deleted: %w", err)
+		return fmt.Errorf("waiting for central to be deleted: %w", err)
 	}
 	return nil
 }
@@ -143,17 +143,17 @@ func WaitForDinosaurClusterIDToBeAssigned(dbFactory *db.ConnectionFactory, dinos
 
 	dinosaurErr := NewPollerBuilder(dbFactory).
 		IntervalAndTimeout(defaultPollInterval, defaultDinosaurClusterAssignmentTimeout).
-		RetryLogMessagef("Waiting for dinosaur named '%s' to have a ClusterID", dinosaurRequestName).
+		RetryLogMessagef("Waiting for central named '%s' to have a ClusterID", dinosaurRequestName).
 		OnRetry(func(attempt int, maxRetries int) (done bool, err error) {
 			if err := dbFactory.New().Where("name = ?", dinosaurRequestName).First(dinosaurFound).Error; err != nil {
 				return false, err
 			}
-			glog.Infof("got dinosaur instance %v", dinosaurFound)
+			glog.Infof("got central instance %v", dinosaurFound)
 			return dinosaurFound.ClusterID != "", nil
 		}).Build().Poll()
 
 	if dinosaurErr != nil {
-		return dinosaurFound, fmt.Errorf("waiting for dinosaur cluster ID to be assigned: %w", dinosaurErr)
+		return dinosaurFound, fmt.Errorf("waiting for central cluster ID to be assigned: %w", dinosaurErr)
 	}
 	return dinosaurFound, nil
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -81,7 +81,7 @@ const (
 
 	// TooManyRequests occurs when a the dinosaur instances capacity gets filled up
 	ErrorTooManyDinosaurInstancesReached       ServiceErrorCode = 24
-	ErrorTooManyDinosaurInstancesReachedReason string           = "The maximum number of allowed dinosaur instances has been reached"
+	ErrorTooManyDinosaurInstancesReachedReason string           = "The maximum number of allowed central instances has been reached"
 
 	// Gone occurs when a record is accessed that has been deleted
 	ErrorGone       ServiceErrorCode = 25
@@ -93,19 +93,19 @@ const (
 
 	// Failed to create sso client - an internal error incurred when calling iam server
 	ErrorFailedToCreateSSOClient       ServiceErrorCode = 106
-	ErrorFailedToCreateSSOClientReason string           = "Failed to create dinosaur client in the mas sso"
+	ErrorFailedToCreateSSOClientReason string           = "Failed to create central client in the mas sso"
 
 	// Failed to get sso client secret  - an internal error incurred when calling iam server
 	ErrorFailedToGetSSOClientSecret       ServiceErrorCode = 107
-	ErrorFailedToGetSSOClientSecretReason string           = "Failed to get dinosaur client secret from the mas sso"
+	ErrorFailedToGetSSOClientSecretReason string           = "Failed to get central client secret from the mas sso"
 
 	// Failed to get sso client - an internal error incurred when calling iam server
 	ErrorFailedToGetSSOClient       ServiceErrorCode = 108
-	ErrorFailedToGetSSOClientReason string           = "Failed to get dinosaur client from the mas sso"
+	ErrorFailedToGetSSOClientReason string           = "Failed to get central client from the mas sso"
 
 	// Failed to delete sso client - an internal error incurred when calling iam server
 	ErrorFailedToDeleteSSOClient       ServiceErrorCode = 109
-	ErrorFailedToDeleteSSOClientReason string           = "Failed to delete dinosaur client from the mas sso"
+	ErrorFailedToDeleteSSOClientReason string           = "Failed to delete central client from the mas sso"
 
 	// Failed to create service account, after validating user's request, but failed at the server end
 	// it is an internal server error
@@ -143,7 +143,7 @@ const (
 
 	// Invalid dinosaur cluster name
 	ErrorMalformedDinosaurClusterName       ServiceErrorCode = 32
-	ErrorMalformedDinosaurClusterNameReason string           = "Dinosaur cluster name is invalid"
+	ErrorMalformedDinosaurClusterNameReason string           = "Central cluster name is invalid"
 
 	// Minimum field length validation
 	ErrorMinimumFieldLength       ServiceErrorCode = 33
@@ -155,11 +155,11 @@ const (
 
 	// Only MultiAZ is supported
 	ErrorOnlyMultiAZSupported       ServiceErrorCode = 35
-	ErrorOnlyMultiAZSupportedReason string           = "Only multiAZ Dinosaurs are supported, use multi_az=true"
+	ErrorOnlyMultiAZSupportedReason string           = "Only multiAZ Centrals are supported, use multi_az=true"
 
 	// Dinosaur cluster name must be unique
 	ErrorDuplicateDinosaurClusterName       ServiceErrorCode = 36
-	ErrorDuplicateDinosaurClusterNameReason string           = "Dinosaur cluster name is already used"
+	ErrorDuplicateDinosaurClusterNameReason string           = "Central cluster name is already used"
 
 	// A generic field validation error when validating API requests input
 	ErrorFieldValidationError       ServiceErrorCode = 37


### PR DESCRIPTION
## Description
I went through all the string literals in the codebase that contain "dinosaur", and changed them to "central" (or "Central", or "centrals") in the following cases:
- they are part of error messages
- they are part of log messages
- are outputted by CLI tools

Left everything else untouched.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
~~- [ ] Documentation added if necessary~~
~~- [ ] CI and all relevant tests are passing~~
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~

