### PR TITLE
ROX-12921: Introduce timeout for ACSCS requests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -296,7 +296,7 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "4e199b4a1c40b497a95fcd1cd896351733849949",
         "is_verified": false,
-        "line_number": 663,
+        "line_number": 668,
         "is_secret": false
       }
     ],
@@ -321,5 +321,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-24T16:16:02Z"
+  "generated_at": "2022-12-15T17:48:26Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ install: verify lint
 .PHONY: install
 
 clean:
-	rm -f fleet-manager fleetshard-sync probe
+	rm -f fleet-manager fleetshard-sync probe/bin/probe
 .PHONY: clean
 
 # Runs the unit tests.

--- a/Makefile
+++ b/Makefile
@@ -779,6 +779,7 @@ deploy/service: CENTRAL_OPERATOR_OPERATOR_ADDON_ID ?= "managed-central-qe"
 deploy/service: FLEETSHARD_ADDON_ID ?= "fleetshard-operator-qe"
 deploy/service: CENTRAL_IDP_ISSUER ?= "https://sso.stage.redhat.com/auth/realms/redhat-external"
 deploy/service: CENTRAL_IDP_CLIENT_ID ?= "rhacs-ms-dev"
+deploy/service: CENTRAL_REQUEST_EXPIRATION_TIMEOUT ?= "1h"
 deploy/service: deploy/envoy deploy/route
 	@if test -z "$(IMAGE_TAG)"; then echo "IMAGE_TAG was not specified"; exit 1; fi
 	@time timeout --foreground 3m bash -c "until oc get routes -n $(NAMESPACE) | grep -q fleet-manager; do echo 'waiting for fleet-manager route to be created'; sleep 1; done"
@@ -818,6 +819,7 @@ deploy/service: deploy/envoy deploy/route
 		-p CENTRAL_OPERATOR_OPERATOR_ADDON_ID="${CENTRAL_OPERATOR_OPERATOR_ADDON_ID}" \
 		-p FLEETSHARD_ADDON_ID="${FLEETSHARD_ADDON_ID}" \
 		-p DATAPLANE_CLUSTER_SCALING_TYPE="${DATAPLANE_CLUSTER_SCALING_TYPE}" \
+		-p CENTRAL_REQUEST_EXPIRATION_TIMEOUT="${CENTRAL_REQUEST_EXPIRATION_TIMEOUT}" \
 		| oc apply -f - -n $(NAMESPACE)
 .PHONY: deploy/service
 

--- a/internal/dinosaur/pkg/config/central.go
+++ b/internal/dinosaur/pkg/config/central.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
@@ -32,6 +33,10 @@ type CentralConfig struct {
 	CentralIDPClientSecret     string `json:"central_idp_client_secret"`
 	CentralIDPClientSecretFile string `json:"central_idp_client_secret_file"`
 	CentralIDPIssuer           string `json:"central_idp_issuer"`
+
+	// TODO: this parameter does not belong here, as it's configuration of central request, not central.
+	// TODO: However, for the time being there's no better place to put this parameter.
+	CentralRequestExpirationTimeout time.Duration `json:"central_request_expiration_timeout"`
 }
 
 // NewCentralConfig ...
@@ -45,6 +50,7 @@ func NewCentralConfig() *CentralConfig {
 		Quota:                            NewCentralQuotaConfig(),
 		CentralIDPClientSecretFile:       "secrets/central.idp-client-secret", //pragma: allowlist secret
 		CentralIDPIssuer:                 "https://sso.redhat.com/auth/realms/redhat-external",
+		CentralRequestExpirationTimeout:  60 * time.Minute,
 	}
 }
 
@@ -62,6 +68,7 @@ func (c *CentralConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.CentralIDPClientID, "central-idp-client-id", c.CentralIDPClientID, "OIDC client_id to pass to Central's auth config")
 	fs.StringVar(&c.CentralIDPClientSecretFile, "central-idp-client-secret-file", c.CentralIDPClientSecretFile, "File containing OIDC client_secret to pass to Central's auth config")
 	fs.StringVar(&c.CentralIDPIssuer, "central-idp-issuer", c.CentralIDPIssuer, "OIDC issuer URL to pass to Central's auth config")
