### PR TITLE
Probe service: change default ProbeRunTimeout

### DIFF
--- a/probe/config/config.go
+++ b/probe/config/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	ProbeCleanUpTimeout     time.Duration `env:"PROBE_CLEANUP_TIMEOUT" envDefault:"5m"`
 	ProbeHTTPRequestTimeout time.Duration `env:"PROBE_HTTP_REQUEST_TIMEOUT" envDefault:"5s"`
 	ProbePollPeriod         time.Duration `env:"PROBE_POLL_PERIOD" envDefault:"5s"`
-	ProbeRunTimeout         time.Duration `env:"PROBE_RUN_TIMEOUT" envDefault:"15m"`
+	ProbeRunTimeout         time.Duration `env:"PROBE_RUN_TIMEOUT" envDefault:"30m"`
 	ProbeRunWaitPeriod      time.Duration `env:"PROBE_RUN_WAIT_PERIOD" envDefault:"30s"`
 
 	ProbeUsername string


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Change the default `ProbeRunTimeout` to 30m. There is a known edge cases when ACSCS instance could take > 15 minutes to provision on production.


