### PR TITLE
Log OCM request to retrieve org id

### DIFF
--- a/pkg/client/ocm/client.go
+++ b/pkg/client/ocm/client.go
@@ -6,6 +6,7 @@ import (
 
 	pkgerrors "github.com/pkg/errors"
 
+	"github.com/golang/glog"
 	sdkClient "github.com/openshift-online/ocm-sdk-go"
 	amsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	v1 "github.com/openshift-online/ocm-sdk-go/authorizations/v1"
@@ -105,7 +106,6 @@ func NewOCMConnection(ocmConfig *OCMConfig, BaseURL string) (*sdkClient.Connecti
 	return connection, func() {
 		_ = connection.Close()
 	}, nil
-
 }
 
 // NewClient ...
@@ -127,7 +127,6 @@ func (c *client) Close() {
 
 // CreateCluster ...
 func (c *client) CreateCluster(cluster *clustersmgmtv1.Cluster) (*clustersmgmtv1.Cluster, error) {
-
 	clusterResource := c.connection.ClustersMgmt().V1().Clusters()
 	response, err := clusterResource.Add().Body(cluster).Send()
 	if err != nil {
@@ -167,7 +166,10 @@ func (c *client) GetExistingClusterMetrics(clusterID string) (*amsv1.Subscriptio
 
 // GetOrganisationIDFromExternalID ...
 func (c *client) GetOrganisationIDFromExternalID(externalID string) (string, error) {
-	res, err := c.connection.AccountsMgmt().V1().Organizations().List().Search(fmt.Sprintf("external_id='%s'", externalID)).Send()
+	request := c.connection.AccountsMgmt().V1().Organizations().List().Search(fmt.Sprintf("external_id='%s'", externalID))
+	// TODO (stehessel/2022-10-05) Remove log statement to avoid log spam
+	glog.Infof("Get organization ID from external ID with request: %+v", request)
+	res, err := request.Send()
 	if err != nil {
 		return "", fmt.Errorf("retrieving organizations: %w", err)
 	}
@@ -353,7 +355,6 @@ func (c *client) GetClusterDNS(clusterID string) (string, error) {
 
 // CreateSyncSet ...
 func (c client) CreateSyncSet(clusterID string, syncset *clustersmgmtv1.Syncset) (*clustersmgmtv1.Syncset, error) {
-
 	clustersResource := c.connection.ClustersMgmt().V1().Clusters()
 	response, syncsetErr := clustersResource.Cluster(clusterID).
 		ExternalConfiguration().
@@ -370,7 +371,6 @@ func (c client) CreateSyncSet(clusterID string, syncset *clustersmgmtv1.Syncset)
 
 // UpdateSyncSet ...
 func (c client) UpdateSyncSet(clusterID string, syncSetID string, syncset *clustersmgmtv1.Syncset) (*clustersmgmtv1.Syncset, error) {
-
 	clustersResource := c.connection.ClustersMgmt().V1().Clusters()
 	response, syncsetErr := clustersResource.Cluster(clusterID).
 		ExternalConfiguration().
@@ -389,7 +389,6 @@ func (c client) UpdateSyncSet(clusterID string, syncSetID string, syncset *clust
 
 // CreateIdentityProvider ...
 func (c client) CreateIdentityProvider(clusterID string, identityProvider *clustersmgmtv1.IdentityProvider) (*clustersmgmtv1.IdentityProvider, error) {
-
 	clustersResource := c.connection.ClustersMgmt().V1().Clusters()
 	response, identityProviderErr := clustersResource.Cluster(clusterID).
 		IdentityProviders().


### PR DESCRIPTION
This log statement is added to debug a panic within the `Send` of the OCM sdk client library.

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
