### PR TITLE
ROX-13106: Show hint to user when OCM user or org is not found

### DIFF
--- a/internal/dinosaur/pkg/handlers/cloud_accounts.go
+++ b/internal/dinosaur/pkg/handlers/cloud_accounts.go
@@ -44,7 +44,7 @@ func (h *cloudAccountsHandler) actionFunc(r *http.Request) func() (i interface{}
 		}
 		organizationID, err := h.client.GetOrganisationIDFromExternalID(orgID)
 		if err != nil {
-			return nil, errors.NewWithCause(errors.ErrorGeneral, err, "error getting cloud accounts: failed to get organization with external id %q", orgID)
+			return nil, errors.OrganisationNotFound(orgID, err)
 		}
 
 		cloudAccounts, err := h.client.GetCustomerCloudAccounts(organizationID, []string{quota.RHACSMarketplaceQuotaID})

--- a/internal/dinosaur/pkg/services/quota/ams_quota_service.go
+++ b/internal/dinosaur/pkg/services/quota/ams_quota_service.go
@@ -40,7 +40,7 @@ var supportedAMSBillingModels = map[string]struct{}{
 func (q amsQuotaService) CheckIfQuotaIsDefinedForInstanceType(dinosaur *dbapi.CentralRequest, instanceType types.DinosaurInstanceType) (bool, *errors.ServiceError) {
 	orgID, err := q.amsClient.GetOrganisationIDFromExternalID(dinosaur.OrganisationID)
 	if err != nil {
-		return false, errors.NewWithCause(errors.ErrorGeneral, err, fmt.Sprintf("failed to get organization with external id %v", dinosaur.OrganisationID))
+		return false, errors.OrganisationNotFound(dinosaur.OrganisationID, err)
 	}
 
 	hasQuota, err := q.hasConfiguredQuotaCost(orgID, instanceType.GetQuotaType())
@@ -134,7 +134,7 @@ func (q amsQuotaService) ReserveQuota(dinosaur *dbapi.CentralRequest, instanceTy
 
 	orgID, err := q.amsClient.GetOrganisationIDFromExternalID(dinosaur.OrganisationID)
 	if err != nil {
-		return "", errors.NewWithCause(errors.ErrorGeneral, err, fmt.Sprintf("Error checking quota: failed to get organization with external id %v", dinosaur.OrganisationID))
+		return "", errors.OrganisationNotFound(dinosaur.OrganisationID, err)
 	}
 	bm, err := q.selectBillingModelFromDinosaurInstanceType(orgID, dinosaur.CloudProvider, dinosaur.CloudAccountID, instanceType)
 	if err != nil {
@@ -171,7 +171,7 @@ func (q amsQuotaService) ReserveQuota(dinosaur *dbapi.CentralRequest, instanceTy
 
 	resp, err := q.amsClient.ClusterAuthorization(cb)
 	if err != nil {
-		return "", errors.NewWithCause(errors.ErrorGeneral, err, "Error reserving quota")
+		return "", errors.FailedClusterAuthorization(err)
 	}
 
 	if resp.Allowed() {

--- a/pkg/client/ocm/client.go
+++ b/pkg/client/ocm/client.go
@@ -176,8 +176,7 @@ func (c *client) GetOrganisationIDFromExternalID(externalID string) (string, err
 
 	items := res.Items()
 	if items.Len() < 1 {
-		// should never happen...
-		return "", serviceErrors.New(serviceErrors.ErrorGeneral, "organisation with external_id '%s' can't be found", externalID)
+		return "", serviceErrors.New(serviceErrors.ErrorNotFound, "organisation with external id '%s' not found", externalID)
 	}
 
 	return items.Get(0).ID(), nil

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -734,3 +734,27 @@ func InvalidCloudAccountID(reason string, values ...interface{}) *ServiceError {
 	message := fmt.Sprintf("%s: %s", ErrorInvalidCloudAccountIDReason, reason)
 	return New(ErrorInvalidCloudAccountID, message, values...)
 }
+
+// OrganisationNotFound converts the error to a ServiceError and returns a reason and hint for the user.
+func OrganisationNotFound(externalID string, err error) *ServiceError {
+	svcErr := ToServiceError(err)
+	reason := "organisation with external id %s not found"
+	// Visiting the OpenShift page in console registers the user and their organisation with OCM.
+	// See https://issues.redhat.com/browse/SDB-3194 for more context.
+	if svcErr.Is404() {
+		reason += " - visit https://console.redhat.com/openshift and try again"
+	}
+	return NewWithCause(svcErr.Code, svcErr, reason, externalID)
+}
+
+// FailedClusterAuthorization converts the error to a ServiceError and returns a reason and hint for the user.
+func FailedClusterAuthorization(err error) *ServiceError {
+	svcErr := ToServiceError(err)
+	reason := "failed to reserve quota"
+	// Visiting the OpenShift page in console registers the user and their organisation with OCM.
+	// See https://issues.redhat.com/browse/SDB-3194 for more context.
+	if svcErr.Is404() {
+		reason += " - visit https://console.redhat.com/openshift and try again"
+	}
+	return NewWithCause(svcErr.Code, svcErr, reason)
+}


### PR DESCRIPTION
## Description
OCM does not load the user information from Red Hat SSO lazily. Instead, it requires that the user has logged into OCM at least once - this can be done by visiting https://console.redhat.com/openshift. See https://issues.redhat.com/browse/SDB-3194 for more context on this behavior.

Our approach here is to inform the user why the creation failed and how they can fix it themselves. 404 in `OrganisationNotFound` occurs when neither org nor user is registered with OCM. 404 in `FailedClusterAuthorization` occurs when the user is unknown to OCM, but they belong to an org that is registered with OCM.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~Unit and integration tests added~
- [x] Added test description under `Test manual`
- [ ] ~Evaluated and added CHANGELOG.md entry if required~
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Tested with local fleet manager and newly created RH accounts.