### PR TITLE
ROX-12689: oc login automatically, drop need for ocm login

### DIFF
--- a/dp-terraform/osd-cluster-idp-setup.sh
+++ b/dp-terraform/osd-cluster-idp-setup.sh
@@ -167,6 +167,7 @@ do
   if [[ -n $ROBOT_TOKEN ]]; then
     echo "Retrieved robot token:"
     echo "$ROBOT_TOKEN"
+    echo "Please save this as parameter '/cluster-${CLUSTER_NAME}/robot_oc_token' in AWS parameter store at https://us-east-1.console.aws.amazon.com/systems-manager/parameters/?region=us-east-1&tab=Table"
     # TODO(porridge): automate storing this in parameter store in a way suitable for terraform script.
     break
   fi


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This approach relieves us from having to automate `ocm` login (unclear if this is even possible at all), at the cost of maintaining some (non-secret) per-cluster information in this script.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~Unit and integration tests added~
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...) :point_right: will update the [environments confluence page](https://docs.engineering.redhat.com/pages/viewpage.action?pageId=288990393) before merging once this is approved, to mention the need to update this script after creating the cluster.
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Tested by prepending the `helm` command with an `echo`, running the script, and checking for the expected post-login output from `oc` was there.