### PR TITLE
fix fleetshard version on stage and upgrade to v3.72

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -46,6 +46,8 @@ case $ENVIRONMENT in
     FM_ENDPOINT="https://xtr6hh3mg6zc80v.api.stage.openshift.com"
 
     ensure_bitwarden_session_exists
+
+    FLEETSHARD_SYNC_IMAGE="quay.io/app-sre/acs-fleet-manager:59142fe"
     # Note: the Red Hat SSO client as of 2022-09-02 is the same between stage and prod.
     FLEETSHARD_SYNC_RED_HAT_SSO_CLIENT_ID=$(bw get username 028ce1a9-f751-4056-9c72-aea70052728b)
     FLEETSHARD_SYNC_RED_HAT_SSO_CLIENT_SECRET=$(bw get password 028ce1a9-f751-4056-9c72-aea70052728b)
@@ -77,6 +79,7 @@ case $ENVIRONMENT in
     FM_ENDPOINT="https://api.openshift.com"
 
     ensure_bitwarden_session_exists
+    FLEETSHARD_SYNC_IMAGE="quay.io/app-sre/acs-fleet-manager:59142fe"
     # Note: the Red Hat SSO client as of 2022-09-02 is the same between stage and prod.
     FLEETSHARD_SYNC_RED_HAT_SSO_CLIENT_ID=$(bw get username 028ce1a9-f751-4056-9c72-aea70052728b)
     FLEETSHARD_SYNC_RED_HAT_SSO_CLIENT_SECRET=$(bw get password 028ce1a9-f751-4056-9c72-aea70052728b)
@@ -127,8 +130,9 @@ helm upgrade rhacs-terraform ./ \
   --set acsOperator.enabled=true \
   --set acsOperator.source="${OPERATOR_SOURCE}" \
   --set acsOperator.sourceNamespace=openshift-marketplace \
-  --set acsOperator.version=v3.71.0 \
+  --set acsOperator.version=v3.72.0 \
   --set acsOperator.upstream="${OPERATOR_USE_UPSTREAM}" \
+  --set fleetshardSync.image="${FLEETSHARD_SYNC_IMAGE}" \
   --set fleetshardSync.authType="RHSSO" \
   --set fleetshardSync.gitCommitSHA="${GIT_COMMIT_SHA}" \
   --set fleetshardSync.gitDescribeTag="${GIT_DESCRIBE_TAG}" \

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 fleetshardSync:
-  image: "quay.io/app-sre/acs-fleet-manager:main"
+  image: "quay.io/app-sre/acs-fleet-manager:59142fe"
   # Sets the commit hash and git describe to identify the deployed version of fleetshard sync
   gitCommitSHA: ""
   gitDescribeTag: ""


### PR DESCRIPTION
## Description
Update dataplane terraforming to deploy rhacs operator v3.72 and pin the fleetshard-sync deployment to a specific commit hash. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
