### PR TITLE
ROX-13593: Add telemetry storage options to managed Centrals

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-telemetry-storage-key.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-telemetry-storage-key.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhacs-telemetry-storage-key
+  namespace: {{ .Release.Namespace | quote }}
+stringData:
+  KEY: {{ .Values.telemetry.storage.key | quote }}
+type: Opaque

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-telemetry-storage-key.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-telemetry-storage-key.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rhacs-telemetry-storage-key
-  namespace: {{ .Release.Namespace | quote }}
-stringData:
-  KEY: {{ .Values.telemetry.storage.key | quote }}
-type: Opaque

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -48,12 +48,9 @@ spec:
             - name: RHSSO_ENDPOINT
               value: {{ .Values.fleetshardSync.redHatSSO.endpoint }}
             - name: TELEMETRY_ENDPOINT
-              value: {{ .Values.fleetshardSync.telemetry.storage.endpoint }}
+              value: {{ .Values.fleetshardSync.telemetry.storage.endpoint | quote }}
             - name: TELEMETRY_STORAGE_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: rhacs-telemetry-storage-key
-                  key: KEY
+              value: {{ .Values.fleetshardSync.telemetry.storage.key | quote }}
           ports:
             - name: monitoring
               containerPort: 8080

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -19,34 +19,41 @@ spec:
     spec:
       serviceAccountName: fleetshard-sync
       containers:
