### PR TITLE
Update observability operator to v3.0.16

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
@@ -4,7 +4,7 @@
 
 # Version of observability operator
 # https://github.com/redhat-developer/observability-operator/releases
-observabilityOperatorVersion: "v3.0.14"
+observabilityOperatorVersion: "v3.0.16"
 
 github:
   # You can generate a new one at https://github.com/settings/tokens/new, for a user


### PR DESCRIPTION
This includes a version jump of the Prometheus operator from v0.45.0 to v0.56.3.

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~Unit and integration tests added~
- [ ] ~Documentation added if necessary~
- [ ] ~CI and all relevant tests are passing~
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Tested on dev cluster.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
