### PR TITLE
ROX-12076: docker image for probe service [5]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,6 +112,10 @@ jobs:
           QUAY_USER: ${{ secrets.QUAY_RHACS_ENG_FM_RW_USERNAME }}
           QUAY_TOKEN: ${{ secrets.QUAY_RHACS_ENG_FM_RW_PASSWORD }}
           QUAY_IMAGE_REPOSITORY: rhacs-eng/fleet-manager
+
+          PROBE_QUAY_USER: ${{ secrets.QUAY_RHACS_ENG_PROBE_RW_USERNAME }}
+          PROBE_QUAY_TOKEN: ${{ secrets.QUAY_RHACS_ENG_PROBE_RW_PASSWORD }}
+          QUAY_PROBE_IMAGE_REPOSITORY: rhacs-eng/blackbox-monitoring-probe-service
         run: |
           chmod +x ./build_deploy.sh
           ./build_deploy.sh

--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,16 @@ version:=$(shell date +%s)
 
 ifeq ($(DEBUG_IMAGE),true)
 IMAGE_NAME = fleet-manager-dbg
+PROBE_IMAGE_NAME = probe-dbg
 IMAGE_TARGET = debug
 else
 IMAGE_NAME = fleet-manager
+PROBE_IMAGE_NAME = probe
 IMAGE_TARGET = standard
 endif
 
 SHORT_IMAGE_REF = "$(IMAGE_NAME):$(image_tag)"
+PROBE_SHORT_IMAGE_REF = "$(PROBE_IMAGE_NAME):$(image_tag)"
 
 # Default namespace for local deployments
 NAMESPACE ?= fleet-manager-${USER}
@@ -52,6 +55,7 @@ IMAGE_REGISTRY ?= default-route-openshift-image-registry.apps-crc.testing
 # exist the push fails. This doesn't apply when the image is pushed to a public
 # repository, like `docker.io` or `quay.io`.
 image_repository:=$(NAMESPACE)/$(IMAGE_NAME)
+probe_image_repository:=$(NAMESPACE)/$(PROBE_IMAGE_NAME)
 
 # In the development environment we are pushing the image directly to the image
 # registry inside the development cluster. That registry has a different name
@@ -478,6 +482,7 @@ db/generate/insert/cluster:
 # Login to docker
 docker/login:
 	@DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) login -u "${QUAY_USER}" --password-stdin <<< "${QUAY_TOKEN}" quay.io
+	@DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) login -u "${QUAY_PROBE_USER}" --password-stdin <<< "${QUAY_PROBE_TOKEN}" quay.io
 .PHONY: docker/login
 
 # Login to the OpenShift internal registry
@@ -494,16 +499,24 @@ image/build: fleet-manager fleetshard-sync
 .PHONY: image/build
 
 # Build the image using by specifying a specific image target within the Dockerfile.
-# IMAGE_REF needs to be set.
-# IMAGE_TARGET (standard or debug) is automatically set.
-image/build/multi-target: GOOS=linux
-image/build/multi-target: IMAGE_REF="$(external_image_registry)/$(image_repository):$(image_tag)"
-image/build/multi-target:
+image/build/multi-target: image/build/multi-target/fleet-manager image/build/multi-target/probe
+.PHONY: image/build/multi-target
+
+image/build/multi-target/fleet-manager: GOOS=linux
+image/build/multi-target/fleet-manager: IMAGE_REF="$(external_image_registry)/$(image_repository):$(image_tag)"
+image/build/multi-target/fleet-manager:
 	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) build --target $(IMAGE_TARGET) -t $(IMAGE_REF) .
 	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) tag $(IMAGE_REF) $(SHORT_IMAGE_REF)
 	@echo "New image tag: $(SHORT_IMAGE_REF). You might want to"
 	@echo "export FLEET_MANAGER_IMAGE=$(SHORT_IMAGE_REF)"
