### PR TITLE
ROX-12076: Remove probe name prefix [6]

### DIFF
--- a/probe/config/config.go
+++ b/probe/config/config.go
@@ -20,7 +20,7 @@ type Config struct {
 	RHSSOClientSecret       string        `env:"RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET"`
 	RHSSOEndpoint           string        `env:"RHSSO_ENDPOINT" envDefault:"https://sso.redhat.com"`
 	RHSSORealm              string        `env:"RHSSO_REALM" envDefault:"redhat-external"`
-	ProbeName               string        `env:"PROBE_NAME" envDefault:"probe"`
+	ProbeName               string        `env:"PROBE_NAME" envDefault:"${HOSTNAME}" envExpand:"true"`
 	ProbeCleanUpTimeout     time.Duration `env:"PROBE_CLEANUP_TIMEOUT" envDefault:"15m"`
 	ProbeHTTPRequestTimeout time.Duration `env:"PROBE_HTTP_REQUEST_TIMEOUT" envDefault:"5s"`
 	ProbePollPeriod         time.Duration `env:"PROBE_POLL_PERIOD" envDefault:"5s"`
@@ -30,7 +30,8 @@ type Config struct {
 
 // GetConfig retrieves the current runtime configuration from the environment and returns it.
 func GetConfig() (*Config, error) {
-	var c Config
+	// Default value if PROBE_NAME and HOSTNAME are not set.
+	c := Config{ProbeName: "probe"}
 
 	if err := env.Parse(&c); err != nil {
 		return nil, errors.Wrap(err, "unable to parse runtime configuration from environment")

--- a/probe/config/config.go
+++ b/probe/config/config.go
@@ -20,8 +20,7 @@ type Config struct {
 	RHSSOClientSecret       string        `env:"RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET"`
 	RHSSOEndpoint           string        `env:"RHSSO_ENDPOINT" envDefault:"https://sso.redhat.com"`
 	RHSSORealm              string        `env:"RHSSO_REALM" envDefault:"redhat-external"`
-	ProbeName               string        `env:"PROBE_NAME" envDefault:"pod"`
-	ProbeNamePrefix         string        `env:"PROBE_NAME_PREFIX" envDefault:"probe"`
+	ProbeName               string        `env:"PROBE_NAME" envDefault:"probe"`
 	ProbeCleanUpTimeout     time.Duration `env:"PROBE_CLEANUP_TIMEOUT" envDefault:"15m"`
 	ProbeHTTPRequestTimeout time.Duration `env:"PROBE_HTTP_REQUEST_TIMEOUT" envDefault:"5s"`
 	ProbePollPeriod         time.Duration `env:"PROBE_POLL_PERIOD" envDefault:"5s"`

--- a/probe/internal/cli/cli_test.go
+++ b/probe/internal/cli/cli_test.go
@@ -17,8 +17,7 @@ import (
 var testConfig = &config.Config{
 	ProbeCleanUpTimeout: 100 * time.Millisecond,
 	ProbeRunTimeout:     100 * time.Millisecond,
-	ProbeName:           "pod",
-	ProbeNamePrefix:     "probe",
+	ProbeName:           "probe",
 	RHSSOClientID:       "client",
 }
 

--- a/probe/pkg/probe/probe.go
+++ b/probe/pkg/probe/probe.go
@@ -59,7 +59,7 @@ func (p *ProbeImpl) newCentralName() (string, error) {
 		return "", errors.Wrapf(err, "reading random bytes for unique central name")
 	}
 	rndString := hex.EncodeToString(rnd)
-	return fmt.Sprintf("%s-%s-%s", p.config.ProbeNamePrefix, p.config.ProbeName, rndString), nil
+	return fmt.Sprintf("%s-%s", p.config.ProbeName, rndString), nil
 }
 
 // Execute the probe of the fleet manager API.
@@ -97,11 +97,10 @@ func (p *ProbeImpl) cleanupFunc(ctx context.Context) error {
 	}
 
 	serviceAccountName := fmt.Sprintf("service-account-%s", p.config.RHSSOClientID)
-	namePrefix := fmt.Sprintf("%s-%s", p.config.ProbeNamePrefix, p.config.ProbeName)
 	success := true
 	for _, central := range centralList.Items {
 		central := central
-		if central.Owner != serviceAccountName || !strings.HasPrefix(central.Name, namePrefix) {
+		if central.Owner != serviceAccountName || !strings.HasPrefix(central.Name, p.config.ProbeName) {
 			continue
 		}
 		if err := p.deleteCentral(ctx, &central); err != nil {

--- a/probe/pkg/probe/probe.go
+++ b/probe/pkg/probe/probe.go
@@ -54,7 +54,7 @@ func recordElapsedTime(start time.Time) {
 }
 
 func (p *ProbeImpl) newCentralName() (string, error) {
-	rnd := make([]byte, 8)
+	rnd := make([]byte, 2)
 	if _, err := rand.Read(rnd); err != nil {
 		return "", errors.Wrapf(err, "reading random bytes for unique central name")
 	}

--- a/probe/pkg/probe/probe_test.go
+++ b/probe/pkg/probe/probe_test.go
@@ -25,8 +25,7 @@ var testConfig = &config.Config{
 	ProbeCleanUpTimeout: 100 * time.Millisecond,
 	ProbeRunTimeout:     100 * time.Millisecond,
 	ProbeRunWaitPeriod:  10 * time.Millisecond,
-	ProbeName:           "pod",
-	ProbeNamePrefix:     "probe",
+	ProbeName:           "probe",
 	RHSSOClientID:       "client",
 }
 
@@ -91,7 +90,7 @@ func TestCreateCentral(t *testing.T) {
 				CreateCentralFunc: func(ctx context.Context, async bool, request public.CentralRequestPayload) (public.CentralRequest, *http.Response, error) {
 					central := public.CentralRequest{
 						Id:           "id-42",
-						Name:         "probe-pod-42",
+						Name:         "probe-42",
 						Status:       constants.CentralRequestStatusAccepted.String(),
 						InstanceType: types.STANDARD.String(),
 					}
@@ -171,7 +170,7 @@ func TestVerifyCentral(t *testing.T) {
 			errType:  &context.DeadlineExceeded,
 			central: &public.CentralRequest{
 				Id:           "id-42",
-				Name:         "probe-pod-42",
+				Name:         "probe-42",
 				Status:       constants.CentralRequestStatusReady.String(),
 				InstanceType: types.STANDARD.String(),
 			},
@@ -223,7 +222,7 @@ func TestDeleteCentral(t *testing.T) {
 					if numGetCentralByIDCalls[name] == 1 {
 						return public.CentralRequest{
 							Id:     "id-42",
-							Name:   "probe-pod-42",
+							Name:   "probe-42",
 							Status: constants.CentralRequestStatusDeprovision.String(),
 						}, nil, nil
 					}
@@ -274,14 +273,14 @@ func TestDeleteCentral(t *testing.T) {
 					if numGetCentralByIDCalls[name] == 1 {
 						return public.CentralRequest{
 							Id:     "id-42",
-							Name:   "probe-pod-42",
+							Name:   "probe-42",
 							Status: constants.CentralRequestStatusDeprovision.String(),
 						}, nil, nil
 					}
 
 					return public.CentralRequest{
 						Id:     "id-42",
-						Name:   "probe-pod-42",
+						Name:   "probe-42",
 						Status: constants.CentralRequestStatusDeleting.String(),
 					}, nil, nil
 				},
@@ -308,7 +307,7 @@ func TestDeleteCentral(t *testing.T) {
 
 			central := &public.CentralRequest{
 				Id:           "id-42",
-				Name:         "probe-pod-42",
+				Name:         "probe-42",
 				Status:       constants.CentralRequestStatusReady.String(),
 				InstanceType: types.STANDARD.String(),
 			}
@@ -345,7 +344,7 @@ func TestCleanUp(t *testing.T) {
 					centralItems := []public.CentralRequest{
 						{
 							Id:    "id-42",
-							Name:  "probe-pod-42",
+							Name:  "probe-42",
 							Owner: "service-account-client",
 						},
 					}
@@ -361,7 +360,7 @@ func TestCleanUp(t *testing.T) {
 					if numGetCentralByIDCalls[name] == 1 {
 						return public.CentralRequest{
 							Id:     "id-42",
-							Name:   "probe-pod-42",
+							Name:   "probe-42",
 							Owner:  "service-account-client",
 							Status: constants.CentralRequestStatusDeprovision.String(),
 						}, nil, nil
@@ -382,7 +381,7 @@ func TestCleanUp(t *testing.T) {
 					centralItems := []public.CentralRequest{
 						{
 							Id:    "id-42",
-							Name:  "probe-pod-42",
+							Name:  "probe-42",
 							Owner: "service-account-wrong-owner",
 						},
 						{

--- a/probe/pkg/runtime/runtime_test.go
+++ b/probe/pkg/runtime/runtime_test.go
@@ -17,8 +17,7 @@ var testConfig = &config.Config{
 	ProbeCleanUpTimeout: 100 * time.Millisecond,
 	ProbeRunTimeout:     100 * time.Millisecond,
 	ProbeRunWaitPeriod:  10 * time.Millisecond,
-	ProbeName:           "pod",
-	ProbeNamePrefix:     "probe",
+	ProbeName:           "probe",
 	RHSSOClientID:       "client",
 }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

I did not realize that the HOSTNAME env variable inside the pod already includes `probe-`. An additional prefix is therefore not necessary.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] ~Added test description under `Test manual`~
- [ ] ~Evaluated and added CHANGELOG.md entry if required~
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~
