### PR TITLE
ROX-13436: remove --debug to stop echoing secrets

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -96,10 +96,9 @@ OPERATOR_SOURCE="redhat-operators"
 #OPERATOR_USE_UPSTREAM=true
 #OPERATOR_SOURCE="rhacs-operators"
 
-# helm template ... to debug changes
+# helm template --debug ... to debug changes
 helm upgrade rhacs-terraform "${SCRIPT_DIR}" \
   --install \
-  --debug \
   --namespace rhacs \
   --create-namespace \
   --set acsOperator.enabled=true \


### PR DESCRIPTION
## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~Unit and integration tests added~
- [x] Added test description under `Test manual`
- [x] ~Evaluated and added CHANGELOG.md entry if required~
- [x] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Ran manually and this time the script just produced the following:
```
[mowsiany@mowsiany rhacs-terraform]$ ./terraform_cluster.sh stage acs-stage-dp-01
Logged into "https://api.acs-stage-dp-01.blbk.p1.openshiftapps.com:6443" as "system:serviceaccount:acscs-dataplane-cd:acscs-cd-robot" using the token provided.

You have access to 117 projects, the list has been suppressed. You can list all projects with 'oc projects'

Using project "default".
Release "rhacs-terraform" has been upgraded. Happy Helming!
NAME: rhacs-terraform
LAST DEPLOYED: Mon Nov  7 11:02:31 2022
NAMESPACE: rhacs
STATUS: deployed
REVISION: 27
TEST SUITE: None
[mowsiany@mowsiany rhacs-terraform]$
```