### PR TITLE
Move cluster params to the Parameter Store

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -64,13 +64,9 @@ function assert_environment() {
 case $CLUSTER_NAME in
 acs-stage-dp-01)
   assert_environment stage
-  CLUSTER_ID="d3ccd7a0-9b33-41e3-9024-6677f42259ed"
-  CLUSTER_URL_INFIX="blbk.p1"
   ;;
 acs-prod-dp-01)
   assert_environment prod
-  CLUSTER_ID="05bbca64-8687-494a-8ac1-0eddc91efdd6"
-  CLUSTER_URL_INFIX="pnz3.p1"
   ;;
 *)
   echo "Unknown cluster ${CLUSTER_NAME}. Please define it in the $0 script if this is a new cluster." >&2


### PR DESCRIPTION
## Description
This PR removes wrongly defined `CLUSTER_ID`s. They are now loaded from the Parameter Store.

Related Slack channel: https://srox.slack.com/archives/C04AGPG4GMN

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Evaluated and added CHANGELOG.md entry if required
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
Diff between yamls

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