-      - name: fleetshard-sync
-        image: {{ .Values.fleetshardSync.image | quote }}
-        imagePullPolicy: IfNotPresent
-        command:
-        - /usr/local/bin/fleetshard-sync
-        env:
-        - name: OCM_TOKEN
-          value: {{ .Values.fleetshardSync.ocmToken }}
-        - name: FLEET_MANAGER_ENDPOINT
-          value: {{ .Values.fleetshardSync.fleetManagerEndpoint }}
-        - name: CLUSTER_ID
-          value: {{ .Values.fleetshardSync.clusterId }}
-        - name: CREATE_AUTH_PROVIDER
-          value: "{{ .Values.fleetshardSync.createAuthProvider }}"
-        - name: AUTH_TYPE
-          value: {{ .Values.fleetshardSync.authType }}
-        - name: STATIC_TOKEN
-          value: {{ .Values.fleetshardSync.staticToken }}
-        - name: EGRESS_PROXY_IMAGE
-          value: {{ .Values.fleetshardSync.egressProxy.image | quote }}
-        - name: RHSSO_SERVICE_ACCOUNT_CLIENT_ID
-          value: {{ .Values.fleetshardSync.redHatSSO.clientId }}
-        - name: RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET
-          value: {{ .Values.fleetshardSync.redHatSSO.clientSecret }}
-        - name: RHSSO_REALM
-          value: {{ .Values.fleetshardSync.redHatSSO.realm }}
-        - name: RHSSO_ENDPOINT
-          value: {{ .Values.fleetshardSync.redHatSSO.endpoint }}
-        ports:
-        - name: monitoring
-          containerPort: 8080
+        - name: fleetshard-sync
+          image: {{ .Values.fleetshardSync.image | quote }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /usr/local/bin/fleetshard-sync
+          env:
+            - name: OCM_TOKEN
+              value: {{ .Values.fleetshardSync.ocmToken }}
+            - name: FLEET_MANAGER_ENDPOINT
+              value: {{ .Values.fleetshardSync.fleetManagerEndpoint }}
+            - name: CLUSTER_ID
+              value: {{ .Values.fleetshardSync.clusterId }}
+            - name: CREATE_AUTH_PROVIDER
+              value: {{ .Values.fleetshardSync.createAuthProvider }}
+            - name: AUTH_TYPE
+              value: {{ .Values.fleetshardSync.authType }}
+            - name: STATIC_TOKEN
+              value: {{ .Values.fleetshardSync.staticToken }}
+            - name: EGRESS_PROXY_IMAGE
+              value: {{ .Values.fleetshardSync.egressProxy.image | quote }}
+            - name: RHSSO_SERVICE_ACCOUNT_CLIENT_ID
+              value: {{ .Values.fleetshardSync.redHatSSO.clientId }}
+            - name: RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET
+              value: {{ .Values.fleetshardSync.redHatSSO.clientSecret }}
+            - name: RHSSO_REALM
+              value: {{ .Values.fleetshardSync.redHatSSO.realm }}
+            - name: RHSSO_ENDPOINT
+              value: {{ .Values.fleetshardSync.redHatSSO.endpoint }}
+            - name: TELEMETRY_ENDPOINT
+              value: {{ .Values.fleetshardSync.telemetry.storage.endpoint }}
+            - name: TELEMETRY_STORAGE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: rhacs-telemetry-storage-key
+                  key: KEY
+          ports:
+            - name: monitoring
+              containerPort: 8080

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -91,6 +91,8 @@ helm upgrade rhacs-terraform "${SCRIPT_DIR}" \
   --set fleetshardSync.fleetManagerEndpoint="${FM_ENDPOINT}" \
   --set fleetshardSync.redHatSSO.clientId="${FLEETSHARD_SYNC_RHSSO_SERVICE_ACCOUNT_CLIENT_ID}" \
   --set fleetshardSync.redHatSSO.clientSecret="${FLEETSHARD_SYNC_RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET}" \
+  --set fleetshardSync.telemetry.storage.endpoint="${FLEETSHARD_SYNC_TELEMETRY_ENDPOINT}" \
+  --set fleetshardSync.telemetry.storage.key="${FLEETSHARD_SYNC_TELEMETRY_STORAGE_KEY}" \
   --set logging.aws.accessKeyId="${LOGGING_AWS_ACCESS_KEY_ID}" \
   --set logging.aws.secretAccessKey="${LOGGING_AWS_SECRET_ACCESS_KEY}" \
   --set observability.github.accessToken="${OBSERVABILITY_GITHUB_ACCESS_TOKEN}" \

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -25,6 +25,11 @@ fleetshardSync:
     realm: "redhat-external"
   egressProxy:
     image: "registry.redhat.io/openshift4/ose-egress-http-proxy:v4.11.0"
+  # API key to push telemetry data to a remote backend. Leaving it empty disables telemetry.
+  telemetry:
+    storage:
+      endpoint: ""
+      key: ""
 
 acsOperator:
   enabled: false

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -25,6 +25,8 @@ type Config struct {
 	CreateAuthProvider   bool          `env:"CREATE_AUTH_PROVIDER" envDefault:"false"`
 	MetricsAddress       string        `env:"FLEETSHARD_METRICS_ADDRESS" envDefault:":8080"`
 	EgressProxyImage     string        `env:"EGRESS_PROXY_IMAGE"`
+	TelemetryEndpoint    string        `env:"TELEMETRY_ENDPOINT"`
+	TelemetryStorageKey  string        `env:"TELEMETRY_STORAGE_KEY"`
 
 	ManagedDBEnabled         bool   `env:"MANAGED_DB_ENABLED" envDefault:"false"`
 	ManagedDBSecurityGroup   string `env:"MANAGED_DB_SECURITY_GROUP"`

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -112,9 +112,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		return nil, errors.Wrap(err, "converting Scanner DB resources")
 	}
 
-	// Set proxy configuration
 	proxyEnvVars := getProxyEnvVars(remoteCentralNamespace)
-	// Set telemetry storage key
 	telemetryEnvVars := getTelemetryEnvVars(r.telemetryOpts)
 	envVars := append(proxyEnvVars, telemetryEnvVars...)
 

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -113,7 +113,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	}
 
 	proxyEnvVars := getProxyEnvVars(remoteCentralNamespace)
