### PR TITLE
ROX-13648: Compute - rather than hardcode - the image tag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This Changelog should be updated for:
 ## [NEXT RELEASE]
 ### Added
 ### Changed
+- Data Plane terraforming now deploys fleetshard image obtained dynamically rather than hardcoded in the script
 ### Deprecated
 ### Removed
 

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -30,18 +30,12 @@ load_external_config observability OBSERVABILITY_
 case $ENVIRONMENT in
   stage)
     FM_ENDPOINT="https://xtr6hh3mg6zc80v.api.stage.openshift.com"
-
-    FLEETSHARD_SYNC_TAG="1cf5fce"
-
     OBSERVABILITY_GITHUB_TAG="master"
     OBSERVABILITY_OBSERVATORIUM_GATEWAY="https://observatorium-mst.api.stage.openshift.com"
     ;;
 
   prod)
     FM_ENDPOINT="https://api.openshift.com"
-
-    FLEETSHARD_SYNC_TAG="1cf5fce"
-
     OBSERVABILITY_GITHUB_TAG="b864d5f155b5455bba78eb7b82bc4bf4190852c7"  # pragma: allowlist secret
     OBSERVABILITY_OBSERVATORIUM_GATEWAY="https://observatorium-mst.api.openshift.com"
     ;;
@@ -58,6 +52,9 @@ if [[ $CLUSTER_ENVIRONMENT != "$ENVIRONMENT" ]]; then
     exit 2
 fi
 
+# Get the first non-merge commit, starting with HEAD.
+# On main this should be HEAD, on production, the latest merged main commit.
+FLEETSHARD_SYNC_TAG="$(git rev-list --no-merges --max-count 1 --abbrev-commit --abbrev=7 HEAD)"
 "${SCRIPT_DIR}/check_image_exists.sh" "${FLEETSHARD_SYNC_TAG}"
 
 load_external_config "cluster-${CLUSTER_NAME}" CLUSTER_


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

The reason for not simply using `git rev-parse` is somewhat subtle, and laid out in detail in [the ticket](https://issues.redhat.com/browse/ROX-13648).

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~Unit and integration tests added~
- [x] Added test description under `Test manual`
- [x] Evaluated and added CHANGELOG.md entry if required
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...): Updated [checklist](https://docs.google.com/spreadsheets/d/1IgLtZqwpQ_4Pj0qe_8huW7KeDGyW9fss_gZOGx249Zc/edit#gid=170110566) and [environments page](https://docs.engineering.redhat.com/pages/viewpage.action?pageId=288990393#Environments(Dev,Stage,Prod)-HowtoBootstrap(akaTerraform)anOSDCluster).
- [x] CI and all relevant tests are passing
- [x] Changed the base branch to `main` once #611 is merged
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Ran the script manually and it correctly looked for the 7-char image tag
- based on current commit, when on this branch
- on the tip of *this* branch when ran from a temporary merge commit