### PR TITLE
ROX-13227: Fix negative DNS caching

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -131,6 +131,17 @@ var _ = Describe("Central", func() {
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Succeed())
 		})
 
+		It("should not expose URLs until the routes are created", func() {
+			if createdCentral == nil {
+				Fail("central not created")
+			}
+			if !routesEnabled {
+				Skip(skipRouteMsg)
+			}
+			Expect(createdCentral.CentralUIURL).To(BeEmpty())
+			Expect(createdCentral.CentralDataURL).To(BeEmpty())
+		})
+
 		It("should create central routes", func() {
 			if createdCentral == nil {
 				Fail("central not created")

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -142,6 +142,15 @@ var _ = Describe("Central", func() {
 			Expect(createdCentral.CentralDataURL).To(BeEmpty())
 		})
 
+		It("should transition central's state to ready", func() {
+			if createdCentral == nil {
+				Fail("central not created")
+			}
+			Eventually(func() string {
+				return centralStatus(createdCentral.Id, client)
+			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Equal(constants.CentralRequestStatusReady.String()))
+		})
+
 		It("should create central routes", func() {
 			if createdCentral == nil {
 				Fail("central not created")
@@ -216,15 +225,6 @@ var _ = Describe("Central", func() {
 				Expect(*recordSet.Name).To(Equal(domain))
 				Expect(*record.Value).To(Equal(reencryptIngress.RouterCanonicalHostname)) // TODO use route specific ingress instead of comparing with reencryptIngress for all cases
 			}
-		})
-
-		It("should transition central's state to ready", func() {
-			if createdCentral == nil {
-				Fail("central not created")
-			}
-			Eventually(func() string {
-				return centralStatus(createdCentral.Id, client)
-			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Equal(constants.CentralRequestStatusReady.String()))
 		})
 
 		It("should spin up an egress proxy with two healthy replicas", func() {

--- a/internal/dinosaur/pkg/presenters/dinosaur.go
+++ b/internal/dinosaur/pkg/presenters/dinosaur.go
@@ -26,7 +26,7 @@ func ConvertDinosaurRequest(dinosaurRequestPayload public.CentralRequestPayload,
 
 // PresentCentralRequest - create CentralRequest in an appropriate format ready to be returned by the API
 func PresentCentralRequest(request *dbapi.CentralRequest) public.CentralRequest {
-	return public.CentralRequest{
+	outputRequest := public.CentralRequest{
 		Id:             request.ID,
 		Kind:           "CentralRequest",
 		Href:           fmt.Sprintf("/api/rhacs/v1/centrals/%s", request.ID),
@@ -37,12 +37,21 @@ func PresentCentralRequest(request *dbapi.CentralRequest) public.CentralRequest 
 		Region:         request.Region,
 		Owner:          request.Owner,
 		Name:           request.Name,
-		CentralUIURL:   fmt.Sprintf("https://%s", request.GetUIHost()),
-		CentralDataURL: fmt.Sprintf("%s:%d", request.GetDataHost(), sensorDataPort),
 		CreatedAt:      request.CreatedAt,
 		UpdatedAt:      request.UpdatedAt,
 		FailedReason:   request.FailedReason,
 		Version:        request.ActualCentralVersion,
 		InstanceType:   request.InstanceType,
 	}
+
+	if request.RoutesCreated {
+		if request.GetUIHost() != "" {
+			outputRequest.CentralUIURL = fmt.Sprintf("https://%s", request.GetUIHost())
+		}
+		if request.GetDataHost() != "" {
+			outputRequest.CentralDataURL = fmt.Sprintf("%s:%d", request.GetDataHost(), sensorDataPort)
+		}
+	}
+
+	return outputRequest
 }


### PR DESCRIPTION
## Description
Fixing negative DNS caching issue: Do not expose URLs until corresponding DNS records are created in Route53.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [x] ~Evaluated and added CHANGELOG.md entry if required~
- [x] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
1. CI green
2. Test with UI

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
