### PR TITLE
ROX-13408: Remove api.iam.acs scope in token request

### DIFF
--- a/openapi/rh-sso-dynamic-client.yaml
+++ b/openapi/rh-sso-dynamic-client.yaml
@@ -19,8 +19,6 @@ security:
 tags:
   - name: acs_tenants
     description: Relevant component to the sso.r.c API for managed ACS
-  - name: service_accounts
-    description: Relevant component to the sso.r.c service account API
 paths:
   /apis/beta/acs/v1:
     post:

--- a/openapi/rh-sso-dynamic-client.yaml
+++ b/openapi/rh-sso-dynamic-client.yaml
@@ -19,18 +19,20 @@ security:
 tags:
   - name: acs_tenants
     description: Relevant component to the sso.r.c API for managed ACS
+  - name: service_accounts
+    description: Relevant component to the sso.r.c service account API
 paths:
   /apis/beta/acs/v1:
     post:
       tags:
         - acs_tenants
-      summary: Create ACS Tenant Client
-      description: Create an ACS Tenant Client. Created ACS Tenant Clients are associated
-        with the account passed along with this request.
+      summary: Create ACS managed central client
+      description: Create an ACS managed central client. Created ACS managed central
+        clients are associated with the supplied organization id.
       operationId: createAcsClient
       requestBody:
-        description: "'name', 'redirect_uris', and 'account_id' belonging to the ACS\
-          \ Tenant"
+        description: "The name, redirect URIs and the organization id of the ACS managed\
+          \ central client"
         content:
           application/json:
             schema:
@@ -51,18 +53,20 @@ paths:
                 $ref: '#/components/schemas/ValidationExceptionData'
               examples:
                 Bad Request Example:
+                  description: Bad Request Example
                   $ref: '#/components/examples/400FieldValidationError'
         "401":
           $ref: '#/components/responses/401'
         "403":
-          description: Exceeded account level threshold limits for creating ACS Tenant
-            Clients.
+          description: Exceeded maximum number of ACS managed central clients per
+            tenant.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RedHatErrorRepresentation'
               examples:
                 acs tenant threshold exceeded:
+                  description: acs tenant threshold exceeded
                   $ref: '#/components/examples/403AcsTenantThresholdExceeded'
         "405":
           description: "Not allowed, API Currently Disabled"
@@ -72,20 +76,21 @@ paths:
                 $ref: '#/components/schemas/RedHatErrorRepresentation'
               examples:
                 acs api disabled:
+                  description: acs api disabled
                   $ref: '#/components/examples/405AcsApiDisabled'
       security:
         - serviceAccounts:
             - api.iam.acs
-  /apis/beta/acs/v1/{id}:
+  /apis/beta/acs/v1/{clientId}:
     delete:
       tags:
         - acs_tenants
-      summary: Delete ACS Tenant Client
-      description: Delete ACS Tenant Client by id. Throws not found exception if the
-        client is not found
+      summary: Delete ACS managed central client
+      description: Delete ACS managed central client by clientId. Throws not found
+        exception if the client is not found
       operationId: deleteAcsClient
       parameters:
-        - name: id
+        - name: clientId
           in: path
           required: true
           schema:
@@ -105,6 +110,7 @@ paths:
                 $ref: '#/components/schemas/RedHatErrorRepresentation'
               examples:
                 client not found:
+                  description: client not found
                   $ref: '#/components/examples/404AcsTenantNotFound'
         "405":
           description: "Not allowed, API Currently Disabled"
@@ -114,6 +120,7 @@ paths:
                 $ref: '#/components/schemas/RedHatErrorRepresentation'
               examples:
                 acs api disabled:
+                  description: acs api disabled
                   $ref: '#/components/examples/405AcsApiDisabled'
       security:
         - serviceAccounts:
@@ -137,6 +144,9 @@ components:
           type: string
         name:
           type: string
+        createdAt:
+          type: integer
+          format: int64
     ValidationExceptionData:
       type: object
       properties:
