### PR TITLE
Split building image scripts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,5 +117,5 @@ jobs:
           QUAY_PROBE_TOKEN: ${{ secrets.QUAY_RHACS_ENG_PROBE_RW_PASSWORD }}
           QUAY_PROBE_IMAGE_REPOSITORY: rhacs-eng/blackbox-monitoring-probe-service
         run: |
-          chmod +x ./build_deploy.sh
-          ./build_deploy.sh
+          chmod +x ./build_push_with_probe.sh.sh
+          ./build_push_with_probe.sh.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,5 +117,7 @@ jobs:
           QUAY_PROBE_TOKEN: ${{ secrets.QUAY_RHACS_ENG_PROBE_RW_PASSWORD }}
           QUAY_PROBE_IMAGE_REPOSITORY: rhacs-eng/blackbox-monitoring-probe-service
         run: |
-          chmod +x ./build_push_with_probe.sh.sh
-          ./build_push_with_probe.sh.sh
+          chmod +x ./build_push_fleet_manager.sh
+          chmod +x ./build_push_probe.sh
+          ./build_push_fleet_manager.sh
+          ./build_push_probe.sh

--- a/build_push_fleet_manager.sh
+++ b/build_push_fleet_manager.sh
@@ -76,8 +76,8 @@ make \
   external_image_registry="quay.io" \
   internal_image_registry="quay.io" \
   image_repository="${IMAGE_REPOSITORY}" \
-  docker/login \
-  image/push
+  docker/login/fleet-manager \
+  image/push/fleet-manager
 
 make \
   DOCKER_CONFIG="${DOCKER_CONFIG}" \

--- a/build_push_fleet_manager.sh
+++ b/build_push_fleet_manager.sh
@@ -87,5 +87,5 @@ make \
   external_image_registry="quay.io" \
   internal_image_registry="quay.io" \
   image_repository="${IMAGE_REPOSITORY}" \
-  docker/login \
-  image/push
+  docker/login/fleet-manager \
+  image/push/fleet-manager

--- a/build_push_fleet_manager.sh
+++ b/build_push_fleet_manager.sh
@@ -1,0 +1,91 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# =====================================================================================================================
+# This script builds and pushes the ACS Fleet Manager service docker image on AppSRE JenkinsCI.
+# You can find CI configuration in app-interface repository:
+# https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/acs-fleet-manager/cicd/jobs.yaml
+# In order to work, it needs the following variables defined in the CI/CD configuration of the project:
+#
+# QUAY_USER - The name of the robot account used to push images to
+# 'quay.io', for example 'openshift-unified-hybrid-cloud+jenkins'.
+#
+# QUAY_TOKEN - The token of the robot account used to push images to
+# 'quay.io'.
+#
+# The machines that run this script need to have access to internet, so that
+# the built images can be pushed to quay.io.
+# =====================================================================================================================
+
+# The version should be a 7-char hash from git. This is what the deployment process in app-interface expects.
+VERSION=$(git rev-parse --short=7 HEAD)
+
+# Set image repository to default value if it is not passed via env
+IMAGE_REPOSITORY="${QUAY_IMAGE_REPOSITORY:-app-sre/acs-fleet-manager}"
+
+# Set the directory for docker configuration:
+DOCKER_CONFIG="${PWD}/.docker"
+
+# Log in to the image registry:
+if [ -z "${QUAY_USER}" ]; then
+  echo "The quay.io push user name hasn't been provided."
+  echo "Make sure to set the QUAY_USER environment variable."
+  exit 1
+fi
+if [ -z "${QUAY_TOKEN}" ]; then
+  echo "The quay.io push token hasn't been provided."
+  echo "Make sure to set the QUAY_TOKEN environment variable."
+  exit 1
+fi
+
+# Set up the docker config directory
+mkdir -p "${DOCKER_CONFIG}"
+
+BRANCH="main"
+if [[ -n "$GITHUB_REF" ]]; then
+  BRANCH="$(echo "$GITHUB_REF" | awk -F/ '{print $NF}')"
+  echo "GITHUB_REF is defined. Set image tag to $BRANCH."
+elif [[ -n "$GIT_BRANCH" ]]; then
+  BRANCH="$(echo "$GIT_BRANCH" | awk -F/ '{print $NF}')"
+  echo "GIT_BRANCH is defined. Set image tag to $BRANCH."
+else
+  echo "No git branch env var found. Set image tag to $BRANCH."
+fi
+
+# Push the image:
+echo "Quay.io user and token is set, will push images to $IMAGE_REPOSITORY"
+make \
+  DOCKER_CONFIG="${DOCKER_CONFIG}" \
+  QUAY_USER="${QUAY_USER}" \
+  QUAY_TOKEN="${QUAY_TOKEN}" \
+  TAG="${VERSION}" \
+  external_image_registry="quay.io" \
+  internal_image_registry="quay.io" \
+  image_repository="${IMAGE_REPOSITORY}" \
+  docker/login \
+  image/push
+
+make \
+  DOCKER_CONFIG="${DOCKER_CONFIG}" \
+  QUAY_USER="${QUAY_USER}" \
+  QUAY_TOKEN="${QUAY_TOKEN}" \
+  TAG="${BRANCH}" \
+  external_image_registry="quay.io" \
+  internal_image_registry="quay.io" \
+  image_repository="${IMAGE_REPOSITORY}" \
+  docker/login \
+  image/push

