### PR TITLE
Sync bitwarden cli in terraform_cluster.sh

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -32,6 +32,7 @@ function ensure_bitwarden_session_exists () {
       export BW_SESSION
     fi
   fi
+  bw sync -f
 }
 
 case $ENVIRONMENT in


### PR DESCRIPTION
## Description
This is the fix to the issue we found while running `terraform_cluster.sh` - bitwarden cli will not show new items until `bw sync` is run. We run `bw sync -f` as a solution to this issue in bw cli: https://github.com/bitwarden/cli/issues/234#issuecomment-800090397

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

1. Run `terraform_cluster.sh` and see a successful sync: 
```
rhacs-terraform % ./terraform_cluster.sh stage acs-meh-dp-01
You are logged in!
? Master password: [hidden]
Syncing complete.
```

