### PR TITLE
probe service: use correct context when invoking the cleanup

### DIFF
--- a/probe/pkg/runtime/runtime.go
+++ b/probe/pkg/runtime/runtime.go
@@ -60,9 +60,9 @@ func (r *Runtime) RunSingle(ctx context.Context) (errReturn error) {
 			// If ONLY the clean up failed, the context error is wrapped and
 			// returned in `SingleRun`.
 			if errReturn != nil {
-				errReturn = errors.Wrapf(errReturn, "%s: %s", errCleanupFailed, cleanupCtx.Err())
+				errReturn = errors.Wrapf(errReturn, "%s: %s", errCleanupFailed, err)
 			} else {
-				errReturn = errors.Wrap(cleanupCtx.Err(), errCleanupFailed.Error())
+				errReturn = errors.Wrap(err, errCleanupFailed.Error())
 			}
 		}
 	}()

--- a/probe/pkg/runtime/runtime.go
+++ b/probe/pkg/runtime/runtime.go
@@ -11,6 +11,10 @@ import (
 	"github.com/stackrox/acs-fleet-manager/probe/pkg/probe"
 )
 
+var (
+	errCleanupFailed = errors.New("cleanup failed")
+)
+
 // Runtime orchestrates probe runs against fleet manager.
 type Runtime struct {
 	Config *config.Config
@@ -50,15 +54,15 @@ func (r *Runtime) RunSingle(ctx context.Context) (errReturn error) {
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), r.Config.ProbeCleanUpTimeout)
 		defer cancel()
 
-		if err := r.probe.CleanUp(ctx); err != nil {
+		if err := r.probe.CleanUp(cleanupCtx); err != nil {
 			// If clean up failed AND the original probe run failed, wrap the
 			// original error and return it in `SingleRun`.
 			// If ONLY the clean up failed, the context error is wrapped and
 			// returned in `SingleRun`.
 			if errReturn != nil {
-				errReturn = errors.Wrapf(errReturn, "cleanup failed: %s", cleanupCtx.Err())
+				errReturn = errors.Wrapf(errReturn, "%s: %s", errCleanupFailed, cleanupCtx.Err())
 			} else {
-				errReturn = errors.Wrap(cleanupCtx.Err(), "cleanup failed")
+				errReturn = errors.Wrap(cleanupCtx.Err(), errCleanupFailed.Error())
 			}
 		}
 	}()


### PR DESCRIPTION
This is a bug that sadly got introduced in my last iteration of #533. The cause is a simple typo (`ctx` vs `cleanupCtx`), however this leads to the cleanup not having its own context. While that would be more "golang native", the issue is that we actually want the a blocking clean up call in this case. Otherwise after a timeout or cancellation of the main context, the probe resources would not get cleaned up properly.

I used `NotContains` in the regression test because I didn't manage to find a clean way to introduce a typed error and propagate it correctly with the other wrapped errors of the main routine.

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] ~Added test description under `Test manual`~
- [ ] ~Evaluated and added CHANGELOG.md entry if required~
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [ ] ~Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
