### PR TITLE
Mass patch command for ACS Tenant deployments

### DIFF
--- a/scripts/mass-patch.sh
+++ b/scripts/mass-patch.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 [deployment name] [patch]" >&2
+    echo "Note: you need to be logged into OC for your cluster's administrator"
+    exit 2
+fi
+
+deployment_name=$1
+patch=$2
+
+rhacs_namespaces=$(oc get ns | grep -E "^rhacs-[a-z0-9]{20}" | awk '{print $1}')
+
+for namespace in $rhacs_namespaces;
+do
+  oc -n "${namespace}" patch deploy/"${deployment_name}" -p "${patch}"
+done


### PR DESCRIPTION
## Description
During the incident of 20th of October, all Central instances across ACSMS dataplane cluster needed to be patched. We had to write a manual script to do that. In case that happens again it would be nice to be able to have a ready script at hand.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

1. Verified that script finds all `rhacs-` namespaces + deployment in that namespace
