### PR TITLE
Build for machine architecture instead of amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -500,7 +500,6 @@ docker/login/internal:
 
 # Build the binary and image
 image/build: GOOS=linux
-image/build: GOARCH=amd64
 image/build: IMAGE_REF="$(external_image_registry)/$(image_repository):$(image_tag)"
 image/build: fleet-manager fleetshard-sync
 	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) build -t $(IMAGE_REF) .
@@ -523,7 +522,6 @@ image/build/internal: binary
 
 # build binary and image and tag image for local deployment
 image/build/local: GOOS=linux
-image/build/local: GOARCH=amd64
 image/build/local: IMAGE_TAG ?= $(image_tag)
 image/build/local: image/build
 	$(DOCKER) image tag "$(external_image_registry)/$(image_repository):$(IMAGE_TAG)" "fleet-manager:$(IMAGE_TAG)"


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Removed hardcoded amd64 architecture, so that we don't build amd64 binaries on arm machines.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
~~- [ ] Added test description under `Test manual`~~
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [ ] CI and all relevant tests are passing
~~- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~~
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~

CI should be enough for testing.
