### PR TITLE
ROX-12763: use claim mappings for admin:org:all role

### DIFF
--- a/fleetshard/pkg/central/reconciler/init_auth.go
+++ b/fleetshard/pkg/central/reconciler/init_auth.go
@@ -56,7 +56,7 @@ var (
 				Props: &storage.GroupProperties{
 					AuthProviderId: providerId,
 					Key:            "groups",
-					Value:          "org_admin",
+					Value:          "org:admin:all",
 					Traits: &storage.Traits{
 						MutabilityMode: storage.Traits_ALLOW_MUTATE_FORCED,
 					},
@@ -160,6 +160,9 @@ func createAuthProviderRequest(central private.ManagedCentral) *storage.AuthProv
 			"client_secret":                central.Spec.Auth.ClientSecret, // pragma: allowlist secret
 			"mode":                         "post",
 			"disable_offline_access_scope": "true",
+		},
+		ClaimMappings: map[string]string{
+			"realm_access.roles": "groups",
 		},
 		// TODO: for testing purposes only; remove once host is correctly specified in fleet-manager
 		ExtraUiEndpoints: []string{"localhost:8443"},

--- a/fleetshard/pkg/central/reconciler/init_auth.go
+++ b/fleetshard/pkg/central/reconciler/init_auth.go
@@ -56,7 +56,7 @@ var (
 				Props: &storage.GroupProperties{
 					AuthProviderId: providerId,
 					Key:            "groups",
-					Value:          "org:admin:all",
+					Value:          "admin:org:all",
 					Traits: &storage.Traits{
 						MutabilityMode: storage.Traits_ALLOW_MUTATE_FORCED,
 					},


### PR DESCRIPTION
## Description
After claim mappings were introduced to central https://github.com/stackrox/stackrox/pull/3460, we can use them to move from using `is_org_admin` claim to `admin:org:all` role.
This PR:
* add claim mapping from `realm_access.roles` to `groups`
* change rule from using `org_admin` to `admin:org:all`

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] Evaluated and added CHANGELOG.md entry if required
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

Follow https://github.com/stackrox/acs-fleet-manager/blob/main/docs/development/setup-developer-osd-cluster.md and
1. Deploy fleet-manager
2. Deploy fleetshard synchronizer in OSD cluster
3. Add routes to access the Central UI: https://github.com/stackrox/acs-fleet-manager/blob/main/docs/development/test-locally-route-hosts.md
4. Go to `Red Hat SSO` auth provider and see rule with `admin:org:all` group
5. Press `Test Login` and see `admin:org:all` in `groups`
