### PR TITLE
Fix the admin API path in docs

### DIFF
--- a/docs/auth/admin-api.md
+++ b/docs/auth/admin-api.md
@@ -43,5 +43,5 @@ token=$(rhoas authtoken)
 ```
 3. Execute arbitrary API calls:
 ```bash
-curl -H "Authorization: Bearer ${token}" http://fleet-manager:8000/api/rhacs/v1/admin/dinosaurs
+curl -H "Authorization: Bearer ${token}" http://fleet-manager:8000/api/rhacs/v1/admin/centrals
 ```


### PR DESCRIPTION
## Description
Fix the changed API path from `dinosaurs` to `centrals`.
