### PR TITLE
ROX-13911: Add RDS provisioning integration test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,9 @@ jobs:
   verify-test:
     name: "Verify & Test"
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     environment: development
     services:
       postgres:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,7 @@ jobs:
   verify-test:
     name: "Verify & Test"
     runs-on: ubuntu-latest
+    environment: dev
     services:
       postgres:
         image: postgres:11
@@ -100,7 +101,17 @@ jobs:
           echo -n "${{ secrets.POSTGRES_PASSWORD }}" > secrets/db.password
       - name: Run Migration Script
         run: make db/migrate
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-rds-integration-tests
       - name: Verify & Test
+        env:
+          RUN_RDS_TESTS: "true"
+          AWS_RDS_SECURITY_GROUP_ID: ${{ secrets.AWS_RDS_SECURITY_GROUP_ID }}
+          AWS_RDS_DB_SUBNET_GROUP_NAME: ${{ secrets.AWS_RDS_DB_SUBNET_GROUP_NAME }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
         run: |
           export GOPATH=$(go env GOPATH)
           export PATH=${PATH}:$GOPATH/bin

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
   verify-test:
     name: "Verify & Test"
     runs-on: ubuntu-latest
-    environment: dev
+    environment: development
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,10 +60,6 @@ jobs:
   verify-test:
     name: "Verify & Test"
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    environment: development
     services:
       postgres:
         image: postgres:11
@@ -104,17 +100,7 @@ jobs:
           echo -n "${{ secrets.POSTGRES_PASSWORD }}" > secrets/db.password
       - name: Run Migration Script
         run: make db/migrate
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github
       - name: Verify & Test
-        env:
-          RUN_RDS_TESTS: "true"
-          AWS_RDS_SECURITY_GROUP_ID: ${{ secrets.AWS_RDS_SECURITY_GROUP_ID }}
-          AWS_RDS_DB_SUBNET_GROUP_NAME: ${{ secrets.AWS_RDS_DB_SUBNET_GROUP_NAME }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
         run: |
           export GOPATH=$(go env GOPATH)
           export PATH=${PATH}:$GOPATH/bin

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-rds-integration-tests
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github
       - name: Verify & Test
         env:
           RUN_RDS_TESTS: "true"

--- a/.github/workflows/rds.yaml
+++ b/.github/workflows/rds.yaml
@@ -1,0 +1,73 @@
+# This runs tests that check the AWS RDS provisioning / deprovisioning logic
+name: AWS RDS integration tests
+
+on:
+  push:
+    branches:
+      - main
+      - release
+    paths-ignore:
+      - '*.md'
+      - '*.sh'
+      - '.github/*.md'
+      - '.github/workflows/openapi_update.yaml'
+      - '.github/CODEOWNERS'
+      - 'templates/**'
+      - '.openapi-generator-ignore'
+      - 'openapi/**'
+      - 'docs/**'
+      - 'pkg/api/openapi/docs/**'
+      - 'pkg/api/openapi/.openapi-generator-ignore'
+
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '*.md'
+      - '*.sh'
+      - '.github/*.md'
+      - '.github/workflows/openapi_update.yaml'
+      - '.github/CODEOWNERS'
+      - 'templates/**'
+      - '.openapi-generator-ignore'
+      - 'openapi/**'
+      - 'docs/**'
+      - 'pkg/api/openapi/docs/**'
+      - 'pkg/api/openapi/.openapi-generator-ignore'
+
+jobs:
+  verify-test:
+    name: "Test RDS Provisioning"
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment: development
+    steps:
+      - name: Set up Go 1.18
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.18"
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+      - name: Cache go module
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github
+      - name: Verify & Test
+        env:
+          AWS_RDS_SECURITY_GROUP_ID: ${{ secrets.AWS_RDS_SECURITY_GROUP_ID }}
+          AWS_RDS_DB_SUBNET_GROUP_NAME: ${{ secrets.AWS_RDS_DB_SUBNET_GROUP_NAME }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          export GOPATH=$(go env GOPATH)
+          export PATH=${PATH}:$GOPATH/bin
+          make test/rds
+        timeout-minutes: 35

--- a/.github/workflows/rds.yaml
+++ b/.github/workflows/rds.yaml
@@ -1,5 +1,5 @@
 # This runs tests that check the AWS RDS provisioning / deprovisioning logic
-name: AWS RDS integration tests
+name: AWS integration tests
 
 on:
   push:
@@ -64,13 +64,12 @@ jobs:
       - name: Verify & Test
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_AUTH_HELPER: "none"
         run: |
+          set -euo pipefail
           source "scripts/lib/external_config.sh"
-          export AWS_AUTH_HELPER="none"
           init_chamber
           load_external_config fleetshard-sync AWS_RDS_
 
-          export GOPATH=$(go env GOPATH)
-          export PATH=${PATH}:$GOPATH/bin
           make test/rds
         timeout-minutes: 35

--- a/.github/workflows/rds.yaml
+++ b/.github/workflows/rds.yaml
@@ -67,6 +67,11 @@ jobs:
           AWS_RDS_DB_SUBNET_GROUP_NAME: ${{ secrets.AWS_RDS_DB_SUBNET_GROUP_NAME }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
         run: |
+          source "scripts/lib/external_config.sh"
+          export AWS_AUTH_HELPER="none"
+          init_chamber
+          load_external_config fleetshard-sync AWS_RDS_
+
           export GOPATH=$(go env GOPATH)
           export PATH=${PATH}:$GOPATH/bin
           make test/rds

--- a/.github/workflows/rds.yaml
+++ b/.github/workflows/rds.yaml
@@ -71,5 +71,8 @@ jobs:
           init_chamber
           load_external_config fleetshard-sync AWS_RDS_
 
+          export AWS_RDS_SECURITY_GROUP=${AWS_RDS_MANAGED_DB_SECURITY_GROUP}
+          export AWS_RDS_SUBNET_GROUP=${AWS_RDS_MANAGED_DB_SUBNET_GROUP}
+
           make test/rds
         timeout-minutes: 35

--- a/.github/workflows/rds.yaml
+++ b/.github/workflows/rds.yaml
@@ -63,8 +63,6 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github
       - name: Verify & Test
         env:
-          AWS_RDS_SECURITY_GROUP_ID: ${{ secrets.AWS_RDS_SECURITY_GROUP_ID }}
-          AWS_RDS_DB_SUBNET_GROUP_NAME: ${{ secrets.AWS_RDS_DB_SUBNET_GROUP_NAME }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
         run: |
           source "scripts/lib/external_config.sh"

--- a/.github/workflows/rds.yaml
+++ b/.github/workflows/rds.yaml
@@ -69,10 +69,6 @@ jobs:
           set -euo pipefail
           source "scripts/lib/external_config.sh"
           init_chamber
-          load_external_config fleetshard-sync AWS_RDS_
 
-          export AWS_RDS_SECURITY_GROUP=${AWS_RDS_MANAGED_DB_SECURITY_GROUP}
-          export AWS_RDS_SUBNET_GROUP=${AWS_RDS_MANAGED_DB_SUBNET_GROUP}
-
-          make test/rds
+          run_chamber exec fleetshard-sync -- make test/rds
         timeout-minutes: 35

--- a/Makefile
+++ b/Makefile
@@ -322,6 +322,13 @@ test: $(GOTESTSUM_BIN)
 		$(shell go list ./... | grep -v /test)
 .PHONY: test
 
+# Runs the AWS RDS integration tests.
+test/rds: $(GOTESTSUM_BIN)
+	RUN_RDS_TESTS=true \
+	$(GOTESTSUM_BIN) --junitfile data/results/rds-integration-tests.xml --format $(GOTESTSUM_FORMAT) -- -p 1 -v -timeout 30m -count=1 \
+		$(shell go list ./fleetshard/pkg/central/cloudprovider/awsclient/... | grep -v /test)
+.PHONY: test/rds
+
 # Precompile everything required for development/test.
 test/prepare:
 	$(GO) test -i ./internal/dinosaur/test/integration/...

--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,7 @@ test: $(GOTESTSUM_BIN)
 test/rds: $(GOTESTSUM_BIN)
 	RUN_RDS_TESTS=true \
 	$(GOTESTSUM_BIN) --junitfile data/results/rds-integration-tests.xml --format $(GOTESTSUM_FORMAT) -- -p 1 -v -timeout 30m -count=1 \
-		$(shell go list ./fleetshard/pkg/central/cloudprovider/awsclient/... | grep -v /test)
+		./fleetshard/pkg/central/cloudprovider/awsclient/...
 .PHONY: test/rds
 
 # Precompile everything required for development/test.

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -24,8 +24,8 @@ func newTestRDS() (*RDS, error) {
 
 	return &RDS{
 		rdsClient:       rdsClient,
-		dbSecurityGroup: os.Getenv("AWS_RDS_SECURITY_GROUP_ID"),
-		dbSubnetGroup:   os.Getenv("AWS_RDS_DB_SUBNET_GROUP_NAME"),
+		dbSecurityGroup: os.Getenv("AWS_RDS_MANAGED_DB_SECURITY_GROUP"),
+		dbSubnetGroup:   os.Getenv("AWS_RDS_MANAGED_DB_SUBNET_GROUP"),
 	}, nil
 }
 

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -112,7 +112,7 @@ func TestRDSProvisioning(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, deletionStarted)
 
-	deleteCtx, deleteCancel := context.WithTimeout(context.TODO(), 15*time.Minute)
+	deleteCtx, deleteCancel := context.WithTimeout(context.TODO(), 10*time.Minute)
 	defer deleteCancel()
 
 	clusterDeleted, err := waitForClusterToBeDeleted(deleteCtx, rdsClient, clusterID)

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -49,7 +49,7 @@ func waitForClusterToBeDeleted(ctx context.Context, rdsClient *RDS, clusterID st
 			return false, err
 		}
 
-		if clusterExists {
+		if !clusterExists {
 			return true, nil
 		}
 

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -24,8 +24,8 @@ func newTestRDS() (*RDS, error) {
 
 	return &RDS{
 		rdsClient:       rdsClient,
-		dbSecurityGroup: os.Getenv("AWS_RDS_MANAGED_DB_SECURITY_GROUP"),
-		dbSubnetGroup:   os.Getenv("AWS_RDS_MANAGED_DB_SUBNET_GROUP"),
+		dbSecurityGroup: os.Getenv("AWS_RDS_SECURITY_GROUP"),
+		dbSubnetGroup:   os.Getenv("AWS_RDS_SUBNET_GROUP"),
 	}, nil
 }
 

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -1,0 +1,108 @@
+package awsclient
+
+import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestRDS() (*RDS, error) {
+	rdsClient, err := newTestRDSClient()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create RDS client: %w", err)
+	}
+
+	return &RDS{
+		rdsClient:       rdsClient,
+		dbSecurityGroup: os.Getenv("AWS_RDS_SECURITY_GROUP_ID"),
+		dbSubnetGroup:   os.Getenv("AWS_RDS_DB_SUBNET_GROUP_NAME"),
+	}, nil
+}
+
+func newTestRDSClient() (*rds.RDS, error) {
+	cfg := &aws.Config{
+		Region: aws.String(os.Getenv("AWS_REGION")),
+	}
+
+	sess, err := session.NewSession(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create session, %w", err)
+	}
+
+	return rds.New(sess), nil
+}
+
+func TestRDSProvisioning(t *testing.T) {
+	if os.Getenv("RUN_RDS_TESTS") != "true" {
+		t.Skip("Skip RDS tests. Set RUN_RDS_TESTS=true env variable to enable RDS tests.")
+	}
+
+	rdsClient, err := newTestRDS()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 15*time.Minute)
+	defer cancel()
+
+	dbID := "test-" + uuid.New().String()
+	dbMasterPassword := "TestRDSProvisioning" // pragma: allowlist secret
+
+	clusterID := getClusterID(dbID)
+	instanceID := getInstanceID(dbID)
+
+	clusterExists, err := rdsClient.clusterExists(clusterID)
+	require.NoError(t, err)
+	require.False(t, clusterExists)
+
+	instanceExists, err := rdsClient.instanceExists(instanceID)
+	require.NoError(t, err)
+	require.False(t, instanceExists)
+
+	_, err = rdsClient.EnsureDBProvisioned(ctx, dbID, dbMasterPassword)
+	assert.NoError(t, err)
+
+	clusterExists, err = rdsClient.clusterExists(clusterID)
+	require.NoError(t, err)
+	require.True(t, clusterExists)
+
+	instanceExists, err = rdsClient.instanceExists(instanceID)
+	require.NoError(t, err)
+	require.True(t, instanceExists)
+
+	clusterStatus, err := rdsClient.clusterStatus(clusterID)
+	require.NoError(t, err)
+	assert.Equal(t, clusterStatus, dbAvailableStatus)
+
+	instanceStatus, err := rdsClient.instanceStatus(instanceID)
+	require.NoError(t, err)
+	assert.Equal(t, instanceStatus, dbAvailableStatus)
+
+	deletionStarted, err := rdsClient.EnsureDBDeprovisioned(dbID)
+	assert.NoError(t, err)
+	assert.True(t, deletionStarted)
+
+	// deletion takes a few minutes, so the cluster and instance should still exist
+	clusterExists, err = rdsClient.clusterExists(clusterID)
+	require.NoError(t, err)
+	assert.True(t, clusterExists)
+
+	instanceExists, err = rdsClient.instanceExists(instanceID)
+	require.NoError(t, err)
+	assert.True(t, instanceExists)
+
+	clusterStatus, err = rdsClient.clusterStatus(clusterID)
+	require.NoError(t, err)
+	assert.Equal(t, clusterStatus, dbDeletingStatus)
+
+	instanceStatus, err = rdsClient.instanceStatus(instanceID)
+	require.NoError(t, err)
+	assert.Equal(t, instanceStatus, dbDeletingStatus)
+}

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/google/uuid"
+	"github.com/stackrox/rox/pkg/random"
 	"github.com/stretchr/testify/require"
 )
 
@@ -53,7 +54,8 @@ func TestRDSProvisioning(t *testing.T) {
 	defer cancel()
 
 	dbID := "test-" + uuid.New().String()
-	dbMasterPassword := "TestRDSProvisioning" // pragma: allowlist secret
+	dbMasterPassword, err := random.GenerateString(25, random.AlphanumericCharacters)
+	require.NoError(t, err)
 
 	clusterID := getClusterID(dbID)
 	instanceID := getInstanceID(dbID)

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -24,8 +24,8 @@ func newTestRDS() (*RDS, error) {
 
 	return &RDS{
 		rdsClient:       rdsClient,
-		dbSecurityGroup: os.Getenv("AWS_RDS_SECURITY_GROUP"),
-		dbSubnetGroup:   os.Getenv("AWS_RDS_SUBNET_GROUP"),
+		dbSecurityGroup: os.Getenv("MANAGED_DB_SECURITY_GROUP"),
+		dbSubnetGroup:   os.Getenv("MANAGED_DB_SUBNET_GROUP"),
 	}, nil
 }
 

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -3,7 +3,6 @@ package awsclient
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/google/uuid"
 	"github.com/stackrox/rox/pkg/random"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Adds an integration test that checks RDS data provisioning and deprovisioning logic, that:
* uses the ACSCS dev account to instantiate a temporary RDS DB
* checks that the instance & cluster are created and deleted on AWS
* runs on CI in a separate check, to save time
* is disabled by default when running the tests, because it requires extra configuration and takes about 10 minutes to run

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [x] Evaluated and added CHANGELOG.md entry if required
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

Relying on the CI to run the tests.