--- a/build_push_probe.sh
+++ b/build_push_probe.sh
@@ -15,15 +15,9 @@
 # limitations under the License.
 #
 
-# This script builds and deploys the Fleet Manager and Probe services. In order to
+# This script builds and deploys the Probe services. In order to
 # work, it needs the following variables defined in the CI/CD configuration of
 # the project:
-#
-# QUAY_USER - The name of the robot account used to push images to
-# 'quay.io', for example 'openshift-unified-hybrid-cloud+jenkins'.
-#
-# QUAY_TOKEN - The token of the robot account used to push images to
-# 'quay.io'.
 #
 # QUAY_PROBE_USER - The name of the robot account used to push images to
 # 'quay.io', for example 'openshift-unified-hybrid-cloud+jenkins'.
@@ -38,23 +32,12 @@
 VERSION=$(git rev-parse --short=7 HEAD)
 
 # Set image repository to default value if it is not passed via env
-IMAGE_REPOSITORY="${QUAY_IMAGE_REPOSITORY:-app-sre/acs-fleet-manager}"
 PROBE_IMAGE_REPOSITORY="${QUAY_PROBE_IMAGE_REPOSITORY:-rhacs-eng/blackbox-monitoring-probe-service}"
 
 # Set the directory for docker configuration:
 DOCKER_CONFIG="${PWD}/.docker"
 
 # Log in to the image registry:
-if [ -z "${QUAY_USER}" ]; then
-  echo "The quay.io push user name hasn't been provided."
-  echo "Make sure to set the QUAY_USER environment variable."
-  exit 1
-fi
-if [ -z "${QUAY_TOKEN}" ]; then
-  echo "The quay.io push token hasn't been provided."
-  echo "Make sure to set the QUAY_TOKEN environment variable."
-  exit 1
-fi
 if [ -z "${QUAY_PROBE_USER}" ]; then
   echo "The probe service quay.io push user name hasn't been provided."
   echo "Make sure to set the QUAY_PROBE_USER environment variable."
@@ -69,47 +52,26 @@ fi
 # Set up the docker config directory
 mkdir -p "${DOCKER_CONFIG}"
 
-BRANCH="main"
-if [[ -n "$GITHUB_REF" ]]; then
-  BRANCH="$(echo "$GITHUB_REF" | awk -F/ '{print $NF}')"
-  echo "GITHUB_REF is defined. Set image tag to $BRANCH."
-elif [[ -n "$GIT_BRANCH" ]]; then
-  BRANCH="$(echo "$GIT_BRANCH" | awk -F/ '{print $NF}')"
-  echo "GIT_BRANCH is defined. Set image tag to $BRANCH."
-else
-  echo "No git branch env var found. Set image tag to $BRANCH."
-fi
-
 # Push the image:
-echo "Quay.io user and token are set, will push images to $IMAGE_REPOSITORY and $PROBE_IMAGE_REPOSITORY."
+echo "Quay.io user and token are set, will push images to $PROBE_IMAGE_REPOSITORY."
 make \
   DOCKER_CONFIG="${DOCKER_CONFIG}" \
-  QUAY_USER="${QUAY_USER}" \
-  QUAY_TOKEN="${QUAY_TOKEN}" \
   QUAY_PROBE_USER="${QUAY_PROBE_USER}" \
   QUAY_PROBE_TOKEN="${QUAY_PROBE_TOKEN}" \
   TAG="${VERSION}" \
   external_image_registry="quay.io" \
   internal_image_registry="quay.io" \
-  image_repository="${IMAGE_REPOSITORY}" \
   probe_image_repository="${PROBE_IMAGE_REPOSITORY}" \
-  docker/login/fleet-manager \
-  image/push/fleet-manager \
   docker/login/probe \
   image/push/probe
 
 make \
   DOCKER_CONFIG="${DOCKER_CONFIG}" \
-  QUAY_USER="${QUAY_USER}" \
-  QUAY_TOKEN="${QUAY_TOKEN}" \
   QUAY_PROBE_USER="${QUAY_PROBE_USER}" \
   QUAY_PROBE_TOKEN="${QUAY_PROBE_TOKEN}" \
-  TAG="${BRANCH}" \
+  TAG="main" \
   external_image_registry="quay.io" \
   internal_image_registry="quay.io" \
-  image_repository="${IMAGE_REPOSITORY}" \
   probe_image_repository="${PROBE_IMAGE_REPOSITORY}" \
-  docker/login/fleet-manager \
-  image/push/fleet-manager \
   docker/login/probe \
   image/push/probe

--- a/build_push_with_probe.sh
+++ b/build_push_with_probe.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-# This script builds and deploys the  Fleet Manager and Probe services. In order to
+# This script builds and deploys the Fleet Manager and Probe services. In order to
 # work, it needs the following variables defined in the CI/CD configuration of
 # the project:
 #

--- a/build_push_with_probe.sh
+++ b/build_push_with_probe.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-# This script builds and deploys the Dinosaur Service Fleet Manager. In order to
+# This script builds and deploys the  Fleet Manager and Probe services. In order to
 # work, it needs the following variables defined in the CI/CD configuration of
 # the project:
 #


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This will fix stage deployment when [app-interface PR](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/52332) is merged 

- Split building script into two separate ones to avoid confusion. One is building main image and probe service and other one is running in app-interface and only builds fleet manager image for stage deployment
- Change script name so it reflects that it only build and pushes image
- Explicitly provide info in the script that it runs on AppSRE infra
