### PR TITLE
Fix removal of centrals that did not get assigned a client origin

### DIFF
--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/deleting_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/deleting_dinosaurs_mgr.go
@@ -129,7 +129,7 @@ func (k *DeletingDinosaurManager) reconcileDeletingDinosaurs(dinosaur *dbapi.Cen
 			}
 		}
 	default:
-		glog.V(7).Infof("invalid client origin %s found for central %s. No deletion will be attempted",
+		glog.V(1).Infof("invalid client origin %s found for central %s. No deletion will be attempted",
 			dinosaur.ClientOrigin, dinosaur.ID)
 	}
 

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/deleting_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/deleting_dinosaurs_mgr.go
@@ -129,8 +129,8 @@ func (k *DeletingDinosaurManager) reconcileDeletingDinosaurs(dinosaur *dbapi.Cen
 			}
 		}
 	default:
-		return errors.Errorf("invalid client origin %q found for client %s",
-			dinosaur.ClientOrigin, dinosaur.ClusterID)
+		glog.V(7).Infof("invalid client origin %s found for central %s. No deletion will be attempted",
+			dinosaur.ClientOrigin, dinosaur.ID)
 	}
 
 	if err := k.dinosaurService.Delete(dinosaur, false); err != nil {


### PR DESCRIPTION
## Description

Currently, it's possible to run into an error within the deletion worker for centrals.

This is possible when the deletion will be triggered during provisioning of the central. At this specific point, no `ClientOrigin` will be associated with the central request.

Since the client origin will be unset, the deletion will currently fail.

Instead of being strict on the deletion of these central requests and erroring out, I've dediced to instead log the occurrence.

## Checklist (Definition of Done)
- [ ] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] Evaluated and added CHANGELOG.md entry if required
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

```
# To run tests locally run:
make db/teardown db/setup db/migrate

# Start the fleet manager.
./fleet-manager serve ...

# Start the fleet shard sync.
CLUSTER_ID=... ./fleetshard-sync

# Create a central request.
./scripts/create-central.sh

# Immediately after creating the central request, delete the central request.
curl -H "Authorization: Bearer $(ocm token)" http://127.0.0.1:8000/api/rhacs/v1/centrals/<id>?async=true -X DELETE

# Ensure that the central request is properly cleaned up and no error will be thrown.
```
