### PR TITLE
Add Kubernetes Label to Tenant Namespaces

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -106,14 +106,18 @@ var _ = Describe("Central", func() {
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Equal(constants.CentralRequestStatusProvisioning.String()))
 		})
 
+		ns := &corev1.Namespace{}
 		It("should create central namespace", func() {
 			if createdCentral == nil {
 				Fail("central not created")
 			}
 			Eventually(func() error {
-				ns := &corev1.Namespace{}
 				return k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: namespaceName}, ns)
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Succeed())
+		})
+
+		It("tenant namespace is labelled as a tenant naemspace", func() {
+			Expect(ns.Labels["rhacscs/type"]).To(Equal("tenant"))
 		})
 
 		It("should create central in its namespace on a managed cluster", func() {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Central", func() {
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Succeed())
 		})
 
-		It("tenant namespace is labelled as a tenant naemspace", func() {
+		It("tenant namespace is labelled as a tenant namespace", func() {
 			_, tenantLabelFound := ns.Labels["rhacs.redhat.com/tenant"]
 			Expect(tenantLabelFound).To(BeTrue())
 		})

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -117,7 +117,8 @@ var _ = Describe("Central", func() {
 		})
 
 		It("tenant namespace is labelled as a tenant naemspace", func() {
-			Expect(ns.Labels["rhacscs/type"]).To(Equal("tenant"))
+			_, tenantLabelFound := ns.Labels["rhacs.redhat.com/tenant"]
+			Expect(tenantLabelFound).To(BeTrue())
 		})
 
 		It("should create central in its namespace on a managed cluster", func() {

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -385,7 +385,7 @@ func (r *CentralReconciler) getNamespace(name string) (*corev1.Namespace, error)
 
 func (r *CentralReconciler) createTenantNamespace(ctx context.Context, namespace *corev1.Namespace) error {
 	namespace.Labels = make(map[string]string)
-	namespace.Labels["rhacscs/type"] = "tenant"
+	namespace.Labels["rhacs.redhat.com/tenant"] = ""
 	err := r.client.Create(ctx, namespace)
 	if err != nil {
 		return fmt.Errorf("creating namespace %q: %w", namespace.ObjectMeta.Name, err)

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -383,15 +383,21 @@ func (r *CentralReconciler) getNamespace(name string) (*corev1.Namespace, error)
 	return namespace, nil
 }
 
+func (r *CentralReconciler) createTenantNamespace(ctx context.Context, namespace *corev1.Namespace) error {
+	namespace.Labels = make(map[string]string)
+	namespace.Labels["rhacscs/type"] = "tenant"
+	err := r.client.Create(ctx, namespace)
+	if err != nil {
+		return fmt.Errorf("creating namespace %q: %w", namespace.ObjectMeta.Name, err)
+	}
+	return nil
+}
+
 func (r *CentralReconciler) ensureNamespaceExists(name string) error {
 	namespace, err := r.getNamespace(name)
 	if err != nil {
 		if apiErrors.IsNotFound(err) {
-			err = r.client.Create(context.Background(), namespace)
-			if err != nil {
-				return fmt.Errorf("creating namespace %q: %w", name, err)
-			}
-			return nil
+			return r.createTenantNamespace(context.Background(), namespace)
 		}
 		return fmt.Errorf("getting namespace %s: %w", name, err)
 	}


### PR DESCRIPTION
## Description

In multiple places we have now logic for retrieving the set of all tenant namespaces by doing some grep-work on `kubectl get ns` output of some sort.

Would be nicer and more robust to have a dedicated label for this.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