-	telemetryEnvVars := getTelemetryEnvVars(r.telemetryOpts)
+	telemetryEnvVars := r.telemetryOpts.toEnvVars()
 	envVars := append(proxyEnvVars, telemetryEnvVars...)
 
 	central := &v1alpha1.Central{

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -597,7 +597,7 @@ func TestTelemetryOptionsAreSetAsEnv(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.testName, func(t *testing.T) {
 			fakeClient := testutils.NewFakeClientBuilder(t).Build()
-			r := NewCentralReconciler(fakeClient, private.ManagedCentral{}, CentralReconcilerOptions{TelemetryOpts: tc.opts})
+			r := NewCentralReconciler(fakeClient, private.ManagedCentral{}, nil, CentralReconcilerOptions{TelemetryOpts: tc.opts})
 
 			_, err := r.Reconcile(context.TODO(), simpleManagedCentral)
 			require.NoError(t, err)

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -575,3 +575,22 @@ func TestNoRoutesSentWhenOneNotCreatedYet(t *testing.T) {
 func centralDeploymentObject() *appsv1.Deployment {
 	return testutils.NewCentralDeployment(centralNamespace)
 }
+
+func TestTelemetryOptionsAreSetAsEnv(t *testing.T) {
+	fakeClient := testutils.NewFakeClientBuilder(t).Build()
+	expectedEndpoint := "https://dummy.endpoint"
+	expectedStorageKey := "dummy-key"
+	r := NewCentralReconciler(fakeClient, private.ManagedCentral{}, CentralReconcilerOptions{
+		TelemetryOpts: TelemetryOptions{Endpoint: expectedEndpoint, StorageKey: expectedStorageKey},
+	})
+
+	_, err := r.Reconcile(context.TODO(), simpleManagedCentral)
+	require.NoError(t, err)
+	central := &v1alpha1.Central{}
+	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralName, Namespace: centralNamespace}, central)
+	require.NoError(t, err)
+
+	envVars := central.Spec.Customize.EnvVars
+	assert.Contains(t, envVars, v1.EnvVar{Name: "ROX_TELEMETRY_ENDPOINT", Value: expectedEndpoint})
+	assert.Contains(t, envVars, v1.EnvVar{Name: "ROX_TELEMETRY_STORAGE_KEY_V1", Value: expectedStorageKey})
+}

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -577,20 +577,45 @@ func centralDeploymentObject() *appsv1.Deployment {
 }
 
 func TestTelemetryOptionsAreSetAsEnv(t *testing.T) {
-	fakeClient := testutils.NewFakeClientBuilder(t).Build()
-	expectedEndpoint := "https://dummy.endpoint"
-	expectedStorageKey := "dummy-key"
-	r := NewCentralReconciler(fakeClient, private.ManagedCentral{}, CentralReconcilerOptions{
-		TelemetryOpts: TelemetryOptions{Endpoint: expectedEndpoint, StorageKey: expectedStorageKey},
-	})
+	tt := []struct {
+		testName string
+		opts     TelemetryOptions
+	}{
+		{
+			testName: "endpoint and storage key not empty",
+			opts:     TelemetryOptions{Endpoint: "https://dummy.endpoint", StorageKey: "dummy-key"},
+		},
+		{
+			testName: "endpoint not empty; storage key empty",
+			opts:     TelemetryOptions{Endpoint: "https://dummy.endpoint", StorageKey: ""},
+		},
+		{
+			testName: "endpoint empty; storage key not empty",
+			opts:     TelemetryOptions{Endpoint: "", StorageKey: "dummy-key"},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.testName, func(t *testing.T) {
+			fakeClient := testutils.NewFakeClientBuilder(t).Build()
+			r := NewCentralReconciler(fakeClient, private.ManagedCentral{}, CentralReconcilerOptions{TelemetryOpts: tc.opts})
 
-	_, err := r.Reconcile(context.TODO(), simpleManagedCentral)
-	require.NoError(t, err)
-	central := &v1alpha1.Central{}
-	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralName, Namespace: centralNamespace}, central)
-	require.NoError(t, err)
+			_, err := r.Reconcile(context.TODO(), simpleManagedCentral)
+			require.NoError(t, err)
+			central := &v1alpha1.Central{}
+			err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralName, Namespace: centralNamespace}, central)
+			require.NoError(t, err)
 
-	envVars := central.Spec.Customize.EnvVars
-	assert.Contains(t, envVars, v1.EnvVar{Name: "ROX_TELEMETRY_ENDPOINT", Value: expectedEndpoint})
-	assert.Contains(t, envVars, v1.EnvVar{Name: "ROX_TELEMETRY_STORAGE_KEY_V1", Value: expectedStorageKey})
+			envVars := central.Spec.Customize.EnvVars
+			if tc.opts.Endpoint != "" {
+				assert.Contains(t, envVars, v1.EnvVar{Name: endpointVariable, Value: tc.opts.Endpoint})
+			} else {
+				assert.NotContains(t, envVars, v1.EnvVar{Name: endpointVariable, Value: tc.opts.Endpoint})
+			}
+			if tc.opts.StorageKey != "" {
+				assert.Contains(t, envVars, v1.EnvVar{Name: storageKeyVariable, Value: tc.opts.StorageKey})
+			} else {
+				assert.NotContains(t, envVars, v1.EnvVar{Name: storageKeyVariable, Value: tc.opts.StorageKey})
+			}
+		})
+	}
 }

