### PR TITLE
ROX-12946: Remove org_id requirement in Central IdP

### DIFF
--- a/fleetshard/pkg/central/reconciler/init_auth.go
+++ b/fleetshard/pkg/central/reconciler/init_auth.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
+
 	"github.com/golang/glog"
 	appsv1 "k8s.io/api/apps/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -165,6 +167,14 @@ func createAuthProviderRequest(central private.ManagedCentral) *storage.AuthProv
 			MutabilityMode: storage.Traits_ALLOW_MUTATE_FORCED,
 		},
 		Active: true,
+	}
+	if central.Spec.Auth.ClientOrigin == dbapi.AuthConfigStaticClientOrigin {
+		request.RequiredAttributes = []*storage.AuthProvider_RequiredAttribute{
+			{
+				AttributeKey:   "orgid",
+				AttributeValue: central.Spec.Auth.OwnerOrgId,
+			},
+		}
 	}
 	return request
 }

--- a/fleetshard/pkg/central/reconciler/init_auth.go
+++ b/fleetshard/pkg/central/reconciler/init_auth.go
@@ -161,12 +161,6 @@ func createAuthProviderRequest(central private.ManagedCentral) *storage.AuthProv
 		},
 		// TODO: for testing purposes only; remove once host is correctly specified in fleet-manager
 		ExtraUiEndpoints: []string{"localhost:8443"},
-		RequiredAttributes: []*storage.AuthProvider_RequiredAttribute{
-			{
-				AttributeKey:   "orgid",
-				AttributeValue: central.Spec.Auth.OwnerOrgId,
-			},
-		},
 		Traits: &storage.Traits{
 			MutabilityMode: storage.Traits_ALLOW_MUTATE_FORCED,
 		},

--- a/internal/dinosaur/pkg/api/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/private/api/openapi.yaml
@@ -201,8 +201,10 @@ components:
           auth:
             clientSecret: ""
             clientId: client-id
+            clientOrigin: shared_static_rhsso
             ownerUserId: f:ac4bcdb5-1fb1-41c5-9323-349698b9b757:username
             orgId: "13442309"
+            issuer: https://sso.stage.redhat.com/auth/realms/redhat-external
           endpoint:
             host: example-central--rfpsqbvq-em-u-u-z--ymjcwac.example.central.com
             tls:
@@ -428,6 +430,8 @@ components:
         clientSecret:
           type: string
         clientId:
+          type: string
+        clientOrigin:
           type: string
         ownerUserId:
           type: string

--- a/internal/dinosaur/pkg/api/private/model_managed_central_all_of_spec_auth.go
+++ b/internal/dinosaur/pkg/api/private/model_managed_central_all_of_spec_auth.go
@@ -14,6 +14,7 @@ package private
 type ManagedCentralAllOfSpecAuth struct {
 	ClientSecret string `json:"clientSecret,omitempty"`
 	ClientId     string `json:"clientId,omitempty"`
+	ClientOrigin string `json:"clientOrigin,omitempty"`
 	OwnerUserId  string `json:"ownerUserId,omitempty"`
 	OwnerOrgId   string `json:"ownerOrgId,omitempty"`
 	Issuer       string `json:"issuer,omitempty"`

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -67,6 +67,7 @@ func (c *ManagedCentralPresenter) PresentManagedCentral(from *dbapi.CentralReque
 			Auth: private.ManagedCentralAllOfSpecAuth{
 				ClientId:     from.AuthConfig.ClientID,
 				ClientSecret: from.AuthConfig.ClientSecret, // pragma: allowlist secret
+				ClientOrigin: from.AuthConfig.ClientOrigin,
 				OwnerOrgId:   from.OrganisationID,
 				OwnerUserId:  from.OwnerUserID,
 				Issuer:       from.AuthConfig.Issuer,

--- a/openapi/fleet-manager-private.yaml
+++ b/openapi/fleet-manager-private.yaml
@@ -254,6 +254,8 @@ components:
                       type: string
                     clientId:
                       type: string
+                    clientOrigin:
+                      type: string
                     ownerUserId:
                       type: string
                     ownerOrgId:
@@ -480,8 +482,10 @@ components:
           auth:
             clientSecret: ""
             clientId: "client-id"
+            clientOrigin: "shared_static_rhsso"
             ownerUserId: "f:ac4bcdb5-1fb1-41c5-9323-349698b9b757:username"
             orgId: "13442309"
+            issuer: "https://sso.stage.redhat.com/auth/realms/redhat-external"
           endpoint:
             host: "example-central--rfpsqbvq-em-u-u-z--ymjcwac.example.central.com"
             tls:


### PR DESCRIPTION
## Description
With dynamic client registration, there is no need for `org_id` check - we will get by with `aud` check instead.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

1. Deploy fleet* without dynamic clients config, create Central
2. Log in into central and verify required attributes check is there 👍 
