### PR TITLE
ROX-12990: Configure default Central resources

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -296,7 +296,7 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "4e199b4a1c40b497a95fcd1cd896351733849949",
         "is_verified": false,
-        "line_number": 673,
+        "line_number": 663,
         "is_secret": false
       }
     ],
@@ -321,5 +321,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-07T12:01:07Z"
+  "generated_at": "2022-10-10T10:14:50Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -296,7 +296,7 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "4e199b4a1c40b497a95fcd1cd896351733849949",
         "is_verified": false,
-        "line_number": 603,
+        "line_number": 673,
         "is_secret": false
       }
     ],
@@ -321,5 +321,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-05T05:17:16Z"
+  "generated_at": "2022-10-07T12:01:07Z"
 }

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -396,7 +396,7 @@ parameters:
 
 - name: CENTRAL_CPU_LIMIT
   displayName: Default CPU limit for central deployments for newly created tenants
-  description: Default CPU request for central deployments for newly created tenants
+  description: Default CPU limit for central deployments for newly created tenants
   value: "250m"
 
 - name: CENTRAL_MEMORY_LIMIT
@@ -435,8 +435,8 @@ parameters:
   value: "1G"
 
 - name: SCANNER_DB_CPU_LIMIT
-  displayName: Default CPU request for scanner-db deployments for newly created tenants
-  description: Default CPU request for scanner-db deployments for newly created tenants
+  displayName: Default CPU limit for scanner-db deployments for newly created tenants
+  description: Default CPU limit for scanner-db deployments for newly created tenants
   value: "500m"
 
 - name: SCANNER_DB_MEMORY_LIMIT

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -444,16 +444,6 @@ parameters:
   description: Default memory limit for scanner-db deployments for newly created tenants
   value: "2G"
 
-- name: SCANNER_ANALYZER_AUTOSCALING
-  displayName: Default autoscaling configuration for scanner deployments for newly created tenants
-  description: Default autoscaling configuration for scanner deployments for newly created tenants, can be "Enabled" or "Disabled"
-  value: "Enabled"
-
-- name: SCANNER_ANALYZER_REPLICAS
-  displayName: Default number of scanner replicas for newly created tenants
-  description: Default number of scanner replicas for newly created tenants
-  value: "2"
-
 objects:
   - kind: ConfigMap
     apiVersion: v1
@@ -1147,11 +1137,6 @@ objects:
                 value: "${SCANNER_DB_CPU_LIMIT}"
               - name: SCANNER_DB_MEMORY_LIMIT
                 value: "${SCANNER_DB_MEMORY_LIMIT}"
-
-              - name: SCANNER_ANALYZER_AUTOSCALING
-                value: "${SCANNER_ANALYZER_AUTOSCALING}"
-              - name: SCANNER_ANALYZER_REPLICAS
-                value: "${SCANNER_ANALYZER_REPLICAS}"
             command:
             - /usr/local/bin/fleet-manager
             - serve

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -366,7 +366,7 @@ parameters:
 
 - name: IMAGE_PULL_POLICY
   displayName: image pull policy
-  description: image pull polilcy
+  description: image pull policy
   value: "IfNotPresent"
 
 - name: TOKEN_ISSUER_URL
@@ -383,6 +383,76 @@ parameters:
   displayName: SupportedProviders configuration file
   description: SupportedProviders configuration file, that it's passed to the fleet manager executable in the flag --providers-config-file
   value: /config/provider-configuration.yaml
