### PR TITLE
ROX-12871: add release-version to Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ This Changelog should be updated for:
 - Changes in the development process (e.g additional required configuration for the e2e test script)
 
 ## [NEXT RELEASE]
+### Added
+### Changed
+### Deprecated
+### Removed
 
+## 2022-11-08.1.3060ea1
 ### Added
 - Data Plane terraforming scripts migration from BitWarden to Parameter Store
 - Update go version to 1.18

--- a/Makefile
+++ b/Makefile
@@ -858,3 +858,10 @@ tag:
 full-image-tag:
 	@echo "$(IMAGE_NAME):$(image_tag)"
 .PHONY: full-image-tag
+
+REVISION ?= 1
+release_date="$(shell date '+%Y-%m-%d')"
+release_commit="$(shell git rev-parse --short=7 HEAD)"
+release-version:
+	@echo "$(release_date).$(REVISION).$(release_commit)"
+.PHONY: release-version

--- a/Makefile
+++ b/Makefile
@@ -859,9 +859,11 @@ full-image-tag:
 	@echo "$(IMAGE_NAME):$(image_tag)"
 .PHONY: full-image-tag
 
-REVISION ?= 1
 release_date="$(shell date '+%Y-%m-%d')"
 release_commit="$(shell git rev-parse --short=7 HEAD)"
+tag_count="$(shell git tag -l $(release_date)* | wc -l)"
+start_rev=1
+rev="$(shell expr $(tag_count) + $(start_rev))"
 release-version:
-	@echo "$(release_date).$(REVISION).$(release_commit)"
+	@echo "$(release_date).$(rev).$(release_commit)"
 .PHONY: release-version


### PR DESCRIPTION
## Description
To make it easier to get a release version string I added a Makefile target. I also updated the CHANGELOG.md to list the 2022-11-08.1.3060ea1 Release, since it wasn't done during release.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~- [ ] Unit and integration tests added~
~- [ ] Added test description under `Test manual`~
~- [ ] Evaluated and added CHANGELOG.md entry if required~
~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
~- [ ] CI and all relevant tests are passing~
~- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

```
# To run tests locally run:
make release-version
```
