### PR TITLE
ROX-13747: first stab at running terraforming in dry-run mode on PRs

### DIFF
--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -1,5 +1,7 @@
 name: Deploy Stage Env
 
+# Please keep dry-run-stage.yaml in sync as far as possible when modifying this file.
+
 concurrency: stage
 
 on:

--- a/.github/workflows/dry-run-stage.yaml
+++ b/.github/workflows/dry-run-stage.yaml
@@ -8,7 +8,6 @@ on:
 jobs:
   terraform:
     name: Dry-Run Re-terraform stage clusters
-    needs: cancel
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/dry-run-stage.yaml
+++ b/.github/workflows/dry-run-stage.yaml
@@ -1,0 +1,36 @@
+name: Dry-Run Deployment of Stage Env
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  terraform:
+    name: Dry-Run Re-terraform stage clusters
+    needs: cancel
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment: stage
+    steps:
+      - name: Set up Go 1.18
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.18"
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github
+      - name: Run terraforming on THE stage cluster in DRY-RUN mode
+        working-directory: ./dp-terraform/helm/rhacs-terraform
+        env:
+          AWS_AUTH_HELPER: none # credentials are populated by the above action
+          HELM_DRY_RUN: true
+        run: |
+          set -euo pipefail
+          ./terraform_cluster.sh stage acs-stage-dp-02

--- a/dp-terraform/helm/rhacs-terraform/check_image_exists.sh
+++ b/dp-terraform/helm/rhacs-terraform/check_image_exists.sh
@@ -5,7 +5,7 @@ org="app-sre"
 image="acs-fleet-manager"
 tag="$1"
 # 40*15s = 10 minutes
-retry_attempts=40
+retry_attempts="${2:-40}"
 sleep_time_sec=15
 
 function image_exists() {
@@ -21,7 +21,7 @@ function image_exists() {
 if image_exists; then
     exit 0
 fi
-for attempt in $(seq 1 ${retry_attempts})
+for attempt in $(seq 1 "${retry_attempts}")
 do
     echo >&2 "Failed to assert image existence on attempt ${attempt}. Sleeping ${sleep_time_sec}s..."
     sleep ${sleep_time_sec}

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -57,10 +57,14 @@ if [[ $CLUSTER_ENVIRONMENT != "$ENVIRONMENT" ]]; then
     exit 2
 fi
 
-if [[ "${HELM_PRINT_ONLY:-}" == "true" ]]; then
-    HELM_DEBUG_FLAGS="--debug --dry-run"
+if [[ "${HELM_DRY_RUN:-}" == "true" ]]; then
+    HELM_FLAGS="--dry-run"
+    "${SCRIPT_DIR}/check_image_exists.sh" "${FLEETSHARD_SYNC_TAG}" 0 || echo >&2 "Ignoring failed image check in dry-run mode."
 else
     "${SCRIPT_DIR}/check_image_exists.sh" "${FLEETSHARD_SYNC_TAG}"
+fi
+if [[ "${HELM_DEBUG:-}" == "true" ]]; then
+    HELM_FLAGS="${HELM_FLAGS:-} --debug"
 fi
 
 load_external_config "cluster-${CLUSTER_NAME}" CLUSTER_
@@ -81,7 +85,7 @@ if [[ "${OPERATOR_USE_UPSTREAM}" == "true" ]]; then
 fi
 
 # shellcheck disable=SC2086
-helm upgrade rhacs-terraform "${SCRIPT_DIR}" ${HELM_DEBUG_FLAGS:-} \
+helm upgrade rhacs-terraform "${SCRIPT_DIR}" ${HELM_FLAGS:-} \
   --install \
   --namespace rhacs \
   --create-namespace \


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Unfortunately it is not as useful as it could be, but perhaps a superficial smoke test is better than nothing.

The reason is that the image is only pushed to the app-sre org on merges to `main`, so it does not exist for the tested PRs. Therefore I need to ignore the outcome of the check script (and avoid useless retries) with something like:

```
    "${SCRIPT_DIR}/check_image_exists.sh" "${FLEETSHARD_SYNC_TAG}" 0 || echo >&2 "Ignoring failed image check in dry-run mode."
```

Perhaps it would make sense to parametrize `check_image_exists.sh` to look in another org, where we (I assume) push on every commit. But this adds yet another variable and increases complexity so I'm not sure it's worth it.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [x] ~Evaluated and added CHANGELOG.md entry if required~
- [x] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Relying on CI.