+
+- name: CENTRAL_CPU_REQUEST
+  displayName: Default CPU request for central deployments for newly created tenants
+  description: Default CPU request for central deployments for newly created tenants
+  value: "100m"
+
+- name: CENTRAL_MEMORY_REQUEST
+  displayName: Default memory request for central deployments for newly created tenants
+  description: Default memory request for central deployments for newly created tenants
+  value: "5G"
+
+- name: CENTRAL_CPU_LIMIT
+  displayName: Default CPU limit for central deployments for newly created tenants
+  description: Default CPU request for central deployments for newly created tenants
+  value: "250m"
+
+- name: CENTRAL_MEMORY_LIMIT
+  displayName: Default memory limit for central deployments for newly created tenants
+  description: Default memory limit for central deployments for newly created tenants
+  value: "10G"
+
+- name: SCANNER_ANALYZER_CPU_REQUEST
+  displayName: Default CPU request for scanner deployments for newly created tenants
+  description: Default CPU request for scanner deployments for newly created tenants
+  value: "250m"
+
+- name: SCANNER_ANALYZER_MEMORY_REQUEST
+  displayName: Default memory request for scanner deployments for newly created tenants
+  description: Default memory request for scanner deployments for newly created tenants
+  value: "700M"
+
+- name: SCANNER_ANALYZER_CPU_LIMIT
+  displayName: Default CPU limit for scanner deployments for newly created tenants
+  description: Default CPU limit for scanner deployments for newly created tenants
+  value: "500m"
+
+- name: SCANNER_ANALYZER_MEMORY_LIMIT
+  displayName: Default memory limit for scanner deployments for newly created tenants
+  description: Default memory limit for scanner deployments for newly created tenants
+  value: "1500M"
+
+- name: SCANNER_DB_CPU_REQUEST
+  displayName: Default CPU request for scanner-db deployments for newly created tenants
+  description: Default CPU request for scanner-db deployments for newly created tenants
+  value: "250m"
+
+- name: SCANNER_DB_MEMORY_REQUEST
+  displayName: Default memory request for scanner-db deployments for newly created tenants
+  description: Default memory request for scanner-db deployments for newly created tenants
+  value: "1G"
+
+- name: SCANNER_DB_CPU_LIMIT
+  displayName: Default CPU request for scanner-db deployments for newly created tenants
+  description: Default CPU request for scanner-db deployments for newly created tenants
+  value: "500m"
+
+- name: SCANNER_DB_MEMORY_LIMIT
+  displayName: Default memory limit for scanner-db deployments for newly created tenants
+  description: Default memory limit for scanner-db deployments for newly created tenants
+  value: "2G"
+
+- name: SCANNER_ANALYZER_AUTOSCALING
+  displayName: Default autoscaling configuration for scanner deployments for newly created tenants
+  description: Default autoscaling configuration for scanner deployments for newly created tenants, can be "Enabled" or "Disabled"
+  value: "Enabled"
+
+- name: SCANNER_ANALYZER_REPLICAS
+  displayName: Default number of scanner replicas for newly created tenants
+  description: Default number of scanner replicas for newly created tenants
+  value: "2"
 
 objects:
   - kind: ConfigMap
@@ -1050,6 +1120,38 @@ objects:
             env:
               - name: "OCM_ENV"
                 value: "${ENVIRONMENT}"
+
+              - name: CENTRAL_CPU_REQUEST
+                value: "${CENTRAL_CPU_REQUEST}"
+              - name: CENTRAL_MEMORY_REQUEST
+                value: ${CENTRAL_MEMORY_REQUEST}""
+              - name: CENTRAL_CPU_LIMIT
+                value: "${CENTRAL_CPU_LIMIT}"
+              - name: CENTRAL_MEMORY_LIMIT
+                value: "${CENTRAL_MEMORY_LIMIT}"
+
+              - name: SCANNER_ANALYZER_CPU_REQUEST
+                value: "${SCANNER_ANALYZER_CPU_REQUEST}"
+              - name: SCANNER_ANALYZER_MEMORY_REQUEST
+                value: "${SCANNER_ANALYZER_MEMORY_REQUEST}"
+              - name: SCANNER_ANALYZER_CPU_LIMIT
+                value: "${SCANNER_ANALYZER_CPU_LIMIT}"
+              - name: SCANNER_ANALYZER_MEMORY_LIMIT
+                value: "${SCANNER_ANALYZER_MEMORY_LIMIT}"
+
+              - name: SCANNER_DB_CPU_REQUEST
+                value: "${SCANNER_DB_CPU_REQUEST}"
+              - name: SCANNER_DB_MEMORY_REQUEST
+                value: "${SCANNER_DB_MEMORY_REQUEST}"
+              - name: SCANNER_DB_CPU_LIMIT
+                value: "${SCANNER_DB_CPU_LIMIT}"
+              - name: SCANNER_DB_MEMORY_LIMIT
+                value: "${SCANNER_DB_MEMORY_LIMIT}"
+
+              - name: SCANNER_ANALYZER_AUTOSCALING
+                value: "${SCANNER_ANALYZER_AUTOSCALING}"
+              - name: SCANNER_ANALYZER_REPLICAS
+                value: "${SCANNER_ANALYZER_REPLICAS}"
             command:
             - /usr/local/bin/fleet-manager
             - serve

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -385,64 +385,64 @@ parameters:
   value: /config/provider-configuration.yaml
 
 - name: CENTRAL_CPU_REQUEST
-  displayName: Default CPU request for central deployments for newly created tenants
+  displayName: Default Central CPU request
   description: Default CPU request for central deployments for newly created tenants
