### PR TITLE
ROX-13396: Add a warning message when there are no parameters for a service

### DIFF
--- a/scripts/lib/external_config.sh
+++ b/scripts/lib/external_config.sh
@@ -113,6 +113,6 @@ load_external_config() {
     local prefix="${2:-}"
     local env_output
     env_output=$(run_chamber env "$service")
-    [[ -z "$env_output" ]] && echo "WARNING: external configuration is empty for service '$service'"
+    [[ -z "$env_output" ]] && echo "WARNING: no parameters found under '/$service' in AWS parameter store of this environment"
     eval "$(echo "$env_output" | sed -E "s/(^export +)(.*)/\1${prefix}\2/")"
 }

--- a/scripts/lib/external_config.sh
+++ b/scripts/lib/external_config.sh
@@ -111,5 +111,8 @@ run_chamber() {
 load_external_config() {
     local service="$1"
     local prefix="${2:-}"
-    eval "$(run_chamber env "$service" | sed -E "s/(^export +)(.*)/\1${prefix}\2/")"
+    local env_output
+    env_output=$(run_chamber env "$service")
+    [[ -z "$env_output" ]] && echo "WARNING: external configuration is empty for service '$service'"
+    eval "$(echo "$env_output" | sed -E "s/(^export +)(.*)/\1${prefix}\2/")"
 }


### PR DESCRIPTION
## Description
This may help the script caller to troubleshoot the problem when some input is incorrect. For example:
1) Wrongly selected environment;
2) Wrongly selected cluster.

Currently in this case the script will fail with the message like:
```
./terraform_cluster.sh: line 62: CLUSTER_ROBOT_OC_TOKEN: unbound variable
```

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~- [ ] Unit and integration tests added~
- [x] Added test description under `Test manual`
- [x] Evaluated and added CHANGELOG.md entry if required
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual
Call terraform with non existing cluster 
```
$ ./terraform_cluster.sh stage acs-stage-dp-99
.... <truncated-output> ....
WARNING: external configuration is empty for service 'cluster-acs-stage-dp-99'
./terraform_cluster.sh: line 62: CLUSTER_ROBOT_OC_TOKEN: unbound variable
```
