### PR TITLE
ROX-12157: remove central-idp-client-id from stage.go

### DIFF
--- a/internal/dinosaur/pkg/config/central.go
+++ b/internal/dinosaur/pkg/config/central.go
@@ -108,7 +108,7 @@ func (c *CentralConfig) ReadFiles() error {
 // specified and false otherwise.
 func (c *CentralConfig) HasStaticAuth() bool {
 	// We don't look at other integral parts of the auth config like
-	// RhSsoIssuer or RhSsoClientSecret. Failure to provide a working auth
+	// CentralIDPIssuer or CentralIDPClientSecret. Failure to provide a working auth
 	// configuration should not mask an intent to use static configuration.
 	return c.CentralIDPClientID != ""
 }

--- a/internal/dinosaur/pkg/environments/stage.go
+++ b/internal/dinosaur/pkg/environments/stage.go
@@ -17,8 +17,6 @@ func NewStageEnvLoader() environments.EnvLoader {
 		"additional-sso-issuers-file":         "config/additional-sso-issuers.yaml",
 		"jwks-file":                           "config/jwks-file-static.json",
 		"fleetshard-authz-config-file":        "config/fleetshard-authz-org-ids-development.yaml",
-		"central-idp-client-id":               "rhacs-ms-dev",
-		"central-idp-issuer":                  "https://sso.stage.redhat.com/auth/realms/redhat-external",
 		"admin-authz-config-file":             "config/admin-authz-roles-dev.yaml",
 	}
 }


### PR DESCRIPTION
## Description
As part of integrating with dynamic client registration endpoint, we need to properly configure `qaprod` environment. To do that, we need to disable static authentication in `qaprod` environment(see https://github.com/stackrox/acs-fleet-manager/blob/b4cf67d02c72c6c144e39a744aa0467a5d252ed1/internal/dinosaur/pkg/config/central.go#L107-L115). `qaprod` environment uses `stage` label, so we need to clean `central-idp-client-id` from `stage.go`

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

1. Executed `OCM_ENV=stage ./fleet-manager serve` and verified it started successfully
