### PR TITLE
ROX-13693: Use Central-ID in database name

### DIFF
--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
@@ -23,6 +23,7 @@ const (
 	dbEngineVersion  = "13.7"
 	dbInstanceClass  = "db.serverless"
 	dbUser           = "rhacs_master"
+	dbPrefix         = "rhacs-"
 	dbInstanceSuffix = "-db-instance"
 	dbClusterSuffix  = "-db-cluster"
 	dbPostgresPort   = 5432
@@ -274,11 +275,11 @@ func NewRDSClient(awsRegion, dbSecurityGroup, dbSubnetGroup string, credentials 
 }
 
 func getClusterID(databaseID string) string {
-	return databaseID + dbClusterSuffix
+	return dbPrefix + databaseID + dbClusterSuffix
 }
 
 func getInstanceID(databaseID string) string {
-	return databaseID + dbInstanceSuffix
+	return dbPrefix + databaseID + dbInstanceSuffix
 }
 
 func newCreateCentralDBClusterInput(clusterID, dbPassword, securityGroup, subnetGroup string) *rds.CreateDBClusterInput {

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -200,8 +200,8 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		if err != nil {
 			return nil, fmt.Errorf("getting DB password from secret: %w", err)
 		}
-		// TODO(ROX-13693): provide the CentralID as DB name, instead of central namespace
-		dbConnectionString, err := r.managedDBProvisioningClient.EnsureDBProvisioned(ctx, remoteCentralNamespace, dbMasterPassword)
+
+		dbConnectionString, err := r.managedDBProvisioningClient.EnsureDBProvisioned(ctx, remoteCentral.Id, dbMasterPassword)
 		if err != nil {
 			return nil, fmt.Errorf("provisioning RDS DB: %w", err)
 		}
@@ -358,7 +358,7 @@ func (r *CentralReconciler) ensureCentralDeleted(ctx context.Context, remoteCent
 	globalDeleted = globalDeleted && centralDeleted
 
 	if r.managedDBEnabled {
-		dbDeleted, err := r.managedDBProvisioningClient.EnsureDBDeprovisioned(central.GetNamespace())
+		dbDeleted, err := r.managedDBProvisioningClient.EnsureDBDeprovisioned(remoteCentral.Id)
 		if err != nil {
 			return false, fmt.Errorf("deprovisioning DB: %v", err)
 		}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This addresses a [code review comment](https://github.com/stackrox/acs-fleet-manager/pull/542#discussion_r1034424909) from #542.

I thought that the Central-ID is not available in fleetshard, and has to be provided by fleet manager. Turns out I was wrong, and so it's a very easy fix.

Note that the names of the DB instance and cluster remain identical, the difference being that now they are formed based on the Central ID instead of the Central namespace (which currently contains the ID, but it's not guaranteed that it would remain so).

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
~~- [ ] Added test description under `Test manual`~~
~~- [ ] Evaluated and added CHANGELOG.md entry if required~~
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
