### PR TITLE
Drop temporary build and deploy script

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,3 +1,0 @@
-#!/bin/bash -e
-# Temporary transitional script until https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/52332/diffs is merged.
-exec "$(dirname "$0")/build_push_fleet_manager.sh" "$@"


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

[app-interface PR](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/52332) is merged so `build_deploy.sh` script is no longer needed because `build_push_fleet_manager.sh` will be used instead
