### PR TITLE
Read central-idp-client-secret-file only when static auth is enabled

### DIFF
--- a/internal/dinosaur/pkg/config/central.go
+++ b/internal/dinosaur/pkg/config/central.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"github.com/stackrox/acs-fleet-manager/pkg/shared"
@@ -75,18 +74,13 @@ func (c *CentralConfig) ReadFiles() error {
 	if err != nil {
 		return fmt.Errorf("reading TLS key file: %w", err)
 	}
-	err = shared.ReadFileValueString(c.CentralIDPClientSecretFile, &c.CentralIDPClientSecret)
-	if err != nil {
-		return fmt.Errorf("reading Central's IdP client secret file: %w", err)
-	}
-	if c.CentralIDPClientSecret != "" {
-		glog.Info("Central's IdP client secret is configured")
-	} else {
-		glog.Infof("Central's IdP client secret from file %q is missing", c.CentralIDPClientSecretFile)
-	}
 
-	// Check that all parts of static auth config are present.
+	// Initialise and check that all parts of static auth config are present.
 	if c.HasStaticAuth() {
+		err = shared.ReadFileValueString(c.CentralIDPClientSecretFile, &c.CentralIDPClientSecret)
+		if err != nil {
+			return fmt.Errorf("reading Central's IdP client secret file: %w", err)
+		}
 		if c.CentralIDPClientSecret == "" {
 			return errors.Errorf("no client_secret specified for static client_id %q;"+
 				" auth configuration is either incorrect or insecure", c.CentralIDPClientID)


### PR DESCRIPTION
## Description
1. Remove logging secret status as unnecessary: we either use static auth and fail if secret is empty, or we do not care.
2. Read secret only when it's needed - when static auth is enabled

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

1. `./fleet-manager serve` - doesn't log anything if secret is not-empty, fails if empty
2. `OCM_ENV=stage ./fleet-manager serve` - doesn't care if secret is empty or not
Note: `OCM_ENV=stage` doesn't have static client ID assigned, that's why it works that way
