### PR TITLE
ROX-13018: Load secrets from Parameter Store on CI / Local deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ vendor
 #reports dir
 reports/
 .envrc
+e2e-report.json
+cover.profile

--- a/dev/env/defaults/00-defaults.env
+++ b/dev/env/defaults/00-defaults.env
@@ -10,7 +10,7 @@ export CLUSTER_ID_DEFAULT="1234567890abcdef1234567890abcdef"
 export CLUSTER_DNS_DEFAULT="cluster.local"
 
 export IMAGE_REGISTRY_DEFAULT="quay.io/rhacs-eng"
-STACKROX_VERSION_TAG="3.72.0-nightly-20220929"
+STACKROX_VERSION_TAG="3.72.0"
 export STACKROX_OPERATOR_VERSION_DEFAULT="${STACKROX_VERSION_TAG}"
 export CENTRAL_VERSION_DEFAULT=$(echo "$STACKROX_VERSION_TAG" | sed -e 's/0-nightly/x-nightly/;')
 export SCANNER_VERSION_DEFAULT="2.25.1" # This one matches the above operator version tag.
@@ -29,7 +29,7 @@ export DATABASE_USER_DEFAULT="fleet_manager"
 export DATABASE_PASSWORD_DEFAULT="letmein" # pragma: allowlist secret
 export DATABASE_TLS_CERT_DEFAULT=""
 
-export AUTH_TYPE_DEFAULT="STATIC_TOKEN"
+export AUTH_TYPE_DEFAULT="RHSSO"
 export OCM_SERVICE_CLIENT_ID_DEFAULT=""
 export OCM_SERVICE_CLIENT_SECRET_DEFAULT=""
 export OCM_SERVICE_TOKEN_DEFAULT=""
@@ -59,3 +59,6 @@ export FLEET_MANAGER_RESOURCES_DEFAULT='{"requests":{"cpu":"200m","memory":"300M
 export FLEETSHARD_SYNC_RESOURCES_DEFAULT='{"requests":{"cpu":"200m","memory":"300Mi"},"limits":{"cpu":"200m","memory":"300Mi"}}'
 export DB_RESOURCES_DEFAULT='{"requests":{"cpu":"100m","memory":"300Mi"},"limits":{"cpu":"100m","memory":"300Mi"}}'
 export RHACS_OPERATOR_RESOURCES_DEFAULTS='{"requests":{"cpu":"200m","memory":"300Mi"},"limits":{"cpu":"200m","memory":"300Mi"}}'
+
+export ENABLE_EXTERNAL_CONFIG_DEFAULT=false
+export CHAMBER_DEFAULT=chamber

--- a/dev/env/defaults/cluster-type-openshift-ci/env
+++ b/dev/env/defaults/cluster-type-openshift-ci/env
@@ -1,6 +1,5 @@
 export SPAWN_LOGGER_DEFAULT="true"
 export DUMP_LOGS_DEFAULT="true"
-export AUTH_TYPE_DEFAULT="STATIC_TOKEN"
 export FINAL_TEAR_DOWN_DEFAULT="true"
 export GOTESTSUM="/usr/local/bin/gotestsum"
 export ENABLE_CENTRAL_EXTERNAL_CERTIFICATE=true

--- a/dev/env/manifests/fleet-manager/01-fleet-manager-secrets.yaml
+++ b/dev/env/manifests/fleet-manager/01-fleet-manager-secrets.yaml
@@ -33,4 +33,3 @@ stringData:
   central-tls.key: ""
   kubeconfig: |
     ${KUBE_CONFIG}
-  fleet-static-token: "${STATIC_TOKEN}"

--- a/dev/env/manifests/fleetshard-sync/01-fleetshard-sync-secrets.yaml
+++ b/dev/env/manifests/fleetshard-sync/01-fleetshard-sync-secrets.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fleetshard-sync
+  namespace: "$ACSMS_NAMESPACE"
+stringData:
+  kubeconfig: |
+    ${KUBE_CONFIG}
+  rhsso-service-account-client-id: "${RHSSO_SERVICE_ACCOUNT_CLIENT_ID}"
+  rhsso-service-account-client-secret: "${RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET}"

--- a/dev/env/manifests/fleetshard-sync/02-fleetshard-sync-deployment.yaml
+++ b/dev/env/manifests/fleetshard-sync/02-fleetshard-sync-deployment.yaml
@@ -29,17 +29,17 @@ spec:
               value: http://fleet-manager:8000
             - name: AUTH_TYPE
               value: "$AUTH_TYPE"
