### PR TITLE
change ClusterPlacementStrategies to validate instance type

### DIFF
--- a/dev/env/defaults/00-defaults.env
+++ b/dev/env/defaults/00-defaults.env
@@ -10,7 +10,7 @@ export CLUSTER_ID_DEFAULT="1234567890abcdef1234567890abcdef"
 export CLUSTER_DNS_DEFAULT="cluster.local"
 
 export IMAGE_REGISTRY_DEFAULT="quay.io/rhacs-eng"
-STACKROX_VERSION_TAG="3.70.0-nightly-20220707"
+STACKROX_VERSION_TAG="3.72.0-nightly-20220929"
 export STACKROX_OPERATOR_VERSION_DEFAULT="${STACKROX_VERSION_TAG}"
 export CENTRAL_VERSION_DEFAULT=$(echo "$STACKROX_VERSION_TAG" | sed -e 's/0-nightly/x-nightly/;')
 export SCANNER_VERSION_DEFAULT="2.25.1" # This one matches the above operator version tag.

--- a/dev/env/manifests/rhacs-operator/marketplace/03-subscription.yaml
+++ b/dev/env/manifests/rhacs-operator/marketplace/03-subscription.yaml
@@ -9,6 +9,6 @@ spec:
   installPlanApproval: Automatic
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: rhacs-operator.v3.70.0
+  startingCSV: rhacs-operator.v3.72.0
   config:
     resources: $RHACS_OPERATOR_RESOURCES

--- a/internal/dinosaur/pkg/services/cluster_placement_strategy.go
+++ b/internal/dinosaur/pkg/services/cluster_placement_strategy.go
@@ -15,7 +15,7 @@ import (
 //go:generate moq -out cluster_placement_strategy_moq.go . ClusterPlacementStrategy
 type ClusterPlacementStrategy interface {
 	// FindCluster finds and returns a Cluster depends on the specific impl.
-	FindCluster(dinosaur *dbapi.CentralRequest) (*api.Cluster, error)
+	FindCluster(central *dbapi.CentralRequest) (*api.Cluster, error)
 }
 
 // NewClusterPlacementStrategy return a concrete strategy impl. depends on the
@@ -45,14 +45,14 @@ type FirstReadyPlacementStrategy struct {
 }
 
 // FindCluster ...
-func (d FirstReadyPlacementStrategy) FindCluster(dinosaur *dbapi.CentralRequest) (*api.Cluster, error) {
+func (d FirstReadyPlacementStrategy) FindCluster(central *dbapi.CentralRequest) (*api.Cluster, error) {
 	clusters, err := d.clusterService.FindAllClusters(FindClusterCriteria{Status: api.ClusterReady})
 	if err != nil {
 		return nil, err
 	}
 
 	for _, c := range clusters {
-		if !c.SkipScheduling && supportsInstanceType(c, dinosaur.InstanceType) {
+		if !c.SkipScheduling && supportsInstanceType(c, central.InstanceType) {
 			return c, nil
 		}
 	}

--- a/internal/dinosaur/pkg/services/cluster_placement_strategy.go
+++ b/internal/dinosaur/pkg/services/cluster_placement_strategy.go
@@ -87,5 +87,12 @@ func (f TargetClusterPlacementStrategy) FindCluster(central *dbapi.CentralReques
 }
 
 func supportsInstanceType(c *api.Cluster, instanceType string) bool {
-	return strings.Contains(c.SupportedInstanceType, instanceType)
+	supportedTypes := strings.Split(c.SupportedInstanceType, ",")
+	for _, t := range supportedTypes {
+		if t == instanceType {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/dinosaur/pkg/services/cluster_placement_strategy_moq.go
+++ b/internal/dinosaur/pkg/services/cluster_placement_strategy_moq.go
@@ -19,7 +19,7 @@ var _ ClusterPlacementStrategy = &ClusterPlacementStrategyMock{}
 //
 // 		// make and configure a mocked ClusterPlacementStrategy
 // 		mockedClusterPlacementStrategy := &ClusterPlacementStrategyMock{
-// 			FindClusterFunc: func(dinosaur *dbapi.CentralRequest) (*api.Cluster, error) {
+// 			FindClusterFunc: func(central *dbapi.CentralRequest) (*api.Cluster, error) {
 // 				panic("mock out the FindCluster method")
 // 			},
 // 		}
@@ -30,43 +30,43 @@ var _ ClusterPlacementStrategy = &ClusterPlacementStrategyMock{}
 // 	}
 type ClusterPlacementStrategyMock struct {
 	// FindClusterFunc mocks the FindCluster method.
-	FindClusterFunc func(dinosaur *dbapi.CentralRequest) (*api.Cluster, error)
+	FindClusterFunc func(central *dbapi.CentralRequest) (*api.Cluster, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
 		// FindCluster holds details about calls to the FindCluster method.
 		FindCluster []struct {
-			// Dinosaur is the dinosaur argument value.
-			Dinosaur *dbapi.CentralRequest
+			// Central is the central argument value.
+			Central *dbapi.CentralRequest
 		}
 	}
 	lockFindCluster sync.RWMutex
 }
 
 // FindCluster calls FindClusterFunc.
-func (mock *ClusterPlacementStrategyMock) FindCluster(dinosaur *dbapi.CentralRequest) (*api.Cluster, error) {
+func (mock *ClusterPlacementStrategyMock) FindCluster(central *dbapi.CentralRequest) (*api.Cluster, error) {
 	if mock.FindClusterFunc == nil {
 		panic("ClusterPlacementStrategyMock.FindClusterFunc: method is nil but ClusterPlacementStrategy.FindCluster was just called")
 	}
 	callInfo := struct {
-		Dinosaur *dbapi.CentralRequest
+		Central *dbapi.CentralRequest
 	}{
-		Dinosaur: dinosaur,
+		Central: central,
 	}
 	mock.lockFindCluster.Lock()
 	mock.calls.FindCluster = append(mock.calls.FindCluster, callInfo)
 	mock.lockFindCluster.Unlock()
-	return mock.FindClusterFunc(dinosaur)
+	return mock.FindClusterFunc(central)
 }
 
 // FindClusterCalls gets all the calls that were made to FindCluster.
 // Check the length with:
 //     len(mockedClusterPlacementStrategy.FindClusterCalls())
 func (mock *ClusterPlacementStrategyMock) FindClusterCalls() []struct {
-	Dinosaur *dbapi.CentralRequest
+	Central *dbapi.CentralRequest
 } {
 	var calls []struct {
-		Dinosaur *dbapi.CentralRequest
+		Central *dbapi.CentralRequest
 	}
 	mock.lockFindCluster.RLock()
 	calls = mock.calls.FindCluster

--- a/internal/dinosaur/pkg/services/cluster_placement_strategy_test.go
+++ b/internal/dinosaur/pkg/services/cluster_placement_strategy_test.go
@@ -70,7 +70,7 @@ func TestFirstClusterPlacementStrategy(t *testing.T) {
 					},
 				}
 			},
-			central:         buildDinosaurRequest(func(dinosaurRequest *dbapi.CentralRequest) {}),
+			central:         buildCentralRequest(func(centralRequest *dbapi.CentralRequest) {}),
 			expectedError:   serviceErrors.New(apiErrors.ErrorGeneral, "error in FindAllClusters"),
 			expectedCluster: nil,
 		},
@@ -83,7 +83,7 @@ func TestFirstClusterPlacementStrategy(t *testing.T) {
 					},
 				}
 			},
-			central:         buildDinosaurRequest(func(dinosaurRequest *dbapi.CentralRequest) {}),
+			central:         buildCentralRequest(func(centralRequest *dbapi.CentralRequest) {}),
 			expectedError:   errors.New("no schedulable cluster found"),
 			expectedCluster: nil,
 		},
@@ -103,7 +103,7 @@ func TestFirstClusterPlacementStrategy(t *testing.T) {
 					},
 				}
 			},
-			central:         buildDinosaurRequest(func(dinosaurRequest *dbapi.CentralRequest) {}),
+			central:         buildCentralRequest(func(centralRequest *dbapi.CentralRequest) {}),
 			expectedError:   errors.New("no schedulable cluster found"),
 			expectedCluster: nil,
 		},
