### PR TITLE
ROX-12921: New worker to clean up timed out central requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ install: verify lint
 .PHONY: install
 
 clean:
-	rm -f fleet-manager fleetshard-sync probe
+	rm -f fleet-manager fleetshard-sync probe/bin/probe
 .PHONY: clean
 
 # Runs the unit tests.

--- a/cmd/fleet-manager/main_test.go
+++ b/cmd/fleet-manager/main_test.go
@@ -51,7 +51,7 @@ func TestInjections(t *testing.T) {
 
 	var workerList []workers.Worker
 	env.MustResolve(&workerList)
-	Expect(workerList).To(HaveLen(9))
+	Expect(workerList).To(HaveLen(10))
 }
 
 func createServicesCommand(env *environments.Env) *cobra.Command {

--- a/internal/dinosaur/pkg/config/central.go
+++ b/internal/dinosaur/pkg/config/central.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
@@ -36,7 +37,7 @@ type CentralConfig struct {
 	// Set in minutes. After timeout is reached, central request is cancelled and marked as failed.
 	// TODO: this parameter does not belong here, as it's configuration of central request, not central.
 	// TODO: However, for the time being there's no better place to put this parameter.
-	CentralRequestExpirationTimeout int `json:"central_request_expiration_timeout"`
+	CentralRequestExpirationTimeout time.Duration `json:"central_request_expiration_timeout"`
 }
 
 // NewCentralConfig ...
@@ -50,7 +51,7 @@ func NewCentralConfig() *CentralConfig {
 		Quota:                            NewCentralQuotaConfig(),
 		CentralIDPClientSecretFile:       "secrets/central.idp-client-secret", //pragma: allowlist secret
 		CentralIDPIssuer:                 "https://sso.redhat.com/auth/realms/redhat-external",
-		CentralRequestExpirationTimeout:  60, // minutes
+		CentralRequestExpirationTimeout:  60 * time.Minute,
 	}
 }
 
@@ -68,7 +69,7 @@ func (c *CentralConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.CentralIDPClientID, "central-idp-client-id", c.CentralIDPClientID, "OIDC client_id to pass to Central's auth config")
 	fs.StringVar(&c.CentralIDPClientSecretFile, "central-idp-client-secret-file", c.CentralIDPClientSecretFile, "File containing OIDC client_secret to pass to Central's auth config")
 	fs.StringVar(&c.CentralIDPIssuer, "central-idp-issuer", c.CentralIDPIssuer, "OIDC issuer URL to pass to Central's auth config")
-	fs.IntVar(&c.CentralRequestExpirationTimeout, "central-request-expiration-timeout", c.CentralRequestExpirationTimeout, "Timeout for central requests")
+	fs.DurationVar(&c.CentralRequestExpirationTimeout, "central-request-expiration-timeout", c.CentralRequestExpirationTimeout, "Timeout for central requests")
 }
 
 // ReadFiles ...

--- a/internal/dinosaur/pkg/config/central.go
+++ b/internal/dinosaur/pkg/config/central.go
@@ -32,6 +32,11 @@ type CentralConfig struct {
 	CentralIDPClientSecret     string `json:"central_idp_client_secret"`
 	CentralIDPClientSecretFile string `json:"central_idp_client_secret_file"`
 	CentralIDPIssuer           string `json:"central_idp_issuer"`
+
+	// Set in minutes. After timeout is reached, central request is cancelled and marked as failed.
+	// TODO: this parameter does not belong here, as it's configuration of central request, not central.
+	// TODO: However, for the time being there's no better place to put this parameter.
+	CentralRequestExpirationTimeout int `json:"central_request_expiration_timeout"`
 }
 
 // NewCentralConfig ...
@@ -45,6 +50,7 @@ func NewCentralConfig() *CentralConfig {
 		Quota:                            NewCentralQuotaConfig(),
 		CentralIDPClientSecretFile:       "secrets/central.idp-client-secret", //pragma: allowlist secret
 		CentralIDPIssuer:                 "https://sso.redhat.com/auth/realms/redhat-external",
+		CentralRequestExpirationTimeout:  60, // minutes
 	}
 }
 
