### PR TITLE
Integrate EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# See https://editorconfig.org/ for more information.
+
+# This is the top-most EditorConfig file
+root = true
+
+# 4 space indentation for Shell scripts
+[*.sh]
+indent_style = space
+indent_size = 4
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ ACS fleet-manager repository for the ACS managed service.
 * [Docker](https://docs.docker.com/get-docker/) - to create database
 * [ocm cli](https://github.com/openshift-online/ocm-cli/releases) - ocm command line tool
 * [Node.js v12.20+](https://nodejs.org/en/download/) and [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
+* IDE with [EditorConfig](https://editorconfig.org/) support enabled:
+  - there is a [plugin for GoLand](https://www.jetbrains.com/help/go/configuring-code-style.html#editorconfig)
+  - there is an [extension for VSCode](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)
 * A running kubernetes cluster
 
   Supported cluster types:


### PR DESCRIPTION
## Description

To use a common indentation style in our Shell scripts.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~Unit and integration tests added~~ (n/a)
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [ ] ~~Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~~ (no ticket)
- [ ] ~~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~ (n/a)

## Test manual

1. Switch to this branch.
2. Make sure that your IDE has an EditorConfig plugin/extension enabled.
3. Save a shell script (with autoformatting on save enabled) and verify that the indentation in the shell script is changed according to the EditorConfig configuration.