@@ -119,7 +119,7 @@ func TestFirstClusterPlacementStrategy(t *testing.T) {
 					},
 				}
 			},
-			central: buildDinosaurRequest(func(centralRequest *dbapi.CentralRequest) {
+			central: buildCentralRequest(func(centralRequest *dbapi.CentralRequest) {
 				centralRequest.InstanceType = "standard"
 			}),
 			expectedError:   errors.New("no schedulable cluster found"),
@@ -139,7 +139,7 @@ func TestFirstClusterPlacementStrategy(t *testing.T) {
 					},
 				}
 			},
-			central: buildDinosaurRequest(func(centralRequest *dbapi.CentralRequest) {
+			central: buildCentralRequest(func(centralRequest *dbapi.CentralRequest) {
 				centralRequest.InstanceType = "standard"
 			}),
 			expectedError: nil,

--- a/internal/dinosaur/pkg/services/cluster_placement_strategy_test.go
+++ b/internal/dinosaur/pkg/services/cluster_placement_strategy_test.go
@@ -1,10 +1,17 @@
 package services
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/config"
+	"github.com/stackrox/acs-fleet-manager/pkg/api"
+
+	apiErrors "github.com/stackrox/acs-fleet-manager/pkg/errors"
 	"github.com/stretchr/testify/require"
+
+	serviceErrors "github.com/stackrox/acs-fleet-manager/pkg/errors"
 )
 
 func TestPlacementStrategyType(t *testing.T) {
@@ -43,5 +50,56 @@ func TestPlacementStrategyType(t *testing.T) {
 
 			require.IsType(t, tc.expectedType, strategy)
 		})
+	}
+}
+
+func TestFirstClusterPlacementStrategy(t *testing.T) {
+
+	tt := []struct {
+		description           string
+		newClusterServiceMock func() ClusterService
+		central               *dbapi.CentralRequest
+		expectedError         error
+		expectedCluster       *api.Cluster
+	}{
+		{
+			description: "should return error if FindAllClusters returns error",
+			newClusterServiceMock: func() ClusterService {
+				return &ClusterServiceMock{
+					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, *serviceErrors.ServiceError) {
+						return nil, serviceErrors.New(apiErrors.ErrorGeneral, "error in FindAllClusters")
+					},
+				}
+			},
+			central:         buildDinosaurRequest(func(dinosaurRequest *dbapi.CentralRequest) {}),
+			expectedError:   serviceErrors.New(apiErrors.ErrorGeneral, "error in FindAllClusters"),
+			expectedCluster: nil,
+		},
+		{
+			description: "should return error if clusters is empty",
+			newClusterServiceMock: func() ClusterService {
+				return &ClusterServiceMock{
+					FindAllClustersFunc: func(criteria FindClusterCriteria) ([]*api.Cluster, *serviceErrors.ServiceError) {
+						return []*api.Cluster{}, nil
+					},
+				}
+			},
+			central:         buildDinosaurRequest(func(dinosaurRequest *dbapi.CentralRequest) {}),
+			expectedError:   errors.New("no schedulable cluster found"),
+			expectedCluster: nil,
+		},
+		// should return error if no clusters with SkipScheduling true was found
+		// should return error if no cluster supporting central instancetype was found
+		// should return first ready cluster
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.description, func(t *testing.T) {
+			strategy := FirstReadyPlacementStrategy{clusterService: tc.newClusterServiceMock()}
+			cluster, err := strategy.FindCluster(tc.central)
+			require.Equal(t, err, tc.expectedError)
+			require.Equal(t, tc.expectedCluster, cluster)
+		})
+
 	}
 }

