### PR TITLE
ROX-12158: fix redhatsso clientId/clientSecret values

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -1090,8 +1090,8 @@ objects:
             - --db-sslmode=${DB_SSLMODE}
             - --db-max-open-connections=${DB_MAX_OPEN_CONNS}
             - --enable-db-debug=${ENABLE_DB_DEBUG}
-            - --redhat-sso-client-id-file=/secrets/service/redhatsso-service.clientId
-            - --redhat-sso-client-secret-file=/secrets/service/redhatsso-service.clientSecret
+            - --redhat-sso-client-id-file=/secrets/fleet-manager-credentials/redhatsso-service.clientId
+            - --redhat-sso-client-secret-file=/secrets/fleet-manager-credentials/redhatsso-service.clientSecret
             - --central-idp-issuer=${CENTRAL_IDP_ISSUER}
             - --ocm-client-id-file=/secrets/fleet-manager-credentials/ocm-service.clientId
             - --ocm-client-secret-file=/secrets/fleet-manager-credentials/ocm-service.clientSecret


### PR DESCRIPTION
## Description
Correct config values are located in `fleet-manager-credentials` secret.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

CI should be enough
