### PR TITLE
ROX-13621 Write cluster params to Parameter Store on cluster IDP setup

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -59,7 +59,7 @@ if [[ $CLUSTER_ENVIRONMENT != "$ENVIRONMENT" ]]; then
 fi
 
 load_external_config "cluster-${CLUSTER_NAME}" CLUSTER_
-oc login --token="${CLUSTER_ROBOT_OC_TOKEN}" --server="https://api.${CLUSTER_NAME}.${CLUSTER_URL_INFIX}.openshiftapps.com:6443"
+oc login --token="${CLUSTER_ROBOT_OC_TOKEN}" --server="$CLUSTER_URL"
 
 OPERATOR_USE_UPSTREAM=false
 OPERATOR_SOURCE="redhat-operators"

--- a/dp-terraform/osd-cluster-idp-setup.sh
+++ b/dp-terraform/osd-cluster-idp-setup.sh
@@ -41,6 +41,7 @@ case $ENVIRONMENT in
 
     # Load configuration
     init_chamber
+    load_external_config "ocm" OCM_
     load_external_config "cluster-$CLUSTER_NAME"
 
     if ! ocm list idps --cluster="${CLUSTER_NAME}" --columns name | grep -qE '^OpenID *$'; then
@@ -96,6 +97,7 @@ case $ENVIRONMENT in
 
     # Load configuration
     init_chamber
+    load_external_config "ocm" OCM_
     load_external_config "cluster-$CLUSTER_NAME"
 
     if ! ocm list idps --cluster="${CLUSTER_NAME}" --columns name | grep -qE '^HTPasswd *$'; then

--- a/dp-terraform/osd-cluster-idp-setup.sh
+++ b/dp-terraform/osd-cluster-idp-setup.sh
@@ -169,10 +169,8 @@ do
   attempt=$((attempt+1))
   ROBOT_TOKEN="$(oc get secret "${ROBOT_TOKEN_RESOURCE}" -n "$ROBOT_NS" -o json | jq -r 'if (has("data") and (.data|has("token"))) then (.data.token|@base64d) else "" end')"
   if [[ -n $ROBOT_TOKEN ]]; then
-    echo "Retrieved robot token:"
-    echo "$ROBOT_TOKEN"
-    echo "Please save this as parameter '/cluster-${CLUSTER_NAME}/robot_oc_token' in AWS parameter store at https://us-east-1.console.aws.amazon.com/systems-manager/parameters/?region=us-east-1&tab=Table"
-    # TODO(porridge): automate storing this in parameter store in a way suitable for terraform script.
+    echo "Saving robot token as parameter '/cluster-${CLUSTER_NAME}/robot_oc_token' in AWS parameter store..."
+    run_chamber write "cluster-$CLUSTER_NAME" "ROBOT_TOKEN" "$ROBOT_TOKEN" --skip-unchanged
     break
   fi
   if [[ $attempt -gt 30 ]]; then


### PR DESCRIPTION
## Description
This change brings more automation to the cluster terraforming workflow. There is no need to access Parameter store manually to save new cluster parameters anymore 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~- [ ] Unit and integration tests added~
- [x] Added test description under `Test manual`
~- [ ] Evaluated and added CHANGELOG.md entry if required~
~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
- tested manually
