### PR TITLE
ROX-13098: Load secrets in IDP cluster creation script to Parameter Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [NEXT RELEASE]
 
 ### Added
+- Data Plane terraforming scripts migration from BitWarden to Parameter Store
 ### Changed
 ### Deprecated
 ### Removed

--- a/docs/development/secret-management.md
+++ b/docs/development/secret-management.md
@@ -36,11 +36,15 @@ Without the alias you have to load the session token manually or always add `aws
 
 ### Write secret
 ```shell
-chamber write <service> <KEY> <VALUE>
+chamber write <service> <KEY> -
+<value>
+^D # end-of-stdin
 ```
 for example:
 ```shell
-chamber write fleetshard-sync RHSSO_SERVICE_ACCOUNT_CLIENT_ID changeme
+chamber write fleetshard-sync RHSSO_SERVICE_ACCOUNT_CLIENT_ID -
+changeme
+^D
 ```
 
 ### Print environment

--- a/docs/development/secret-management.md
+++ b/docs/development/secret-management.md
@@ -1,0 +1,49 @@
+# Secret Management
+
+## Overview / Tools
+Application Secrets are stored in AWS Parameter Store.
+The following tools are used to integrate with Parameter Store:
+- [chamber](https://github.com/segmentio/chamber) - CLI for managing secrets
+- [aws-vault](https://github.com/99designs/aws-vault) - supplementary tool to store AWS credentials in the secure local storage
+
+The main usage is to load the secrets as environment variables for deploying a service.
+Secrets are divided to subgroups per each service. The following services are currently exist:
+
+**Application specific:**
+- fleet-manager
+- fleetshard-sync
+- logging
+- observability
+
+**Cluster specific:**
+- acs-stage-dp-01
+- acs-prod-dp-01
+
+## Instructions
+No additional steps are required to use the tools.
+Dependent scripts source the [helper script](./../../scripts/lib/external_config.sh) with command wrapper.
+With this script, the tools are automatically installed from the appropriate `Makefile`  targets.
+It is also recommended to install the tools in the local go bin folder so that you can easily use `chamber` from the command line.
+
+## Tips / Examples
+### Useful environment aliases
+```shell
+alias chamberdev='aws-vault exec dev -- chamber'
+alias chamberstage='aws-vault exec stage -- chamber'
+alias chamberprod='aws-vault exec prod -- chamber'
+```
+Without the alias you have to load the session token manually or always add `aws-vault exec` in the beginning.
+
+### Write secret
+```shell
+chamber write <service> <KEY> <VALUE>
+```
+for example:
+```shell
+chamber write fleetshard-sync RHSSO_SERVICE_ACCOUNT_CLIENT_ID changeme
+```
+
+### Print environment
+```shell
+chamber env fleetshard-sync
+```

--- a/docs/development/setup-osd-cluster-idp.md
+++ b/docs/development/setup-osd-cluster-idp.md
@@ -2,11 +2,9 @@
 
 ## Pre-reqs
 
-1. `jq` installed.
-2. `bw` - BitWarden CLI installed.
-3. `ocm` installed.
+1. `ocm` installed.
 
-Additionally, you will require access to our BitWarden vault.
+Additionally, you will require access to the environment specific AWS account.
 
 ## Creating the IdPs
 
@@ -29,13 +27,13 @@ Afterwards, you can call the script and adjust the parameters based on your need
 
 The script will handle the following (again, split by environments):
 - stage:
-  1. Fetch required credentials from BitWarden.
+  1. Fetch required credentials from AWS Parameter Store. The first time it runs, it will ask for AWS credentials.
   2. Create the OIDC IdP for the cluster.
   3. Create the user <-> group mapping for cluster-admins.
   4. Create the HTPasswd IdP for the cluster.
   5. Create the `acsms-stage-admin` user and map it to cluster-admins group.
 - prod:
-  1. Fetch required credentials from BitWarden.
+  1. Fetch required credentials from AWS Parameter Store. The first time it runs, it will ask for AWS credentials.
   2. Create the HTPasswd IdP for the cluster.
   3. Create the `acsms-prod-admin` user and map it to cluster-admins group.
 

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -21,13 +21,6 @@ CLUSTER_NAME=$2
 
 export AWS_PROFILE="$ENVIRONMENT"
 
-# Loads config from the external storage to the environment and applying a prefix to a variable name (if exists).
-load_external_config() {
-    local service="$1"
-    local prefix="${2:-}"
-    eval "$(run_chamber env "$service" | sed -E "s/(^export +)(.*)/\1${prefix}\2/")"
-}
-
 init_chamber
 
 load_external_config fleetshard-sync FLEETSHARD_SYNC_

--- a/scripts/lib/external_config.sh
+++ b/scripts/lib/external_config.sh
@@ -80,3 +80,10 @@ run_chamber() {
         chamber "${args[@]}"
     fi
 }
+
+# Loads config from the external storage to the environment and applying a prefix to a variable name (if exists).
+load_external_config() {
+    local service="$1"
+    local prefix="${2:-}"
+    eval "$(run_chamber env "$service" | sed -E "s/(^export +)(.*)/\1${prefix}\2/")"
+}


### PR DESCRIPTION
## Description
This PR migrates secrets loading in `osd-cluster-idp-setup.sh` from BitWarden to Parameter Store

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~[ ] Unit and integration tests added~
- [x] Added test description under `Test manual`
- [x] Evaluated and added CHANGELOG.md entry if required
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
1. Add `echo` to `ocm` commands
2. Capture the output
3. Compare the `diff` between main and branch. 

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
