### PR TITLE
Fix `release-version` makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -861,7 +861,7 @@ full-image-tag:
 
 release_date="$(shell date '+%Y-%m-%d')"
 release_commit="$(shell git rev-parse --short=7 HEAD)"
-tag_count="$(shell git tag -l $(release_date)* | wc -l)"
+tag_count="$(shell git tag -l $(release_date)* | wc -l | xargs)" # use xargs to remove unnecessary whitespace
 start_rev=1
 rev="$(shell expr $(tag_count) + $(start_rev))"
 release-version:


### PR DESCRIPTION
## Description
Fix `release-version` makefile target

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Evaluated and added CHANGELOG.md entry if required
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

 - Run `make release-version` with existing tag `2022-11-23.2.377f59e`
 - Run `make release-version` without existing tag `2022-11-23.1.377f59e`