### PR TITLE
Fix stern dependency in the build image

### DIFF
--- a/.openshift-ci/build-root/Dockerfile
+++ b/.openshift-ci/build-root/Dockerfile
@@ -59,9 +59,9 @@ RUN curl -L --retry 10 --silent --show-error --fail -o /tmp/node-linux-x64.tar.g
     rm /tmp/node-linux-x64.tar.gz
 ENV PATH="/usr/local/lib/nodejs/node-v${NODE_VERSION}-linux-x64/bin:${PATH}"
 
-ARG STERN_VERSION="1.11.0"
+ARG STERN_VERSION="1.22.0"
 RUN curl -L --retry 10 --silent --show-error --fail -o "/usr/local/bin/stern" \
-    "https://github.com/wercker/stern/releases/download/${STERN_VERSION}/stern_linux_amd64" && \
+    "https://github.com/stern/stern/releases/download/${STERN_VERSION}/stern_linux_amd64" && \
     chmod +x /usr/local/bin/stern
 
 ARG GOTESTSUM_VERSION=1.8.1

--- a/.openshift-ci/build-root/Dockerfile
+++ b/.openshift-ci/build-root/Dockerfile
@@ -60,8 +60,10 @@ RUN curl -L --retry 10 --silent --show-error --fail -o /tmp/node-linux-x64.tar.g
 ENV PATH="/usr/local/lib/nodejs/node-v${NODE_VERSION}-linux-x64/bin:${PATH}"
 
 ARG STERN_VERSION="1.22.0"
-RUN curl -L --retry 10 --silent --show-error --fail -o "/usr/local/bin/stern" \
-    "https://github.com/stern/stern/releases/download/${STERN_VERSION}/stern_linux_amd64" && \
+RUN curl -L --retry 10 --silent --show-error --fail -o "/tmp/stern_linux_amd64.tar.gz" \
+    "https://github.com/stern/stern/releases/download/v${STERN_VERSION}/stern_${STERN_VERSION}_linux_amd64.tar.gz" && \
+    tar -xf /tmp/stern_linux_amd64.tar.gz stern && \
+    mv stern /usr/local/bin/stern && \
     chmod +x /usr/local/bin/stern
 
 ARG GOTESTSUM_VERSION=1.8.1


### PR DESCRIPTION
## Description
Fix broken stern link in the openshift CI build image

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Evaluated and added CHANGELOG.md entry if required
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
Build CI image locally
```
build-root git:(yury/fix-stern-link) ✗ docker run test_stern stern -v
version: 1.22.0
commit: f6f4f640be851ccbd311b609d94a6fdab432d212
built at: 2022-09-27T13:34:04Z
```