### PR TITLE
ROX-13098: Load config from Parameter Store for the Dataplane Terraforming

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+external-sources=true

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# shellcheck source=/dev/null
+# shellcheck source=scripts/lib/external_config.sh
 source "$SCRIPT_DIR/../../../scripts/lib/external_config.sh"
 
 if [[ $# -ne 2 ]]; then
@@ -29,7 +29,7 @@ export AWS_PROFILE="$ENVIRONMENT"
 load_external_config() {
     local service="$1"
     local prefix="${2:-}"
-    eval "$(run_chamber env "$service" | sed -E "s/(^export )(.*)/\1${prefix}\2/")"
+    eval "$(run_chamber env "$service" | sed -E "s/(^export +)(.*)/\1${prefix}\2/")"
 }
 
 case $ENVIRONMENT in


### PR DESCRIPTION
## Description
Change the way of loading secrets in the Data Plane Terraforming script for **stage** and **prod** environments from BitWarden to the Parameter Store.
All necessary tools are installed automatically (implemented in #492).

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~[ ] Unit and integration tests added~
- [x] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
1. Changed `helm upgrade` to `helm template`
2. Run the script and save the output. Enter AWS stage credentials when prompted:
  ```
  ./dp-terraform/helm/rhacs-terraform/terraform_cluster.sh stage acs-stage-[dp-01](https://issues.redhat.com//browse/dp-01) > ./tmp/resources-actual.yaml
  ```
4. Checkout `main` branch
5. Run the script and save the output:
  ```
  ./dp-terraform/helm/rhacs-terraform/terraform_cluster.sh stage acs-stage-[dp-01](https://issues.redhat.com//browse/dp-01) > ./tmp/resources-expected.yaml
  ```
6. Ensure that there are no errors in the output and the diff is empty:
```
diff ./tmp/resources-expected.yaml ./tmp/resources-actual.yaml
```
7. Same checked for prod environment
