### PR TITLE
ROX-13593: Add tenant ID as a k8s label

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -40,7 +40,7 @@ const (
 	helmReleaseName = "tenant-resources"
 
 	managedServicesAnnotation = "platform.stackrox.io/managed-services"
-	tenantIDLabelKey = "rhacs.redhat.com/tenant"
+	tenantIDLabelKey          = "rhacs.redhat.com/tenant"
 
 	centralDbSecretName = "central-db-password" // pragma: allowlist secret
 )

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -38,6 +38,7 @@ const (
 )
 
 var simpleManagedCentral = private.ManagedCentral{
+	Id: centralID,
 	Metadata: private.ManagedCentralAllOfMetadata{
 		Name:      centralName,
 		Namespace: centralNamespace,
@@ -81,6 +82,7 @@ func TestReconcileCreate(t *testing.T) {
 	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralName, Namespace: centralNamespace}, central)
 	require.NoError(t, err)
 	assert.Equal(t, centralName, central.GetName())
+	assert.Equal(t, simpleManagedCentral.Id, central.GetLabels()[tenantIDLabelKey])
 	assert.Equal(t, "1", central.GetAnnotations()[revisionAnnotationKey])
 	assert.Equal(t, "true", central.GetAnnotations()[managedServicesAnnotation])
 	assert.Equal(t, true, *central.Spec.Central.Exposure.Route.Enabled)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
The tenant ID may be used to query tenant resources in scripts and tooling. In addition, the tenant ID identifies the Segment group for telemetry users.

I decided to opt for a k8s label instead of an annotation because I think it fits better semantically as it identifies the resource and is useful in k8s queries.

As far as I understand the reconciler, the label should be set for all existing and new tenants.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] ~Evaluated and added CHANGELOG.md entry if required~
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

