### PR TITLE
version bump for fleetshard-sync

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -47,7 +47,7 @@ case $ENVIRONMENT in
 
     ensure_bitwarden_session_exists
 
-    FLEETSHARD_SYNC_IMAGE="quay.io/app-sre/acs-fleet-manager:59142fe"
+    FLEETSHARD_SYNC_IMAGE="quay.io/app-sre/acs-fleet-manager:5602823"
     # Note: the Red Hat SSO client as of 2022-09-02 is the same between stage and prod.
     FLEETSHARD_SYNC_RED_HAT_SSO_CLIENT_ID=$(bw get username 028ce1a9-f751-4056-9c72-aea70052728b)
     FLEETSHARD_SYNC_RED_HAT_SSO_CLIENT_SECRET=$(bw get password 028ce1a9-f751-4056-9c72-aea70052728b)
@@ -79,7 +79,7 @@ case $ENVIRONMENT in
     FM_ENDPOINT="https://api.openshift.com"
 
     ensure_bitwarden_session_exists
-    FLEETSHARD_SYNC_IMAGE="quay.io/app-sre/acs-fleet-manager:59142fe"
+    FLEETSHARD_SYNC_IMAGE="quay.io/app-sre/acs-fleet-manager:0b2f1b4"
     # Note: the Red Hat SSO client as of 2022-09-02 is the same between stage and prod.
     FLEETSHARD_SYNC_RED_HAT_SSO_CLIENT_ID=$(bw get username 028ce1a9-f751-4056-9c72-aea70052728b)
     FLEETSHARD_SYNC_RED_HAT_SSO_CLIENT_SECRET=$(bw get password 028ce1a9-f751-4056-9c72-aea70052728b)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
We've pinned the deployed version of stage/prod to the image with first 7 letters of the commit hash in the AppSRE image repository. The version for prod was deployed during the debugging session for our Service Preview. The version for prod/stage are different because I updated stage today to the latest image used by fleet-manager in order to fix the SSO issue for stage. I didn't want to deploy prod with that version yet, since we're planning to put out another version today once https://issues.redhat.com/browse/ROX-12842 is done

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~- [ ] Unit and integration tests added~
~- [ ] Documentation added if necessary~
~- [ ] CI and all relevant tests are passing~
~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
