### PR TITLE
ROX-13262: Implement AWS auth for RDS

### DIFF
--- a/dev/env/manifests/fleetshard-sync/01-fleetshard-sync-secrets.yaml
+++ b/dev/env/manifests/fleetshard-sync/01-fleetshard-sync-secrets.yaml
@@ -8,6 +8,4 @@ stringData:
     ${KUBE_CONFIG}
   rhsso-service-account-client-id: "${RHSSO_SERVICE_ACCOUNT_CLIENT_ID}"
   rhsso-service-account-client-secret: "${RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET}"
-  rds-access-key-id: "${MANAGED_DB_ACCESS_KEY_ID}"
-  rds-secret-access-key: "${MANAGED_DB_SECRET_ACCESS_KEY}"
-  rds-sesion-token: "${MANAGED_DB_SESSION_TOKEN}"
+  aws-role-arn: "${AWS_ROLE_ARN}"

--- a/dev/env/manifests/fleetshard-sync/02-fleetshard-sync-deployment.yaml
+++ b/dev/env/manifests/fleetshard-sync/02-fleetshard-sync-deployment.yaml
@@ -49,24 +49,12 @@ spec:
               value: "$MANAGED_DB_SECURITY_GROUP"
             - name: MANAGED_DB_SUBNET_GROUP
               value: "$MANAGED_DB_SUBNET_GROUP"
-            - name: MANAGED_DB_ACCESS_KEY_ID
+            - name: AWS_ROLE_ARN
               valueFrom:
                 secretKeyRef:
                   name: fleetshard-sync
