### PR TITLE
ROX-12836: Ensure authprovider is created already active

### DIFF
--- a/fleetshard/pkg/central/reconciler/init_auth.go
+++ b/fleetshard/pkg/central/reconciler/init_auth.go
@@ -165,6 +165,7 @@ func createAuthProviderRequest(central private.ManagedCentral) *storage.AuthProv
 		Traits: &storage.Traits{
 			MutabilityMode: storage.Traits_ALLOW_MUTATE_FORCED,
 		},
+		Active: true,
 	}
 	return request
 }


### PR DESCRIPTION
## Description
Addendum to https://github.com/stackrox/acs-fleet-manager/pull/446.

By default, an auth provider is activated upon first user log in. This activation modifies auth provider via [`WithValidateCallback()`](https://github.com/stackrox/stackrox/blob/65e557c81746314df201508a1f37576ebdc3060a/pkg/auth/authproviders/provider_options.go#L101) which in turn calls [`UpdateAuthProvider()`](https://github.com/stackrox/stackrox/blob/5fca258dcedc15748bbd7957ea4d5fc7fbec2a48/central/authprovider/datastore/datastore_impl.go#L64) and breaks in `verifyExistsAndMutable()` because the auth provider is immutable.

This PR work arounds the problem by creating the auth provider already in the active state.

Long-term solution is moving from call ACS API to declarative configuration.

## Checklist (Definition of Done)
- [ ] ~Unit and integration tests added~ <= if we had done it in the first place, we would not have needed this PR
- [ ] ~Documentation added if necessary~
- [ ] CI and all relevant tests are passing
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Tested by Daniel on a standalone cluster.
