### PR TITLE
Upgrade go version to 1.18 for app-interface CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -525,7 +525,7 @@ db/generate/insert/cluster:
 
 # Login to docker
 docker/login:
-	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) login -u "${QUAY_USER}" --password-stdin <<< "${QUAY_TOKEN}" quay.io
+	@DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) login -u "${QUAY_USER}" --password-stdin <<< "${QUAY_TOKEN}" quay.io
 .PHONY: docker/login
 
 # Login to the OpenShift internal registry
@@ -564,7 +564,7 @@ image/build/local: image/build
 
 # Build and push the image
 image/push: IMAGE_REF="$(external_image_registry)/$(image_repository):$(image_tag)"
-image/push: image/build
+image/push: image/build/multi-target
 	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) push $(IMAGE_REF)
 	@echo
 	@echo "Image was pushed as $(IMAGE_REF). You might want to"

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 #
 # Copyright (c) 2018 Red Hat, Inc.
 #
@@ -36,20 +36,6 @@ IMAGE_REPOSITORY="${QUAY_IMAGE_REPOSITORY:-app-sre/acs-fleet-manager}"
 
 # Set the directory for docker configuration:
 DOCKER_CONFIG="${PWD}/.docker"
-
-# Set the Go path:
-export GOPATH="${PWD}/.gopath"
-# TODO(porridge): clean up this quick hack needed to get build working on jenkins
-jenkins_go117="/opt/go/1.17.8"
-export PATH="${jenkins_go117}/bin:${PATH}:${GOPATH}/bin"
-LINK="${GOPATH}/src/github.com/stackrox/acs-fleet-manager"
-
-# print go version
-go version
-
-mkdir -p "$(dirname "${LINK}")"
-ln -sf "${PWD}" "${LINK}"
-cd "${LINK}"
 
 # Log in to the image registry:
 if [ -z "${QUAY_USER}" ]; then


### PR DESCRIPTION
## Description
This PR upgrades go version in the `build_deploy.sh` script, which is used in app-interface CI.
Main idea is to use the multi-stage build, introduced by @mtesseract instead of using go installation on the host node.
Current version of the multi-stage `Dockerfile` already has go version 1.18.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~- [ ] Unit and integration tests added~
- [x] Added test description under `Test manual`
~- [ ] Evaluated and added CHANGELOG.md entry if required~
~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
~- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
Run `build-and-deploy.sh` manually. I have no permission to push the images to app-sre quay, but at least the build was successful and I can run the images locally. I can also confirm that `standard` build image is used in the `Dockerfile`
