### PR TITLE
Add secret for data plane monitoring dead man's switch

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-03-secret-dead-mans-switch.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-03-secret-dead-mans-switch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhacs-dead-mans-switch
+  namespace: { { include "observability.namespace" . } }
+stringData:
+  SNITCH_URL: { { .Values.deadMansSwitch.url | quote } }
+type: Opaque

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
@@ -27,3 +27,7 @@ observatorium:
 pagerduty:
   # PagerDuty integration key, which is generated within a Ruleset.
   key: ""
+
+deadMansSwitch:
+  # Webhook URL of the dead man's switch provider.
+  url: ""

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -64,6 +64,7 @@ case $ENVIRONMENT in
     )
     # Note: the PagerDuty Service Key as of 2022-09-02 is the same between stage and prod.
     PAGERDUTY_SERVICE_KEY=$(bw get item "3615347e-1dde-46b5-b2e3-af0300a049fa" | jq '.fields[] | select(.name == "Integration Key") | .value' --raw-output)
+    DEAD_MANS_SWITCH_URL=$(bw get item "1906e300-5897-4b7d-b395-af2700d7eac2")
     ;;
 
   prod)
@@ -96,6 +97,7 @@ case $ENVIRONMENT in
     )
     # Note: the PagerDuty Service Key as of 2022-09-02 is the same between stage and prod.
     PAGERDUTY_SERVICE_KEY=$(bw get item "3615347e-1dde-46b5-b2e3-af0300a049fa" | jq '.fields[] | select(.name == "Integration Key") | .value' --raw-output)
+    DEAD_MANS_SWITCH_URL=$(bw get item "c8b26dbc-c9f0-4bc4-8c8e-af2700d795b2")
     ;;
 
   *)
@@ -147,7 +149,8 @@ helm upgrade rhacs-terraform ./ \
   --set observability.observatorium.gateway="${OBSERVABILITY_OBSERVATORIUM_GATEWAY}" \
   --set observability.observatorium.metricsClientId="${OBSERVABILITY_OBSERVATORIUM_METRICS_CLIENT_ID}" \
   --set observability.observatorium.metricsSecret="${OBSERVABILITY_OBSERVATORIUM_METRICS_SECRET}" \
-  --set observability.pagerduty.key="${PAGERDUTY_SERVICE_KEY}"
+  --set observability.pagerduty.key="${PAGERDUTY_SERVICE_KEY}" \
+  --set observability.deadMansSwitch.url="${DEAD_MANS_SWITCH_URL}"
 
 # To uninstall an existing release:
 # helm uninstall rhacs-terraform --namespace rhacs

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -50,6 +50,8 @@ observability:
     metricsSecret: ""
   pagerduty:
     key: ""
+  deadMansSwitch:
+    url: ""
 
 # See available parameters in charts/logging/values.yaml
 # - enabled flag is used to completely enable/disable logging sub-chart


### PR DESCRIPTION
The URLs for stage and prod are set to checks on healthchecks.io, which is used as the dead man's switch provider.

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~Unit and integration tests added~
- [ ] ~Documentation added if necessary~
- [ ] ~CI and all relevant tests are passing~
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Tested the dead man's switch setup via healthcheck.io on a dev cluster.