### PR TITLE
Allow retrieval of ID tokens within fleetmanager auth

### DIFF
--- a/pkg/client/fleetmanager/auth.go
+++ b/pkg/client/fleetmanager/auth.go
@@ -17,6 +17,10 @@ import (
 type Auth interface {
 	// AddAuth will add authentication information to the request, e.g. in the form of the Authorization header.
 	AddAuth(req *http.Request) error
+
+	// RetrieveIDToken will return the ID token, if available.
+	// If the ID token cannot be retrieved, an error will be returned.
+	RetrieveIDToken() (string, error)
 }
 
 type authFactory interface {

--- a/pkg/client/fleetmanager/auth_ocm.go
+++ b/pkg/client/fleetmanager/auth_ocm.go
@@ -78,5 +78,12 @@ func (o *ocmAuth) AddAuth(req *http.Request) error {
 }
 
 func (o *ocmAuth) RetrieveIDToken() (string, error) {
-	return "", errors.New("retrieving ID tokens using the OCM auth type is currently not supported")
+	// Our internal definition of the ID token is to have a `aud` claim set.
+	// The OCM bearer token, by default, has the `aud` claim set, hence we can just return it here.
+	access, _, err := o.conn.Tokens(ocmTokenExpirationMargin)
+	if err != nil {
+		return "", errors.Wrap(err, "retrieving access token via OCM auth type")
+	}
+
+	return access, nil
 }

--- a/pkg/client/fleetmanager/auth_ocm.go
+++ b/pkg/client/fleetmanager/auth_ocm.go
@@ -76,3 +76,7 @@ func (o *ocmAuth) AddAuth(req *http.Request) error {
 	setBearer(req, access)
 	return nil
 }
+
+func (o *ocmAuth) RetrieveIDToken() (string, error) {
+	return "", errors.New("retrieving ID tokens using the OCM auth type is currently not supported")
+}

--- a/pkg/client/fleetmanager/auth_rhsso.go
+++ b/pkg/client/fleetmanager/auth_rhsso.go
@@ -72,9 +72,9 @@ func (r *rhSSOAuth) RetrieveIDToken() (string, error) {
 	if idTokenRaw == nil {
 		return "", errors.New("no ID token could be retrieved")
 	}
-	if idToken, ok := idTokenRaw.(string); !ok {
+	idToken, ok := idTokenRaw.(string)
+	if !ok {
 		return "", errors.New("ID token was in an unsupported format")
-	} else {
-		return idToken, nil
 	}
+	return idToken, nil
 }

--- a/pkg/client/fleetmanager/auth_rhsso.go
+++ b/pkg/client/fleetmanager/auth_rhsso.go
@@ -24,7 +24,6 @@ var (
 
 type rhSSOAuth struct {
 	tokenSource oauth2.TokenSource
-	test        oauth2.TokenSource
 }
 
 type rhSSOAuthFactory struct{}
@@ -61,4 +60,21 @@ func (r *rhSSOAuth) AddAuth(req *http.Request) error {
 	}
 	setBearer(req, token.AccessToken)
 	return nil
+}
+
+func (r *rhSSOAuth) RetrieveIDToken() (string, error) {
+	t, err := r.tokenSource.Token()
+	if err != nil {
+		return "", errors.Wrap(err, "retrieving token from token source")
+	}
+
+	idTokenRaw := t.Extra("id_token")
+	if idTokenRaw == nil {
+		return "", errors.New("no ID token could be retrieved")
+	}
+	if idToken, ok := idTokenRaw.(string); !ok {
+		return "", errors.New("ID token was in an unsupported format")
+	} else {
+		return idToken, nil
+	}
 }

--- a/pkg/client/fleetmanager/auth_static_token.go
+++ b/pkg/client/fleetmanager/auth_static_token.go
@@ -45,5 +45,7 @@ func (s *staticTokenAuth) AddAuth(req *http.Request) error {
 }
 
 func (s *staticTokenAuth) RetrieveIDToken() (string, error) {
+	// Since we plan to minimize the usage of the static token auth type, potentially removing it going forward,
+	// we skip implementing the `id_token` interface for it.
 	return "", errors.New("retrieving ID tokens using the static token auth type is currently not supported")
 }

--- a/pkg/client/fleetmanager/auth_static_token.go
+++ b/pkg/client/fleetmanager/auth_static_token.go
@@ -43,3 +43,7 @@ func (s *staticTokenAuth) AddAuth(req *http.Request) error {
 	setBearer(req, s.token)
 	return nil
 }
+
+func (s *staticTokenAuth) RetrieveIDToken() (string, error) {
+	return "", errors.New("retrieving ID tokens using the static token auth type is currently not supported")
+}


### PR DESCRIPTION
## Description

The changes made within #616 require an ID token, where the `aud` claim is set to be used in combination with the AWS libraries.

Currently, the RH SSO auth type does specify the `openid` scope, but returns a `Bearer token` without the `aud` claim set.
Instead, RH SSO returns an `id_token`, which has all the required claims (i.e. the `aud` claim).

This PR addresses the shortcoming, creating a new abstraction `RetrieveIDToken`, and explicitly returning the `id_token` for the RH SSO auth type.

## Checklist (Definition of Done)
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Evaluated and added CHANGELOG.md entry if required
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

```
# Manually run the RH SSO auth type with appropriate configuration (e.g. via temporary unit test) and ensure that the returned token has all required claims via e.g. jwt.io
```