@@ -62,6 +68,7 @@ func (c *CentralConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.CentralIDPClientID, "central-idp-client-id", c.CentralIDPClientID, "OIDC client_id to pass to Central's auth config")
 	fs.StringVar(&c.CentralIDPClientSecretFile, "central-idp-client-secret-file", c.CentralIDPClientSecretFile, "File containing OIDC client_secret to pass to Central's auth config")
 	fs.StringVar(&c.CentralIDPIssuer, "central-idp-issuer", c.CentralIDPIssuer, "OIDC issuer URL to pass to Central's auth config")
+	fs.IntVar(&c.CentralRequestExpirationTimeout, "central-request-expiration-timeout", c.CentralRequestExpirationTimeout, "Timeout for central requests")
 }
 
 // ReadFiles ...

--- a/internal/dinosaur/pkg/config/central.go
+++ b/internal/dinosaur/pkg/config/central.go
@@ -34,7 +34,6 @@ type CentralConfig struct {
 	CentralIDPClientSecretFile string `json:"central_idp_client_secret_file"`
 	CentralIDPIssuer           string `json:"central_idp_issuer"`
 
-	// Set in minutes. After timeout is reached, central request is cancelled and marked as failed.
 	// TODO: this parameter does not belong here, as it's configuration of central request, not central.
 	// TODO: However, for the time being there's no better place to put this parameter.
 	CentralRequestExpirationTimeout time.Duration `json:"central_request_expiration_timeout"`

--- a/internal/dinosaur/pkg/migrations/202211282100_add_central_timeout_lease_type.go
+++ b/internal/dinosaur/pkg/migrations/202211282100_add_central_timeout_lease_type.go
@@ -1,0 +1,40 @@
+package migrations
+
+// Migrations should NEVER use types from other packages. Types can change
+// and then migrations run on a _new_ database will fail or behave unexpectedly.
+// Instead of importing types, always re-create the type in the migration, as
+// is done here, even though the same type is defined in pkg/api
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/stackrox/acs-fleet-manager/pkg/api"
+	"github.com/stackrox/acs-fleet-manager/pkg/db"
+	"gorm.io/gorm"
+)
+
+const centralTimeoutLeaseType = "timeout_central"
+
+// addCentralTimeoutLease adds a leader lease value for the timeout_Central lease and its
+// worker.
+// It is similar to addLeaderLease.
+func addCentralTimeoutLease() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "202211282100",
+		Migrate: func(tx *gorm.DB) error {
+			// Set an initial already expired lease for timeout_central.
+			err := tx.Create(&api.LeaderLease{
+				Expires:   &db.DinosaurAdditionalLeasesExpireTime,
+				LeaseType: centralTimeoutLeaseType,
+				Leader:    api.NewID(),
+			}).Error
+
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return nil
+		},
+	}
+}

--- a/internal/dinosaur/pkg/migrations/migrations.go
+++ b/internal/dinosaur/pkg/migrations/migrations.go
@@ -37,6 +37,7 @@ var migrations = []*gormigrate.Migration{
 	addClientOriginToCentralRequest(),
 	changeCentralClientOrigin(),
 	addCloudAccountIDToCentralRequest(),
+	addCentralTimeoutLease(),
 }
 
 // New ...

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -111,7 +111,7 @@ type DinosaurService interface {
 	ListCentralsWithoutAuthConfig() ([]*dbapi.CentralRequest, *errors.ServiceError)
 	VerifyAndUpdateDinosaurAdmin(ctx context.Context, dinosaurRequest *dbapi.CentralRequest) *errors.ServiceError
 	ListComponentVersions() ([]DinosaurComponentVersions, error)
-	ListInProgressCentralsOlderThan(lastCreationTime time.Time) ([]*dbapi.CentralRequest, *errors.ServiceError)
+	ListTimedOutCentrals(lastCreationTime time.Time) ([]*dbapi.CentralRequest, *errors.ServiceError)
 }
 
 var _ DinosaurService = &dinosaurService{}
@@ -146,7 +146,7 @@ func NewDinosaurService(connectionFactory *db.ConnectionFactory, clusterService 
 	}
 }
 
