### PR TITLE
Make probe service generate central name starting with char and max 32

### DIFF
--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -61,8 +61,8 @@ func (h adminDinosaurHandler) Create(w http.ResponseWriter, r *http.Request) {
 		MarshalInto: &dinosaurRequest,
 		Validate: []handlers.Validate{
 			handlers.ValidateAsyncEnabled(r, "creating central requests"),
-			handlers.ValidateLength(&dinosaurRequest.Name, "name", &handlers.MinRequiredFieldLength, &MaxDinosaurNameLength),
-			ValidDinosaurClusterName(&dinosaurRequest.Name, "name"),
+			handlers.ValidateLength(&dinosaurRequest.Name, "name", &handlers.MinRequiredFieldLength, &MaxCentralNameLength),
+			ValidCentralInstanceName(&dinosaurRequest.Name, "name"),
 			ValidateDinosaurClusterNameIsUnique(r.Context(), &dinosaurRequest.Name, h.service),
 			ValidateDinosaurClaims(ctx, &dinosaurRequest, &convDinosaur),
 			ValidateCloudProvider(&h.service, &convDinosaur, h.providerConfig, "creating central requests"),

--- a/internal/dinosaur/pkg/handlers/dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/dinosaur.go
@@ -68,8 +68,8 @@ func (h dinosaurHandler) Create(w http.ResponseWriter, r *http.Request) {
 		MarshalInto: &dinosaurRequest,
 		Validate: []handlers.Validate{
 			handlers.ValidateAsyncEnabled(r, "creating central requests"),
-			handlers.ValidateLength(&dinosaurRequest.Name, "name", &handlers.MinRequiredFieldLength, &MaxDinosaurNameLength),
-			ValidDinosaurClusterName(&dinosaurRequest.Name, "name"),
+			handlers.ValidateLength(&dinosaurRequest.Name, "name", &handlers.MinRequiredFieldLength, &MaxCentralNameLength),
+			ValidCentralInstanceName(&dinosaurRequest.Name, "name"),
 			ValidateDinosaurClusterNameIsUnique(r.Context(), &dinosaurRequest.Name, h.service),
 			ValidateDinosaurClaims(ctx, &dinosaurRequest, convDinosaur),
 			ValidateCloudProvider(&h.service, convDinosaur, h.providerConfig, "creating central requests"),

--- a/internal/dinosaur/pkg/handlers/validation.go
+++ b/internal/dinosaur/pkg/handlers/validation.go
@@ -20,20 +20,20 @@ import (
 )
 
 var (
-	// ValidDinosaurClusterNameRegexp ...
-	ValidDinosaurClusterNameRegexp = regexp.MustCompile(`^[a-z]([-a-z0-9]*[a-z0-9])?$`)
+	// ValidCentralNameRegexp ...
+	ValidCentralNameRegexp = regexp.MustCompile(`^[a-z]([-a-z0-9]*[a-z0-9])?$`)
 
-	// MaxDinosaurNameLength ...
-	MaxDinosaurNameLength = 32
+	// MaxCentralNameLength ...
+	MaxCentralNameLength = 32
 
 	supportedResources = []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory}
 )
 
-// ValidDinosaurClusterName ...
-func ValidDinosaurClusterName(value *string, field string) handlers.Validate {
+// ValidCentralInstanceName ...
+func ValidCentralInstanceName(value *string, field string) handlers.Validate {
 	return func() *errors.ServiceError {
-		if !ValidDinosaurClusterNameRegexp.MatchString(*value) {
-			return errors.MalformedDinosaurClusterName("%s does not match %s", field, ValidDinosaurClusterNameRegexp.String())
+		if !ValidCentralNameRegexp.MatchString(*value) {
+			return errors.MalformedDinosaurClusterName("%s does not match %s", field, ValidCentralNameRegexp.String())
 		}
 		return nil
 	}

--- a/internal/dinosaur/pkg/handlers/validation_test.go
+++ b/internal/dinosaur/pkg/handlers/validation_test.go
@@ -84,40 +84,40 @@ func Test_Validation_validateDinosaurClusterNameIsUnique(t *testing.T) {
 	}
 }
 
-func Test_Validations_validateDinosaurClusterNames(t *testing.T) {
+func Test_Validations_validateCentralInstanceNames(t *testing.T) {
 	tests := []struct {
 		description string
 		name        string
 		expectError bool
 	}{
 		{
-			description: "valid dinosaur cluster name",
-			name:        "test-dinosaur1",
+			description: "valid central instance name",
+			name:        "test-central1",
 			expectError: false,
 		},
 		{
-			description: "valid dinosaur cluster name with multiple '-'",
-			name:        "test-my-cluster",
+			description: "valid central instance name with multiple '-'",
+			name:        "test-my-instance",
 			expectError: false,
 		},
 		{
-			description: "invalid dinosaur cluster name begins with number",
-			name:        "1test-cluster",
+			description: "invalid central instance name begins with number",
+			name:        "1test-instance",
 			expectError: true,
 		},
 		{
-			description: "invalid dinosaur cluster name with invalid characters",
+			description: "invalid central instance name with invalid characters",
 			name:        "test-c%*_2",
 			expectError: true,
 		},
 		{
-			description: "invalid dinosaur cluster name with upper-case letters",
-			name:        "Test-cluster",
+			description: "invalid central instance name with upper-case letters",
+			name:        "Test-instance",
 			expectError: true,
 		},
 		{
-			description: "invalid dinosaur cluster name with spaces",
-			name:        "test cluster",
+			description: "invalid central instance name with spaces",
+			name:        "test instance",
 			expectError: true,
 		},
 	}
@@ -125,7 +125,7 @@ func Test_Validations_validateDinosaurClusterNames(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			gomega.RegisterTestingT(t)
-			validateFn := ValidDinosaurClusterName(&tt.name, "name")
+			validateFn := ValidCentralInstanceName(&tt.name, "name")
 			err := validateFn()
 			if tt.expectError {
 				gomega.Expect(err).Should(gomega.HaveOccurred())

--- a/probe/pkg/probe/probe.go
+++ b/probe/pkg/probe/probe.go
@@ -61,9 +61,11 @@ func (p *ProbeImpl) generateCentralName() (string, error) {
 	}
 	rndString := hex.EncodeToString(rnd)
 	// Central instance name have to match ^[a-z]([-a-z0-9]*[a-z0-9])?$ regexp
-	// Also Central name nust contain no more than 32 characters
 	centralName := fmt.Sprintf("probe-%s-%s", p.config.ProbeName, rndString)
-	centralName = centralName[:handlers.MaxCentralNameLength]
+	// Also Central name nust contain no more than 32 characters
+	if len(centralName) > handlers.MaxCentralNameLength {
+		centralName = centralName[:handlers.MaxCentralNameLength]
+	}
 	return centralName, nil
 }
 

--- a/probe/pkg/probe/probe_test.go
+++ b/probe/pkg/probe/probe_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/public"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/dinosaurs/types"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/handlers"
 	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
 	"github.com/stackrox/acs-fleet-manager/probe/config"
 	"github.com/stackrox/rox/pkg/concurrency"
@@ -42,6 +43,19 @@ func makeHTTPResponse(statusCode int) *http.Response {
 func newHTTPClientMock(fn httputil.RoundTripperFunc) *http.Client {
 	return &http.Client{
 		Transport: httputil.RoundTripperFunc(fn),
+	}
+}
+
+func TestGenerateCentralName(t *testing.T) {
+	probe := New(testConfig, nil, nil)
+	for i := 0; i < 10; i++ {
+		centralName, err := probe.generateCentralName()
+		require.NoError(t, err)
+
+		matchedName := handlers.ValidCentralNameRegexp.MatchString(centralName)
+		matchedLength := len(centralName) < handlers.MaxCentralNameLength
+		assert.True(t, matchedName)
+		assert.True(t, matchedLength)
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Fleet Manager dos not allow creating a central which begins with a number:
```
curl -XPOST --header "Authorization: Bearer $(ocm token)" 'https://XXX.XXX.openshift.com/api/rhacs/v1/centrals?async=true' --data '{"region": "us-east-1", "cloud_provider": "aws", "multi_az": true, "name": "3akurlov-number-test"}' | jq
{
  "id": "32",
  "kind": "Error",
  "href": "/api/rhacs/v1/errors/32",
  "code": "RHACS-MGMT-32",
  "reason": "name does not match ^[a-z]([-a-z0-9]*[a-z0-9])?$",
  "operation_id": "XXX"
}
```
it is possible that the Probe service might generate a central name starting with number or longer that 32 characters on local machine or on CI. This PR fixes it. Every probe generated central names will start with `probe-` prefix.

Also, added small dinosaur renaming.


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
~- [ ] Evaluated and added CHANGELOG.md entry if required~
~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

**TODO:** Add manual testing efforts

```
make probe && ./probe/bin/probe run

...

W1130 16:50:27.156627   42410 probe.go:202] central instance ce3nmb0n2at7tjbvesi0 not in target state "ready"
W1130 16:50:32.148967   42410 probe.go:202] central instance ce3nmb0n2at7tjbvesi0 not in target state "ready"
W1130 16:50:37.144199   42410 probe.go:202] central instance ce3nmb0n2at7tjbvesi0 not in target state "ready"
I1130 16:50:42.157684   42410 probe.go:198] central instance ce3nmb0n2at7tjbvesi0 is in "ready" state
I1130 16:50:47.716239   42410 probe.go:166] deletion of central instance ce3nmb0n2at7tjbvesi0 requested
W1130 16:50:52.839356   42410 probe.go:229] central instance ce3nmb0n2at7tjbvesi0 not deleted
W1130 16:50:57.843778   42410 probe.go:229] central instance ce3nmb0n2at7tjbvesi0 not deleted
W1130 16:51:02.842207   42410 probe.go:229] central instance ce3nmb0n2at7tjbvesi0 not deleted
W1130 16:51:07.850256   42410 probe.go:229] central instance ce3nmb0n2at7tjbvesi0 not deleted
W1130 16:51:12.837200   42410 probe.go:229] central instance ce3nmb0n2at7tjbvesi0 not deleted
W1130 16:51:18.128135   42410 probe.go:229] central instance ce3nmb0n2at7tjbvesi0 not deleted
W1130 16:51:22.843268   42410 probe.go:229] central instance ce3nmb0n2at7tjbvesi0 not deleted
W1130 16:51:28.080676   42410 probe.go:229] central instance ce3nmb0n2at7tjbvesi0 not deleted
W1130 16:51:32.850638   42410 probe.go:229] central instance ce3nmb0n2at7tjbvesi0 not deleted
I1130 16:51:38.122393   42410 probe.go:221] central instance ce3nmb0n2at7tjbvesi0 has been deleted
I1130 16:51:38.122414   42410 probe.go:53] elapsed time: 3m42.019062937s
I1130 16:51:38.122437   42410 probe.go:87] probe run has ended
I1130 16:51:43.263739   42410 probe.go:119] finished clean up attempt of probe resource
```
