### PR TITLE
Do not make the default group immutable

### DIFF
--- a/fleetshard/pkg/central/reconciler/init_auth.go
+++ b/fleetshard/pkg/central/reconciler/init_auth.go
@@ -30,9 +30,6 @@ var (
 			return &storage.Group{
 				Props: &storage.GroupProperties{
 					AuthProviderId: providerId,
-					Traits: &storage.Traits{
-						MutabilityMode: storage.Traits_ALLOW_MUTATE_FORCED,
-					},
 				},
 				RoleName: "None",
 			}


### PR DESCRIPTION
## Description

Within [pull/397](https://github.com/stackrox/acs-fleet-manager/pull/397), the default group (the group which only has the auth provider ID set), was incorrectly declared as immutable.

When developing the feature of adding immutability to groups within [pull/2663](https://github.com/stackrox/stackrox/pull/2663), the expection was done for default groups to **not** be immutable ([see here](https://github.com/stackrox/stackrox/pull/2663/files#diff-dcb0ff277bf5c2b44fe253a6f5dcbf331b017ee6c8594ddce08f47f48c069e65R44-R47)).

The reasoning for a default group to not be immutable is that customers shall have the possiblity to change the default group for non-administrative users from `None` to a role of their choice.
If the group would be immutable, this wouldn't be the case and only the administrator / owner of the managed central would be able to login it  all times.

## Test manual

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
