### PR TITLE
Fix drop tty requirement from e2e staging run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -594,7 +594,7 @@ test/e2e/probe/run:
 	-e OCM_USERNAME="${OCM_USERNAME}" \
 	-e OCM_TOKEN="${OCM_TOKEN}" \
 	-e FLEET_MANAGER_ENDPOINT="${FLEET_MANAGER_ENDPOINT}" \
-	--rm -it $(IMAGE_REF) \
+	--rm $(IMAGE_REF) \
 	run
 .PHONY: test/e2e/probe/run
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Should fix staging e2e job
https://ci.ext.devshift.net/job/acs-fleet-manager-e2e-main/lastBuild/console
