### PR TITLE
ROX-13811: Enable Performance Insights for managed DBs

### DIFF
--- a/dev/env/manifests/fleetshard-sync/02-fleetshard-sync-deployment.yaml
+++ b/dev/env/manifests/fleetshard-sync/02-fleetshard-sync-deployment.yaml
@@ -49,6 +49,8 @@ spec:
               value: "$MANAGED_DB_SECURITY_GROUP"
             - name: MANAGED_DB_SUBNET_GROUP
               value: "$MANAGED_DB_SUBNET_GROUP"
+            - name: MANAGED_DB_PERFORMANCE_INSIGHTS
+              value: "$MANAGED_DB_PERFORMANCE_INSIGHTS"
             - name: AWS_ROLE_ARN
               valueFrom:
                 secretKeyRef:

--- a/dp-terraform/helm/rhacs-terraform/Chart.yaml
+++ b/dp-terraform/helm/rhacs-terraform/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.3.0"
+version: "0.4.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.0"
+appVersion: "0.4.0"
 
 # List of sub-charts and other dependencies
 dependencies:

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -63,7 +63,7 @@ spec:
         - name: MANAGED_DB_SECURITY_GROUP
           value: {{ required "fleetshardSync.managedDB.securityGroup is required when fleetshardSync.managedDB.enabled = true" .Values.fleetshardSync.managedDB.securityGroup }}
         - name: MANAGED_DB_PERFORMANCE_INSIGHTS
-          value: { { .Values.fleetshardSync.managedDB.performanceInsights | quote } }
+          value: {{ .Values.fleetshardSync.managedDB.performanceInsights | quote }}
         {{- end }}
         - name: AWS_REGION
           value: {{ .Values.fleetshardSync.aws.region }}

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -62,6 +62,8 @@ spec:
           value: {{ required "fleetshardSync.managedDB.subnetGroup is required when fleetshardSync.managedDB.enabled = true" .Values.fleetshardSync.managedDB.subnetGroup }}
         - name: MANAGED_DB_SECURITY_GROUP
           value: {{ required "fleetshardSync.managedDB.securityGroup is required when fleetshardSync.managedDB.enabled = true" .Values.fleetshardSync.managedDB.securityGroup }}
+        - name: MANAGED_DB_PERFORMANCE_INSIGHTS
+          value: { { .Values.fleetshardSync.managedDB.performanceInsights | quote } }
         {{- end }}
         - name: AWS_REGION
           value: {{ .Values.fleetshardSync.aws.region }}

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -99,6 +99,7 @@ helm upgrade rhacs-terraform "${SCRIPT_DIR}" ${HELM_DEBUG_FLAGS:-} \
   --set fleetshardSync.managedDB.enabled=true \
   --set fleetshardSync.managedDB.subnetGroup="${FLEETSHARD_SYNC_MANAGED_DB_SUBNET_GROUP}" \
   --set fleetshardSync.managedDB.securityGroup="${FLEETSHARD_SYNC_MANAGED_DB_SECURITY_GROUP}" \
+  --set fleetshardSync.managedDB.performanceInsights=true \
   --set fleetshardSync.aws.roleARN="${FLEETSHARD_SYNC_AWS_ROLE_ARN}" \
   --set logging.aws.accessKeyId="${LOGGING_AWS_ACCESS_KEY_ID}" \
   --set logging.aws.secretAccessKey="${LOGGING_AWS_SECRET_ACCESS_KEY}" \

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -29,6 +29,7 @@ fleetshardSync:
     enabled: true
     subnetGroup: ""
     securityGroup: ""