-.PHONY: image/build/multi-target
+.PHONY: image/build/multi-target/fleet-manager
+
+image/build/multi-target/probe: GOOS=linux
+image/build/multi-target/probe: IMAGE_REF="$(external_image_registry)/$(probe_image_repository):$(image_tag)"
+image/build/multi-target/probe:
+	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) build --target $(IMAGE_TARGET) -t $(IMAGE_REF) .
+	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) tag $(IMAGE_REF) $(PROBE_SHORT_IMAGE_REF)
+.PHONY: image/build/multi-target/probe
 
 # build binary and image and tag image for local deployment
 image/build/local: GOOS=linux
@@ -515,18 +528,29 @@ image/build/local: image/build
 .PHONY: image/build/local
 
 # Build and push the image
-image/push: IMAGE_REF="$(external_image_registry)/$(image_repository):$(image_tag)"
-image/push: image/build/multi-target
+image/push: image/push/fleet-manager image/push/probe
+.PHONY: image/push
+
+image/push/fleet-manager: IMAGE_REF="$(external_image_registry)/$(image_repository):$(image_tag)"
+image/push/fleet-manager: image/build/multi-target/fleet-manager
 	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) push $(IMAGE_REF)
 	@echo
 	@echo "Image was pushed as $(IMAGE_REF). You might want to"
 	@echo "export FLEET_MANAGER_IMAGE=$(IMAGE_REF)"
-.PHONY: image/push
+.PHONY: image/push/fleet-manager
+
+image/push/probe: IMAGE_REF="$(external_image_registry)/$(probe_image_repository):$(image_tag)"
+image/push/probe: image/build/multi-target/probe
+	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) push $(IMAGE_REF)
+	@echo
+	@echo "Image was pushed as $(IMAGE_REF).
+.PHONY: image/push/probe
 
 # push the image to the OpenShift internal registry
 image/push/internal: IMAGE_TAG ?= $(image_tag)
 image/push/internal: docker/login/internal
 	$(DOCKER) push "$(shell oc get route default-route -n openshift-image-registry -o jsonpath="{.spec.host}")/$(image_repository):$(IMAGE_TAG)"
+	$(DOCKER) push "$(shell oc get route default-route -n openshift-image-registry -o jsonpath="{.spec.host}")/$(probe_image_repository):$(IMAGE_TAG)"
 .PHONY: image/push/internal
 
 # build and push the image to an OpenShift cluster's internal registry

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -33,6 +33,7 @@ VERSION=$(git rev-parse --short=7 HEAD)
 
 # Set image repository to default value if it is not passed via env
 IMAGE_REPOSITORY="${QUAY_IMAGE_REPOSITORY:-app-sre/acs-fleet-manager}"
+PROBE_IMAGE_REPOSITORY="${QUAY_PROBE_IMAGE_REPOSITORY:-rhacs-eng/blackbox-monitoring-probe-service}"
 
 # Set the directory for docker configuration:
 DOCKER_CONFIG="${PWD}/.docker"
@@ -46,6 +47,16 @@ fi
 if [ -z "${QUAY_TOKEN}" ]; then
   echo "The quay.io push token hasn't been provided."
   echo "Make sure to set the QUAY_TOKEN environment variable."
+  exit 1
+fi
+if [ -z "${QUAY_PROBE_USER}" ]; then
+  echo "The probe service quay.io push user name hasn't been provided."
+  echo "Make sure to set the QUAY_PROBE_USER environment variable."
+  exit 1
+fi
+if [ -z "${QUAY_PROBE_TOKEN}" ]; then
+  echo "The probe service quay.io push token hasn't been provided."
+  echo "Make sure to set the QUAY_PROBE_TOKEN environment variable."
   exit 1
 fi
 
@@ -64,7 +75,7 @@ else
 fi
 
 # Push the image:
-echo "Quay.io user and token is set, will push images to $IMAGE_REPOSITORY"
+echo "Quay.io user and token are set, will push images to $IMAGE_REPOSITORY and $PROBE_IMAGE_REPOSITORY."
 make \
   DOCKER_CONFIG="${DOCKER_CONFIG}" \
   QUAY_USER="${QUAY_USER}" \
@@ -73,6 +84,7 @@ make \
   external_image_registry="quay.io" \
   internal_image_registry="quay.io" \
   image_repository="${IMAGE_REPOSITORY}" \
+  probe_image_repository="${PROBE_IMAGE_REPOSITORY}" \
   docker/login \
   image/push
 
@@ -80,9 +92,12 @@ make \
   DOCKER_CONFIG="${DOCKER_CONFIG}" \
   QUAY_USER="${QUAY_USER}" \
   QUAY_TOKEN="${QUAY_TOKEN}" \
+  QUAY_PROBE_USER="${QUAY_PROBE_USER}" \
+  QUAY_PROBE_TOKEN="${QUAY_PROBE_TOKEN}" \
   TAG="${BRANCH}" \
   external_image_registry="quay.io" \
   internal_image_registry="quay.io" \
   image_repository="${IMAGE_REPOSITORY}" \
+  probe_image_repository="${PROBE_IMAGE_REPOSITORY}" \
   docker/login \
   image/push

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -25,6 +25,12 @@
 # QUAY_TOKEN - The token of the robot account used to push images to
 # 'quay.io'.
 #
+# PROBE_QUAY_USER - The name of the robot account used to push images to
+# 'quay.io', for example 'openshift-unified-hybrid-cloud+jenkins'.
+#
+# PROBE_QUAY_TOKEN - The token of the robot account used to push images to
+# 'quay.io'.
+#
 # The machines that run this script need to have access to internet, so that
 # the built images can be pushed to quay.io.
 
@@ -80,13 +86,17 @@ make \
   DOCKER_CONFIG="${DOCKER_CONFIG}" \
   QUAY_USER="${QUAY_USER}" \
   QUAY_TOKEN="${QUAY_TOKEN}" \
+  QUAY_PROBE_USER="${QUAY_PROBE_USER}" \
+  QUAY_PROBE_TOKEN="${QUAY_PROBE_TOKEN}" \
   TAG="${VERSION}" \
   external_image_registry="quay.io" \
   internal_image_registry="quay.io" \
   image_repository="${IMAGE_REPOSITORY}" \
   probe_image_repository="${PROBE_IMAGE_REPOSITORY}" \
-  docker/login \
-  image/push
+  docker/login/fleet-manager \
+  image/push/fleet-manager \
+  docker/login/probe \
+  image/push/probe
 
 make \
   DOCKER_CONFIG="${DOCKER_CONFIG}" \
@@ -99,5 +109,7 @@ make \
   internal_image_registry="quay.io" \
   image_repository="${IMAGE_REPOSITORY}" \
   probe_image_repository="${PROBE_IMAGE_REPOSITORY}" \
-  docker/login \
-  image/push
+  docker/login/fleet-manager \
+  image/push/fleet-manager \
+  docker/login/probe \
+  image/push/probe

--- a/probe/Dockerfile
+++ b/probe/Dockerfile
@@ -21,7 +21,7 @@ ENV GOFLAGS=${GOFLAGS}
 
 RUN mkdir /src
 WORKDIR /src
-RUN CGO_ENABLED=0 go install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@latest
+RUN CGO_ENABLED=0 go install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@v1.9.1
 COPY go.*  ./
 RUN go mod download
 COPY . ./
@@ -32,14 +32,14 @@ RUN GOARGS="-gcflags 'all=-N -l'" make probe
 FROM build as build-standard
 RUN make probe
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 as debug
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.7 as debug
 COPY --from=build-debug /go/bin/dlv /src/probe/bin /stackrox/
 COPY --from=build-debug /src /src
 EXPOSE 7070
 ENTRYPOINT [ "/stackrox/dlv" , "--listen=:40000", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "/stackrox/probe"]
 CMD ["start"]
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 as standard
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.7 as standard
 COPY --from=build-standard /src/probe/bin /stackrox/
 EXPOSE 7070
 ENTRYPOINT ["/stackrox/probe"]

