### PR TITLE
Migrate shared_static_sso -> shared_static_rhsso

### DIFF
--- a/internal/dinosaur/pkg/migrations/202210271100_change_central_client_origin.go
+++ b/internal/dinosaur/pkg/migrations/202210271100_change_central_client_origin.go
@@ -1,0 +1,74 @@
+package migrations
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/stackrox/acs-fleet-manager/pkg/api"
+	"github.com/stackrox/acs-fleet-manager/pkg/db"
+	"gorm.io/gorm"
+)
+
+// This migration is needed to switch from mistakenly added "shared_static_sso" client origin
+// to "shared_static_rhsso".
+func changeCentralClientOrigin() *gormigrate.Migration {
+	type AuthConfig struct {
+		ClientID     string `json:"idp_client_id"`
+		ClientSecret string `json:"idp_client_secret"`
+		Issuer       string `json:"idp_issuer"`
+		ClientOrigin string `json:"client_origin"`
+	}
+
+	type CentralRequest struct {
+		db.Model
+		Region                        string
+		ClusterID                     string
+		CloudProvider                 string
+		MultiAZ                       bool
+		Name                          string
+		Status                        string
+		SubscriptionID                string
+		Owner                         string
+		OwnerAccountID                string
+		OwnerUserID                   string
+		Host                          string
+		OrganisationID                string
+		FailedReason                  string
+		PlacementID                   string
+		Central                       api.JSON
+		Scanner                       api.JSON
+		DesiredCentralVersion         string
+		ActualCentralVersion          string
+		DesiredCentralOperatorVersion string
+		ActualCentralOperatorVersion  string
+		CentralUpgrading              bool
+		CentralOperatorUpgrading      bool
+		InstanceType                  string
+		QuotaType                     string
+		Routes                        api.JSON
+		RoutesCreated                 bool
+		Namespace                     string
+		RoutesCreationID              string
+		DeletionTimestamp             *time.Time
+		AuthConfig
+	}
+
+	return &gormigrate.Migration{
+		ID: "202210271100",
+		Migrate: func(tx *gorm.DB) error {
+			err := tx.Model(&CentralRequest{}).
+				Where("client_origin = ?", "shared_static_sso").
+				Update("client_origin", "shared_static_rhsso").Error
+
+			if err != nil {
+				return fmt.Errorf("setting shared_static_rhsso instead of shared_static_sso as value for "+
+					"ClientOrigin in migration 202210271100: %w", err)
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return nil
+		},
+	}
+}

--- a/internal/dinosaur/pkg/migrations/migrations.go
+++ b/internal/dinosaur/pkg/migrations/migrations.go
@@ -35,6 +35,7 @@ var migrations = []*gormigrate.Migration{
 	addCentralAuthLease(),
 	addSkipSchedulingToClusters(),
 	addClientOriginToCentralRequest(),
+	changeCentralClientOrigin(),
 }
 
 // New ...


### PR DESCRIPTION
## Description
https://github.com/stackrox/acs-fleet-manager/pull/460 introduced a DB migration that adds `client_origin` and incorrectly sets its initial value to `shared_static_sso`. That prevented central entires with such `client_origin` from being deleted, as `fleet-manager` can only handle `shared_static_rhsso` `client_origin` value.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Evaluated and added CHANGELOG.md entry if required
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
1. Run migrations without new migration, insert central request with `shared_static_sso` client origin:
```
<***>@<*****>-MacBook-Pro acs-fleet-manager % make db/setup
...
<***>@Ivans-MacBook-Pro acs-fleet-manager % make db/migrate
...
I1027 11:36:46.213705   54556 cmd.go:22] Database has 10 migrations applied
<***>@<*****>-MacBook-Pro acs-fleet-manager % make db/login
...
serviceapitests=# insert into central_requests (id, client_origin) values ('123', 'shared_static_sso');
INSERT 0 1
serviceapitests=# quit
```
2. Run migrations **with** the new migration and see the value being replaced with `shared_static_rhsso`:
```
<***>@<*****>-MacBook-Pro acs-fleet-manager % make db/migrate
...
I1027 11:39:46.039779   54843 cmd.go:22] Database has 11 migrations applied
<***>@<*****>-MacBook-Pro acs-fleet-manager % make db/login  
...
serviceapitests=# select * from central_requests;
 id  | created_at |          updated_at           | deleted_at | region | cluster_id | cloud_provider | multi_az | name | status | subscription_id | owner | owner_account_id
 | host | organisation_id | failed_reason | placement_id | desired_central_version | actual_central_version | desired_central_operator_version | actual_central_operator_vers
ion | central_upgrading | central_operator_upgrading | instance_type | quota_type | routes | routes_created | namespace | routes_creation_id | deletion_timestamp | owner_use
r_id | central | scanner | client_id | client_secret | issuer |    client_origin    
-----+------------+-------------------------------+------------+--------+------------+----------------+----------+------+--------+-----------------+-------+-----------------
-+------+-----------------+---------------+--------------+-------------------------+------------------------+----------------------------------+-----------------------------
----+-------------------+----------------------------+---------------+------------+--------+----------------+-----------+--------------------+--------------------+----------
-----+---------+---------+-----------+---------------+--------+---------------------
 123 |            | 2022-10-27 09:39:46.016742+00 |            |        |            |                |          |      |        |                 |       |                 
 |      |                 |               |              |                         |                        |                                  |                             
    |                   |                            |               |            |        |                |           |                    |                    |          
     |         |         |           |               |        | shared_static_rhsso
serviceapitests=# exit
```
