### PR TITLE
ROX-13450: fix image check

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/check_image_exists.sh
+++ b/dp-terraform/helm/rhacs-terraform/check_image_exists.sh
@@ -30,3 +30,4 @@ do
     fi
 done
 echo >&2 "Timed out waiting for the image to appear."
+exit 1


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Followup to #611 where during testing I did run the script in the failure case and it printed the correct message, **but I did not check the return code** :facepalm:
The script had happily always returned 0 eventually. So it did work as intended (delay for as long as necessary) _as long as the build eventually succeeded_.

This (combined with an unexpected shallow repo that resulted in wrong imagetag being used) is what caused a production outage during last release.
cc @kurlov 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~Unit and integration tests added~
- [x] Added test description under `Test manual`
- [x] ~Evaluated and added CHANGELOG.md entry if required~
- [x] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Since we only push the image to `app-sre` org on merges, this is hard to integration-test properly. Following up on this in https://issues.redhat.com/browse/ROX-13747
But I did check this time that exit code is 1 where necessary. :wink: