### PR TITLE
Enable verbose mode for Ginkgo

### DIFF
--- a/.openshift-ci/tests/e2e.sh
+++ b/.openshift-ci/tests/e2e.sh
@@ -28,7 +28,7 @@ if [[ "${OPENSHIFT_CI:-}" == "true" ]]; then
     export QUAY_TOKEN="${IMAGE_PUSH_PASSWORD:-}"
     export CLUSTER_TYPE="openshift-ci"
     export GOARGS="-mod=mod" # For some reason we need this in the offical base images.
-    export GINKGO_FLAGS="--no-color"
+    export GINKGO_FLAGS="--no-color -v"
     # When running in OpenShift CI, ensure we also run the auth E2E tests.
     RUN_AUTH_E2E_DEFAULT="true"
 fi


### PR DESCRIPTION
## Description

To make sure that we  generate output showing exactly which test specs have been executed, not just failing ones.
This has already been enabled in the `Makefile` in the form of a default `GINKGO_FLAGS` setting, but since CI overwrites this with a custom flags configuration we need the `-v` also in there.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
