### PR TITLE
ROX-13593: Add tenant ID to managed resources

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -154,6 +154,9 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 			},
 			Customize: &v1alpha1.CustomizeSpec{
 				EnvVars: envVars,
+				Labels: map[string]string{
+					tenantIDLabelKey: remoteCentral.Id,
+				},
 			},
 		},
 	}

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -89,6 +89,7 @@ func TestReconcileCreate(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, centralName, central.GetName())
 	assert.Equal(t, simpleManagedCentral.Id, central.GetLabels()[tenantIDLabelKey])
+	assert.Equal(t, simpleManagedCentral.Id, central.Spec.Customize.Labels[tenantIDLabelKey])
 	assert.Equal(t, "1", central.GetAnnotations()[revisionAnnotationKey])
 	assert.Equal(t, "true", central.GetAnnotations()[managedServicesAnnotation])
 	assert.Equal(t, true, *central.Spec.Central.Exposure.Route.Enabled)


### PR DESCRIPTION
In addition to labelling the Central CR (see #627), this applies the labels to resources managed by the ACS operator.

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] ~Added test description under `Test manual`~
- [ ] ~Evaluated and added CHANGELOG.md entry if required~
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~