### PR TITLE
ROX-12137: Use billing_marketplace_account instead of cloud_account_id

### DIFF
--- a/internal/dinosaur/pkg/services/quota/ams_quota_service.go
+++ b/internal/dinosaur/pkg/services/quota/ams_quota_service.go
@@ -88,8 +88,8 @@ func (q amsQuotaService) hasConfiguredQuotaCost(organizationID string, quotaType
 // dinosaur instance type by looking at the resource name and product of the
 // instanceType. Only QuotaCosts that have available quota, or that contain a
 // RelatedResource with "cost" 0 are considered. Only
-// "standard" and "marketplace" billing models are considered. If both are
-// detected "marketplace" is returned.
+// "standard" and "marketplace-*" billing models are considered. If both are
+// detected "marketplace-*" is returned.
 func (q amsQuotaService) getAvailableBillingModelFromDinosaurInstanceType(orgID string, instanceType types.DinosaurInstanceType) (string, error) {
 	quotaCosts, err := q.amsClient.GetQuotaCostsForProduct(orgID, instanceType.GetQuotaType().GetResourceName(), instanceType.GetQuotaType().GetProduct())
 	if err != nil {
@@ -100,11 +100,10 @@ func (q amsQuotaService) getAvailableBillingModelFromDinosaurInstanceType(orgID 
 	for _, qc := range quotaCosts {
 		for _, rr := range qc.RelatedResources() {
 			if qc.Consumed() < qc.Allowed() || rr.Cost() == 0 {
-				if rr.BillingModel() == string(amsv1.BillingModelMarketplace) {
+				if rr.BillingModel() != "" && rr.BillingModel() != string(amsv1.BillingModelStandard) {
 					return rr.BillingModel(), nil
-				} else if rr.BillingModel() == string(amsv1.BillingModelStandard) {
-					billingModel = rr.BillingModel()
 				}
+				billingModel = rr.BillingModel()
 			}
 		}
 	}

--- a/internal/dinosaur/pkg/services/quota/ams_quota_service.go
+++ b/internal/dinosaur/pkg/services/quota/ams_quota_service.go
@@ -98,29 +98,29 @@ func (q amsQuotaService) selectBillingModelFromDinosaurInstanceType(orgID, cloud
 		return "", errors.InsufficientQuotaError("%v: error getting quotas for product %s", err, instanceType.GetQuotaType().GetProduct())
 	}
 
-	hasGenericMarketplace := false
-	hasMarketplaceAWS := false
-	hasStandardMarketplace := false
+	hasBillingModelMarketplace := false
+	hasBillingModelMarketplaceAWS := false
+	hasBillingModelStandard := false
 	for _, qc := range quotaCosts {
 		for _, rr := range qc.RelatedResources() {
 			if qc.Consumed() < qc.Allowed() || rr.Cost() == 0 {
-				hasGenericMarketplace = hasGenericMarketplace || rr.BillingModel() == string(amsv1.BillingModelMarketplace)
-				hasMarketplaceAWS = hasMarketplaceAWS || rr.BillingModel() == string(amsv1.BillingModelMarketplaceAWS)
-				hasStandardMarketplace = hasStandardMarketplace || rr.BillingModel() == string(amsv1.BillingModelStandard)
+				hasBillingModelMarketplace = hasBillingModelMarketplace || rr.BillingModel() == string(amsv1.BillingModelMarketplace)
+				hasBillingModelMarketplaceAWS = hasBillingModelMarketplaceAWS || rr.BillingModel() == string(amsv1.BillingModelMarketplaceAWS)
+				hasBillingModelStandard = hasBillingModelStandard || rr.BillingModel() == string(amsv1.BillingModelStandard)
 			}
 		}
 	}
 
 	if cloudAccountID != "" && cloudProviderID == awsCloudProvider {
-		if hasMarketplaceAWS || hasGenericMarketplace {
+		if hasBillingModelMarketplaceAWS || hasBillingModelMarketplace {
 			return string(amsv1.BillingModelMarketplaceAWS), nil
 		}
 		return "", errors.InvalidCloudAccountID("No subscription available for cloud account %s", cloudAccountID)
 	}
-	if hasGenericMarketplace {
+	if hasBillingModelMarketplace {
 		return string(amsv1.BillingModelMarketplace), nil
 	}
-	if hasStandardMarketplace {
+	if hasBillingModelStandard {
 		return string(amsv1.BillingModelStandard), nil
 	}
 	return "", errors.InsufficientQuotaError("No available billing model found")

--- a/internal/dinosaur/pkg/services/quota/ams_quota_service.go
+++ b/internal/dinosaur/pkg/services/quota/ams_quota_service.go
@@ -14,6 +14,7 @@ import (
 
 // RHACSMarketplaceQuotaID is default quota id used by ACS SKUs.
 const RHACSMarketplaceQuotaID = "cluster|rhinfra|rhacs|marketplace"
+const awsCloudProvider = "aws"
 
 type amsQuotaService struct {
 	amsClient ocm.AMSClient
@@ -110,7 +111,7 @@ func (q amsQuotaService) selectBillingModelFromDinosaurInstanceType(orgID, cloud
 		}
 	}
 
-	if cloudAccountID != "" && cloudProviderID == "aws" {
+	if cloudAccountID != "" && cloudProviderID == awsCloudProvider {
 		if hasMarketplaceAWS || hasGenericMarketplace {
 			return string(amsv1.BillingModelMarketplaceAWS), nil
 		}

--- a/internal/dinosaur/pkg/services/quota/ams_quota_service.go
+++ b/internal/dinosaur/pkg/services/quota/ams_quota_service.go
@@ -30,8 +30,9 @@ func newBaseQuotaReservedResourceResourceBuilder() amsv1.ReservedResourceBuilder
 }
 
 var supportedAMSBillingModels = map[string]struct{}{
-	string(amsv1.BillingModelMarketplace): {},
-	string(amsv1.BillingModelStandard):    {},
+	string(amsv1.BillingModelMarketplace):    {},
+	string(amsv1.BillingModelStandard):       {},
+	string(amsv1.BillingModelMarketplaceAWS): {},
 }
 
 // CheckIfQuotaIsDefinedForInstanceType ...


### PR DESCRIPTION
## Description
To get AMS to bill the cloud account, we need to use `billing_marketplace_account` instead of `cloud_account_id` parameter.
Links:
1. [Slack discussion](https://coreos.slack.com/archives/C0493H149DK/p1669915157049259) with AMS team
2. [Article from AMS](https://source.redhat.com/groups/public/ocm_team/ocm_blog/handling_multiple_marketplaces_in_ams)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Evaluated and added CHANGELOG.md entry if required
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