+    performanceInsights: true
   aws:
     region: "us-east-1"
     roleARN: ""

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -38,9 +38,10 @@ type AWS struct {
 
 // ManagedDB for configuring managed DB specific parameters
 type ManagedDB struct {
-	Enabled       bool   `env:"MANAGED_DB_ENABLED" envDefault:"false"`
-	SecurityGroup string `env:"MANAGED_DB_SECURITY_GROUP"`
-	SubnetGroup   string `env:"MANAGED_DB_SUBNET_GROUP"`
+	Enabled             bool   `env:"MANAGED_DB_ENABLED" envDefault:"false"`
+	SecurityGroup       string `env:"MANAGED_DB_SECURITY_GROUP"`
+	SubnetGroup         string `env:"MANAGED_DB_SUBNET_GROUP"`
+	PerformanceInsights bool   `env:"MANAGED_DB_PERFORMANCE_INSIGHTS" envDefault:"false"`
 }
 
 // GetConfig retrieves the current runtime configuration from the environment and returns it.

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
@@ -35,9 +35,12 @@ const (
 	dbInstanceClass         = "db.serverless"
 	dbPostgresPort          = 5432
 	dbName                  = "postgres"
-	dbMinCapacity           = 0.5
-	dbMaxCapacity           = 16
 	dbBackupRetentionPeriod = 30
+
+	// The Aurora Serverless v2 DB instance configuration in ACUs (Aurora Capacity Units)
+	// 1 ACU = 1 vCPU + 2GB RAM
+	dbMinCapacityACU = 0.5
+	dbMaxCapacityACU = 16
 )
 
 // RDS is an AWS RDS client tied to one Central instance. It provisions and deprovisions databases
@@ -293,8 +296,8 @@ func newCreateCentralDBClusterInput(clusterID, dbPassword, securityGroup, subnet
 		VpcSecurityGroupIds: aws.StringSlice([]string{securityGroup}),
 		DBSubnetGroupName:   aws.String(subnetGroup),
 		ServerlessV2ScalingConfiguration: &rds.ServerlessV2ScalingConfiguration{
-			MinCapacity: aws.Float64(dbMinCapacity),
-			MaxCapacity: aws.Float64(dbMaxCapacity),
+			MinCapacity: aws.Float64(dbMinCapacityACU),
+			MaxCapacity: aws.Float64(dbMaxCapacityACU),
 		},
 		BackupRetentionPeriod: aws.Int64(dbBackupRetentionPeriod),
 		StorageEncrypted:      aws.Bool(true),


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

We'd like to enable Performance Insights (an AWS RDS feature) for the first users of Field Trial, to get a better idea of DB usage.

With this PR, the feature can be enabled using an environment variable for fleetshard-sync. Perhaps in the future we could allow it to be enabled on a per-customer basis (e.g. in the admin API)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
~~- [ ] Added test description under `Test manual`~~
~~- [ ] Evaluated and added CHANGELOG.md entry if required~~
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [ ] CI and all relevant tests are passing

~~- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~~
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~

## Test manual

Tested in a local cluster, with the RDS database provisioned in a dev account.
```
# run the operator locally (from stackrox/operator)
make install run

# all other commands are run from the acs-fleet-manager root dir
# bootstrap the test env
INSTALL_OPERATOR=NO INSTALL_OLM=NO ./dev/env/scripts/bootstrap.sh

# bring up fleet-manager and fleet-shard
INSTALL_OPERATOR=NO MANAGED_DB_ENABLED=TRUE MANAGED_DB_SUBNET_GROUP=acs-dev-dp-01-subnet-group-1 MANAGED_DB_SECURITY_GROUP=sg-066eb99769c899e79 MANAGED_DB_PERFORMANCE_INSIGHTS=TRUE ./dev/env/scripts/up.sh

# create a test central
./scripts/create-central.sh

# verify that the Central is up and running
# verify in the AWS console that the DB is being created, Perf Insights are enabled, and is finally deleted

#delete test central
curl -X DELETE -H "Authorization: Bearer $(ocm token)" -H "Content-Type: application/json" \
  http://127.0.0.1:8000/api/rhacs/v1/centrals/cdvq4mmsbpn001pjdfkg\?async\=true
```