### PR TITLE
ROX-13561: Change Stage environment terraform CD from acs-stage-dp-01 to acs-stage-dp-02, supporting multi-AZ change.

### DIFF
--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -41,7 +41,7 @@ jobs:
           AWS_AUTH_HELPER: none # credentials are populated by the above action
         run: |
           set -euo pipefail
-          ./terraform_cluster.sh stage acs-stage-dp-01
+          ./terraform_cluster.sh stage acs-stage-dp-02
 
   deploy-probe:
     name: Deploy blackbox monitoring probe service to stage
@@ -69,4 +69,4 @@ jobs:
           USE_AWS_VAULT: false
         run: |
           set -euo pipefail
-          ./deploy.sh stage acs-stage-dp-01
+          ./deploy.sh stage acs-stage-dp-02


### PR DESCRIPTION
## Description
Use CD to terraform acs-stage-dp-02 (instead of acs-stage-dp-01, which will be turned down shortly).

## Checklist (Definition of Done)
- ~~[ ] Unit and integration tests added~~
- ~~[ ] Added test description under `Test manual`~~
- ~~[ ] Evaluated and added CHANGELOG.md entry if required~~
- ~~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- ~~[ ] CI and all relevant tests are passing~~
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- ~~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~

## Test manual

Not possible with CD (confirmed by Marcin).