+	fs.DurationVar(&c.CentralRequestExpirationTimeout, "central-request-expiration-timeout", c.CentralRequestExpirationTimeout, "Timeout for central requests")
 }
 
 // ReadFiles ...

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/accepted_centrals_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/accepted_centrals_mgr.go
@@ -27,10 +27,11 @@ type AcceptedCentralManager struct {
 	quotaServiceFactory    services.QuotaServiceFactory
 	clusterPlmtStrategy    services.ClusterPlacementStrategy
 	dataPlaneClusterConfig *config.DataplaneClusterConfig
+	centralRequestTimeout  time.Duration
 }
 
 // NewAcceptedCentralManager creates a new manager
-func NewAcceptedCentralManager(centralService services.DinosaurService, quotaServiceFactory services.QuotaServiceFactory, clusterPlmtStrategy services.ClusterPlacementStrategy, dataPlaneClusterConfig *config.DataplaneClusterConfig) *AcceptedCentralManager {
+func NewAcceptedCentralManager(centralService services.DinosaurService, quotaServiceFactory services.QuotaServiceFactory, clusterPlmtStrategy services.ClusterPlacementStrategy, dataPlaneClusterConfig *config.DataplaneClusterConfig, centralConfig *config.CentralConfig) *AcceptedCentralManager {
 	return &AcceptedCentralManager{
 		BaseWorker: workers.BaseWorker{
 			ID:         uuid.New().String(),
@@ -41,6 +42,7 @@ func NewAcceptedCentralManager(centralService services.DinosaurService, quotaSer
 		quotaServiceFactory:    quotaServiceFactory,
 		clusterPlmtStrategy:    clusterPlmtStrategy,
 		dataPlaneClusterConfig: dataPlaneClusterConfig,
+		centralRequestTimeout:  centralConfig.CentralRequestExpirationTimeout,
 	}
 }
 
@@ -80,6 +82,11 @@ func (k *AcceptedCentralManager) Reconcile() []error {
 }
 
 func (k *AcceptedCentralManager) reconcileAcceptedCentral(centralRequest *dbapi.CentralRequest) error {
+	// Check if instance creation is not expired before trying to reconcile it.
+	// Otherwise, assign status Failed.
+	if err := CheckTimeout(k.centralService, k.centralRequestTimeout, centralRequest); err != nil {
+		return err
+	}
 	cluster, err := k.clusterPlmtStrategy.FindCluster(centralRequest)
 	if err != nil {
 		return errors.Wrapf(err, "failed to find cluster for central request %s", centralRequest.ID)

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/accepted_centrals_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/accepted_centrals_mgr.go
@@ -84,7 +84,7 @@ func (k *AcceptedCentralManager) Reconcile() []error {
 func (k *AcceptedCentralManager) reconcileAcceptedCentral(centralRequest *dbapi.CentralRequest) error {
 	// Check if instance creation is not expired before trying to reconcile it.
 	// Otherwise, assign status Failed.
-	if err := CheckTimeout(k.centralService, k.centralRequestTimeout, centralRequest); err != nil {
+	if err := FailIfTimeoutExceeded(k.centralService, k.centralRequestTimeout, centralRequest); err != nil {
 		return err
 	}
 	cluster, err := k.clusterPlmtStrategy.FindCluster(centralRequest)

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/preparing_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/preparing_dinosaurs_mgr.go
@@ -78,7 +78,7 @@ func (k *PreparingDinosaurManager) Reconcile() []error {
 func (k *PreparingDinosaurManager) reconcilePreparingDinosaur(dinosaur *dbapi.CentralRequest) error {
 	// Check if instance creation is not expired before trying to reconcile it.
 	// Otherwise, assign status Failed.
-	if err := CheckTimeout(k.dinosaurService, k.centralRequestTimeout, dinosaur); err != nil {
+	if err := FailIfTimeoutExceeded(k.dinosaurService, k.centralRequestTimeout, dinosaur); err != nil {
 		return err
 	}
 	if err := k.dinosaurService.PrepareDinosaurRequest(dinosaur); err != nil {

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/preparing_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/preparing_dinosaurs_mgr.go
@@ -3,6 +3,8 @@ package dinosaurmgrs
 import (
 	"time"
 
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/config"
+
 	"github.com/google/uuid"
 	constants2 "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
@@ -20,18 +22,20 @@ import (
 // PreparingDinosaurManager represents a dinosaur manager that periodically reconciles dinosaur requests
 type PreparingDinosaurManager struct {
 	workers.BaseWorker
-	dinosaurService services.DinosaurService
+	dinosaurService       services.DinosaurService
+	centralRequestTimeout time.Duration
 }
 
 // NewPreparingDinosaurManager creates a new dinosaur manager
-func NewPreparingDinosaurManager(dinosaurService services.DinosaurService) *PreparingDinosaurManager {
+func NewPreparingDinosaurManager(dinosaurService services.DinosaurService, centralConfig *config.CentralConfig) *PreparingDinosaurManager {
 	return &PreparingDinosaurManager{
 		BaseWorker: workers.BaseWorker{
 			ID:         uuid.New().String(),
 			WorkerType: "preparing_dinosaur",
 			Reconciler: workers.Reconciler{},
 		},
-		dinosaurService: dinosaurService,
+		dinosaurService:       dinosaurService,
+		centralRequestTimeout: centralConfig.CentralRequestExpirationTimeout,
 	}
 }
 
@@ -72,6 +76,11 @@ func (k *PreparingDinosaurManager) Reconcile() []error {
 }
 
 func (k *PreparingDinosaurManager) reconcilePreparingDinosaur(dinosaur *dbapi.CentralRequest) error {
+	// Check if instance creation is not expired before trying to reconcile it.
+	// Otherwise, assign status Failed.
+	if err := CheckTimeout(k.dinosaurService, k.centralRequestTimeout, dinosaur); err != nil {
+		return err
+	}
 	if err := k.dinosaurService.PrepareDinosaurRequest(dinosaur); err != nil {
 		return k.handleDinosaurRequestCreationError(dinosaur, err)
 	}

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/provisioning_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/provisioning_dinosaurs_mgr.go
@@ -64,7 +64,7 @@ func (k *ProvisioningDinosaurManager) Reconcile() []error {
 		glog.Infof("provisioning centrals count = %d", len(provisioningDinosaurs))
 	}
 	for _, dinosaur := range provisioningDinosaurs {
-		if err := CheckTimeout(k.dinosaurService, k.centralRequestTimeout, dinosaur); err != nil {
+		if err := FailIfTimeoutExceeded(k.dinosaurService, k.centralRequestTimeout, dinosaur); err != nil {
 			encounteredErrors = append(encounteredErrors, err)
 		} else {
 			glog.V(10).Infof("provisioning central id = %s", dinosaur.ID)

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/provisioning_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/provisioning_dinosaurs_mgr.go
@@ -3,6 +3,8 @@ package dinosaurmgrs
 import (
 	"time"
 
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/config"
+
 	"github.com/google/uuid"
 	constants2 "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/services"
@@ -17,20 +19,22 @@ import (
 // ProvisioningDinosaurManager represents a dinosaur manager that periodically reconciles dinosaur requests
 type ProvisioningDinosaurManager struct {
 	workers.BaseWorker
-	dinosaurService      services.DinosaurService
-	observatoriumService services.ObservatoriumService
+	dinosaurService       services.DinosaurService
+	observatoriumService  services.ObservatoriumService
+	centralRequestTimeout time.Duration
 }
 
 // NewProvisioningDinosaurManager creates a new dinosaur manager
-func NewProvisioningDinosaurManager(dinosaurService services.DinosaurService, observatoriumService services.ObservatoriumService) *ProvisioningDinosaurManager {
+func NewProvisioningDinosaurManager(dinosaurService services.DinosaurService, observatoriumService services.ObservatoriumService, centralConfig *config.CentralConfig) *ProvisioningDinosaurManager {
 	return &ProvisioningDinosaurManager{
 		BaseWorker: workers.BaseWorker{
 			ID:         uuid.New().String(),
 			WorkerType: "provisioning_dinosaur",
 			Reconciler: workers.Reconciler{},
 		},
-		dinosaurService:      dinosaurService,
-		observatoriumService: observatoriumService,
+		dinosaurService:       dinosaurService,
+		observatoriumService:  observatoriumService,
+		centralRequestTimeout: centralConfig.CentralRequestExpirationTimeout,
 	}
 }
 
@@ -60,9 +64,13 @@ func (k *ProvisioningDinosaurManager) Reconcile() []error {
 		glog.Infof("provisioning centrals count = %d", len(provisioningDinosaurs))
 	}
 	for _, dinosaur := range provisioningDinosaurs {
-		glog.V(10).Infof("provisioning central id = %s", dinosaur.ID)
-		metrics.UpdateCentralRequestsStatusSinceCreatedMetric(constants2.CentralRequestStatusProvisioning, dinosaur.ID, dinosaur.ClusterID, time.Since(dinosaur.CreatedAt))
-		// TODO implement additional reconcilation logic for provisioning dinosaurs
+		if err := CheckTimeout(k.dinosaurService, k.centralRequestTimeout, dinosaur); err != nil {
+			encounteredErrors = append(encounteredErrors, err)
+		} else {
+			glog.V(10).Infof("provisioning central id = %s", dinosaur.ID)
+			metrics.UpdateCentralRequestsStatusSinceCreatedMetric(constants2.CentralRequestStatusProvisioning, dinosaur.ID, dinosaur.ClusterID, time.Since(dinosaur.CreatedAt))
+			// TODO implement additional reconcilation logic for provisioning dinosaurs
+		}
 	}
 
 	return encounteredErrors

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/timeout.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/timeout.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stackrox/acs-fleet-manager/pkg/metrics"
 )
 
-// CheckTimeout checks timeout on a dinosaur instance and moves it to failed if timeout is exceeded.
-func CheckTimeout(dinosaurService services.DinosaurService, timeout time.Duration, dinosaur *dbapi.CentralRequest) error {
+// FailIfTimeoutExceeded checks timeout on a dinosaur instance and moves it to failed if timeout is exceeded.
+func FailIfTimeoutExceeded(dinosaurService services.DinosaurService, timeout time.Duration, dinosaur *dbapi.CentralRequest) error {
 	if dinosaur.CreatedAt.Before(time.Now().Add(-timeout)) {
 		dinosaur.Status = constants2.CentralRequestStatusFailed.String()
 		dinosaur.FailedReason = "Creation time went over the timeout. Interrupting central initialization."

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/timeout.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/timeout.go
@@ -1,0 +1,26 @@
+package dinosaurmgrs
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	constants2 "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/services"
+	"github.com/stackrox/acs-fleet-manager/pkg/metrics"
+)
+
+// CheckTimeout checks timeout on a dinosaur instance and moves it to failed if timeout is exceeded.
+func CheckTimeout(dinosaurService services.DinosaurService, timeout time.Duration, dinosaur *dbapi.CentralRequest) error {
+	if dinosaur.CreatedAt.Before(time.Now().Add(-timeout)) {
+		dinosaur.Status = constants2.CentralRequestStatusFailed.String()
+		dinosaur.FailedReason = "Creation time went over the timeout. Interrupting central initialization."
+
+		if err := dinosaurService.Update(dinosaur); err != nil {
+			return errors.Wrapf(err, "failed to update timed out central %s", dinosaur.ID)
+		}
+		metrics.UpdateCentralRequestsStatusSinceCreatedMetric(constants2.CentralRequestStatusFailed, dinosaur.ID, dinosaur.ClusterID, time.Since(dinosaur.CreatedAt))
+		metrics.IncreaseCentralTimeoutCountMetric(dinosaur.ID, dinosaur.ClusterID)
+	}
+	return nil
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -121,6 +121,11 @@ var CentralPerClusterCountMetricsLabels = []string{
 	LabelClusterExternalID,
 }
 
+var centralTimeoutCountMetricLabels = []string{
+	LabelID,
+	LabelClusterID,
+}
+
 // ClusterOperationsCountMetricsLabels - is the slice of labels to add to Central operations count metrics
 var ClusterOperationsCountMetricsLabels = []string{
 	labelOperation,
@@ -415,6 +420,24 @@ var centralStatusSinceCreatedMetric = prometheus.NewGaugeVec(
 	},
 	centralStatusSinceCreatedMetricLabels,
 )
+
+var centralTimeoutCountMetric = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Subsystem: FleetManager,
+		Name:      "central_timeout_total_count",
+		Help:      "number of total timed-out centrals",
+	},
+	centralTimeoutCountMetricLabels,
+)
+
+// IncreaseCentralTimeoutCountMetric - increase counter for the centralTimeoutCountMetric
+func IncreaseCentralTimeoutCountMetric(centralID, clusterID string) {
+	labels := prometheus.Labels{
+		LabelID:        centralID,
+		LabelClusterID: clusterID,
+	}
+	centralTimeoutCountMetric.With(labels).Inc()
+}
 
 // IncreaseCentralSuccessOperationsCountMetric - increase counter for the centralOperationsSuccessCountMetric
 func IncreaseCentralSuccessOperationsCountMetric(operation constants2.CentralOperation) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -715,6 +715,7 @@ func init() {
 	prometheus.MustRegister(reconcilerFailureCountMetric)
 	prometheus.MustRegister(reconcilerErrorsCountMetric)
 	prometheus.MustRegister(leaderWorkerMetric)
+	prometheus.MustRegister(centralTimeoutCountMetric)
 
 	// metrics for observatorium
 	prometheus.MustRegister(observatoriumRequestCountMetric)
@@ -780,6 +781,7 @@ func Reset() {
 	reconcilerFailureCountMetric.Reset()
 	reconcilerErrorsCountMetric.Reset()
 	leaderWorkerMetric.Reset()
+	centralTimeoutCountMetric.Reset()
 
 	ResetMetricsForObservatorium()
 

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -444,6 +444,11 @@ parameters:
   description: Default memory limit for scanner-db deployments for newly created tenants
   value: "2500M"
 
+- name: CENTRAL_REQUEST_EXPIRATION_TIMEOUT
+  displayName: Central request expiration timeout
+  description: Maximum interval after which central request is canceled
+  value: "1h"
+
 objects:
   - kind: ConfigMap
     apiVersion: v1
@@ -1233,6 +1238,7 @@ objects:
             - --central-operator-addon-id=${CENTRAL_OPERATOR_OPERATOR_ADDON_ID}
             - --fleetshard-addon-id=${FLEETSHARD_ADDON_ID}
             - --alsologtostderr
+            - --central-request-expiration-timeout=${CENTRAL_REQUEST_EXPIRATION_TIMEOUT}
             - -v=${GLOG_V}
             resources:
               requests:


### PR DESCRIPTION
## Description
Alternative approach to https://github.com/stackrox/acs-fleet-manager/pull/618 as suggested by Evan.
Instead of creating a new worker to check for a timeout in this PR existing workers check for timeout for instances in corresponding status.

There are a few caveats to the implementation:
* `accepted_centrals_mgr` has a separate timeout for a certain kind of transient errors
* `preparing_dinosaurs_mgr` has separate timeout for server errors, and fail request immediately on client errors. The only value timeout brings here is that the timeout is checked before `PrepareDinosaurRequest` is executed.
* `provisioning_dinosaurs_mgr` did not own transition from `Provisioning` state before. There is a race condition now between updates coming from `fleetshard-sync` and timeout logic. In worst case scenario, for a short moment instance will become `Ready` before switching to `Failed`. That, of course, is behaviour only possible when timeout was just hit. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Evaluated and added CHANGELOG.md entry if required
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

1. Deployed fleet-manager locally
2. Logged in to the database and saw `failed` status and that `failed_reason` is `Creation time went over the 
timeout. Interrupting central initialization.`
3. Accessed `localhost:8080/metrics` and saw individual records per timed out request:
```
# HELP acs_fleet_manager_central_timeout_total_count number of total timed-out centrals
# TYPE acs_fleet_manager_central_timeout_total_count counter
acs_fleet_manager_central_timeout_total_count{cluster_id="20fusbtpjsm0t7fabl144ptnt9e2iaig",id="cedjb207t2un94jubmrg"} 1
acs_fleet_manager_central_timeout_total_count{cluster_id="20fusbtpjsm0t7fabl144ptnt9e2iaig",id="cedje9g7t2un94jubmu0"} 1
acs_fleet_manager_central_timeout_total_count{cluster_id="20fusbtpjsm0t7fabl144ptnt9e2iaig",id="cedjfn87t2un94jubmvg"} 1
```
4. Verified that time passed before timeout is hit matches with configuration value