--- a/probe/Dockerfile
+++ b/probe/Dockerfile
@@ -32,14 +32,14 @@ RUN GOARGS="-gcflags 'all=-N -l'" make probe
 FROM build as build-standard
 RUN make probe
 
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.7 as debug
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7 as debug
 COPY --from=build-debug /go/bin/dlv /src/probe/bin /stackrox/
 COPY --from=build-debug /src /src
 EXPOSE 7070
 ENTRYPOINT [ "/stackrox/dlv" , "--listen=:40000", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "/stackrox/probe"]
 CMD ["start"]
 
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.7 as standard
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7 as standard
 COPY --from=build-standard /src/probe/bin /stackrox/
 EXPOSE 7070
 ENTRYPOINT ["/stackrox/probe"]

--- a/probe/Dockerfile
+++ b/probe/Dockerfile
@@ -1,13 +1,49 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+FROM registry.access.redhat.com/ubi8/s2i-base:1-388 AS build
 
-COPY bin/probe /stackrox/
+ARG GO_VERSION=1.18.8
+RUN curl -L --retry 10 --silent --show-error --fail -o /tmp/go.linux-amd64.tar.gz \
+	"https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \
+	tar -C /usr/local -xzf /tmp/go.linux-amd64.tar.gz && \
+	rm -f /tmp/go.linux-amd64.tar.gz
+ENV PATH="/usr/local/go/bin:${PATH}"
 
+ARG GOPATH=/go
+ENV GOPATH=${GOPATH}
+
+ARG GOCACHE=/go/.cache
+ENV GOCACHE=${GOCACHE}
+
+ARG GOROOT=/usr/local/go
+ENV GOROOT=${GOROOT}
+
+ARG GOFLAGS=-mod=mod
+ENV GOFLAGS=${GOFLAGS}
+
+RUN mkdir /src
+WORKDIR /src
+RUN CGO_ENABLED=0 go install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@latest
+COPY go.*  ./
+RUN go mod download
+COPY . ./
+
+FROM build as build-debug
+RUN GOARGS="-gcflags 'all=-N -l'" make probe
+
+FROM build as build-standard
+RUN make probe
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 as debug
+COPY --from=build-debug /go/bin/dlv /src/probe/bin /stackrox/
+COPY --from=build-debug /src /src
 EXPOSE 7070
-
-ENTRYPOINT ["/stackrox/probe"]
-
+ENTRYPOINT [ "/stackrox/dlv" , "--listen=:40000", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "/stackrox/probe"]
 CMD ["start"]
 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 as standard
+COPY --from=build-standard /src/probe/bin /stackrox/
+EXPOSE 7070
+ENTRYPOINT ["/stackrox/probe"]
+CMD ["start"]
 LABEL name="probe" \
 	vendor="Red Hat" \
 	version="0.0.1" \


### PR DESCRIPTION
## Description

Add support for building and pushing Docker images for the probe service.
The images are pushed to `rhacs-eng:blackbox-monitoring-probe-service`
inside the stackrox quay.io organization.

In contrast to fleetmanager and fleetshard-sync, which are bundled together
in the same image, a new image for the probe is created. Consequently, the
relevant Makefile commands have been split into `/fleetmanager` and `/probe`
components.

In addition, the probe Dockerfile has been updated to reflect the latest
changes to the fleetmanager/fleetshard-sync Dockerfile.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~Unit and integration tests added~
- [x] Added test description under `Test manual`
- [ ] ~Evaluated and added CHANGELOG.md entry if required~
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Pushed image to repo via Makefile.
