### PR TITLE
Minor improvements to terraform script

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -4,6 +4,8 @@ set -eo pipefail
 # Requires: `jq`
 # Requires: BitWarden CLI `bw`
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 if [[ $# -ne 2 ]]; then
     echo "Usage: $0 [environment] [cluster]" >&2
     echo "Known environments: stage prod"
@@ -42,6 +44,10 @@ case $ENVIRONMENT in
       exit 1
     fi
     CLUSTER_ID=$(ocm list cluster "${CLUSTER_NAME}" --no-headers --columns="ID")
+    if [[ -z "${CLUSTER_ID}" ]]; then
+      echo "CLUSTER_ID is empty. Make sure ${CLUSTER_NAME} points to an existing cluster."
+      exit 1
+    fi
 
     FM_ENDPOINT="https://xtr6hh3mg6zc80v.api.stage.openshift.com"
 
@@ -75,6 +81,10 @@ case $ENVIRONMENT in
       exit 1
     fi
     CLUSTER_ID=$(ocm list cluster "${CLUSTER_NAME}" --no-headers --columns="ID")
+    if [[ -z "${CLUSTER_ID}" ]]; then
+      echo "CLUSTER_ID is empty. Make sure ${CLUSTER_NAME} points to an existing cluster."
+      exit 1
+    fi
 
     FM_ENDPOINT="https://api.openshift.com"
 
@@ -122,7 +132,7 @@ OPERATOR_SOURCE="redhat-operators"
 #OPERATOR_SOURCE="rhacs-operators"
 
 # helm template ... to debug changes
-helm upgrade rhacs-terraform ./ \
+helm upgrade rhacs-terraform "${SCRIPT_DIR}" \
   --install \
   --debug \
   --namespace rhacs \

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -38,16 +38,6 @@ case $ENVIRONMENT in
   stage)
     # TODO: Fetch OCM token and log in as appropriate user as part of script.
     EXPECT_OCM_ID="2ECw6PIE06TzjScQXe6QxMMt3Sa"
-    ACTUAL_OCM_ID=$(ocm whoami | jq -r '.id')
-    if [[ "${EXPECT_OCM_ID}" != "${ACTUAL_OCM_ID}" ]]; then
-      echo "Must be logged into rhacs-managed-service-stage account in OCM to get cluster ID"
-      exit 1
-    fi
-    CLUSTER_ID=$(ocm list cluster "${CLUSTER_NAME}" --no-headers --columns="ID")
-    if [[ -z "${CLUSTER_ID}" ]]; then
-      echo "CLUSTER_ID is empty. Make sure ${CLUSTER_NAME} points to an existing cluster."
-      exit 1
-    fi
 
     FM_ENDPOINT="https://xtr6hh3mg6zc80v.api.stage.openshift.com"
 
@@ -75,16 +65,6 @@ case $ENVIRONMENT in
   prod)
     # TODO: Fetch OCM token and log in as appropriate user as part of script.
     EXPECT_OCM_ID="2BBslbGSQs5PS2HCfJKqOPcCN4r"
-    ACTUAL_OCM_ID=$(ocm whoami | jq -r '.id')
-    if [[ "${EXPECT_OCM_ID}" != "${ACTUAL_OCM_ID}" ]]; then
-      echo "Must be logged into rhacs-managed-service-prod account in OCM to get cluster ID"
-      exit 1
-    fi
-    CLUSTER_ID=$(ocm list cluster "${CLUSTER_NAME}" --no-headers --columns="ID")
-    if [[ -z "${CLUSTER_ID}" ]]; then
-      echo "CLUSTER_ID is empty. Make sure ${CLUSTER_NAME} points to an existing cluster."
-      exit 1
-    fi
 
     FM_ENDPOINT="https://api.openshift.com"
 
@@ -118,6 +98,17 @@ GIT_COMMIT_SHA=$(git rev-parse HEAD)
 GIT_DESCRIBE_TAG=$(git describe --tag)
 OPERATOR_USE_UPSTREAM=false
 OPERATOR_SOURCE="redhat-operators"
+
+ACTUAL_OCM_ID=$(ocm whoami | jq -r '.id')
+if [[ "${EXPECT_OCM_ID}" != "${ACTUAL_OCM_ID}" ]]; then
+  echo "Must be logged into rhacs-managed-service-prod account in OCM to get cluster ID"
+  exit 1
+fi
+CLUSTER_ID=$(ocm list cluster "${CLUSTER_NAME}" --no-headers --columns="ID")
+if [[ -z "${CLUSTER_ID}" ]]; then
+  echo "CLUSTER_ID is empty. Make sure ${CLUSTER_NAME} points to an existing cluster."
+  exit 1
+fi
 
 ## Uncomment this section if you want to deploy an upstream version of the operator.
 ## Update the global pull secret within the dataplane cluster to include the read-only credentials for quay.io/rhacs-eng


### PR DESCRIPTION
## Description

This PR will bring minor improvements to the terraform script:
- Skip with execution if CLUSTER_ID is empty. Previously, this was undetected and installed the chart, which lead to a CrashLoopBackOff from fleetshard-sync when an incorrect cluster name was provided (e.g. typo).
- Make sure the script is callable from a _different_ directory. Previously, it was only callable when navigating to `dp-terraform/helm/rhacs-terraform`.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
~~- [ ] Documentation added if necessary~~
- [ ] CI and all relevant tests are passing
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~

## Test manual

```
# Temporarily add `--dry-run` to the Helm invocation.

./dp-terraform/helm/rhacs-terraform/terraform_cluster.sh stage invalid-name

# Observe the error message and no Helm dry-run.

./dp-terraform/helm/rhacs-terraform/terraform_cluster.sh stage acs-stage-dp-01

# Observe no error message and the helm dry-run output.
```