--- a/fleetshard/pkg/central/reconciler/telemetry.go
+++ b/fleetshard/pkg/central/reconciler/telemetry.go
@@ -1,0 +1,25 @@
+package reconciler
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TelemetryOptions defines parameters for pushing telemetry to a remote storage.
+type TelemetryOptions struct {
+	Endpoint   string
+	StorageKey string
+}
+
+func getTelemetryEnvVars(telemetryOpts TelemetryOptions) []corev1.EnvVar {
+	envVars := []corev1.EnvVar{
+		{
+			Name:  "ROX_TELEMETRY_ENDPOINT",
+			Value: telemetryOpts.Endpoint,
+		},
+		{
+			Name:  "ROX_TELEMETRY_STORAGE_KEY_V1",
+			Value: telemetryOpts.StorageKey,
+		},
+	}
+	return envVars
+}

--- a/fleetshard/pkg/central/reconciler/telemetry.go
+++ b/fleetshard/pkg/central/reconciler/telemetry.go
@@ -4,22 +4,33 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	endpointVariable   = "ROX_TELEMETRY_ENDPOINT"
+	storageKeyVariable = "ROX_TELEMETRY_STORAGE_KEY_V1"
+)
+
 // TelemetryOptions defines parameters for pushing telemetry to a remote storage.
 type TelemetryOptions struct {
 	Endpoint   string
 	StorageKey string
 }
 
-func getTelemetryEnvVars(telemetryOpts TelemetryOptions) []corev1.EnvVar {
-	envVars := []corev1.EnvVar{
-		{
-			Name:  "ROX_TELEMETRY_ENDPOINT",
-			Value: telemetryOpts.Endpoint,
-		},
-		{
-			Name:  "ROX_TELEMETRY_STORAGE_KEY_V1",
-			Value: telemetryOpts.StorageKey,
-		},
+func appendNotEmpty(envVars []corev1.EnvVar, item corev1.EnvVar) []corev1.EnvVar {
+	if item.Name != "" && item.Value != "" {
+		envVars = append(envVars, item)
 	}
+	return envVars
+}
+
+func (t *TelemetryOptions) toEnvVars() []corev1.EnvVar {
+	envVars := []corev1.EnvVar{}
+	envVars = appendNotEmpty(envVars, corev1.EnvVar{
+		Name:  endpointVariable,
+		Value: t.Endpoint,
+	})
+	envVars = appendNotEmpty(envVars, corev1.EnvVar{
+		Name:  storageKeyVariable,
+		Value: t.StorageKey,
+	})
 	return envVars
 }

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -95,6 +95,10 @@ func (r *Runtime) Start() error {
 		WantsAuthProvider: r.config.CreateAuthProvider,
 		EgressProxyImage:  r.config.EgressProxyImage,
 		ManagedDBEnabled:  r.config.ManagedDBEnabled,
+		TelemetryOpts: centralReconciler.TelemetryOptions{
+			Endpoint:   r.config.TelemetryEndpoint,
+			StorageKey: r.config.TelemetryStorageKey,
+		},
 	}
 
 	ticker := concurrency.NewRetryTicker(func(ctx context.Context) (timeToNextTick time.Duration, err error) {


### PR DESCRIPTION
Add telemetry storage options to managed Centrals. The plan is to use Segment as telemetry backend. This does not include service annotations to identify Central instances in Segment, only the parameters needed to push data to Segment itself.

The telemetry options are passed as env variables via `Customize` part of the CRD. This adds the env vars to all pods (Central, Scanner, Scanner-DB). I did not find a way to only add the env vars to Central - I think this would require a change to the CRD/RHACS operator code.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] ~Evaluated and added CHANGELOG.md entry if required~
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

