### PR TITLE
Make image for E2E tests instead of Base build image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,17 +1,13 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
 # Ignore build and test binaries.
 bin/
-e2e/
-dev
 tmp*
-test*
 docs/
 dp-terraform/
 config/
 secrets/
 stackrox/
 .pre-commit-config.yaml
-scripts/
 templates/
 .artifacts/
 .DS_Store

--- a/.openshift-ci/e2e-runtime/Dockerfile
+++ b/.openshift-ci/e2e-runtime/Dockerfile
@@ -1,0 +1,63 @@
+FROM quay.io/centos/centos:stream9
+
+RUN rm -f /etc/yum.repos.d/* && { \
+    echo "[baseos]"; \
+    echo "name=CentOS Stream \$releasever - BaseOS"; \
+    echo "baseurl=http://mirror.stream.centos.org/\$releasever-stream/BaseOS/\$basearch/os/"; \
+    echo "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"; \
+    echo "gpgcheck=1"; \
+    echo "repo_gpgcheck=0"; \
+    echo "metadata_expire=6h"; \
+    echo "countme=1"; \
+    echo "enabled=1"; \
+    echo; \
+    echo "[appstream]"; \
+    echo "name=CentOS Stream $releasever - AppStream"; \
+    echo "baseurl=http://mirror.stream.centos.org/\$releasever-stream/AppStream/\$basearch/os/"; \
+    echo "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"; \
+    echo "gpgcheck=1"; \
+    echo "repo_gpgcheck=0"; \
+    echo "metadata_expire=6h"; \
+    echo "countme=1"; \
+    echo "enabled=1"; \
+    } > "/etc/yum.repos.d/centos.repo"
+
+RUN dnf update -y && dnf -y install make which git gettext jq gcc && dnf clean all && rm -rf /var/cache/dnf
+
+COPY --from=registry.ci.openshift.org/openshift/release:golang-1.18 /usr/local/go /usr/local/go
+COPY --from=quay.io/openshift/origin-cli:4.13 /usr/bin/oc /usr/bin
+COPY --from=quay.io/operator-framework/operator-sdk:v1.25 /usr/local/bin/operator-sdk /usr/local/bin
+
+ENV GOPATH=/go
+ENV GOROOT=/usr/local/go
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+RUN ln -s /usr/bin/oc /usr/bin/kubectl
+
+ARG YQ_VERSION=4.27.5
+RUN curl -L --retry 10 --silent --show-error --fail -o /tmp/yq_linux_amd64.tar.gz \
+    "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64.tar.gz" && \
+    tar -xzf /tmp/yq_linux_amd64.tar.gz ./yq_linux_amd64 && \
+    mv yq_linux_amd64 /usr/local/bin/yq && \
+    chmod +x /usr/local/bin/yq && \
+    rm /tmp/yq_linux_amd64.tar.gz
+
+ARG STERN_VERSION="1.22.0"
+RUN curl -L --retry 10 --silent --show-error --fail -o "/tmp/stern_linux_amd64.tar.gz" \
+    "https://github.com/stern/stern/releases/download/v${STERN_VERSION}/stern_${STERN_VERSION}_linux_amd64.tar.gz" && \
+    tar -xf /tmp/stern_linux_amd64.tar.gz stern && \
+    mv stern /usr/local/bin/stern && \
+    chmod +x /usr/local/bin/stern
+
+ARG OCM_VERSION=0.1.64
+RUN curl -L --retry 10 --silent --show-error --fail -o "/usr/local/bin/ocm" \
+    "https://github.com/openshift-online/ocm-cli/releases/download/v${OCM_VERSION}/ocm-linux-amd64" && \
+    chmod +x /usr/local/bin/ocm
+
+RUN mkdir /src $GOPATH
+WORKDIR /src
+
+COPY . .
+RUN chmod 775 -R /src && chmod 775 -R $GOPATH
+
+CMD ./.openshift-ci/tests/e2e.sh

--- a/.openshift-ci/e2e-runtime/docker_run_e2e.sh
+++ b/.openshift-ci/e2e-runtime/docker_run_e2e.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+docker run \
+    -v "${KUBECONFIG:-$HOME/.kube/config}":/var/kubeconfig -e KUBECONFIG=/var/kubeconfig \
+    -e STATIC_TOKEN="$STATIC_TOKEN" -e STATIC_TOKEN_ADMIN="$STATIC_TOKEN_ADMIN" \
+    -e QUAY_USER="$QUAY_USER" -e QUAY_TOKEN="$QUAY_TOKEN" \
+    -e USE_AWS_VAULT=false -e AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN" \
+    -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+    -e FLEET_MANAGER_IMAGE="$FLEET_MANAGER_IMAGE" \
+    --net=host --name acscs-e2e --rm acscs-e2e

--- a/.openshift-ci/e2e-runtime/e2e_dockerized.sh
+++ b/.openshift-ci/e2e-runtime/e2e_dockerized.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -eo pipefail
+
+GITROOT="$(git rev-parse --show-toplevel)"
+export GITROOT
+# shellcheck source=dev/env/scripts/docker.sh
+source "${GITROOT}/dev/env/scripts/docker.sh"
+# shellcheck source=scripts/lib/external_config.sh
+source "${GITROOT}/scripts/lib/external_config.sh"
+
+init_chamber
+
+FLEET_MANAGER_IMAGE=$(make -s -C "$GITROOT" full-image-tag)
+export FLEET_MANAGER_IMAGE
+
+# Run the necessary docker actions out of the container
+preload_dependency_images
+ensure_fleet_manager_image_exists
+
+docker build -t acscs-e2e -f "$GITROOT/.openshift-ci/e2e-runtime/Dockerfile" "${GITROOT}"
+
+aws-vault exec dev -- "$GITROOT/.openshift-ci/e2e-runtime/docker_run_e2e.sh"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,6 @@
-FROM registry.access.redhat.com/ubi8/s2i-base:1-388 AS build
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS build
 
-ARG GO_VERSION=1.18.8
-RUN curl -L --retry 10 --silent --show-error --fail -o /tmp/go.linux-amd64.tar.gz \
-    "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \
-    tar -C /usr/local -xzf /tmp/go.linux-amd64.tar.gz && \
-    rm -f /tmp/go.linux-amd64.tar.gz
-ENV PATH="/usr/local/go/bin:${PATH}"
-
-ARG GOPATH=/go
-ENV GOPATH=${GOPATH}
-
-ARG GOCACHE=/go/.cache
-ENV GOCACHE=${GOCACHE}
-
-ARG GOROOT=/usr/local/go
-ENV GOROOT=${GOROOT}
-
-ARG GOFLAGS=-mod=mod
-ENV GOFLAGS=${GOFLAGS}
+ENV GOFLAGS="-mod=mod"
 
 RUN mkdir /src
 WORKDIR /src

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ $(GINKGO_BIN): $(TOOLS_DIR)/go.mod $(TOOLS_DIR)/go.sum
 	@cd $(TOOLS_DIR) && GOBIN=${LOCAL_BIN_PATH} $(GO) install github.com/onsi/ginkgo/v2/ginkgo
 
 OPENAPI_GENERATOR ?= ${LOCAL_BIN_PATH}/openapi-generator
-NPM ?= "$(shell which npm)"
+NPM ?= "$(shell which npm 2> /dev/null)"
 openapi-generator:
 ifeq (, $(shell which ${NPM} 2> /dev/null))
 	@echo "npm is not available please install it to be able to install openapi-generator"
@@ -135,7 +135,7 @@ ifeq (, $(shell which ${LOCAL_BIN_PATH}/openapi-generator 2> /dev/null))
 endif
 
 SPECTRAL ?= ${LOCAL_BIN_PATH}/spectral
-NPM ?= "$(shell which npm)"
+NPM ?= "$(shell which npm 2> /dev/null)"
 specinstall:
 ifeq (, $(shell which ${NPM} 2> /dev/null))
 	@echo "npm is not available please install it to be able to install spectral"
@@ -342,7 +342,6 @@ test/cluster/cleanup:
 .PHONY: test/cluster/cleanup
 
 test/e2e: $(GINKGO_BIN)
-	GOBIN=${LOCAL_BIN_PATH} \
 	CLUSTER_ID=1234567890abcdef1234567890abcdef \
 	RUN_E2E=true \
 	ENABLE_CENTRAL_EXTERNAL_CERTIFICATE=$(ENABLE_CENTRAL_EXTERNAL_CERTIFICATE) \
@@ -356,6 +355,12 @@ test/e2e: $(GINKGO_BIN)
 		--slow-spec-threshold=5m \
 		 ./e2e/...
 .PHONY: test/e2e
+
+# Deploys the necessary applications to the selected cluster and runs e2e tests inside the container
+# Useful for debugging Openshift CI runs locally
+test/deploy/e2e-dockerized:
+	./.openshift-ci/e2e-runtime/e2e_dockerized.sh
+.PHONY: test/deploy/e2e-dockerized
 
 test/e2e/reset:
 	@./dev/env/scripts/reset

--- a/dev/env/scripts/bootstrap.sh
+++ b/dev/env/scripts/bootstrap.sh
@@ -4,6 +4,9 @@ GITROOT="$(git rev-parse --show-toplevel)"
 export GITROOT
 # shellcheck source=/dev/null
 source "${GITROOT}/dev/env/scripts/lib.sh"
+# shellcheck source=/dev/null
+source "${GITROOT}/dev/env/scripts/docker.sh"
+
 init
 
 cat <<EOF
@@ -152,15 +155,7 @@ EOF
         fi
     fi
 
-    log "Preloading images into ${CLUSTER_TYPE} cluster..."
-    docker_pull "postgres:13"
-    if [[ "$INSTALL_OPERATOR" == "true" ]]; then
-        # Preload images required by Central installation.
-        docker_pull "${IMAGE_REGISTRY}/scanner:${SCANNER_VERSION}"
-        docker_pull "${IMAGE_REGISTRY}/scanner-db:${SCANNER_VERSION}"
-        docker_pull "${IMAGE_REGISTRY}/main:${CENTRAL_VERSION}"
-    fi
-    log "Images preloaded"
+    preload_dependency_images
 fi
 
 log

--- a/dev/env/scripts/docker.sh
+++ b/dev/env/scripts/docker.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+GITROOT_DEFAULT=$(git rev-parse --show-toplevel)
+export GITROOT=${GITROOT:-$GITROOT_DEFAULT}
+
+# shellcheck source=/dev/null
+source "$GITROOT/scripts/lib/log.sh"
+
+_docker_images=""
+
+DOCKER=${DOCKER:-docker}
+CLUSTER_TYPE=${CLUSTER_TYPE:-default}
+
+is_running_inside_docker() {
+    if [[ -f "/.dockerenv" ]]; then
+        return 0
+    fi
+    return 1
+}
+
+docker_pull() {
+    local image_ref="${1:-}"
+    if [[ -z "${_docker_images}" ]]; then
+        _docker_images=$($DOCKER images --format '{{.Repository}}:{{.Tag}}')
+    fi
+    if echo "${_docker_images}" | grep -q "^${image_ref}$"; then
+        log "Skipping pulling of image ${image_ref}, as it is already there"
+    else
+        log "Pulling image ${image_ref}"
+        $DOCKER pull "$image_ref"
+    fi
+}
+
+docker_logged_in() {
+    local registry="${1:-}"
+    if [[ -z "$registry" ]]; then
+        log "docker_logged_in() called with empty registry argument"
+        return 1
+    fi
+    if jq -ec ".auths[\"${registry}\"]" <"$DOCKER_CONFIG/config.json" >/dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+ensure_fleet_manager_image_exists() {
+    if [[ "$FLEET_MANAGER_IMAGE" =~ ^[0-9a-z.-]+$ ]]; then
+        log "FLEET_MANAGER_IMAGE='${FLEET_MANAGER_IMAGE}' looks like an image tag. Setting:"
+        FLEET_MANAGER_IMAGE="quay.io/rhacs-eng/fleet-manager:${FLEET_MANAGER_IMAGE}"
+        log "FLEET_MANAGER_IMAGE='${FLEET_MANAGER_IMAGE}'"
+    fi
+
+    if is_local_deploy; then
+        # We are deploying locally. Locally we support Quay images and freshly built images.
+        if [[ "$FLEET_MANAGER_IMAGE" =~ ^fleet-manager.*:.* ]]; then
+            # Local image reference, which cannot be pulled.
+            image_available=$(if $DOCKER image inspect "${FLEET_MANAGER_IMAGE}" >/dev/null 2>&1; then echo "true"; else echo "false"; fi)
+            if [[ "$image_available" != "true" || "$FLEET_MANAGER_IMAGE" =~ dirty$ ]]; then
+                # Attempt to build this image.
+                if [[ "$FLEET_MANAGER_IMAGE" == "$(make -s -C "${GITROOT}" full-image-tag)" ]]; then
+                    # Looks like we can build this tag from the current state of the repository.
+                    if [[ "$DEBUG_PODS" == "true" ]]; then
+                        log "Building image with debugging support..."
+                        make -C "${GITROOT}" image/build/multi-target
+                    else
+                        # We *could* also use image/build/multi-target, because that
+                        # target also supports building of standard (i.e. non-debug) images.
+                        # But until there is a reliable and portable caching mechanism for dockerized
+                        # Go projects, this would be regression in terms of build performance.
+                        # Hence we don't use the image/build/multi-target target here, but the
+                        # older `image/build/local` target, which uses a hybrid building
+                        # approach and is much faster.
+                        log "Building standard image..."
+                        make -C "${GITROOT}" image/build/local
+                    fi
+                else
+                    die "Cannot find image '${FLEET_MANAGER_IMAGE}' and don't know how to build it"
+                fi
+            else
+                log "Image ${FLEET_MANAGER_IMAGE} found, skipping building of a new image."
+            fi
+        else
+            log "Trying to pull image '${FLEET_MANAGER_IMAGE}'..."
+            docker_pull "$FLEET_MANAGER_IMAGE"
+        fi
+
+        # Verify that the image is there.
+        if ! $DOCKER image inspect "$FLEET_MANAGER_IMAGE" >/dev/null 2>&1; then
+            die "Image ${FLEET_MANAGER_IMAGE} not available in cluster, aborting"
+        fi
+    else
+        # We are deploying to a remote cluster.
+        if [[ "$FLEET_MANAGER_IMAGE" =~ ^fleet-manager:.* ]]; then
+            die "Error: When deploying to a remote target cluster FLEET_MANAGER_IMAGE must point to an image pullable from the target cluster."
+        fi
+    fi
+}
+
+is_local_deploy() {
+    if [[ "$CLUSTER_TYPE" == "openshift-ci" || "$CLUSTER_TYPE" == "infra-openshift" ]]; then
+        return 1
+    fi
+    if is_running_inside_docker; then
+        return 1
+    fi
+    return 0
+}
+
+preload_dependency_images() {
+    if is_running_inside_docker; then
+        return
+    fi
+    log "Preloading images into ${CLUSTER_TYPE} cluster..."
+    docker_pull "postgres:13"
+    if [[ "$INSTALL_OPERATOR" == "true" ]]; then
+        # Preload images required by Central installation.
+        docker_pull "${IMAGE_REGISTRY}/scanner:${SCANNER_VERSION}"
+        docker_pull "${IMAGE_REGISTRY}/scanner-db:${SCANNER_VERSION}"
+        docker_pull "${IMAGE_REGISTRY}/main:${CENTRAL_VERSION}"
+    fi
+    log "Images preloaded"
+}

--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -299,34 +299,6 @@ is_openshift_cluster() {
     fi
 }
 
-_docker_images=""
-
-docker_pull() {
-    local image_ref="${1:-}"
-    if [[ -z "${_docker_images}" ]]; then
-        _docker_images=$($DOCKER images --format '{{.Repository}}:{{.Tag}}')
-    fi
-    if echo "${_docker_images}" | grep -q "^${image_ref}$"; then
-        log "Skipping pulling of image ${image_ref}, as it is already there"
-    else
-        log "Pulling image ${image_ref}"
-        $DOCKER pull "$image_ref"
-    fi
-}
-
-docker_logged_in() {
-    local registry="${1:-}"
-    if [[ -z "$registry" ]]; then
-        log "docker_logged_in() called with empty registry argument"
-        return 1
-    fi
-    if jq -ec ".auths[\"${registry}\"]" <"$DOCKER_CONFIG/config.json" >/dev/null 2>&1; then
-        return 0
-    else
-        return 1
-    fi
-}
-
 delete_tenant_namespaces() {
     central_namespaces=$($KUBECTL get namespace -o jsonpath='{range .items[?(@.status.phase == "Active")]}{.metadata.name}{"\n"}{end}' | grep '^rhacs-.*$' || true)
     if [[ ! "$central_namespaces" ]]; then

--- a/docs/development/setup-test-environment.md
+++ b/docs/development/setup-test-environment.md
@@ -61,6 +61,13 @@ $ ./.openshift-ci/test/e2e.sh
 ```
 This will trigger the FULL test lifecycle including the cluster bootstrap, building the image (unless `FLEET_MANAGER_IMAGE` points to a specific image tag), deploying it and running E2E tests.
 
+As an alternative you can invoke e2e tests inside the container:
+```shell
+$ make test/deploy/e2e-dockerized
+```
+This may be useful when you're debugging Openshift CI issues specific to the container environment.
+It also does not require extra [tools](#Required tools) dependencies, such as `jq`, `kubectl` or `operator-sdk`.
+
 ### Controlling the execution
 In certain situations it is also useful to be able to execute the respective building blocks manually:
 ##### Prepare the cluster


### PR DESCRIPTION
## Description
This PR is intended for covering 2 problems:
1. `Dockerfile` changes made in the branch are not reflected in the CI build;
2. No way to reproduce CI builds locally inside the container (i.e. when image build is broken).

The main idea is to introduce a dedicated image for E2E. Instead of building the base image which Dockerfile is taken from the `main` branch, we're now building E2E specific image which Dockerfile is taken from the feature branch which is going to be merged to main.

Related Openshift CI change: openshift/release#34027

Further steps:
1. Merge this PR
2. Merge Openshift CI PR
3. Remove openshift CI [build root Dockerfile](https://github.com/stackrox/acs-fleet-manager/blob/82d893723c9b344c9f6d1f9f75d189eb2b61c1ed/.openshift-ci/build-root/Dockerfile)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~- [ ] Unit and integration tests added~
- [x] Added test description under `Test manual`
- [x] Evaluated and added CHANGELOG.md entry if required
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
~- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

1. `make test/deploy/e2e-dockerized`
2. `make test/e2e`
3. `./.openshift-ci/e2e-runtime/e2e_dockerized.sh`
4. Openshift CI rehearsal builds are green