--- a/internal/dinosaur/pkg/services/dinosaur_test.go
+++ b/internal/dinosaur/pkg/services/dinosaur_test.go
@@ -21,32 +21,32 @@ const (
 )
 
 var (
-	testDinosaurRequestRegion   = "us-east-1"
-	testDinosaurRequestProvider = "aws"
-	testDinosaurRequestName     = "test-cluster"
-	testClusterID               = "test-cluster-id"
-	testID                      = "test"
-	testUser                    = "test-user"
+	testCentralRequestRegion   = "us-east-1"
+	testCentralRequestProvider = "aws"
+	testCentralRequestName     = "test-cluster"
+	testClusterID              = "test-cluster-id"
+	testID                     = "test"
+	testUser                   = "test-user"
 )
 
-// build a test dinosaur request
-func buildDinosaurRequest(modifyFn func(dinosaurRequest *dbapi.CentralRequest)) *dbapi.CentralRequest {
-	dinosaurRequest := &dbapi.CentralRequest{
+// build a test central request
+func buildCentralRequest(modifyFn func(centralRequest *dbapi.CentralRequest)) *dbapi.CentralRequest {
+	centralRequest := &dbapi.CentralRequest{
 		Meta: api.Meta{
 			ID:        testID,
 			DeletedAt: gorm.DeletedAt{Valid: true},
 		},
-		Region:        testDinosaurRequestRegion,
+		Region:        testCentralRequestRegion,
 		ClusterID:     testClusterID,
-		CloudProvider: testDinosaurRequestProvider,
-		Name:          testDinosaurRequestName,
+		CloudProvider: testCentralRequestProvider,
+		Name:          testCentralRequestName,
 		MultiAZ:       false,
 		Owner:         testUser,
 	}
 	if modifyFn != nil {
-		modifyFn(dinosaurRequest)
+		modifyFn(centralRequest)
 	}
-	return dinosaurRequest
+	return centralRequest
 }
 
 // This test should act as a "golden" test to describe the general testing approach taken in the service, for people
@@ -132,13 +132,13 @@ func Test_dinosaurService_Get(t *testing.T) {
 				ctx: authenticatedCtx,
 				id:  testID,
 			},
-			want: buildDinosaurRequest(nil),
+			want: buildCentralRequest(nil),
 			setupFn: func() {
 				mocket.Catcher.Reset().
 					NewMock().
 					WithQuery(`SELECT * FROM "central_requests" WHERE id = $1 AND owner = $2`).
 					WithArgs(testID, testUser).
-					WithReply(converters.ConvertDinosaurRequest(buildDinosaurRequest(nil)))
+					WithReply(converters.ConvertDinosaurRequest(buildCentralRequest(nil)))
 			},
 		},
 	}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Added validation to the ClusterPlacementStrategies to not schedule central requests to clusters that don't support the instancetype of that request. This enables us to allow/block eval instance creation based on `dataplane-cluster-configuration.yaml`

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