-                  key: "rds-access-key-id"
-                  optional: true
-            - name: MANAGED_DB_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: fleetshard-sync
-                  key: "rds-secret-access-key"
-                  optional: true
-            - name: MANAGED_DB_SESSION_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: fleetshard-sync
-                  key: "rds-sesion-token"
-                  optional: true
+                  key: "aws-role-arn"
+
           image: "${FLEET_MANAGER_IMAGE}"
           imagePullPolicy: IfNotPresent
           name: fleetshard-sync

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -50,8 +50,13 @@ func GetConfig() (*Config, error) {
 	if c.AuthType == "" {
 		configErrors.AddError(errors.New("AUTH_TYPE unset in the environment"))
 	}
-	if c.ManagedDBEnabled && c.AWSRoleARN == "" {
-		configErrors.AddError(errors.New("MANAGED_DB_ENABLED == true and AWS_ROLE_ARN unset in the environment"))
+	if c.ManagedDBEnabled {
+		if c.AWSRoleARN == "" {
+			configErrors.AddError(errors.New("MANAGED_DB_ENABLED == true and AWS_ROLE_ARN unset in the environment"))
+		}
+		if c.ManagedDBSecurityGroup == "" {
+			configErrors.AddError(errors.New("MANAGED_DB_ENABLED == true and MANAGED_DB_SECURITY_GROUP unset in the environment"))
+		}
 	}
 	cfgErr := configErrors.ToError()
 	if cfgErr != nil {

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -50,8 +50,8 @@ func GetConfig() (*Config, error) {
 	if c.AuthType == "" {
 		configErrors.AddError(errors.New("AUTH_TYPE unset in the environment"))
 	}
-	if c.AWSRoleARN == "" {
-		configErrors.AddError(errors.New("AWS_ROLE_ARN unset in the environment"))
+	if c.ManagedDBEnabled && c.AWSRoleARN == "" {
+		configErrors.AddError(errors.New("MANAGED_DB_ENABLED == true and AWS_ROLE_ARN unset in the environment"))
 	}
 	cfgErr := configErrors.ToError()
 	if cfgErr != nil {

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -25,12 +25,22 @@ type Config struct {
 	CreateAuthProvider   bool          `env:"CREATE_AUTH_PROVIDER" envDefault:"false"`
 	MetricsAddress       string        `env:"FLEETSHARD_METRICS_ADDRESS" envDefault:":8080"`
 	EgressProxyImage     string        `env:"EGRESS_PROXY_IMAGE"`
-	AWSRegion            string        `env:"AWS_REGION" envDefault:"us-east-1"`
-	AWSRoleARN           string        `env:"AWS_ROLE_ARN"`
 
-	ManagedDBEnabled       bool   `env:"MANAGED_DB_ENABLED" envDefault:"false"`
-	ManagedDBSecurityGroup string `env:"MANAGED_DB_SECURITY_GROUP"`
-	ManagedDBSubnetGroup   string `env:"MANAGED_DB_SUBNET_GROUP"`
+	AWS       AWS
+	ManagedDB ManagedDB
+}
+
+// AWS for configuring AWS specific parameters
+type AWS struct {
+	Region  string `env:"AWS_REGION" envDefault:"us-east-1"`
+	RoleARN string `env:"AWS_ROLE_ARN"`
+}
+
+// ManagedDB for configuring managed DB specific parameters
+type ManagedDB struct {
+	Enabled       bool   `env:"MANAGED_DB_ENABLED" envDefault:"false"`
+	SecurityGroup string `env:"MANAGED_DB_SECURITY_GROUP"`
+	SubnetGroup   string `env:"MANAGED_DB_SUBNET_GROUP"`
 }
 
 // GetConfig retrieves the current runtime configuration from the environment and returns it.
@@ -50,7 +60,7 @@ func GetConfig() (*Config, error) {
 	if c.AuthType == "" {
 		configErrors.AddError(errors.New("AUTH_TYPE unset in the environment"))
 	}
-	validateManagedDBConfig(c, configErrors)
+	validateManagedDBConfig(c, &configErrors)
 
 	cfgErr := configErrors.ToError()
 	if cfgErr != nil {
@@ -59,14 +69,14 @@ func GetConfig() (*Config, error) {
 	return &c, nil
 }
 
-func validateManagedDBConfig(c Config, configErrors errorhelpers.ErrorList) {
-	if !c.ManagedDBEnabled {
+func validateManagedDBConfig(c Config, configErrors *errorhelpers.ErrorList) {
+	if !c.ManagedDB.Enabled {
 		return
 	}
-	if c.AWSRoleARN == "" {
+	if c.AWS.RoleARN == "" {
 		configErrors.AddError(errors.New("MANAGED_DB_ENABLED == true and AWS_ROLE_ARN unset in the environment"))
 	}
-	if c.ManagedDBSecurityGroup == "" {
+	if c.ManagedDB.SecurityGroup == "" {
 		configErrors.AddError(errors.New("MANAGED_DB_ENABLED == true and MANAGED_DB_SECURITY_GROUP unset in the environment"))
 	}
 }

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -25,13 +25,12 @@ type Config struct {
 	CreateAuthProvider   bool          `env:"CREATE_AUTH_PROVIDER" envDefault:"false"`
 	MetricsAddress       string        `env:"FLEETSHARD_METRICS_ADDRESS" envDefault:":8080"`
 	EgressProxyImage     string        `env:"EGRESS_PROXY_IMAGE"`
+	AWSRegion            string        `env:"AWS_REGION" envDefault:"us-east-1"`
+	AWSRoleARN           string        `env:"AWS_ROLE_ARN"`
 
-	ManagedDBEnabled         bool   `env:"MANAGED_DB_ENABLED" envDefault:"false"`
-	ManagedDBSecurityGroup   string `env:"MANAGED_DB_SECURITY_GROUP"`
-	ManagedDBSubnetGroup     string `env:"MANAGED_DB_SUBNET_GROUP"`
-	ManagedDBAccessKeyID     string `env:"MANAGED_DB_ACCESS_KEY_ID"`
-	ManagedDBSecretAccessKey string `env:"MANAGED_DB_SECRET_ACCESS_KEY"`
-	ManagedDBSessionToken    string `env:"MANAGED_DB_SESSION_TOKEN"` // needed for local testing with STS only
+	ManagedDBEnabled       bool   `env:"MANAGED_DB_ENABLED" envDefault:"false"`
+	ManagedDBSecurityGroup string `env:"MANAGED_DB_SECURITY_GROUP"`
+	ManagedDBSubnetGroup   string `env:"MANAGED_DB_SUBNET_GROUP"`
 }
 
 // GetConfig retrieves the current runtime configuration from the environment and returns it.
@@ -50,6 +49,9 @@ func GetConfig() (*Config, error) {
 	}
 	if c.AuthType == "" {
 		configErrors.AddError(errors.New("AUTH_TYPE unset in the environment"))
+	}
+	if c.AWSRoleARN == "" {
+		configErrors.AddError(errors.New("AWS_ROLE_ARN unset in the environment"))
 	}
 	cfgErr := configErrors.ToError()
 	if cfgErr != nil {

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -50,17 +50,23 @@ func GetConfig() (*Config, error) {
 	if c.AuthType == "" {
 		configErrors.AddError(errors.New("AUTH_TYPE unset in the environment"))
 	}
-	if c.ManagedDBEnabled {
-		if c.AWSRoleARN == "" {
-			configErrors.AddError(errors.New("MANAGED_DB_ENABLED == true and AWS_ROLE_ARN unset in the environment"))
-		}
-		if c.ManagedDBSecurityGroup == "" {
-			configErrors.AddError(errors.New("MANAGED_DB_ENABLED == true and MANAGED_DB_SECURITY_GROUP unset in the environment"))
-		}
-	}
+	validateManagedDBConfig(c, configErrors)
+
 	cfgErr := configErrors.ToError()
 	if cfgErr != nil {
 		return nil, errors.Wrap(cfgErr, "unexpected configuration settings")
 	}
 	return &c, nil
+}
+
+func validateManagedDBConfig(c Config, configErrors errorhelpers.ErrorList) {
+	if !c.ManagedDBEnabled {
+		return
+	}
+	if c.AWSRoleARN == "" {
+		configErrors.AddError(errors.New("MANAGED_DB_ENABLED == true and AWS_ROLE_ARN unset in the environment"))
+	}
+	if c.ManagedDBSecurityGroup == "" {
+		configErrors.AddError(errors.New("MANAGED_DB_ENABLED == true and MANAGED_DB_SECURITY_GROUP unset in the environment"))
+	}
 }

--- a/fleetshard/config/config_test.go
+++ b/fleetshard/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -11,9 +10,6 @@ import (
 
 func TestSingleton_Success(t *testing.T) {
 	t.Setenv("CLUSTER_ID", "some-value")
-	t.Cleanup(func() {
-		_ = os.Unsetenv("CLUSTER_ID")
-	})
 	cfg, err := GetConfig()
 	require.NoError(t, err)
 	assert.Equal(t, cfg.FleetManagerEndpoint, "http://127.0.0.1:8000")
@@ -26,8 +22,6 @@ func TestSingleton_Success(t *testing.T) {
 }
 
 func TestSingleton_Failure(t *testing.T) {
-	t.Cleanup(func() {
-	})
 	cfg, err := GetConfig()
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
@@ -38,27 +32,18 @@ func TestSingleton_Success_WhenManagedDBEnabled(t *testing.T) {
 	t.Setenv("AWS_ROLE_ARN", "arn:aws:iam::012456789:role/fake_role")
 	t.Setenv("MANAGED_DB_ENABLED", "true")
 	t.Setenv("MANAGED_DB_SECURITY_GROUP", "some-group")
-	t.Cleanup(func() {
-		_ = os.Unsetenv("CLUSTER_ID")
-		_ = os.Unsetenv("AWS_ROLE_ARN")
-		_ = os.Unsetenv("MANAGED_DB_ENABLED")
-		_ = os.Unsetenv("MANAGED_DB_SECURITY_GROUP")
-	})
 	cfg, err := GetConfig()
 	require.NoError(t, err)
-	assert.Equal(t, cfg.AWSRoleARN, "arn:aws:iam::012456789:role/fake_role")
-	assert.Equal(t, cfg.AWSRegion, "us-east-1")
+	assert.Equal(t, cfg.AWS.RoleARN, "arn:aws:iam::012456789:role/fake_role")
+	assert.Equal(t, cfg.AWS.Region, "us-east-1")
+	assert.Equal(t, cfg.ManagedDB.Enabled, true)
+	assert.Equal(t, cfg.ManagedDB.SecurityGroup, "some-group")
 }
 
 func TestSingleton_Failure_WhenManagedDBEnabledAndAWSRoleArnNotSet(t *testing.T) {
 	t.Setenv("CLUSTER_ID", "some-value")
 	t.Setenv("MANAGED_DB_ENABLED", "true")
 	t.Setenv("MANAGED_DB_SECURITY_GROUP", "some-group")
-	t.Cleanup(func() {
-		_ = os.Unsetenv("CLUSTER_ID")
-		_ = os.Unsetenv("MANAGED_DB_ENABLED")
-		_ = os.Unsetenv("MANAGED_DB_SECURITY_GROUP")
-	})
 	cfg, err := GetConfig()
 	assert.Error(t, err, "MANAGED_DB_ENABLED == true and AWS_ROLE_ARN unset in the environment")
 	assert.Nil(t, cfg)
@@ -68,12 +53,6 @@ func TestSingleton_Failure_WhenManagedDBEnabledAndManagedDbSecurityGroupNotSet(t
 	t.Setenv("CLUSTER_ID", "some-value")
 	t.Setenv("MANAGED_DB_ENABLED", "true")
 	t.Setenv("AWS_ROLE_ARN", "arn:aws:iam::012456789:role/fake_role")
-
-	t.Cleanup(func() {
-		_ = os.Unsetenv("CLUSTER_ID")
-		_ = os.Unsetenv("MANAGED_DB_ENABLED")
-		_ = os.Unsetenv("AWS_ROLE_ARN")
-	})
 	cfg, err := GetConfig()
 	assert.Error(t, err, "MANAGED_DB_ENABLED == true and MANAGED_DB_SECURITY_GROUP unset in the environment")
 	assert.Nil(t, cfg)

--- a/fleetshard/config/config_test.go
+++ b/fleetshard/config/config_test.go
@@ -37,10 +37,12 @@ func TestSingleton_Success_WhenManagedDBEnabled(t *testing.T) {
 	t.Setenv("CLUSTER_ID", "some-value")
 	t.Setenv("AWS_ROLE_ARN", "arn:aws:iam::012456789:role/fake_role")
 	t.Setenv("MANAGED_DB_ENABLED", "true")
+	t.Setenv("MANAGED_DB_SECURITY_GROUP", "some-group")
 	t.Cleanup(func() {
 		_ = os.Unsetenv("CLUSTER_ID")
 		_ = os.Unsetenv("AWS_ROLE_ARN")
 		_ = os.Unsetenv("MANAGED_DB_ENABLED")
+		_ = os.Unsetenv("MANAGED_DB_SECURITY_GROUP")
 	})
 	cfg, err := GetConfig()
 	require.NoError(t, err)
@@ -51,11 +53,28 @@ func TestSingleton_Success_WhenManagedDBEnabled(t *testing.T) {
 func TestSingleton_Failure_WhenManagedDBEnabledAndAWSRoleArnNotSet(t *testing.T) {
 	t.Setenv("CLUSTER_ID", "some-value")
 	t.Setenv("MANAGED_DB_ENABLED", "true")
+	t.Setenv("MANAGED_DB_SECURITY_GROUP", "some-group")
 	t.Cleanup(func() {
 		_ = os.Unsetenv("CLUSTER_ID")
 		_ = os.Unsetenv("MANAGED_DB_ENABLED")
+		_ = os.Unsetenv("MANAGED_DB_SECURITY_GROUP")
 	})
 	cfg, err := GetConfig()
 	assert.Error(t, err, "MANAGED_DB_ENABLED == true and AWS_ROLE_ARN unset in the environment")
+	assert.Nil(t, cfg)
+}
+
+func TestSingleton_Failure_WhenManagedDBEnabledAndManagedDbSecurityGroupNotSet(t *testing.T) {
+	t.Setenv("CLUSTER_ID", "some-value")
+	t.Setenv("MANAGED_DB_ENABLED", "true")
+	t.Setenv("AWS_ROLE_ARN", "arn:aws:iam::012456789:role/fake_role")
+
+	t.Cleanup(func() {
+		_ = os.Unsetenv("CLUSTER_ID")
+		_ = os.Unsetenv("MANAGED_DB_ENABLED")
+		_ = os.Unsetenv("AWS_ROLE_ARN")
+	})
+	cfg, err := GetConfig()
+	assert.Error(t, err, "MANAGED_DB_ENABLED == true and MANAGED_DB_SECURITY_GROUP unset in the environment")
 	assert.Nil(t, cfg)
 }

--- a/fleetshard/config/config_test.go
+++ b/fleetshard/config/config_test.go
@@ -32,3 +32,30 @@ func TestSingleton_Failure(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 }
+
+func TestSingleton_Success_WhenManagedDBEnabled(t *testing.T) {
+	t.Setenv("CLUSTER_ID", "some-value")
+	t.Setenv("AWS_ROLE_ARN", "arn:aws:iam::012456789:role/fake_role")
+	t.Setenv("MANAGED_DB_ENABLED", "true")
+	t.Cleanup(func() {
+		_ = os.Unsetenv("CLUSTER_ID")
+		_ = os.Unsetenv("AWS_ROLE_ARN")
+		_ = os.Unsetenv("MANAGED_DB_ENABLED")
+	})
+	cfg, err := GetConfig()
+	require.NoError(t, err)
+	assert.Equal(t, cfg.AWSRoleARN, "arn:aws:iam::012456789:role/fake_role")
+	assert.Equal(t, cfg.AWSRegion, "us-east-1")
+}
+
+func TestSingleton_Failure_WhenManagedDBEnabledAndAWSRoleArnNotSet(t *testing.T) {
+	t.Setenv("CLUSTER_ID", "some-value")
+	t.Setenv("MANAGED_DB_ENABLED", "true")
+	t.Cleanup(func() {
+		_ = os.Unsetenv("CLUSTER_ID")
+		_ = os.Unsetenv("MANAGED_DB_ENABLED")
+	})
+	cfg, err := GetConfig()
+	assert.Error(t, err, "MANAGED_DB_ENABLED == true and AWS_ROLE_ARN unset in the environment")
+	assert.Nil(t, cfg)
+}

--- a/fleetshard/main.go
+++ b/fleetshard/main.go
@@ -36,9 +36,9 @@ func main() {
 	glog.Infof("RuntimePollPeriod: %s", config.RuntimePollPeriod.String())
 	glog.Infof("AuthType: %s", config.AuthType)
 
-	glog.Infof("ManagedDBEnabled: %t", config.ManagedDBEnabled)
-	glog.Infof("ManagedDBSecurityGroup: %s", config.ManagedDBSecurityGroup)
-	glog.Infof("ManagedDBSubnetGroup: %s", config.ManagedDBSubnetGroup)
+	glog.Infof("ManagedDB.Enabled: %t", config.ManagedDB.Enabled)
+	glog.Infof("ManagedDB.SecurityGroup: %s", config.ManagedDB.SecurityGroup)
+	glog.Infof("ManagedDB.SubnetGroup: %s", config.ManagedDB.SubnetGroup)
 
 	runtime, err := runtime.NewRuntime(config, k8s.CreateClientOrDie())
 	if err != nil {

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
@@ -10,9 +10,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	awscredentials "github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/golang/glog"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/config"
+	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
 )
 
 const (
@@ -261,16 +265,16 @@ func (r *RDS) waitForInstanceToBeAvailable(ctx context.Context, instanceID strin
 }
 
 // NewRDSClient initializes a new awsclient.RDS
-func NewRDSClient(awsRegion, dbSecurityGroup, dbSubnetGroup string, credentials AWSCredentials) (*RDS, error) {
-	rdsClient, err := newRdsClient(awsRegion, credentials.AccessKeyID, credentials.SecretAccessKey, credentials.SessionToken)
+func NewRDSClient(config *config.Config, auth fleetmanager.Auth) (*RDS, error) {
+	rdsClient, err := newRdsClient(config, auth)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create RDS client, %w", err)
 	}
 
 	return &RDS{
 		rdsClient:       rdsClient,
-		dbSecurityGroup: dbSecurityGroup,
-		dbSubnetGroup:   dbSubnetGroup,
+		dbSecurityGroup: config.ManagedDBSecurityGroup,
+		dbSubnetGroup:   config.ManagedDBSubnetGroup,
 	}, nil
 }
 
@@ -324,19 +328,37 @@ func newDeleteCentralDBClusterInput(clusterID string, skipFinalSnapshot bool) *r
 	}
 }
 
-func newRdsClient(awsRegion, accessKeyID, secretAccessKey, sessionToken string) (*rds.RDS, error) {
+func newRdsClient(config *config.Config, auth fleetmanager.Auth) (*rds.RDS, error) {
 	cfg := &aws.Config{
-		Region: aws.String(awsRegion),
-		Credentials: awscredentials.NewStaticCredentials(
-			accessKeyID,
-			secretAccessKey,
-			sessionToken),
+		Region: aws.String(config.AWSRegion),
 	}
-
 	sess, err := session.NewSession(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create session, %w", err)
+		return nil, fmt.Errorf("unable to create session for STS client, %w", err)
+	}
+	stsClient := sts.New(sess)
+
+	roleProvider := stscreds.NewWebIdentityRoleProviderWithOptions(stsClient, config.AWSRoleARN, "gosession",
+		&tokenFetcher{auth: auth})
+
+	cfg.Credentials = awscredentials.NewCredentials(roleProvider)
+
+	sess, err = session.NewSession(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create session for RDS client, %w", err)
 	}
 
 	return rds.New(sess), nil
+}
+
+type tokenFetcher struct {
+	auth fleetmanager.Auth
+}
+
+func (f *tokenFetcher) FetchToken(_ awscredentials.Context) ([]byte, error) {
+	token, err := f.auth.RetrieveIDToken()
+	if err != nil {
+		return nil, fmt.Errorf("retrieving token from token source: %w", err)
+	}
+	return []byte(token), nil
 }

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/service/sts"
 	openshiftRouteV1 "github.com/openshift/api/route/v1"
 	"github.com/pkg/errors"
@@ -155,9 +156,11 @@ func TestReconcileCreateWithManagedDBNoCredentials(t *testing.T) {
 			ManagedDBEnabled: true})
 
 	_, err = r.Reconcile(context.TODO(), simpleManagedCentral)
-	var awsErr awserr.Error
+	var awsErr, awsOrigErr awserr.Error
 	require.ErrorAs(t, err, &awsErr)
-	assert.Equal(t, awsErr.Code(), sts.ErrCodeInvalidIdentityTokenException)
+	assert.Equal(t, awsErr.Code(), stscreds.ErrCodeWebIdentity)
+	require.ErrorAs(t, awsErr.OrigErr(), &awsOrigErr)
+	assert.Equal(t, awsOrigErr.Code(), sts.ErrCodeInvalidIdentityTokenException)
 }
 
 func TestReconcileUpdateSucceeds(t *testing.T) {

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -71,7 +71,7 @@ func NewRuntime(config *config.Config, k8sClient ctrlClient.Client) (*Runtime, e
 		return nil, errors.Wrap(err, "failed to create fleet manager client")
 	}
 	var dbProvisionClient cloudprovider.DBClient
-	if config.ManagedDBEnabled {
+	if config.ManagedDB.Enabled {
 		dbProvisionClient, err = awsclient.NewRDSClient(config, auth)
 		if err != nil {
 			return nil, fmt.Errorf("creating managed DB provisioning client: %v", err)
@@ -103,7 +103,7 @@ func (r *Runtime) Start() error {
 		UseRoutes:         routesAvailable,
 		WantsAuthProvider: r.config.CreateAuthProvider,
 		EgressProxyImage:  r.config.EgressProxyImage,
-		ManagedDBEnabled:  r.config.ManagedDBEnabled,
+		ManagedDBEnabled:  r.config.ManagedDB.Enabled,
 	}
 
 	ticker := concurrency.NewRetryTicker(func(ctx context.Context) (timeToNextTick time.Duration, err error) {

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -36,12 +36,13 @@ var backoff = wait.Backoff{
 
 // Runtime represents the runtime to reconcile all centrals associated with the given cluster.
 type Runtime struct {
-	config           *config.Config
-	client           *fleetmanager.Client
-	clusterID        string
-	reconcilers      reconcilerRegistry
-	k8sClient        ctrlClient.Client
-	statusResponseCh chan private.DataPlaneCentralStatus
+	config            *config.Config
+	client            *fleetmanager.Client
+	clusterID         string
+	reconcilers       reconcilerRegistry
+	k8sClient         ctrlClient.Client
+	dbProvisionClient cloudprovider.DBClient
+	statusResponseCh  chan private.DataPlaneCentralStatus
 }
 
 // NewRuntime creates a new runtime
@@ -69,13 +70,21 @@ func NewRuntime(config *config.Config, k8sClient ctrlClient.Client) (*Runtime, e
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create fleet manager client")
 	}
+	var dbProvisionClient cloudprovider.DBClient
+	if config.ManagedDBEnabled {
+		dbProvisionClient, err = awsclient.NewRDSClient(config, auth)
+		if err != nil {
+			return nil, fmt.Errorf("creating managed DB provisioning client: %v", err)
+		}
+	}
 
 	return &Runtime{
-		config:      config,
-		k8sClient:   k8sClient,
-		client:      client,
-		clusterID:   config.ClusterID,
-		reconcilers: make(reconcilerRegistry),
+		config:            config,
+		k8sClient:         k8sClient,
+		client:            client,
+		clusterID:         config.ClusterID,
+		dbProvisionClient: dbProvisionClient,
+		reconcilers:       make(reconcilerRegistry),
 	}, nil
 }
 
@@ -109,13 +118,7 @@ func (r *Runtime) Start() error {
 		glog.Infof("Received %d centrals", len(list.Items))
 		for _, central := range list.Items {
 			if _, ok := r.reconcilers[central.Id]; !ok {
-				var managedDBProvisioningClient cloudprovider.DBClient
-				if r.config.ManagedDBEnabled {
-					if managedDBProvisioningClient, err = r.createDBProvisioningClient(); err != nil {
-						return 0, err
-					}
-				}
-				r.reconcilers[central.Id] = centralReconciler.NewCentralReconciler(r.k8sClient, central, managedDBProvisioningClient, reconcilerOpts)
+				r.reconcilers[central.Id] = centralReconciler.NewCentralReconciler(r.k8sClient, central, r.dbProvisionClient, reconcilerOpts)
 			}
 
 			reconciler := r.reconcilers[central.Id]
@@ -145,25 +148,6 @@ func (r *Runtime) Start() error {
 	}
 
 	return nil
-}
-
-func (r *Runtime) createDBProvisioningClient() (*awsclient.RDS, error) {
-	const awsRegion = "us-east-1" // TODO(ROX-13699): do not hardcode AWS region
-	rds, err := awsclient.NewRDSClient(
-		awsRegion,
-		r.config.ManagedDBSecurityGroup,
-		r.config.ManagedDBSubnetGroup, awsclient.AWSCredentials{
-			AccessKeyID:     r.config.ManagedDBAccessKeyID,
-			SecretAccessKey: r.config.ManagedDBSecretAccessKey, //pragma: allowlist secret
-			SessionToken:    r.config.ManagedDBSessionToken,
-		})
-	if err != nil {
-		err = fmt.Errorf("creating managed DB provisioning client: %v", err)
-		glog.Error(err)
-		return nil, err
-	}
-
-	return rds, nil
 }
 
 func (r *Runtime) handleReconcileResult(central private.ManagedCentral, status *private.DataPlaneCentralStatus, err error) {


### PR DESCRIPTION
## Description
This PR adds AWS authorization for fleedshard-sync using RHSSO identity provider.
Fleetshard-sync uses RHSSO client credentials to get an ID token. Then it calls AWS STS to assume the fleetshard-sync-service role using the RH SSO ID token.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [x] ~Evaluated and added CHANGELOG.md entry if required~
- [x] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
Tested on a local cluster.

##### Prerequisites:
1. Operator upgraded to 3.73.0
2. AWS account configured

##### Steps:
1. `export MANAGED_DB_ENABLED=true`
3. `make deploy/dev`
4. Create Central
5. Ensure that create Aurora DB request is propagated to AWS
6. Wait until DB is provisioned
7. Delete Central Instance
8. Ensure that Aurora DB instance is deprovisioned.

Not tested: 
- Due to the lack of connectivity it is unable to test Central connection to DB. 

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
