### PR TITLE
ROX-12076: OCM auth [8]

### DIFF
--- a/deploy/helm/probe/templates/01-operator-02-secret-ocm-token.yaml
+++ b/deploy/helm/probe/templates/01-operator-02-secret-ocm-token.yaml
@@ -1,0 +1,10 @@
+{{- if eq .Values.authType "OCM" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhacs-probe-ocm-token
+  namespace: {{ .Values.namespace | quote }}
+stringData:
+  TOKEN: {{ .Values.ocm.token | quote }}
+type: Opaque
+{{- end }}

--- a/deploy/helm/probe/templates/01-operator-02-secret-rhsso-client-secret.yaml
+++ b/deploy/helm/probe/templates/01-operator-02-secret-rhsso-client-secret.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.authType "RHSSO" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,3 +7,4 @@ metadata:
 stringData:
   CLIENT_SECRET: {{ .Values.redHatSSO.clientSecret | quote }}
 type: Opaque
+{{- end }}

--- a/deploy/helm/probe/templates/01-operator-03-deployment.yaml
+++ b/deploy/helm/probe/templates/01-operator-03-deployment.yaml
@@ -24,6 +24,9 @@ spec:
           env:
             - name: FLEET_MANAGER_ENDPOINT
               value: {{ .Values.fleetManagerEndpoint | quote }}
+            - name: AUTH_TYPE
+              value: {{ .Values.authType | quote }}
+            {{- if eq .Values.authType "RHSSO" }}
             - name: RHSSO_SERVICE_ACCOUNT_CLIENT_ID
               value: {{ .Values.redHatSSO.clientId | quote  }}
             - name: RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET
@@ -35,7 +38,15 @@ spec:
               value: {{ .Values.redHatSSO.endpoint | quote  }}
             - name: RHSSO_REALM
               value: {{ .Values.redHatSSO.realm | quote  }}
+            {{- else if eq .Values.authType "OCM" }}
+            - name: OCM_USERNAME
+              value: {{ .Values.ocm.username | quote  }}
+            - name: OCM_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: rhacs-probe-ocm-token
+                  key: TOKEN
+            {{- end }}
           ports:
             - name: monitoring
               containerPort: 7070
-      terminationGracePeriodSeconds: 900

--- a/deploy/helm/probe/templates/01-operator-03-deployment.yaml
+++ b/deploy/helm/probe/templates/01-operator-03-deployment.yaml
@@ -50,3 +50,4 @@ spec:
           ports:
             - name: monitoring
               containerPort: 7070
+      terminationGracePeriodSeconds: 300

--- a/deploy/helm/probe/templates/01-operator-03-deployment.yaml
+++ b/deploy/helm/probe/templates/01-operator-03-deployment.yaml
@@ -38,3 +38,4 @@ spec:
           ports:
             - name: monitoring
               containerPort: 7070
+      terminationGracePeriodSeconds: 900

--- a/deploy/helm/probe/values.yaml
+++ b/deploy/helm/probe/values.yaml
@@ -1,9 +1,12 @@
 image: "quay.io/rhacs-eng/blackbox-monitoring-probe-service:main"
 namespace: "rhacs-probe"
 fleetManagerEndpoint: ""
-authType: ""
+# Must be either 'RHSSO' or 'OCM'.
+authType: "RHSSO"
 ocm:
+  # The username of the Red Hat SSO account.
   username: ""
+  # The refresh token obtained from `ocm token --refresh`.
   token: ""
 redHatSSO:
   clientId: ""

--- a/deploy/helm/probe/values.yaml
+++ b/deploy/helm/probe/values.yaml
@@ -1,6 +1,10 @@
 image: "quay.io/rhacs-eng/blackbox-monitoring-probe-service:main"
 namespace: "rhacs-probe"
 fleetManagerEndpoint: ""
+authType: ""
+ocm:
+  username: ""
+  token: ""
 redHatSSO:
   clientId: ""
   clientSecret: ""

--- a/probe/config/config.go
+++ b/probe/config/config.go
@@ -19,11 +19,7 @@ type Config struct {
 	FleetManagerEndpoint    string        `env:"FLEET_MANAGER_ENDPOINT" envDefault:"http://127.0.0.1:8000"`
 	MetricsAddress          string        `env:"METRICS_ADDRESS" envDefault:":7070"`
 	RHSSOClientID           string        `env:"RHSSO_SERVICE_ACCOUNT_CLIENT_ID"`
-	RHSSOClientSecret       string        `env:"RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET"`
-	RHSSOEndpoint           string        `env:"RHSSO_ENDPOINT" envDefault:"https://sso.redhat.com"`
-	RHSSORealm              string        `env:"RHSSO_REALM" envDefault:"redhat-external"`
 	OCMUsername             string        `env:"OCM_USERNAME"`
-	OCMRefreshToken         string        `env:"OCM_TOKEN"`
 	ProbeName               string        `env:"PROBE_NAME" envDefault:"${HOSTNAME}" envExpand:"true"`
 	ProbeCleanUpTimeout     time.Duration `env:"PROBE_CLEANUP_TIMEOUT" envDefault:"5m"`
 	ProbeHTTPRequestTimeout time.Duration `env:"PROBE_HTTP_REQUEST_TIMEOUT" envDefault:"5s"`
@@ -49,16 +45,10 @@ func GetConfig() (*Config, error) {
 		if c.RHSSOClientID == "" {
 			configErrors.AddError(errors.New("RHSSO_SERVICE_ACCOUNT_CLIENT_ID unset in the environment"))
 		}
-		if c.RHSSOClientSecret == "" {
-			configErrors.AddError(errors.New("RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET unset in the environment"))
-		}
 		c.ProbeUsername = fmt.Sprintf("service-account-%s", c.RHSSOClientID)
 	case "OCM":
 		if c.OCMUsername == "" {
 			configErrors.AddError(errors.New("OCM_USERNAME unset in the environment"))
-		}
-		if c.AuthType == "OCM" && c.OCMRefreshToken == "" {
-			configErrors.AddError(errors.New("OCM_TOKEN unset in the environment"))
 		}
 		c.ProbeUsername = c.OCMUsername
 	default:

--- a/probe/config/config.go
+++ b/probe/config/config.go
@@ -44,7 +44,8 @@ func GetConfig() (*Config, error) {
 	}
 
 	var configErrors errorhelpers.ErrorList
-	if c.AuthType == "RHSSO" {
+	switch c.AuthType {
+	case "RHSSO":
 		if c.RHSSOClientID == "" {
 			configErrors.AddError(errors.New("RHSSO_SERVICE_ACCOUNT_CLIENT_ID unset in the environment"))
 		}
@@ -52,7 +53,7 @@ func GetConfig() (*Config, error) {
 			configErrors.AddError(errors.New("RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET unset in the environment"))
 		}
 		c.ProbeUsername = fmt.Sprintf("service-account-%s", c.RHSSOClientID)
-	} else if c.AuthType == "OCM" {
+	case "OCM":
 		if c.OCMUsername == "" {
 			configErrors.AddError(errors.New("OCM_USERNAME unset in the environment"))
 		}
@@ -60,7 +61,7 @@ func GetConfig() (*Config, error) {
 			configErrors.AddError(errors.New("OCM_TOKEN unset in the environment"))
 		}
 		c.ProbeUsername = c.OCMUsername
-	} else {
+	default:
 		configErrors.AddError(errors.New("AUTH_TYPE not supported"))
 	}
 	if cfgErr := configErrors.ToError(); cfgErr != nil {

--- a/probe/config/config.go
+++ b/probe/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/stackrox/rox/pkg/errorhelpers"
@@ -12,6 +13,7 @@ import (
 
 // Config contains this application's runtime configuration.
 type Config struct {
+	AuthType                string        `env:"AUTH_TYPE" envDefault:"RHSSO"`
 	DataCloudProvider       string        `env:"DATA_PLANE_CLOUD_PROVIDER" envDefault:"aws"`
 	DataPlaneRegion         string        `env:"DATA_PLANE_REGION" envDefault:"us-east-1"`
 	FleetManagerEndpoint    string        `env:"FLEET_MANAGER_ENDPOINT" envDefault:"http://127.0.0.1:8000"`
@@ -20,12 +22,16 @@ type Config struct {
 	RHSSOClientSecret       string        `env:"RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET"`
 	RHSSOEndpoint           string        `env:"RHSSO_ENDPOINT" envDefault:"https://sso.redhat.com"`
 	RHSSORealm              string        `env:"RHSSO_REALM" envDefault:"redhat-external"`
+	OCMUsername             string        `env:"OCM_USERNAME"`
+	OCMRefreshToken         string        `env:"OCM_TOKEN"`
 	ProbeName               string        `env:"PROBE_NAME" envDefault:"${HOSTNAME}" envExpand:"true"`
 	ProbeCleanUpTimeout     time.Duration `env:"PROBE_CLEANUP_TIMEOUT" envDefault:"15m"`
 	ProbeHTTPRequestTimeout time.Duration `env:"PROBE_HTTP_REQUEST_TIMEOUT" envDefault:"5s"`
 	ProbePollPeriod         time.Duration `env:"PROBE_POLL_PERIOD" envDefault:"5s"`
 	ProbeRunTimeout         time.Duration `env:"PROBE_RUN_TIMEOUT" envDefault:"15m"`
 	ProbeRunWaitPeriod      time.Duration `env:"PROBE_RUN_WAIT_PERIOD" envDefault:"30s"`
+
+	ProbeUsername string
 }
 
 // GetConfig retrieves the current runtime configuration from the environment and returns it.
@@ -38,11 +44,24 @@ func GetConfig() (*Config, error) {
 	}
 
 	var configErrors errorhelpers.ErrorList
-	if c.RHSSOClientID == "" {
-		configErrors.AddError(errors.New("RHSSO_SERVICE_ACCOUNT_CLIENT_ID unset in the environment"))
-	}
-	if c.RHSSOClientSecret == "" {
-		configErrors.AddError(errors.New("RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET unset in the environment"))
+	if c.AuthType == "RHSSO" {
+		if c.RHSSOClientID == "" {
+			configErrors.AddError(errors.New("RHSSO_SERVICE_ACCOUNT_CLIENT_ID unset in the environment"))
+		}
+		if c.RHSSOClientSecret == "" {
+			configErrors.AddError(errors.New("RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET unset in the environment"))
+		}
+		c.ProbeUsername = fmt.Sprintf("service-account-%s", c.RHSSOClientID)
+	} else if c.AuthType == "OCM" {
+		if c.OCMUsername == "" {
+			configErrors.AddError(errors.New("OCM_USERNAME unset in the environment"))
+		}
+		if c.AuthType == "OCM" && c.OCMRefreshToken == "" {
+			configErrors.AddError(errors.New("OCM_TOKEN unset in the environment"))
+		}
+		c.ProbeUsername = c.OCMUsername
+	} else {
+		configErrors.AddError(errors.New("AUTH_TYPE not supported"))
 	}
 	if cfgErr := configErrors.ToError(); cfgErr != nil {
 		return nil, errors.Wrap(cfgErr, "unexpected configuration settings")

--- a/probe/config/config.go
+++ b/probe/config/config.go
@@ -25,7 +25,7 @@ type Config struct {
 	OCMUsername             string        `env:"OCM_USERNAME"`
 	OCMRefreshToken         string        `env:"OCM_TOKEN"`
 	ProbeName               string        `env:"PROBE_NAME" envDefault:"${HOSTNAME}" envExpand:"true"`
-	ProbeCleanUpTimeout     time.Duration `env:"PROBE_CLEANUP_TIMEOUT" envDefault:"15m"`
+	ProbeCleanUpTimeout     time.Duration `env:"PROBE_CLEANUP_TIMEOUT" envDefault:"5m"`
 	ProbeHTTPRequestTimeout time.Duration `env:"PROBE_HTTP_REQUEST_TIMEOUT" envDefault:"5s"`
 	ProbePollPeriod         time.Duration `env:"PROBE_POLL_PERIOD" envDefault:"5s"`
 	ProbeRunTimeout         time.Duration `env:"PROBE_RUN_TIMEOUT" envDefault:"15m"`

--- a/probe/config/config_test.go
+++ b/probe/config/config_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestGetConfig_Success(t *testing.T) {
 	t.Setenv("FLEET_MANAGER_ENDPOINT", "http://127.0.0.1:8888")
+	t.Setenv("AUTH_TYPE", "RHSSO")
 	t.Setenv("RHSSO_SERVICE_ACCOUNT_CLIENT_ID", "dummy")
 	t.Setenv("RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET", "dummy")
 
@@ -21,6 +22,7 @@ func TestGetConfig_Success(t *testing.T) {
 }
 
 func TestGetConfig_Failure(t *testing.T) {
+	t.Setenv("AUTH_TYPE", "RHSSO")
 	t.Setenv("RHSSO_SERVICE_ACCOUNT_CLIENT_ID", "")
 	t.Setenv("RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET", "")
 

--- a/probe/internal/cli/cli.go
+++ b/probe/internal/cli/cli.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -89,7 +90,7 @@ func (cli *CLI) handleInterrupt(runFunc func(context.Context) error) error {
 	defer cancel()
 
 	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, os.Interrupt)
+	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-sigs
 		glog.Error("received SIGINT signal, shutting down ...")

--- a/probe/pkg/fleetmanager/client.go
+++ b/probe/pkg/fleetmanager/client.go
@@ -9,11 +9,16 @@ import (
 
 // New creates a new fleet manager client.
 func New(config *config.Config) (fleetmanager.PublicClient, error) {
-	auth, err := fleetmanager.NewRHSSOAuth(fleetmanager.RHSSOOption{
-		ClientID:     config.RHSSOClientID,
-		ClientSecret: config.RHSSOClientSecret, // pragma: allowlist secret
-		Realm:        config.RHSSORealm,
-		Endpoint:     config.RHSSOEndpoint,
+	auth, err := fleetmanager.NewAuth(config.AuthType, fleetmanager.Option{
+		Sso: fleetmanager.RHSSOOption{
+			ClientID:     config.RHSSOClientID,
+			ClientSecret: config.RHSSOClientSecret, //pragma: allowlist secret
+			Realm:        config.RHSSORealm,
+			Endpoint:     config.RHSSOEndpoint,
+		},
+		Ocm: fleetmanager.OCMOption{
+			RefreshToken: config.OCMRefreshToken,
+		},
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create fleet manager authentication")

--- a/probe/pkg/fleetmanager/client.go
+++ b/probe/pkg/fleetmanager/client.go
@@ -9,17 +9,7 @@ import (
 
 // New creates a new fleet manager client.
 func New(config *config.Config) (fleetmanager.PublicClient, error) {
-	auth, err := fleetmanager.NewAuth(config.AuthType, fleetmanager.Option{
-		Sso: fleetmanager.RHSSOOption{
-			ClientID:     config.RHSSOClientID,
-			ClientSecret: config.RHSSOClientSecret, //pragma: allowlist secret
-			Realm:        config.RHSSORealm,
-			Endpoint:     config.RHSSOEndpoint,
-		},
-		Ocm: fleetmanager.OCMOption{
-			RefreshToken: config.OCMRefreshToken,
-		},
-	})
+	auth, err := fleetmanager.NewAuth(config.AuthType, fleetmanager.OptionFromEnv())
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create fleet manager authentication")
 	}

--- a/probe/pkg/probe/probe.go
+++ b/probe/pkg/probe/probe.go
@@ -161,11 +161,6 @@ func (p *ProbeImpl) deleteCentral(ctx context.Context, centralRequest *public.Ce
 		return errors.Wrapf(err, "deletion of central instance %s failed", centralRequest.Id)
 	}
 
-	_, err = p.ensureCentralState(ctx, centralRequest, constants.CentralRequestStatusDeprovision.String())
-	if err != nil {
-		return errors.Wrapf(err, "central instance %s did not reach deprovision state", centralRequest.Id)
-	}
-
 	err = p.ensureCentralDeleted(ctx, centralRequest)
 	if err != nil {
 		return errors.Wrapf(err, "central instance %s could not be deleted", centralRequest.Id)

--- a/probe/pkg/probe/probe.go
+++ b/probe/pkg/probe/probe.go
@@ -163,7 +163,7 @@ func (p *ProbeImpl) deleteCentral(ctx context.Context, centralRequest *public.Ce
 
 	err = p.ensureCentralDeleted(ctx, centralRequest)
 	if err != nil {
-		return errors.Wrapf(err, "central instance %s could not be deleted", centralRequest.Id)
+		return errors.Wrapf(err, "central instance %s with status %s could not be deleted", centralRequest.Id, centralRequest.Status)
 	}
 	return nil
 }

--- a/probe/pkg/probe/probe.go
+++ b/probe/pkg/probe/probe.go
@@ -96,11 +96,10 @@ func (p *ProbeImpl) cleanupFunc(ctx context.Context) error {
 		return err
 	}
 
-	serviceAccountName := fmt.Sprintf("service-account-%s", p.config.RHSSOClientID)
 	success := true
 	for _, central := range centralList.Items {
 		central := central
-		if central.Owner != serviceAccountName || !strings.HasPrefix(central.Name, p.config.ProbeName) {
+		if central.Owner != p.config.ProbeUsername || !strings.HasPrefix(central.Name, p.config.ProbeName) {
 			continue
 		}
 		if err := p.deleteCentral(ctx, &central); err != nil {

--- a/probe/pkg/probe/probe_test.go
+++ b/probe/pkg/probe/probe_test.go
@@ -27,6 +27,7 @@ var testConfig = &config.Config{
 	ProbeRunWaitPeriod:  10 * time.Millisecond,
 	ProbeName:           "probe",
 	RHSSOClientID:       "client",
+	ProbeUsername:       "service-account-client",
 }
 
 func makeHTTPResponse(statusCode int) *http.Response {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Based on the learnings from e2e testing the probe on a dev cluster, I had to do some adjustments:
* Add OCM auth as a workaround. The reason behind this is that OCM does not seem to correctly support
  RHSSO service accounts when they represent the user instead of the calling service.
* I also added some minor adjustments:
  * Reduced clean up timeout to 5 minutes.
  * Catch SIGTERM signal.
  * Don't wait for deprovision in clean up.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] ~Evaluated and added CHANGELOG.md entry if required~
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Tested on dev cluster.
