### PR TITLE
Fix up.sh script

### DIFF
--- a/.openshift-ci/e2e-runtime/e2e_dockerized.sh
+++ b/.openshift-ci/e2e-runtime/e2e_dockerized.sh
@@ -3,6 +3,10 @@ set -eo pipefail
 
 GITROOT="$(git rev-parse --show-toplevel)"
 export GITROOT
+
+export DOCKER=${DOCKER:-docker}
+export CLUSTER_TYPE=${CLUSTER_TYPE:-default}
+
 # shellcheck source=dev/env/scripts/docker.sh
 source "${GITROOT}/dev/env/scripts/docker.sh"
 # shellcheck source=scripts/lib/external_config.sh

--- a/dev/env/scripts/docker.sh
+++ b/dev/env/scripts/docker.sh
@@ -8,9 +8,6 @@ source "$GITROOT/scripts/lib/log.sh"
 
 _docker_images=""
 
-DOCKER=${DOCKER:-docker}
-CLUSTER_TYPE=${CLUSTER_TYPE:-default}
-
 is_running_inside_docker() {
     if [[ -f "/.dockerenv" ]]; then
         return 0


### PR DESCRIPTION
## Description
PR #603 broke `up.sh` script (`make deploy/dev`). When I execute it I'm receiving the following message:
```
/.../dev/env/scripts/lib.sh: line 77: /.../dev/env/defaults/cluster-type-default/*: No such file or directory
```
The reason is that `init` called after sourcing the `docker.sh` in the `bootstrap.sh`. It means that the `CLUSTER_TYPE` is always resolved as "default".

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Evaluated and added CHANGELOG.md entry if required
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
`make deploy/dev`

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