@@ -165,6 +175,7 @@ components:
             - acs_invalid_redirect_uri
             - acs_invalid_client
             - acs_disabled
+            - general_failure
         error_description:
           type: string
     AcsClientRequestData:
@@ -183,6 +194,7 @@ components:
           items:
             type: string
         orgId:
+          pattern: "\\d{1,10}"
           type: string
   responses:
     "401":

--- a/pkg/client/redhatsso/api/api/openapi.yaml
+++ b/pkg/client/redhatsso/api/api/openapi.yaml
@@ -19,8 +19,6 @@ security:
 tags:
 - description: Relevant component to the sso.r.c API for managed ACS
   name: acs_tenants
-- description: Relevant component to the sso.r.c service account API
-  name: service_accounts
 paths:
   /apis/beta/acs/v1:
     post:

--- a/pkg/client/redhatsso/api/api/openapi.yaml
+++ b/pkg/client/redhatsso/api/api/openapi.yaml
@@ -19,19 +19,21 @@ security:
 tags:
 - description: Relevant component to the sso.r.c API for managed ACS
   name: acs_tenants
+- description: Relevant component to the sso.r.c service account API
+  name: service_accounts
 paths:
   /apis/beta/acs/v1:
     post:
-      description: Create an ACS Tenant Client. Created ACS Tenant Clients are associated
-        with the account passed along with this request.
+      description: Create an ACS managed central client. Created ACS managed central
+        clients are associated with the supplied organization id.
       operationId: createAcsClient
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/AcsClientRequestData'
-        description: '''name'', ''redirect_uris'', and ''account_id'' belonging to
-          the ACS Tenant'
+        description: The name, redirect URIs and the organization id of the ACS managed
+          central client
         required: true
       responses:
         "201":
@@ -63,8 +65,8 @@ paths:
                   $ref: '#/components/examples/403AcsTenantThresholdExceeded'
               schema:
                 $ref: '#/components/schemas/RedHatErrorRepresentation'
-          description: Exceeded account level threshold limits for creating ACS Tenant
-            Clients.
+          description: Exceeded maximum number of ACS managed central clients per
+            tenant.
         "405":
           content:
             application/json:
@@ -77,18 +79,18 @@ paths:
       security:
       - serviceAccounts:
         - api.iam.acs
-      summary: Create ACS Tenant Client
+      summary: Create ACS managed central client
       tags:
       - acs_tenants
-  /apis/beta/acs/v1/{id}:
+  /apis/beta/acs/v1/{clientId}:
     delete:
-      description: Delete ACS Tenant Client by id. Throws not found exception if the
-        client is not found
+      description: Delete ACS managed central client by clientId. Throws not found
+        exception if the client is not found
       operationId: deleteAcsClient
       parameters:
       - explode: false
         in: path
-        name: id
+        name: clientId
         required: true
         schema:
           type: string
@@ -125,7 +127,7 @@ paths:
       security:
       - serviceAccounts:
         - api.iam.acs
-      summary: Delete ACS Tenant Client
+      summary: Delete ACS managed central client
       tags:
       - acs_tenants
 components:
@@ -178,6 +180,7 @@ components:
       type: object
     AcsClientResponseData:
       example:
+        createdAt: 0
         clientId: clientId
         name: name
         secret: secret
@@ -188,6 +191,9 @@ components:
           type: string
         name:
           type: string
+        createdAt:
+          format: int64
+          type: integer
       type: object
     ValidationExceptionData:
       properties:
@@ -215,6 +221,7 @@ components:
           - acs_invalid_redirect_uri
           - acs_invalid_client
           - acs_disabled
+          - general_failure
           type: string
         error_description:
           type: string
@@ -237,6 +244,7 @@ components:
           type: array
           uniqueItems: true
         orgId:
+          pattern: \d{1,10}
           type: string
       required:
       - orgId

--- a/pkg/client/redhatsso/api/api_acs_tenants.go
+++ b/pkg/client/redhatsso/api/api_acs_tenants.go
@@ -28,10 +28,10 @@ var (
 type AcsTenantsApiService service
 
 /*
-CreateAcsClient Create ACS Tenant Client
-Create an ACS Tenant Client. Created ACS Tenant Clients are associated with the account passed along with this request.
+CreateAcsClient Create ACS managed central client
+Create an ACS managed central client. Created ACS managed central clients are associated with the supplied organization id.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param acsClientRequestData 'name', 'redirect_uris', and 'account_id' belonging to the ACS Tenant
+ * @param acsClientRequestData The name, redirect URIs and the organization id of the ACS managed central client
 @return AcsClientResponseData
 */
 func (a *AcsTenantsApiService) CreateAcsClient(ctx _context.Context, acsClientRequestData AcsClientRequestData) (AcsClientResponseData, *_nethttp.Response, error) {
@@ -145,12 +145,12 @@ func (a *AcsTenantsApiService) CreateAcsClient(ctx _context.Context, acsClientRe
 }
 
 /*
-DeleteAcsClient Delete ACS Tenant Client
-Delete ACS Tenant Client by id. Throws not found exception if the client is not found
+DeleteAcsClient Delete ACS managed central client
+Delete ACS managed central client by clientId. Throws not found exception if the client is not found
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param id
+ * @param clientId
 */
-func (a *AcsTenantsApiService) DeleteAcsClient(ctx _context.Context, id string) (*_nethttp.Response, error) {
+func (a *AcsTenantsApiService) DeleteAcsClient(ctx _context.Context, clientId string) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
@@ -160,8 +160,8 @@ func (a *AcsTenantsApiService) DeleteAcsClient(ctx _context.Context, id string) 
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/apis/beta/acs/v1/{id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", _neturl.QueryEscape(parameterToString(id, "")), -1)
+	localVarPath := a.client.cfg.BasePath + "/apis/beta/acs/v1/{clientId}"
+	localVarPath = strings.Replace(localVarPath, "{"+"clientId"+"}", _neturl.QueryEscape(parameterToString(clientId, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}

--- a/pkg/client/redhatsso/api/model_acs_client_response_data.go
+++ b/pkg/client/redhatsso/api/model_acs_client_response_data.go
@@ -13,7 +13,8 @@ package api
 
 // AcsClientResponseData struct for AcsClientResponseData
 type AcsClientResponseData struct {
-	ClientId string `json:"clientId,omitempty"`
-	Secret   string `json:"secret,omitempty"`
-	Name     string `json:"name,omitempty"`
+	ClientId  string `json:"clientId,omitempty"`
+	Secret    string `json:"secret,omitempty"`
+	Name      string `json:"name,omitempty"`
+	CreatedAt int64  `json:"createdAt,omitempty"`
 }

--- a/pkg/client/redhatsso/dynamicclients/client.go
+++ b/pkg/client/redhatsso/dynamicclients/client.go
@@ -9,7 +9,7 @@ import (
 
 // NewDynamicClientsAPI returns new instance of dynamic clients sso.redhat.com API client.
 func NewDynamicClientsAPI(realmConfig *iam.IAMRealmConfig) *api.AcsTenantsApiService {
-	httpClient := redhatsso.NewSSOAuthHTTPClient(realmConfig, "api.iam.acs")
+	httpClient := redhatsso.NewSSOAuthHTTPClient(realmConfig)
 	configuration := &api.Configuration{
 		BasePath:  realmConfig.BaseURL + realmConfig.APIEndpointURI,
 		UserAgent: "RHACS-Fleet-Manager/1.0",


### PR DESCRIPTION
## Description

As discussed [here](https://chat.google.com/room/AAAAnbZRzRE/k7ObQN-Ybkk), `api.iam.acs` is made into the default scope. We can stop requesting it before we switch to `api.iam.clients`.


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] Evaluated and added CHANGELOG.md entry if required
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

1. `POST https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token` - removed `api.iam.acs` in request, still in response