-  value: "100m"
+  value: "50m"
 
 - name: CENTRAL_MEMORY_REQUEST
-  displayName: Default memory request for central deployments for newly created tenants
+  displayName: Default Central memory request
   description: Default memory request for central deployments for newly created tenants
-  value: "5G"
+  value: "250Mi"
 
 - name: CENTRAL_CPU_LIMIT
-  displayName: Default CPU limit for central deployments for newly created tenants
+  displayName: Default Central CPU limit
   description: Default CPU limit for central deployments for newly created tenants
   value: "250m"
 
 - name: CENTRAL_MEMORY_LIMIT
-  displayName: Default memory limit for central deployments for newly created tenants
+  displayName: Default Central memory limit
   description: Default memory limit for central deployments for newly created tenants
-  value: "10G"
+  value: "4G"
 
 - name: SCANNER_ANALYZER_CPU_REQUEST
-  displayName: Default CPU request for scanner deployments for newly created tenants
+  displayName: Default Scanner CPU request
   description: Default CPU request for scanner deployments for newly created tenants
-  value: "250m"
+  value: "5m"
 
 - name: SCANNER_ANALYZER_MEMORY_REQUEST
-  displayName: Default memory request for scanner deployments for newly created tenants
+  displayName: Default Scanner memory request
   description: Default memory request for scanner deployments for newly created tenants
-  value: "700M"
+  value: "100M"
 
 - name: SCANNER_ANALYZER_CPU_LIMIT
-  displayName: Default CPU limit for scanner deployments for newly created tenants
+  displayName: Default Scanner CPU limit
   description: Default CPU limit for scanner deployments for newly created tenants
-  value: "500m"
-
-- name: SCANNER_ANALYZER_MEMORY_LIMIT
-  displayName: Default memory limit for scanner deployments for newly created tenants
-  description: Default memory limit for scanner deployments for newly created tenants
-  value: "1500M"
-
-- name: SCANNER_DB_CPU_REQUEST
-  displayName: Default CPU request for scanner-db deployments for newly created tenants
-  description: Default CPU request for scanner-db deployments for newly created tenants
   value: "250m"
 
+- name: SCANNER_ANALYZER_MEMORY_LIMIT
+  displayName: Default Scanner memory limit
+  description: Default memory limit for scanner deployments for newly created tenants
+  value: "2500M"
+
+- name: SCANNER_DB_CPU_REQUEST
+  displayName: Default Scanner DB CPU request
+  description: Default CPU request for scanner-db deployments for newly created tenants
+  value: "10m"
+
 - name: SCANNER_DB_MEMORY_REQUEST
-  displayName: Default memory request for scanner-db deployments for newly created tenants
+  displayName: Default Scanner DB memory request
   description: Default memory request for scanner-db deployments for newly created tenants
-  value: "1G"
+  value: "500M"
 
 - name: SCANNER_DB_CPU_LIMIT
-  displayName: Default CPU limit for scanner-db deployments for newly created tenants
+  displayName: Default Scanner DB CPU limit
   description: Default CPU limit for scanner-db deployments for newly created tenants
-  value: "500m"
+  value: "250m"
 
 - name: SCANNER_DB_MEMORY_LIMIT
-  displayName: Default memory limit for scanner-db deployments for newly created tenants
+  displayName: Default Scanner DB memory limit
   description: Default memory limit for scanner-db deployments for newly created tenants
-  value: "2G"
+  value: "2500M"
 
 objects:
   - kind: ConfigMap

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -1114,7 +1114,7 @@ objects:
               - name: CENTRAL_CPU_REQUEST
                 value: "${CENTRAL_CPU_REQUEST}"
               - name: CENTRAL_MEMORY_REQUEST
-                value: ${CENTRAL_MEMORY_REQUEST}""
+                value: "${CENTRAL_MEMORY_REQUEST}"
               - name: CENTRAL_CPU_LIMIT
                 value: "${CENTRAL_CPU_LIMIT}"
               - name: CENTRAL_MEMORY_LIMIT


### PR DESCRIPTION
## Description

This is part of https://issues.redhat.com/browse/ROX-12990.

Configure default central resources in service template. Can be easily adjusted in the future.
This is for *new* tenants. Currently effective defaults are in `internal/dinosaur/pkg/defaults`.

Essentially: new configuration reflects that current CPU usage is <= old defaults and current memory usage is >= old defaults.

Especially watch out for copy and paste bugs.

The new settings would be automatically deployed on staging, I believe.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [x] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
