### PR TITLE
ROX-12640: Prefer schedule replicas on different nodes

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -895,15 +895,13 @@ objects:
           affinity:
             podAntiAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
-              - podAffinityTerm:
-                  labelSelector:
-                    matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                      - fleet-manager
-                  topologyKey: failure-domain.beta.kubernetes.io/zone
-                weight: 100
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - fleet-manager
+                topologyKey: "kubernetes.io/hostname"
           serviceAccount: fleet-manager
           serviceAccountName: fleet-manager
           volumes:


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
- `topologyKey: "kubernetes.io/hostname"` will suggest the orchestrator to avoid deploying pods in the same host name
- drop `podAffinityTerm` because there is only one condition so specifying `weight` is redundant

Details https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity

## Test manual

Will test stage deployment