-func (k *dinosaurService) ListInProgressCentralsOlderThan(lastCreationTime time.Time) ([]*dbapi.CentralRequest, *errors.ServiceError) {
+func (k *dinosaurService) ListTimedOutCentrals(lastCreationTime time.Time) ([]*dbapi.CentralRequest, *errors.ServiceError) {
 	dbConn := k.connectionFactory.New().
 		Where("created_at  <=  ?", lastCreationTime).
 		Where("status IN (?)", dinosaurTimeoutStatuses)

--- a/internal/dinosaur/pkg/services/dinosaurservice_moq.go
+++ b/internal/dinosaur/pkg/services/dinosaurservice_moq.go
@@ -13,6 +13,7 @@ import (
 	serviceError "github.com/stackrox/acs-fleet-manager/pkg/errors"
 	"github.com/stackrox/acs-fleet-manager/pkg/services"
 	"sync"
+	"time"
 )
 
 // Ensure, that DinosaurServiceMock does implement DinosaurService.
@@ -81,6 +82,9 @@ var _ DinosaurService = &DinosaurServiceMock{}
 //			},
 //			ListDinosaursWithRoutesNotCreatedFunc: func() ([]*dbapi.CentralRequest, *serviceError.ServiceError) {
 //				panic("mock out the ListDinosaursWithRoutesNotCreated method")
+//			},
+//			ListTimedOutCentralsFunc: func(lastCreationTime time.Time) ([]*dbapi.CentralRequest, *serviceError.ServiceError) {
+//				panic("mock out the ListTimedOutCentrals method")
 //			},
 //			PrepareDinosaurRequestFunc: func(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError {
 //				panic("mock out the PrepareDinosaurRequest method")
@@ -166,6 +170,9 @@ type DinosaurServiceMock struct {
 
 	// ListDinosaursWithRoutesNotCreatedFunc mocks the ListDinosaursWithRoutesNotCreated method.
 	ListDinosaursWithRoutesNotCreatedFunc func() ([]*dbapi.CentralRequest, *serviceError.ServiceError)
+
+	// ListTimedOutCentralsFunc mocks the ListTimedOutCentrals method.
+	ListTimedOutCentralsFunc func(lastCreationTime time.Time) ([]*dbapi.CentralRequest, *serviceError.ServiceError)
 
 	// PrepareDinosaurRequestFunc mocks the PrepareDinosaurRequest method.
 	PrepareDinosaurRequestFunc func(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError
@@ -283,6 +290,11 @@ type DinosaurServiceMock struct {
 		// ListDinosaursWithRoutesNotCreated holds details about calls to the ListDinosaursWithRoutesNotCreated method.
 		ListDinosaursWithRoutesNotCreated []struct {
 		}
+		// ListTimedOutCentrals holds details about calls to the ListTimedOutCentrals method.
+		ListTimedOutCentrals []struct {
+			// LastCreationTime is the lastCreationTime argument value.
+			LastCreationTime time.Time
+		}
 		// PrepareDinosaurRequest holds details about calls to the PrepareDinosaurRequest method.
 		PrepareDinosaurRequest []struct {
 			// DinosaurRequest is the dinosaurRequest argument value.
@@ -346,6 +358,7 @@ type DinosaurServiceMock struct {
 	lockListCentralsWithoutAuthConfig     sync.RWMutex
 	lockListComponentVersions             sync.RWMutex
 	lockListDinosaursWithRoutesNotCreated sync.RWMutex
+	lockListTimedOutCentrals              sync.RWMutex
 	lockPrepareDinosaurRequest            sync.RWMutex
 	lockRegisterDinosaurDeprovisionJob    sync.RWMutex
 	lockRegisterDinosaurJob               sync.RWMutex
@@ -951,6 +964,38 @@ func (mock *DinosaurServiceMock) ListDinosaursWithRoutesNotCreatedCalls() []stru
 	mock.lockListDinosaursWithRoutesNotCreated.RLock()
 	calls = mock.calls.ListDinosaursWithRoutesNotCreated
 	mock.lockListDinosaursWithRoutesNotCreated.RUnlock()
+	return calls
+}
+
+// ListTimedOutCentrals calls ListTimedOutCentralsFunc.
+func (mock *DinosaurServiceMock) ListTimedOutCentrals(lastCreationTime time.Time) ([]*dbapi.CentralRequest, *serviceError.ServiceError) {
+	if mock.ListTimedOutCentralsFunc == nil {
+		panic("DinosaurServiceMock.ListTimedOutCentralsFunc: method is nil but DinosaurService.ListTimedOutCentrals was just called")
+	}
+	callInfo := struct {
+		LastCreationTime time.Time
+	}{
+		LastCreationTime: lastCreationTime,
+	}
+	mock.lockListTimedOutCentrals.Lock()
+	mock.calls.ListTimedOutCentrals = append(mock.calls.ListTimedOutCentrals, callInfo)
+	mock.lockListTimedOutCentrals.Unlock()
+	return mock.ListTimedOutCentralsFunc(lastCreationTime)
+}
+
+// ListTimedOutCentralsCalls gets all the calls that were made to ListTimedOutCentrals.
+// Check the length with:
+//
+//	len(mockedDinosaurService.ListTimedOutCentralsCalls())
+func (mock *DinosaurServiceMock) ListTimedOutCentralsCalls() []struct {
+	LastCreationTime time.Time
+} {
+	var calls []struct {
+		LastCreationTime time.Time
+	}
+	mock.lockListTimedOutCentrals.RLock()
+	calls = mock.calls.ListTimedOutCentrals
+	mock.lockListTimedOutCentrals.RUnlock()
 	return calls
 }
 

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/centrals_timeout_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/centrals_timeout_mgr.go
@@ -1,0 +1,85 @@
+package dinosaurmgrs
+
+import (
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	constants2 "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/config"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/services"
+	"github.com/stackrox/acs-fleet-manager/pkg/workers"
+)
+
+// CentralsTimeoutManager represents a manager that periodically reconciles central requests
+type CentralsTimeoutManager struct {
+	workers.BaseWorker
+	centralService services.DinosaurService
+	timeout        time.Duration
+}
+
+var _ workers.Worker = (*CentralsTimeoutManager)(nil)
+
+// NewCentralsTimeoutManager creates a new manager
+func NewCentralsTimeoutManager(centralService services.DinosaurService, centralConfig *config.CentralConfig) *CentralsTimeoutManager {
+	return &CentralsTimeoutManager{
+		BaseWorker: workers.BaseWorker{
+			ID:         uuid.New().String(),
+			WorkerType: "timeout_central",
+			Reconciler: workers.Reconciler{},
+		},
+		centralService: centralService,
+		timeout:        time.Duration(centralConfig.CentralRequestExpirationTimeout) * time.Minute,
+	}
+}
+
+// Start initializes the manager to reconcile central requests
+func (k *CentralsTimeoutManager) Start() {
+	k.StartWorker(k)
+}
+
+// Stop causes the process for reconciling central requests to stop.
+func (k *CentralsTimeoutManager) Stop() {
+	k.StopWorker(k)
+}
+
+// Reconcile ...
+func (k *CentralsTimeoutManager) Reconcile() []error {
+	glog.Infoln("reconciling centrals reached timeout")
+	var encounteredErrors []error
+
+	// list central requests eligible to be cancelled
+	lastCreatedAt := time.Now().Add(-k.timeout)
+	timedOutCentralRequests, serviceErr := k.centralService.ListInProgressCentralsOlderThan(lastCreatedAt)
+
+	if serviceErr != nil {
+		encounteredErrors = append(encounteredErrors, errors.Wrap(serviceErr, "failed to list timed out centrals"))
+	} else {
+		glog.Infof("timed out centrals count = %d", len(timedOutCentralRequests))
+	}
+	for _, centralRequest := range timedOutCentralRequests {
+		glog.V(10).Infof("timed out central id = %s", centralRequest.ID)
+		if err := k.reconcileTimedOutCentral(centralRequest); err != nil {
+			encounteredErrors = append(encounteredErrors, errors.Wrapf(err, "failed to reconcile timed out central %s", centralRequest.ID))
+			continue
+		}
+	}
+
+	return encounteredErrors
+}
+
+func (k *CentralsTimeoutManager) reconcileTimedOutCentral(centralRequest *dbapi.CentralRequest) error {
+	// Force deletion on the side of dataplane cluster in case central already went into provisioning stage.
+	if centralRequest.Status == constants2.CentralRequestStatusProvisioning.String() {
+		now := time.Now()
+		centralRequest.DeletionTimestamp = &now
+	}
+	centralRequest.Status = constants2.CentralRequestStatusFailed.String()
+	centralRequest.FailedReason = "Creation time went over the timeout. Interrupting central initialization."
+	if err := k.centralService.Update(centralRequest); err != nil {
+		return errors.Wrapf(err, "failed to update timed out central %s", centralRequest.ID)
+	}
+	return nil
+}

--- a/internal/dinosaur/providers.go
+++ b/internal/dinosaur/providers.go
@@ -88,6 +88,7 @@ func ServiceProviders() di.Option {
 		di.Provide(dinosaurmgrs.NewReadyDinosaurManager, di.As(new(workers.Worker))),
 		di.Provide(dinosaurmgrs.NewDinosaurCNAMEManager, di.As(new(workers.Worker))),
 		di.Provide(dinosaurmgrs.NewCentralAuthConfigManager, di.As(new(workers.Worker))),
+		di.Provide(dinosaurmgrs.NewCentralsTimeoutManager, di.As(new(workers.Worker))),
 		di.Provide(presenters.NewManagedCentralPresenter),
 	)
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -121,6 +121,11 @@ var CentralPerClusterCountMetricsLabels = []string{
 	LabelClusterExternalID,
 }
 
+var centralTimeoutCountMetricLabels = []string{
+	LabelID,
+	LabelClusterID,
+}
+
 // ClusterOperationsCountMetricsLabels - is the slice of labels to add to Central operations count metrics
 var ClusterOperationsCountMetricsLabels = []string{
 	labelOperation,
@@ -415,6 +420,24 @@ var centralStatusSinceCreatedMetric = prometheus.NewGaugeVec(
 	},
 	centralStatusSinceCreatedMetricLabels,
 )
+
+var centralTimeoutCountMetric = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Subsystem: FleetManager,
+		Name:      "central_timeout_total_count",
+		Help:      "number of total timed-out centrals",
+	},
+	centralTimeoutCountMetricLabels,
+)
+
+// IncreaseCentralTimeoutCountMetric - increase counter for the centralTimeoutCountMetric
+func IncreaseCentralTimeoutCountMetric(centralID, clusterID string) {
+	labels := prometheus.Labels{
+		LabelID:        centralID,
+		LabelClusterID: clusterID,
+	}
+	centralTimeoutCountMetric.With(labels).Inc()
+}
 
 // IncreaseCentralSuccessOperationsCountMetric - increase counter for the centralOperationsSuccessCountMetric
 func IncreaseCentralSuccessOperationsCountMetric(operation constants2.CentralOperation) {


### PR DESCRIPTION
## Description
This PR introduces time out to central requests. If the timeout is reached and a central request is still in progress(statuses `Accepted`, `Preparing`, `Provisioning`), then the request is failed and all associated resources are cleaned up.

What this PR has:
* new worker to reconcile timed-out central requests
* timeout configuration parameter

What will be introduced in other PRs:
* metrics and alerts
* introducing timeout environment variable

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] Evaluated and added CHANGELOG.md entry if required
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

1. `./fleet-manager serve --central-request-expiration-timeout=1`
2.  Create central request via `curl`
3. Wait for 1 minute and see lines similar to
```
I1129 06:41:28.065697   99362 centrals_timeout_mgr.go:49] reconciling centrals reached timeout
I1129 06:41:28.071921   99362 centrals_timeout_mgr.go:59] timed out centrals count = 1
I1129 06:41:28.071938   99362 centrals_timeout_mgr.go:62] timed out central id = ce2pmeg7t2uo88ikr00g
```
