### PR TITLE
ROX-13648: Revert "Rollback automatic tag resolution on prod (#645)"

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -32,17 +32,12 @@ case $ENVIRONMENT in
     FM_ENDPOINT="https://xtr6hh3mg6zc80v.api.stage.openshift.com"
     OBSERVABILITY_GITHUB_TAG="master"
     OBSERVABILITY_OBSERVATORIUM_GATEWAY="https://observatorium-mst.api.stage.openshift.com"
-    # Get the first non-merge commit, starting with HEAD.
-    # On main this should be HEAD
-    FLEETSHARD_SYNC_TAG="$(git rev-list --no-merges --max-count 1 --abbrev-commit --abbrev=7 HEAD)"
     ;;
 
   prod)
     FM_ENDPOINT="https://api.openshift.com"
     OBSERVABILITY_GITHUB_TAG="production"
     OBSERVABILITY_OBSERVATORIUM_GATEWAY="https://observatorium-mst.api.openshift.com"
-
-    FLEETSHARD_SYNC_TAG="1df0bc5"
     ;;
 
   *)
@@ -56,6 +51,10 @@ if [[ $CLUSTER_ENVIRONMENT != "$ENVIRONMENT" ]]; then
     echo "Cluster ${CLUSTER_NAME} is expected to be in environment ${CLUSTER_ENVIRONMENT}, not ${ENVIRONMENT}" >&2
     exit 2
 fi
+
+# Get the first non-merge commit, starting with HEAD.
+# On main this should be HEAD, on production, the latest merged main commit.
+FLEETSHARD_SYNC_TAG="$(git rev-list --no-merges --max-count 1 --abbrev-commit --abbrev=7 HEAD)"
 
 if [[ "${HELM_PRINT_ONLY:-}" == "true" ]]; then
     HELM_DEBUG_FLAGS="--debug --dry-run"


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This reverts commit 1847f55d50861bfa2b309927b1f64365840164c7.

The checkout method was fixed in #647 so we can go back to commit auto-discovery.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~Unit and integration tests added~
- [x] Added test description under `Test manual`
- [x] ~Evaluated and added CHANGELOG.md entry if required~
- [x] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Ran the script manually.

For stage it worked.

```
[mowsiany@mowsiany rhacs-terraform]$ AWS_AUTH_HELPER=aws-vault HELM_PRINT_ONLY=true ./terraform_cluster.sh stage acs-stage-dp-02
Logged into "https://api.acs-stage-dp-02.8csb.p1.openshiftapps.com:6443" as "system:serviceaccount:acscs-dataplane-cd:acscs-cd-robot" using the token provided.

You have access to 114 projects, the list has been suppressed. You can list all projects with 'oc projects'

Using project "default".
history.go:56: [debug] getting history for release rhacs-terraform
upgrade.go:142: [debug] preparing upgrade for rhacs-terraform
upgrade.go:150: [debug] performing update for rhacs-terraform
upgrade.go:313: [debug] dry run for rhacs-terraform
Release "rhacs-terraform" has been upgraded. Happy Helming!
NAME: rhacs-terraform
LAST DEPLOYED: Fri Dec  9 08:27:57 2022
NAMESPACE: rhacs
STATUS: pending-upgrade
REVISION: 31
TEST SUITE: None
USER-SUPPLIED VALUES:
[snip]
```

For production there was an unrelated failure that I think is expected at this point?

```
AWS_AUTH_HELPER=aws-vault HELM_PRINT_ONLY=true ./terraform_cluster.sh prod acs-prod-dp-01
Logged into "https://api.acs-prod-dp-01.pnz3.p1.openshiftapps.com:6443" as "system:serviceaccount:acscs-dataplane-cd:acscs-cd-robot" using the token provided.

You have access to 173 projects, the list has been suppressed. You can list all projects with 'oc projects'

Using project "default".
./terraform_cluster.sh: line 83: FLEETSHARD_SYNC_MANAGED_DB_SUBNET_GROUP: unbound variable
```