### PR TITLE
Remove update-trigger-like annotations.

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -5,9 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: fleetshard-sync
-    managed-service.rhacs.redhat.com/update-trigger: {{ now | date "20060102150405" | quote }}
-    managed-service.rhacs.redhat.com/git-commit-sha: {{ .Values.fleetshardSync.gitCommitSHA }}
-    managed-service.rhacs.redhat.com/git-describe-tag: {{ .Values.fleetshardSync.gitDescribeTag }}
 spec:
   replicas: 1
   selector:

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -96,8 +96,6 @@ case $ENVIRONMENT in
     ;;
 esac
 
-GIT_COMMIT_SHA=$(git rev-parse HEAD)
-GIT_DESCRIBE_TAG=$(git describe --tag)
 OPERATOR_USE_UPSTREAM=false
 OPERATOR_SOURCE="redhat-operators"
 
@@ -137,8 +135,6 @@ helm upgrade rhacs-terraform "${SCRIPT_DIR}" \
   --set acsOperator.upstream="${OPERATOR_USE_UPSTREAM}" \
   --set fleetshardSync.image="${FLEETSHARD_SYNC_IMAGE}" \
   --set fleetshardSync.authType="RHSSO" \
-  --set fleetshardSync.gitCommitSHA="${GIT_COMMIT_SHA}" \
-  --set fleetshardSync.gitDescribeTag="${GIT_DESCRIBE_TAG}" \
   --set fleetshardSync.clusterId="${CLUSTER_ID}" \
   --set fleetshardSync.fleetManagerEndpoint="${FM_ENDPOINT}" \
   --set fleetshardSync.redHatSSO.clientId="${FLEETSHARD_SYNC_RED_HAT_SSO_CLIENT_ID}" \

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -4,9 +4,6 @@
 
 fleetshardSync:
   image: "quay.io/app-sre/acs-fleet-manager:59142fe"
-  # Sets the commit hash and git describe to identify the deployed version of fleetshard sync
-  gitCommitSHA: ""
-  gitDescribeTag: ""
   # Can be either OCM, RHSSO, STATIC_TOKEN. When choosing RHSSO, make sure the clientId/secret is set. By default, uses OCM.
   authType: "OCM"
   # OCM refresh token, only required in combination with authType=OCM.


### PR DESCRIPTION
## Description

Now that `image:` points at a more or less immutable tag, these are no longer needed.
Ref: discussion in https://github.com/stackrox/acs-fleet-manager/pull/406

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~Unit and integration tests added~
- [ ] ~Documentation added if necessary~
- [x] CI and all relevant tests are passing
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Not applicable.