### PR TITLE
ROX-12689: Trim whitespace around URL

### DIFF
--- a/dp-terraform/osd-cluster-idp-setup.sh
+++ b/dp-terraform/osd-cluster-idp-setup.sh
@@ -118,7 +118,8 @@ case $ENVIRONMENT in
     ;;
 esac
 
-CLUSTER_URL="$(ocm list cluster "${CLUSTER_NAME}" --no-headers --columns api.url)"
+# The ocm command likes to return trailing whitespace, so try and trim it:
+CLUSTER_URL="$(ocm list cluster "${CLUSTER_NAME}" --no-headers --columns api.url | awk '{print $1}')"
 
 # Use a temporary KUBECONFIG to avoid storing credentials in and changing current context in user's day-to-day kubeconfig.
 KUBECONFIG="$(mktemp)"


### PR DESCRIPTION
## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~Unit and integration tests added~
- [x] Added test description under `Test manual`
- [x] ~Evaluated and added CHANGELOG.md entry if required~
- [x] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Ran the script after this change and it went fine (rather than fail with `error: not a valid URL: parse "https://api.acs-prod-dp-01.pnz3.p1.openshiftapps.com:6443 ": invalid port ":6443 " after host` like before).