-            - name: STATIC_TOKEN
+            - name: RHSSO_SERVICE_ACCOUNT_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: fleet-manager
-                  key: "fleet-static-token"
+                  name: fleetshard-sync
+                  key: "rhsso-service-account-client-id"
                   optional: false
-            - name: OCM_TOKEN
+            - name: RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: fleet-manager
-                  key: "ocm-service.token"
+                  name: fleetshard-sync
+                  key: "rhsso-service-account-client-secret"
                   optional: false
             - name: RUNTIME_POLL_PERIOD
               value: 10s
@@ -57,7 +57,7 @@ spec:
       volumes:
         - name: secrets
           secret:
-            secretName: fleet-manager # pragma: allowlist secret
+            secretName: fleetshard-sync # pragma: allowlist secret
             optional: false
         - name: config
           configMap:

--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -88,6 +88,11 @@ init() {
         source "$env_file"
     done
 
+    ENABLE_EXTERNAL_CONFIG="${ENABLE_EXTERNAL_CONFIG:-ENABLE_EXTERNAL_CONFIG_DEFAULT}"
+    if [[ "$ENABLE_EXTERNAL_CONFIG" == "true" ]]; then
+        load_external_config
+    fi
+
     if [[ -z "${CENTRAL_IDP_CLIENT_SECRET:-}" ]]; then
         die "Error: CENTRAL_IDP_CLIENT_SECRET not set. Please make sure that it is initialized properly."
     fi
@@ -307,4 +312,10 @@ docker_logged_in() {
     else
         return 1
     fi
+}
+
+load_external_config() {
+  local chamber="${CHAMBER:-$CHAMBER_DEFAULT}"
+  eval "$($chamber env fleet-manager)"
+  eval "$($chamber env fleetshard-sync)"
 }

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -23,7 +23,7 @@ $ go clean -testcache && CLUSTER_ID=1234567890abcdef1234567890abcdef \
   CLUSTER_ID=1234567890abcdef1234567890abcdef \
   STATIC_TOKEN=$(bw get item "64173bbc-d9fb-4d4a-b397-aec20171b025" | jq '.fields[] | select(.name | contains("JWT")) | .value' --raw-output) \
   OCM_TOKEN=$(ocm token --refresh) \
-  RHSSO_CLIENT_ID=$(bw get username 028ce1a9-f751-4056-9c72-aea70052728b) RHSSO_CLIENT_SECRET=$(bw get password 028ce1a9-f751-4056-9c72-aea70052728b) \
+  RHSSO_SERVICE_ACCOUNT_CLIENT_ID=$(bw get username 028ce1a9-f751-4056-9c72-aea70052728b) RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET=$(bw get password 028ce1a9-f751-4056-9c72-aea70052728b) \
   go test ./e2e/...
 
 # To clean up the environment run

--- a/e2e/e2e_auth_test.go
+++ b/e2e/e2e_auth_test.go
@@ -117,17 +117,11 @@ var _ = Describe("AuthN/Z Fleet* components", func() {
 
 	Describe("RH SSO auth type", func() {
 		BeforeEach(func() {
-			// Read the client ID / secret from environment variables. If not set, skip the tests.
-			clientID := os.Getenv("RHSSO_CLIENT_ID")
-			clientSecret := os.Getenv("RHSSO_CLIENT_SECRET")
-			if clientID == "" || clientSecret == "" {
-				Skip("RHSSO_CLIENT_ID / RHSSO_CLIENT_SECRET not set, cannot initialize auth type")
-			}
-
 			rhSSOOpt := authOption.Sso
-			rhSSOOpt.ClientID = clientID
-			rhSSOOpt.ClientSecret = clientSecret //pragma: allowlist secret
-
+			// Skip the tests if client ID / secret read from environment variables not set.
+			if rhSSOOpt.ClientID == "" || rhSSOOpt.ClientSecret == "" {
+				Skip("RHSSO_SERVICE_ACCOUNT_CLIENT_ID / RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET not set, cannot initialize auth type")
+			}
 			// Create the auth type for RH SSO.
 			auth, err := fleetmanager.NewRHSSOAuth(rhSSOOpt)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
## Description
This PR adds loading from the Parameter Store on dev / local environment.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

TODO: Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
