### PR TITLE
CI Test Env: Fix timeout issue (hopefully)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ endif
 
 ifndef TEST_TIMEOUT
 	ifeq ($(OCM_ENV), integration)
-		TEST_TIMEOUT=15m
+		TEST_TIMEOUT=30m
 	else
 		TEST_TIMEOUT=5h
 	endif

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
 	. "github.com/onsi/ginkgo/v2"
-	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
 	"k8s.io/client-go/rest"
@@ -57,9 +56,7 @@ func TestE2E(t *testing.T) {
 		t.Skip("Skip e2e tests. Set RUN_E2E=true env variable to enable e2e tests.")
 	}
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "RHACS ManagedServices Suite", types.ReporterConfig{
-		SlowSpecThreshold: 5 * time.Minute,
-	})
+	RunSpecs(t, "RHACS ManagedServices Suite")
 }
 
 // TODO: Deploy fleet-manager, fleetshard-sync and database into a cluster

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
 	"k8s.io/client-go/rest"
@@ -56,7 +57,9 @@ func TestE2E(t *testing.T) {
 		t.Skip("Skip e2e tests. Set RUN_E2E=true env variable to enable e2e tests.")
 	}
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "RHACS ManagedServices Suite")
+	RunSpecs(t, "RHACS ManagedServices Suite", types.ReporterConfig{
+		SlowSpecThreshold: 5 * time.Minute,
+	})
 }
 
 // TODO: Deploy fleet-manager, fleetshard-sync and database into a cluster


### PR DESCRIPTION
## Description

It seems that the recent flakes in CI e2e tests are caused by a timeout being configured to low for our e2e tests.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

n/a

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
