### PR TITLE
Add app-interface build CI embeddable status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ACS Fleet Manager
 [![Dinosaur counter](https://dinosaurs.rhacs-dev.com/)](https://sourcegraph.com/search?q=context:global+repo:stackrox/acs-fleet-manager+dinosaur+count:all&patternType=standard)
 
+[![Build Status](https://ci.ext.devshift.net/buildStatus/icon?job=stackrox-acs-fleet-manager-build-and-push-main)](https://ci.ext.devshift.net/job/stackrox-acs-fleet-manager-build-and-push-main/)
+
 ACS fleet-manager repository for the ACS managed service.
 
 ## Quickstart


### PR DESCRIPTION
Add an unprotected (exposes the badge to users having at least ViewStatus permission on the job) embeddable status for [build app-inteface CI job](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/acs-fleet-manager/cicd/jobs.yaml#L29)

Jenkins docs: https://ci.ext.devshift.net/job/stackrox-acs-fleet-manager-build-and-push-main/badge/

**Note:** embeddable status will be grey with text "not run" for anyone who does not auth in Red Hat SSO