### PR TITLE
ROX-12344: Add organisation name to central request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -481,7 +481,7 @@ db/start:
 .PHONY: db/start
 
 db/migrate:
-	OCM_ENV=integration $(GO) run ./cmd/fleet-manager migrate
+	$(GO) run ./cmd/fleet-manager migrate
 .PHONY: db/migrate
 
 db/teardown:

--- a/internal/dinosaur/pkg/api/dbapi/central_request_types.go
+++ b/internal/dinosaur/pkg/api/dbapi/central_request_types.go
@@ -33,9 +33,10 @@ type CentralRequest struct {
 	OwnerUserID    string `json:"owner_user_id"`
 	// Instance-independent part of the Central's hostname. For example, this
 	// can be `rhacs-dev.com`, `acs-stage.rhcloud.com`, etc.
-	Host           string `json:"host"`
-	OrganisationID string `json:"organisation_id" gorm:"index"`
-	FailedReason   string `json:"failed_reason"`
+	Host             string `json:"host"`
+	OrganisationID   string `json:"organisation_id" gorm:"index"`
+	OrganisationName string `json:"organisation_name"`
+	FailedReason     string `json:"failed_reason"`
 	// PlacementID field should be updated every time when a CentralRequest is assigned to an OSD cluster (even if it's the same one again)
 	PlacementID string   `json:"placement_id"`
 	Central     api.JSON `json:"central"` // Schema is defined by dbapi.CentralSpec

--- a/internal/dinosaur/pkg/api/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/private/api/openapi.yaml
@@ -437,6 +437,8 @@ components:
           type: string
         ownerOrgId:
           type: string
+        ownerOrgName:
+          type: string
         issuer:
           type: string
     ManagedCentral_allOf_spec_uiEndpoint_tls:

--- a/internal/dinosaur/pkg/api/private/model_managed_central_all_of_spec_auth.go
+++ b/internal/dinosaur/pkg/api/private/model_managed_central_all_of_spec_auth.go
@@ -17,5 +17,6 @@ type ManagedCentralAllOfSpecAuth struct {
 	ClientOrigin string `json:"clientOrigin,omitempty"`
 	OwnerUserId  string `json:"ownerUserId,omitempty"`
 	OwnerOrgId   string `json:"ownerOrgId,omitempty"`
+	OwnerOrgName string `json:"ownerOrgName,omitempty"`
 	Issuer       string `json:"issuer,omitempty"`
 }

--- a/internal/dinosaur/pkg/handlers/cloud_accounts.go
+++ b/internal/dinosaur/pkg/handlers/cloud_accounts.go
@@ -42,12 +42,12 @@ func (h *cloudAccountsHandler) actionFunc(r *http.Request) func() (i interface{}
 		if err != nil {
 			return nil, errors.NewWithCause(errors.ErrorForbidden, err, "cannot make request without orgID claim")
 		}
-		organizationID, err := h.client.GetOrganisationIDFromExternalID(orgID)
+		organization, err := h.client.GetOrganisationFromExternalID(orgID)
 		if err != nil {
 			return nil, errors.OrganisationNotFound(orgID, err)
 		}
 
-		cloudAccounts, err := h.client.GetCustomerCloudAccounts(organizationID, []string{quota.RHACSMarketplaceQuotaID})
+		cloudAccounts, err := h.client.GetCustomerCloudAccounts(organization.ID(), []string{quota.RHACSMarketplaceQuotaID})
 		if err != nil {
 			return nil, errors.NewWithCause(errors.ErrorGeneral, err, "failed to fetch cloud accounts from AMS")
 		}

--- a/internal/dinosaur/pkg/handlers/cloud_accounts_test.go
+++ b/internal/dinosaur/pkg/handlers/cloud_accounts_test.go
@@ -31,8 +31,9 @@ func TestGetSuccess(t *testing.T) {
 		Build()
 	assert.NoError(t, err)
 	c := ocm.ClientMock{
-		GetOrganisationIDFromExternalIDFunc: func(externalID string) (string, error) {
-			return "external-id", nil
+		GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+			org, _ := v1.NewOrganization().ID("external-id").Build()
+			return org, nil
 		},
 		GetCustomerCloudAccountsFunc: func(externalID string, quotaID []string) ([]*v1.CloudAccount, error) {
 			return []*v1.CloudAccount{
@@ -65,9 +66,10 @@ func TestGetSuccess(t *testing.T) {
 func TestGetNoOrgId(t *testing.T) {
 	timesClientCalled := 0
 	c := ocm.ClientMock{
-		GetOrganisationIDFromExternalIDFunc: func(externalID string) (string, error) {
+		GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
 			timesClientCalled++
-			return "external-id", nil
+			org, _ := v1.NewOrganization().ID("external-id").Build()
+			return org, nil
 		},
 		GetCustomerCloudAccountsFunc: func(externalID string, quotaID []string) ([]*v1.CloudAccount, error) {
 			timesClientCalled++
@@ -100,8 +102,8 @@ func TestGetNoOrgId(t *testing.T) {
 func TestGetCannotGetOrganizationID(t *testing.T) {
 	timesClientCalled := 0
 	c := ocm.ClientMock{
-		GetOrganisationIDFromExternalIDFunc: func(externalID string) (string, error) {
-			return "", errors.New("test failure")
+		GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+			return nil, errors.New("test failure")
 		},
 		GetCustomerCloudAccountsFunc: func(externalID string, quotaID []string) ([]*v1.CloudAccount, error) {
 			timesClientCalled++

--- a/internal/dinosaur/pkg/migrations/202212150000_add_organisation_name.go
+++ b/internal/dinosaur/pkg/migrations/202212150000_add_organisation_name.go
@@ -58,13 +58,13 @@ func addOrganisationNameToCentralRequest() *gormigrate.Migration {
 		ID: "202212150000",
 		Migrate: func(tx *gorm.DB) error {
 			if err := tx.Migrator().AddColumn(&CentralRequest{}, "OrganisationName"); err != nil {
-				return fmt.Errorf("adding new column OrganisationName in migration 202212150000: %w", err)
+				return fmt.Errorf("adding column OrganisationName in migration 202212150000: %w", err)
 			}
 			return nil
 		},
 		Rollback: func(tx *gorm.DB) error {
 			if err := tx.Migrator().DropColumn(&CentralRequest{}, "OrganisationName"); err != nil {
-				return fmt.Errorf("rolling back new column OrganisationName in migration 202212150000: %w", err)
+				return fmt.Errorf("rolling back column OrganisationName in migration 202212150000: %w", err)
 			}
 			return nil
 		},

--- a/internal/dinosaur/pkg/migrations/202212150000_add_organisation_name.go
+++ b/internal/dinosaur/pkg/migrations/202212150000_add_organisation_name.go
@@ -93,7 +93,14 @@ func addOrganisationNameToCentralRequest(ocmConfig *ocm.OCMConfig) *gormigrate.M
 			}
 
 			rows, err := tx.Model(&CentralRequest{}).Where("organisation_name IS NULL").Rows()
-			defer rows.Close()
+			if err != nil {
+				return errors.Wrapf(err, "fetching rows where organisation_name is NULL in migration %s", id)
+			}
+			defer func() {
+				if err := rows.Close(); err != nil {
+					panic(errors.Wrapf(err, "closing rows in migration %s", id))
+				}
+			}()
 
 			for rows.Next() {
 				var central CentralRequest

--- a/internal/dinosaur/pkg/migrations/202212150000_add_organisation_name.go
+++ b/internal/dinosaur/pkg/migrations/202212150000_add_organisation_name.go
@@ -1,0 +1,72 @@
+package migrations
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/stackrox/acs-fleet-manager/pkg/api"
+	"gorm.io/gorm"
+)
+
+func addOrganisationNameToCentralRequest() *gormigrate.Migration {
+	type AuthConfig struct {
+		ClientID     string `json:"idp_client_id"`
+		ClientSecret string `json:"idp_client_secret"`
+		Issuer       string `json:"idp_issuer"`
+		ClientOrigin string `json:"client_origin"`
+	}
+
+	type CentralRequest struct {
+		api.Meta
+		Region           string   `json:"region"`
+		ClusterID        string   `json:"cluster_id" gorm:"index"`
+		CloudProvider    string   `json:"cloud_provider"`
+		CloudAccountID   string   `json:"cloud_account_id"`
+		MultiAZ          bool     `json:"multi_az"`
+		Name             string   `json:"name" gorm:"index"`
+		Status           string   `json:"status" gorm:"index"`
+		SubscriptionID   string   `json:"subscription_id"`
+		Owner            string   `json:"owner" gorm:"index"`
+		OwnerAccountID   string   `json:"owner_account_id"`
+		OwnerUserID      string   `json:"owner_user_id"`
+		Host             string   `json:"host"`
+		OrganisationID   string   `json:"organisation_id" gorm:"index"`
+		OrganisationName string   `json:"organisation_name"`
+		FailedReason     string   `json:"failed_reason"`
+		PlacementID      string   `json:"placement_id"`
+		Central          api.JSON `json:"central"`
+		Scanner          api.JSON `json:"scanner"`
+
+		DesiredCentralVersion         string     `json:"desired_central_version"`
+		ActualCentralVersion          string     `json:"actual_central_version"`
+		DesiredCentralOperatorVersion string     `json:"desired_central_operator_version"`
+		ActualCentralOperatorVersion  string     `json:"actual_central_operator_version"`
+		CentralUpgrading              bool       `json:"central_upgrading"`
+		CentralOperatorUpgrading      bool       `json:"central_operator_upgrading"`
+		InstanceType                  string     `json:"instance_type"`
+		QuotaType                     string     `json:"quota_type"`
+		Routes                        api.JSON   `json:"routes"`
+		RoutesCreated                 bool       `json:"routes_created"`
+		Namespace                     string     `json:"namespace"`
+		RoutesCreationID              string     `json:"routes_creation_id"`
+		DeletionTimestamp             *time.Time `json:"deletionTimestamp"`
+		AuthConfig
+	}
+
+	return &gormigrate.Migration{
+		ID: "202212150000",
+		Migrate: func(tx *gorm.DB) error {
+			if err := tx.Migrator().AddColumn(&CentralRequest{}, "OrganisationName"); err != nil {
+				return fmt.Errorf("adding new column OrganisationName in migration 202212150000: %w", err)
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			if err := tx.Migrator().DropColumn(&CentralRequest{}, "OrganisationName"); err != nil {
+				return fmt.Errorf("rolling back new column OrganisationName in migration 202212150000: %w", err)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/dinosaur/pkg/migrations/202212150000_add_organisation_name.go
+++ b/internal/dinosaur/pkg/migrations/202212150000_add_organisation_name.go
@@ -104,14 +104,15 @@ func addOrganisationNameToCentralRequest(ocmConfig *ocm.OCMConfig) *gormigrate.M
 
 			for rows.Next() {
 				var central CentralRequest
-				tx.ScanRows(rows, &central)
+				if err := tx.ScanRows(rows, &central); err != nil {
+					return errors.Wrapf(err, "scanning rows in migration %s", id)
+				}
 
 				orgName, err := fetchOrgName(amsClient, central.OrganisationID)
 				if err != nil {
 					return errors.Wrapf(err, "fetching organisation_name in migration %s", id)
 				}
-				err = tx.Model(&central).Update("organisation_name", orgName).Error
-				if err != nil {
+				if err = tx.Model(&central).Update("organisation_name", orgName).Error; err != nil {
 					return errors.Wrapf(err, "updating organisation_name in migration %s", id)
 				}
 			}

--- a/internal/dinosaur/pkg/migrations/migrations.go
+++ b/internal/dinosaur/pkg/migrations/migrations.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/stackrox/acs-fleet-manager/pkg/client/ocm"
 	"github.com/stackrox/acs-fleet-manager/pkg/db"
 )
 
@@ -24,31 +25,33 @@ import (
 //
 //  4. Create one function in a separate file that returns your Migration. Add that single function call
 //     to the end of this list.
-var migrations = []*gormigrate.Migration{
-	addCentralRequest(),
-	addClusters(),
-	addLeaderLease(),
-	sampleMigration(),
-	addOwnerUserIDToCentralRequest(),
-	addResourcesToCentralRequest(),
-	addAuthConfigToCentralRequest(),
-	addCentralAuthLease(),
-	addSkipSchedulingToClusters(),
-	addClientOriginToCentralRequest(),
-	changeCentralClientOrigin(),
-	addCloudAccountIDToCentralRequest(),
-	addOrganisationNameToCentralRequest(),
+func getMigrations(ocmConfig *ocm.OCMConfig) []*gormigrate.Migration {
+	return []*gormigrate.Migration{
+		addCentralRequest(),
+		addClusters(),
+		addLeaderLease(),
+		sampleMigration(),
+		addOwnerUserIDToCentralRequest(),
+		addResourcesToCentralRequest(),
+		addAuthConfigToCentralRequest(),
+		addCentralAuthLease(),
+		addSkipSchedulingToClusters(),
+		addClientOriginToCentralRequest(),
+		changeCentralClientOrigin(),
+		addCloudAccountIDToCentralRequest(),
+		addOrganisationNameToCentralRequest(ocmConfig),
+	}
 }
 
 // New ...
-func New(dbConfig *db.DatabaseConfig) (*db.Migration, func(), error) {
+func New(dbConfig *db.DatabaseConfig, ocmConfig *ocm.OCMConfig) (*db.Migration, func(), error) {
+	migrations := getMigrations(ocmConfig)
 	m, f, err := db.NewMigration(dbConfig, &gormigrate.Options{
 		TableName:      "migrations",
 		IDColumnName:   "id",
 		IDColumnSize:   255,
 		UseTransaction: false,
 	}, migrations)
-
 	if err != nil {
 		return m, f, fmt.Errorf("assembling database migration: %w", err)
 	}

--- a/internal/dinosaur/pkg/migrations/migrations.go
+++ b/internal/dinosaur/pkg/migrations/migrations.go
@@ -37,6 +37,7 @@ var migrations = []*gormigrate.Migration{
 	addClientOriginToCentralRequest(),
 	changeCentralClientOrigin(),
 	addCloudAccountIDToCentralRequest(),
+	addOrganisationNameToCentralRequest(),
 }
 
 // New ...

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -69,6 +69,7 @@ func (c *ManagedCentralPresenter) PresentManagedCentral(from *dbapi.CentralReque
 				ClientSecret: from.AuthConfig.ClientSecret, // pragma: allowlist secret
 				ClientOrigin: from.AuthConfig.ClientOrigin,
 				OwnerOrgId:   from.OrganisationID,
+				OwnerOrgName: from.OrganisationName,
 				OwnerUserId:  from.OwnerUserID,
 				Issuer:       from.AuthConfig.Issuer,
 			},

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -338,7 +338,7 @@ func (k *dinosaurService) PrepareDinosaurRequest(dinosaurRequest *dbapi.CentralR
 	}
 	orgName := org.Name()
 	if orgName == "" {
-		return errors.OrganisationNameInvalid(dinosaurRequest.OrganisationID, org.Name())
+		return errors.OrganisationNameInvalid(dinosaurRequest.OrganisationID, orgName)
 	}
 
 	// Update the fields of the CentralRequest record in the database.

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -336,13 +336,17 @@ func (k *dinosaurService) PrepareDinosaurRequest(dinosaurRequest *dbapi.CentralR
 	if err != nil {
 		return errors.OrganisationNotFound(dinosaurRequest.OrganisationID, err)
 	}
+	orgName := org.Name()
+	if orgName == "" {
+		return errors.OrganisationNameInvalid(dinosaurRequest.OrganisationID, org.Name())
+	}
 
 	// Update the fields of the CentralRequest record in the database.
 	updatedCentralRequest := &dbapi.CentralRequest{
 		Meta: api.Meta{
 			ID: dinosaurRequest.ID,
 		},
-		OrganisationName: org.Name(),
+		OrganisationName: orgName,
 		Status:           dinosaurConstants.CentralRequestStatusProvisioning.String(),
 	}
 	if err := k.Update(updatedCentralRequest); err != nil {

--- a/internal/dinosaur/pkg/services/quota/ams_quota_service.go
+++ b/internal/dinosaur/pkg/services/quota/ams_quota_service.go
@@ -38,14 +38,14 @@ var supportedAMSBillingModels = map[string]struct{}{
 
 // CheckIfQuotaIsDefinedForInstanceType ...
 func (q amsQuotaService) CheckIfQuotaIsDefinedForInstanceType(dinosaur *dbapi.CentralRequest, instanceType types.DinosaurInstanceType) (bool, *errors.ServiceError) {
-	orgID, err := q.amsClient.GetOrganisationIDFromExternalID(dinosaur.OrganisationID)
+	org, err := q.amsClient.GetOrganisationFromExternalID(dinosaur.OrganisationID)
 	if err != nil {
 		return false, errors.OrganisationNotFound(dinosaur.OrganisationID, err)
 	}
 
-	hasQuota, err := q.hasConfiguredQuotaCost(orgID, instanceType.GetQuotaType())
+	hasQuota, err := q.hasConfiguredQuotaCost(org.ID(), instanceType.GetQuotaType())
 	if err != nil {
-		return false, errors.NewWithCause(errors.ErrorGeneral, err, fmt.Sprintf("failed to get assigned quota of type %v for organization with id %v", instanceType.GetQuotaType(), orgID))
+		return false, errors.NewWithCause(errors.ErrorGeneral, err, fmt.Sprintf("failed to get assigned quota of type %v for organization with id %v", instanceType.GetQuotaType(), org.ID()))
 	}
 
 	return hasQuota, nil
@@ -132,11 +132,11 @@ func (q amsQuotaService) ReserveQuota(dinosaur *dbapi.CentralRequest, instanceTy
 
 	rr := newBaseQuotaReservedResourceResourceBuilder()
 
-	orgID, err := q.amsClient.GetOrganisationIDFromExternalID(dinosaur.OrganisationID)
+	org, err := q.amsClient.GetOrganisationFromExternalID(dinosaur.OrganisationID)
 	if err != nil {
 		return "", errors.OrganisationNotFound(dinosaur.OrganisationID, err)
 	}
-	bm, err := q.selectBillingModelFromDinosaurInstanceType(orgID, dinosaur.CloudProvider, dinosaur.CloudAccountID, instanceType)
+	bm, err := q.selectBillingModelFromDinosaurInstanceType(org.ID(), dinosaur.CloudProvider, dinosaur.CloudAccountID, instanceType)
 	if err != nil {
 		svcErr := errors.ToServiceError(err)
 		return "", errors.NewWithCause(svcErr.Code, svcErr, "Error getting billing model")
@@ -145,7 +145,7 @@ func (q amsQuotaService) ReserveQuota(dinosaur *dbapi.CentralRequest, instanceTy
 	glog.Infof("Billing model of Central request %s with quota type %s has been set to %s.", dinosaur.ID, instanceType.GetQuotaType(), bm)
 
 	if bm != string(amsv1.BillingModelStandard) {
-		if err := q.verifyCloudAccountInAMS(dinosaur, orgID); err != nil {
+		if err := q.verifyCloudAccountInAMS(dinosaur, org.ID()); err != nil {
 			return "", err
 		}
 		rr.BillingMarketplaceAccount(dinosaur.CloudAccountID)

--- a/internal/dinosaur/pkg/services/quota/ams_quota_service.go
+++ b/internal/dinosaur/pkg/services/quota/ams_quota_service.go
@@ -45,7 +45,7 @@ func (q amsQuotaService) CheckIfQuotaIsDefinedForInstanceType(dinosaur *dbapi.Ce
 
 	hasQuota, err := q.hasConfiguredQuotaCost(org.ID(), instanceType.GetQuotaType())
 	if err != nil {
-		return false, errors.NewWithCause(errors.ErrorGeneral, err, fmt.Sprintf("failed to get assigned quota of type %v for organization with id %v", instanceType.GetQuotaType(), org.ID()))
+		return false, errors.NewWithCause(errors.ErrorGeneral, err, fmt.Sprintf("failed to get assigned quota of type %v for organization with external id %v and id %v", instanceType.GetQuotaType(), dinosaur.OrganisationID, org.ID()))
 	}
 
 	return hasQuota, nil

--- a/internal/dinosaur/pkg/services/quota/ams_quota_service_test.go
+++ b/internal/dinosaur/pkg/services/quota/ams_quota_service_test.go
@@ -55,8 +55,9 @@ func Test_AMSCheckQuota(t *testing.T) {
 						cloudAuthorizationResp, _ := v1.NewClusterAuthorizationResponse().Allowed(true).Build()
 						return cloudAuthorizationResp, nil
 					},
-					GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+						org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+						return org, nil
 					},
 					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 						if product != string(ocm.RHACSProduct) {
@@ -94,8 +95,9 @@ func Test_AMSCheckQuota(t *testing.T) {
 						cloudAuthorizationResp, _ := v1.NewClusterAuthorizationResponse().Allowed(false).Build()
 						return cloudAuthorizationResp, nil
 					},
-					GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+						org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+						return org, nil
 					},
 					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 						if product != string(ocm.RHACSProduct) {
@@ -129,8 +131,9 @@ func Test_AMSCheckQuota(t *testing.T) {
 						cloudAuthorizationResp, _ := v1.NewClusterAuthorizationResponse().Allowed(false).Build()
 						return cloudAuthorizationResp, nil
 					},
-					GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+						org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+						return org, nil
 					},
 					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 						return []*v1.QuotaCost{}, nil
@@ -157,8 +160,9 @@ func Test_AMSCheckQuota(t *testing.T) {
 					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
 						return nil, fmt.Errorf("some errors")
 					},
-					GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+						org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+						return org, nil
 					},
 					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 						if product != string(ocm.RHACSProduct) {
@@ -232,8 +236,9 @@ func Test_AMSReserveQuota(t *testing.T) {
 					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
 						return mockClusterAuthorizationResponse(), nil
 					},
-					GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+						org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+						return org, nil
 					},
 					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHACSProduct)).ResourceName(resourceName).Cost(1)
@@ -261,8 +266,9 @@ func Test_AMSReserveQuota(t *testing.T) {
 					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
 						return mockClusterAuthorizationResponse(), nil
 					},
-					GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+						org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+						return org, nil
 					},
 					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHACSProduct)).ResourceName(resourceName).Cost(1)
@@ -293,8 +299,9 @@ func Test_AMSReserveQuota(t *testing.T) {
 					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
 						return mockClusterAuthorizationResponse(), nil
 					},
-					GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+						org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+						return org, nil
 					},
 					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHACSProduct)).ResourceName(resourceName).Cost(1)
@@ -325,8 +332,9 @@ func Test_AMSReserveQuota(t *testing.T) {
 					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
 						return mockClusterAuthorizationResponse(), nil
 					},
-					GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+						org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+						return org, nil
 					},
 					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHACSTrialProduct)).ResourceName(resourceName).Cost(0)
@@ -354,8 +362,9 @@ func Test_AMSReserveQuota(t *testing.T) {
 					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
 						return mockClusterAuthorizationResponse(), nil
 					},
-					GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+						org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+						return org, nil
 					},
 					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHACSProduct)).ResourceName(resourceName).Cost(1)
@@ -384,8 +393,9 @@ func Test_AMSReserveQuota(t *testing.T) {
 					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
 						return mockClusterAuthorizationResponse(), nil
 					},
-					GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+						org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+						return org, nil
 					},
 					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 						return []*v1.QuotaCost{}, nil
@@ -408,8 +418,9 @@ func Test_AMSReserveQuota(t *testing.T) {
 					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
 						return mockClusterAuthorizationResponse(), nil
 					},
-					GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+						org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+						return org, nil
 					},
 					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 						rrbq1 := v1.NewRelatedResource().BillingModel(string("unknownbillingmodelone")).Product(string(ocm.RHACSProduct)).ResourceName(resourceName).Cost(1)
@@ -439,8 +450,9 @@ func Test_AMSReserveQuota(t *testing.T) {
 						cloudAuthorizationResp, _ := v1.NewClusterAuthorizationResponse().Allowed(false).Build()
 						return cloudAuthorizationResp, nil
 					},
-					GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+						org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+						return org, nil
 					},
 					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHACSProduct)).ResourceName(resourceName).Cost(1)
@@ -466,8 +478,9 @@ func Test_AMSReserveQuota(t *testing.T) {
 					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
 						return mockClusterAuthorizationResponse(), nil
 					},
-					GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+						org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+						return org, nil
 					},
 					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHACSTrialProduct)).ResourceName(resourceName).Cost(0)
@@ -493,8 +506,9 @@ func Test_AMSReserveQuota(t *testing.T) {
 					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
 						return mockClusterAuthorizationResponse(), nil
 					},
-					GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+						org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+						return org, nil
 					},
 					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHACSTrialProduct)).ResourceName(resourceName).Cost(0)
@@ -527,8 +541,9 @@ func Test_AMSReserveQuota(t *testing.T) {
 					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
 						return mockClusterAuthorizationResponse(), nil
 					},
-					GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+						org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+						return org, nil
 					},
 					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHACSTrialProduct)).ResourceName(resourceName).Cost(0)
@@ -561,8 +576,9 @@ func Test_AMSReserveQuota(t *testing.T) {
 					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
 						return mockClusterAuthorizationResponse(), nil
 					},
-					GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+						org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+						return org, nil
 					},
 					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHACSTrialProduct)).ResourceName(resourceName).Cost(0)
@@ -599,8 +615,9 @@ func Test_AMSReserveQuota(t *testing.T) {
 					ClusterAuthorizationFunc: func(cb *v1.ClusterAuthorizationRequest) (*v1.ClusterAuthorizationResponse, error) {
 						return mockClusterAuthorizationResponse(), nil
 					},
-					GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-						return fmt.Sprintf("fake-org-id-%s", externalId), nil
+					GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+						org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+						return org, nil
 					},
 					GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 						rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHACSTrialProduct)).ResourceName(resourceName).Cost(0)
@@ -745,8 +762,9 @@ func Test_amsQuotaService_CheckIfQuotaIsDefinedForInstanceType(t *testing.T) {
 		{
 			name: "returns false if no quota cost exists for the dinosaur's organization",
 			ocmClient: &ocm.ClientMock{
-				GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-					return fmt.Sprintf("fake-org-id-%s", externalId), nil
+				GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+					org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+					return org, nil
 				},
 				GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 					return []*v1.QuotaCost{}, nil
@@ -762,8 +780,9 @@ func Test_amsQuotaService_CheckIfQuotaIsDefinedForInstanceType(t *testing.T) {
 		{
 			name: "returns false if the quota cost billing model is not among the supported ones",
 			ocmClient: &ocm.ClientMock{
-				GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-					return fmt.Sprintf("fake-org-id-%s", externalId), nil
+				GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+					org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+					return org, nil
 				},
 				GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 					rrbq1 := v1.NewRelatedResource().BillingModel("unknownbillingmodel").Product(string(ocm.RHACSProduct)).ResourceName(resourceName).Cost(1)
@@ -785,8 +804,9 @@ func Test_amsQuotaService_CheckIfQuotaIsDefinedForInstanceType(t *testing.T) {
 		{
 			name: "returns true if there is at least a 'standard' quota cost billing model",
 			ocmClient: &ocm.ClientMock{
-				GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-					return fmt.Sprintf("fake-org-id-%s", externalId), nil
+				GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+					org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+					return org, nil
 				},
 				GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 					rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelStandard)).Product(string(ocm.RHACSProduct)).ResourceName(resourceName).Cost(1)
@@ -808,8 +828,9 @@ func Test_amsQuotaService_CheckIfQuotaIsDefinedForInstanceType(t *testing.T) {
 		{
 			name: "returns true if there is at least a 'marketplace' quota cost billing model",
 			ocmClient: &ocm.ClientMock{
-				GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-					return fmt.Sprintf("fake-org-id-%s", externalId), nil
+				GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+					org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+					return org, nil
 				},
 				GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 					rrbq1 := v1.NewRelatedResource().BillingModel("unknownbillingmodel").Product(string(ocm.RHACSProduct)).ResourceName(resourceName).Cost(1)
@@ -836,8 +857,9 @@ func Test_amsQuotaService_CheckIfQuotaIsDefinedForInstanceType(t *testing.T) {
 		{
 			name: "returns false if there is no supported billing model with an 'allowed' value greater than 0",
 			ocmClient: &ocm.ClientMock{
-				GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-					return fmt.Sprintf("fake-org-id-%s", externalId), nil
+				GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+					org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+					return org, nil
 				},
 				GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 					rrbq1 := v1.NewRelatedResource().BillingModel(string(v1.BillingModelMarketplace)).Product(string(ocm.RHACSProduct)).ResourceName(resourceName).Cost(1)
@@ -863,8 +885,8 @@ func Test_amsQuotaService_CheckIfQuotaIsDefinedForInstanceType(t *testing.T) {
 		{
 			name: "returns an error if it fails retrieving the organization ID",
 			ocmClient: &ocm.ClientMock{
-				GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-					return "", fmt.Errorf("error getting org")
+				GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+					return nil, fmt.Errorf("error getting org")
 				},
 				GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 					return []*v1.QuotaCost{}, nil
@@ -879,8 +901,9 @@ func Test_amsQuotaService_CheckIfQuotaIsDefinedForInstanceType(t *testing.T) {
 		{
 			name: "returns an error if it fails retrieving quota costs",
 			ocmClient: &ocm.ClientMock{
-				GetOrganisationIDFromExternalIDFunc: func(externalId string) (string, error) {
-					return fmt.Sprintf("fake-org-id-%s", externalId), nil
+				GetOrganisationFromExternalIDFunc: func(externalId string) (*v1.Organization, error) {
+					org, _ := v1.NewOrganization().ID(fmt.Sprintf("fake-org-id-%s", externalId)).Build()
+					return org, nil
 				},
 				GetQuotaCostsForProductFunc: func(organizationID, resourceName, product string) ([]*v1.QuotaCost, error) {
 					return []*v1.QuotaCost{}, fmt.Errorf("error getting quota costs")

--- a/openapi/fleet-manager-private.yaml
+++ b/openapi/fleet-manager-private.yaml
@@ -260,6 +260,8 @@ components:
                       type: string
                     ownerOrgId:
                       type: string
+                    ownerOrgName:
+                      type: string
                     issuer:
                       type: string
                 uiEndpoint:

--- a/pkg/client/ocm/client.go
+++ b/pkg/client/ocm/client.go
@@ -317,10 +317,6 @@ func (c client) CreateAddonWithParams(clusterID string, addonID string, params [
 
 // CreateAddon ...
 func (c client) CreateAddon(clusterID string, addonID string) (*clustersmgmtv1.AddOnInstallation, error) {
-	if c.connection == nil {
-		return nil, serviceErrors.InvalidOCMConnection()
-	}
-
 	return c.CreateAddonWithParams(clusterID, addonID, []Parameter{})
 }
 
@@ -380,10 +376,6 @@ func (c client) UpdateAddonParameters(clusterID string, addonInstallationID stri
 
 // GetClusterDNS ...
 func (c *client) GetClusterDNS(clusterID string) (string, error) {
-	if c.connection == nil {
-		return "", serviceErrors.InvalidOCMConnection()
-	}
-
 	if clusterID == "" {
 		return "", serviceErrors.Validation("clusterID cannot be empty")
 	}

--- a/pkg/client/ocm/client.go
+++ b/pkg/client/ocm/client.go
@@ -129,6 +129,10 @@ func (c *client) Close() {
 
 // CreateCluster ...
 func (c *client) CreateCluster(cluster *clustersmgmtv1.Cluster) (*clustersmgmtv1.Cluster, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	clusterResource := c.connection.ClustersMgmt().V1().Clusters()
 	response, err := clusterResource.Add().Body(cluster).Send()
 	if err != nil {
@@ -141,6 +145,10 @@ func (c *client) CreateCluster(cluster *clustersmgmtv1.Cluster) (*clustersmgmtv1
 
 // GetExistingClusterMetrics ...
 func (c *client) GetExistingClusterMetrics(clusterID string) (*amsv1.SubscriptionMetrics, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	subscriptions, err := c.connection.AccountsMgmt().V1().Subscriptions().List().Search(fmt.Sprintf("cluster_id='%s'", clusterID)).Send()
 	if err != nil {
 		return nil, fmt.Errorf("retrieving subscriptions: %w", err)
@@ -168,6 +176,10 @@ func (c *client) GetExistingClusterMetrics(clusterID string) (*amsv1.Subscriptio
 
 // GetOrganisationFromExternalID takes the external org id as input, and returns the OCM org.
 func (c *client) GetOrganisationFromExternalID(externalID string) (*amsv1.Organization, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	request := c.connection.AccountsMgmt().V1().Organizations().List().Search(fmt.Sprintf("external_id='%s'", externalID))
 	res, err := request.Send()
 	if err != nil {
@@ -184,6 +196,10 @@ func (c *client) GetOrganisationFromExternalID(externalID string) (*amsv1.Organi
 
 // GetRequiresTermsAcceptance ...
 func (c *client) GetRequiresTermsAcceptance(username string) (termsRequired bool, redirectURL string, err error) {
+	if c.connection == nil {
+		return false, "", serviceErrors.InvalidOCMConnection()
+	}
+
 	// Check for Appendix 4 Terms
 	request, err := v1.NewTermsReviewRequest().AccountUsername(username).SiteCode(TermsSitecode).EventCode(TermsEventcodeRegister).Build()
 	if err != nil {
@@ -206,6 +222,10 @@ func (c *client) GetRequiresTermsAcceptance(username string) (termsRequired bool
 
 // GetClusterIngresses sends a GET request to ocm to retrieve the ingresses of an OSD cluster
 func (c *client) GetClusterIngresses(clusterID string) (*clustersmgmtv1.IngressesListResponse, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	clusterIngresses := c.connection.ClustersMgmt().V1().Clusters().Cluster(clusterID).Ingresses()
 	ingressList, err := clusterIngresses.List().Send()
 	if err != nil {
@@ -217,6 +237,10 @@ func (c *client) GetClusterIngresses(clusterID string) (*clustersmgmtv1.Ingresse
 
 // GetCluster ...
 func (c client) GetCluster(clusterID string) (*clustersmgmtv1.Cluster, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	resp, err := c.connection.ClustersMgmt().V1().Clusters().Cluster(clusterID).Get().Send()
 	if err != nil {
 		return nil, fmt.Errorf("sending get cluster request: %w", err)
@@ -226,6 +250,10 @@ func (c client) GetCluster(clusterID string) (*clustersmgmtv1.Cluster, error) {
 
 // GetClusterStatus ...
 func (c client) GetClusterStatus(id string) (*clustersmgmtv1.ClusterStatus, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	resp, err := c.connection.ClustersMgmt().V1().Clusters().Cluster(id).Status().Get().Send()
 	if err != nil {
 		return nil, fmt.Errorf("sending cluster status request: %w", err)
@@ -235,6 +263,10 @@ func (c client) GetClusterStatus(id string) (*clustersmgmtv1.ClusterStatus, erro
 
 // GetCloudProviders ...
 func (c *client) GetCloudProviders() (*clustersmgmtv1.CloudProviderList, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	providersCollection := c.connection.ClustersMgmt().V1().CloudProviders()
 	providersResponse, err := providersCollection.List().Send()
 	if err != nil {
@@ -246,6 +278,10 @@ func (c *client) GetCloudProviders() (*clustersmgmtv1.CloudProviderList, error) 
 
 // GetRegions ...
 func (c *client) GetRegions(provider *clustersmgmtv1.CloudProvider) (*clustersmgmtv1.CloudRegionList, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	regionsCollection := c.connection.ClustersMgmt().V1().CloudProviders().CloudProvider(provider.ID()).Regions()
 	regionsResponse, err := regionsCollection.List().Send()
 	if err != nil {
@@ -258,6 +294,10 @@ func (c *client) GetRegions(provider *clustersmgmtv1.CloudProvider) (*clustersmg
 
 // CreateAddonWithParams ...
 func (c client) CreateAddonWithParams(clusterID string, addonID string, params []Parameter) (*clustersmgmtv1.AddOnInstallation, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	addon := clustersmgmtv1.NewAddOn().ID(addonID)
 	addonParameters := newAddonParameterListBuilder(params)
 	addonInstallationBuilder := clustersmgmtv1.NewAddOnInstallation().Addon(addon)
@@ -277,11 +317,19 @@ func (c client) CreateAddonWithParams(clusterID string, addonID string, params [
 
 // CreateAddon ...
 func (c client) CreateAddon(clusterID string, addonID string) (*clustersmgmtv1.AddOnInstallation, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	return c.CreateAddonWithParams(clusterID, addonID, []Parameter{})
 }
 
 // GetAddon ...
 func (c client) GetAddon(clusterID string, addonID string) (*clustersmgmtv1.AddOnInstallation, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	resp, err := c.connection.ClustersMgmt().V1().Clusters().Cluster(clusterID).Addons().List().Send()
 	if err != nil {
 		return nil, fmt.Errorf("sending AddOnInstallationList request: %w", err)
@@ -301,6 +349,10 @@ func (c client) GetAddon(clusterID string, addonID string) (*clustersmgmtv1.AddO
 
 // UpdateAddonParameters ...
 func (c client) UpdateAddonParameters(clusterID string, addonInstallationID string, parameters []Parameter) (*clustersmgmtv1.AddOnInstallation, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	addonInstallationResp, err := c.connection.ClustersMgmt().V1().Clusters().Cluster(clusterID).Addons().Addoninstallation(addonInstallationID).Get().Send()
 	if err != nil {
 		return nil, fmt.Errorf("sending AddOnInstallationGet request: %w", err)
@@ -328,6 +380,10 @@ func (c client) UpdateAddonParameters(clusterID string, addonInstallationID stri
 
 // GetClusterDNS ...
 func (c *client) GetClusterDNS(clusterID string) (string, error) {
+	if c.connection == nil {
+		return "", serviceErrors.InvalidOCMConnection()
+	}
+
 	if clusterID == "" {
 		return "", serviceErrors.Validation("clusterID cannot be empty")
 	}
@@ -354,6 +410,10 @@ func (c *client) GetClusterDNS(clusterID string) (string, error) {
 
 // CreateSyncSet ...
 func (c client) CreateSyncSet(clusterID string, syncset *clustersmgmtv1.Syncset) (*clustersmgmtv1.Syncset, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	clustersResource := c.connection.ClustersMgmt().V1().Clusters()
 	response, syncsetErr := clustersResource.Cluster(clusterID).
 		ExternalConfiguration().
@@ -370,6 +430,10 @@ func (c client) CreateSyncSet(clusterID string, syncset *clustersmgmtv1.Syncset)
 
 // UpdateSyncSet ...
 func (c client) UpdateSyncSet(clusterID string, syncSetID string, syncset *clustersmgmtv1.Syncset) (*clustersmgmtv1.Syncset, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	clustersResource := c.connection.ClustersMgmt().V1().Clusters()
 	response, syncsetErr := clustersResource.Cluster(clusterID).
 		ExternalConfiguration().
@@ -388,6 +452,10 @@ func (c client) UpdateSyncSet(clusterID string, syncSetID string, syncset *clust
 
 // CreateIdentityProvider ...
 func (c client) CreateIdentityProvider(clusterID string, identityProvider *clustersmgmtv1.IdentityProvider) (*clustersmgmtv1.IdentityProvider, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	clustersResource := c.connection.ClustersMgmt().V1().Clusters()
 	response, identityProviderErr := clustersResource.Cluster(clusterID).
 		IdentityProviders().
@@ -403,6 +471,10 @@ func (c client) CreateIdentityProvider(clusterID string, identityProvider *clust
 
 // GetIdentityProviderList ...
 func (c client) GetIdentityProviderList(clusterID string) (*clustersmgmtv1.IdentityProviderList, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	clusterResource := c.connection.ClustersMgmt().V1().Clusters()
 	response, getIDPErr := clusterResource.Cluster(clusterID).
 		IdentityProviders().
@@ -417,6 +489,10 @@ func (c client) GetIdentityProviderList(clusterID string) (*clustersmgmtv1.Ident
 
 // GetSyncSet ...
 func (c client) GetSyncSet(clusterID string, syncSetID string) (*clustersmgmtv1.Syncset, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	clustersResource := c.connection.ClustersMgmt().V1().Clusters()
 	response, syncsetErr := clustersResource.Cluster(clusterID).
 		ExternalConfiguration().
@@ -434,6 +510,10 @@ func (c client) GetSyncSet(clusterID string, syncSetID string) (*clustersmgmtv1.
 
 // DeleteSyncSet Status returns the response status code.
 func (c client) DeleteSyncSet(clusterID string, syncsetID string) (int, error) {
+	if c.connection == nil {
+		return 0, serviceErrors.InvalidOCMConnection()
+	}
+
 	clustersResource := c.connection.ClustersMgmt().V1().Clusters()
 	response, syncsetErr := clustersResource.Cluster(clusterID).
 		ExternalConfiguration().
@@ -456,6 +536,10 @@ func (c client) ScaleDownComputeNodes(clusterID string, decrement int) (*cluster
 
 // scaleComputeNodes scales the Compute nodes up or down by the value of `numNodes`
 func (c client) scaleComputeNodes(clusterID string, numNodes int) (*clustersmgmtv1.Cluster, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	clusterClient := c.connection.ClustersMgmt().V1().Clusters().Cluster(clusterID)
 
 	cluster, err := clusterClient.Get().Send()
@@ -485,6 +569,10 @@ func (c client) scaleComputeNodes(clusterID string, numNodes int) (*clustersmgmt
 
 // SetComputeNodes ...
 func (c client) SetComputeNodes(clusterID string, numNodes int) (*clustersmgmtv1.Cluster, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	clusterClient := c.connection.ClustersMgmt().V1().Clusters().Cluster(clusterID)
 
 	patch, err := clustersmgmtv1.NewCluster().Nodes(clustersmgmtv1.NewClusterNodes().Compute(numNodes)).
@@ -535,6 +623,10 @@ func sameParameters(parameterList *clustersmgmtv1.AddOnInstallationParameterList
 
 // DeleteCluster ...
 func (c client) DeleteCluster(clusterID string) (int, error) {
+	if c.connection == nil {
+		return 0, serviceErrors.InvalidOCMConnection()
+	}
+
 	clustersResource := c.connection.ClustersMgmt().V1().Clusters()
 	response, deleteClusterError := clustersResource.Cluster(clusterID).Delete().Send()
 
@@ -547,6 +639,10 @@ func (c client) DeleteCluster(clusterID string) (int, error) {
 
 // ClusterAuthorization ...
 func (c client) ClusterAuthorization(cb *amsv1.ClusterAuthorizationRequest) (*amsv1.ClusterAuthorizationResponse, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	glog.V(10).Infof("Sending request to OCM '%v'", *cb)
 
 	r, err := c.connection.AccountsMgmt().V1().
@@ -562,6 +658,10 @@ func (c client) ClusterAuthorization(cb *amsv1.ClusterAuthorizationRequest) (*am
 
 // DeleteSubscription ...
 func (c client) DeleteSubscription(id string) (int, error) {
+	if c.connection == nil {
+		return 0, serviceErrors.InvalidOCMConnection()
+	}
+
 	r := c.connection.AccountsMgmt().V1().Subscriptions().Subscription(id).Delete()
 	resp, err := r.Send()
 	return resp.Status(), err
@@ -569,6 +669,10 @@ func (c client) DeleteSubscription(id string) (int, error) {
 
 // FindSubscriptions ...
 func (c client) FindSubscriptions(query string) (*amsv1.SubscriptionsListResponse, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	r, err := c.connection.AccountsMgmt().V1().Subscriptions().List().Search(query).Send()
 	if err != nil {
 		return nil, fmt.Errorf("querying the accounts management service for subscriptions: %w", err)
@@ -580,6 +684,10 @@ func (c client) FindSubscriptions(query string) (*amsv1.SubscriptionsListRespons
 // whose relatedResources contains at least a relatedResource that has the
 // given resourceName and product
 func (c client) GetQuotaCostsForProduct(organizationID, resourceName, product string) ([]*amsv1.QuotaCost, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	var res []*amsv1.QuotaCost
 	organizationClient := c.connection.AccountsMgmt().V1().Organizations()
 	quotaCostClient := organizationClient.Organization(organizationID).QuotaCost()
@@ -603,6 +711,10 @@ func (c client) GetQuotaCostsForProduct(organizationID, resourceName, product st
 }
 
 func (c *client) GetCustomerCloudAccounts(organizationID string, quotaIDs []string) ([]*amsv1.CloudAccount, error) {
+	if c.connection == nil {
+		return nil, serviceErrors.InvalidOCMConnection()
+	}
+
 	var res []*amsv1.CloudAccount
 	organizationClient := c.connection.AccountsMgmt().V1().Organizations()
 	quotaCostClient := organizationClient.Organization(organizationID).QuotaCost()

--- a/pkg/client/ocm/client_moq.go
+++ b/pkg/client/ocm/client_moq.go
@@ -80,8 +80,8 @@ var _ Client = &ClientMock{}
 //			GetIdentityProviderListFunc: func(clusterID string) (*clustersmgmtv1.IdentityProviderList, error) {
 //				panic("mock out the GetIdentityProviderList method")
 //			},
-//			GetOrganisationIDFromExternalIDFunc: func(externalID string) (string, error) {
-//				panic("mock out the GetOrganisationIDFromExternalID method")
+//			GetOrganisationFromExternalIDFunc: func(externalID string) (*amsv1.Organization, error) {
+//				panic("mock out the GetOrganisationFromExternalID method")
 //			},
 //			GetQuotaCostsForProductFunc: func(organizationID string, resourceName string, product string) ([]*amsv1.QuotaCost, error) {
 //				panic("mock out the GetQuotaCostsForProduct method")
@@ -177,8 +177,8 @@ type ClientMock struct {
 	// GetIdentityProviderListFunc mocks the GetIdentityProviderList method.
 	GetIdentityProviderListFunc func(clusterID string) (*clustersmgmtv1.IdentityProviderList, error)
 
-	// GetOrganisationIDFromExternalIDFunc mocks the GetOrganisationIDFromExternalID method.
-	GetOrganisationIDFromExternalIDFunc func(externalID string) (string, error)
+	// GetOrganisationFromExternalIDFunc mocks the GetOrganisationFromExternalID method.
+	GetOrganisationFromExternalIDFunc func(externalID string) (*amsv1.Organization, error)
 
 	// GetQuotaCostsForProductFunc mocks the GetQuotaCostsForProduct method.
 	GetQuotaCostsForProductFunc func(organizationID string, resourceName string, product string) ([]*amsv1.QuotaCost, error)
@@ -321,8 +321,8 @@ type ClientMock struct {
 			// ClusterID is the clusterID argument value.
 			ClusterID string
 		}
-		// GetOrganisationIDFromExternalID holds details about calls to the GetOrganisationIDFromExternalID method.
-		GetOrganisationIDFromExternalID []struct {
+		// GetOrganisationFromExternalID holds details about calls to the GetOrganisationFromExternalID method.
+		GetOrganisationFromExternalID []struct {
 			// ExternalID is the externalID argument value.
 			ExternalID string
 		}
@@ -392,36 +392,36 @@ type ClientMock struct {
 			Syncset *clustersmgmtv1.Syncset
 		}
 	}
-	lockClusterAuthorization            sync.RWMutex
-	lockConnection                      sync.RWMutex
-	lockCreateAddon                     sync.RWMutex
-	lockCreateAddonWithParams           sync.RWMutex
-	lockCreateCluster                   sync.RWMutex
-	lockCreateIdentityProvider          sync.RWMutex
-	lockCreateSyncSet                   sync.RWMutex
-	lockDeleteCluster                   sync.RWMutex
-	lockDeleteSubscription              sync.RWMutex
-	lockDeleteSyncSet                   sync.RWMutex
-	lockFindSubscriptions               sync.RWMutex
-	lockGetAddon                        sync.RWMutex
-	lockGetCloudProviders               sync.RWMutex
-	lockGetCluster                      sync.RWMutex
-	lockGetClusterDNS                   sync.RWMutex
-	lockGetClusterIngresses             sync.RWMutex
-	lockGetClusterStatus                sync.RWMutex
-	lockGetCustomerCloudAccounts        sync.RWMutex
-	lockGetExistingClusterMetrics       sync.RWMutex
-	lockGetIdentityProviderList         sync.RWMutex
-	lockGetOrganisationIDFromExternalID sync.RWMutex
-	lockGetQuotaCostsForProduct         sync.RWMutex
-	lockGetRegions                      sync.RWMutex
-	lockGetRequiresTermsAcceptance      sync.RWMutex
-	lockGetSyncSet                      sync.RWMutex
-	lockScaleDownComputeNodes           sync.RWMutex
-	lockScaleUpComputeNodes             sync.RWMutex
-	lockSetComputeNodes                 sync.RWMutex
-	lockUpdateAddonParameters           sync.RWMutex
-	lockUpdateSyncSet                   sync.RWMutex
+	lockClusterAuthorization          sync.RWMutex
+	lockConnection                    sync.RWMutex
+	lockCreateAddon                   sync.RWMutex
+	lockCreateAddonWithParams         sync.RWMutex
+	lockCreateCluster                 sync.RWMutex
+	lockCreateIdentityProvider        sync.RWMutex
+	lockCreateSyncSet                 sync.RWMutex
+	lockDeleteCluster                 sync.RWMutex
+	lockDeleteSubscription            sync.RWMutex
+	lockDeleteSyncSet                 sync.RWMutex
+	lockFindSubscriptions             sync.RWMutex
+	lockGetAddon                      sync.RWMutex
+	lockGetCloudProviders             sync.RWMutex
+	lockGetCluster                    sync.RWMutex
+	lockGetClusterDNS                 sync.RWMutex
+	lockGetClusterIngresses           sync.RWMutex
+	lockGetClusterStatus              sync.RWMutex
+	lockGetCustomerCloudAccounts      sync.RWMutex
+	lockGetExistingClusterMetrics     sync.RWMutex
+	lockGetIdentityProviderList       sync.RWMutex
+	lockGetOrganisationFromExternalID sync.RWMutex
+	lockGetQuotaCostsForProduct       sync.RWMutex
+	lockGetRegions                    sync.RWMutex
+	lockGetRequiresTermsAcceptance    sync.RWMutex
+	lockGetSyncSet                    sync.RWMutex
+	lockScaleDownComputeNodes         sync.RWMutex
+	lockScaleUpComputeNodes           sync.RWMutex
+	lockSetComputeNodes               sync.RWMutex
+	lockUpdateAddonParameters         sync.RWMutex
+	lockUpdateSyncSet                 sync.RWMutex
 }
 
 // ClusterAuthorization calls ClusterAuthorizationFunc.
@@ -1086,35 +1086,35 @@ func (mock *ClientMock) GetIdentityProviderListCalls() []struct {
 	return calls
 }
 
-// GetOrganisationIDFromExternalID calls GetOrganisationIDFromExternalIDFunc.
-func (mock *ClientMock) GetOrganisationIDFromExternalID(externalID string) (string, error) {
-	if mock.GetOrganisationIDFromExternalIDFunc == nil {
-		panic("ClientMock.GetOrganisationIDFromExternalIDFunc: method is nil but Client.GetOrganisationIDFromExternalID was just called")
+// GetOrganisationFromExternalID calls GetOrganisationFromExternalIDFunc.
+func (mock *ClientMock) GetOrganisationFromExternalID(externalID string) (*amsv1.Organization, error) {
+	if mock.GetOrganisationFromExternalIDFunc == nil {
+		panic("ClientMock.GetOrganisationFromExternalIDFunc: method is nil but Client.GetOrganisationFromExternalID was just called")
 	}
 	callInfo := struct {
 		ExternalID string
 	}{
 		ExternalID: externalID,
 	}
-	mock.lockGetOrganisationIDFromExternalID.Lock()
-	mock.calls.GetOrganisationIDFromExternalID = append(mock.calls.GetOrganisationIDFromExternalID, callInfo)
-	mock.lockGetOrganisationIDFromExternalID.Unlock()
-	return mock.GetOrganisationIDFromExternalIDFunc(externalID)
+	mock.lockGetOrganisationFromExternalID.Lock()
+	mock.calls.GetOrganisationFromExternalID = append(mock.calls.GetOrganisationFromExternalID, callInfo)
+	mock.lockGetOrganisationFromExternalID.Unlock()
+	return mock.GetOrganisationFromExternalIDFunc(externalID)
 }
 
-// GetOrganisationIDFromExternalIDCalls gets all the calls that were made to GetOrganisationIDFromExternalID.
+// GetOrganisationFromExternalIDCalls gets all the calls that were made to GetOrganisationFromExternalID.
 // Check the length with:
 //
-//	len(mockedClient.GetOrganisationIDFromExternalIDCalls())
-func (mock *ClientMock) GetOrganisationIDFromExternalIDCalls() []struct {
+//	len(mockedClient.GetOrganisationFromExternalIDCalls())
+func (mock *ClientMock) GetOrganisationFromExternalIDCalls() []struct {
 	ExternalID string
 } {
 	var calls []struct {
 		ExternalID string
 	}
-	mock.lockGetOrganisationIDFromExternalID.RLock()
-	calls = mock.calls.GetOrganisationIDFromExternalID
-	mock.lockGetOrganisationIDFromExternalID.RUnlock()
+	mock.lockGetOrganisationFromExternalID.RLock()
+	calls = mock.calls.GetOrganisationFromExternalID
+	mock.lockGetOrganisationFromExternalID.RUnlock()
 	return calls
 }
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -753,6 +753,12 @@ func OrganisationNotFound(externalID string, err error) *ServiceError {
 	return NewWithCause(svcErr.Code, svcErr, reason, externalID)
 }
 
+// OrganisationNameInvalid indicates that OCM organisation was found, but its name is invalid.
+func OrganisationNameInvalid(externalID string, name string) *ServiceError {
+	reason := "organisation with external id %s has invalid name %q"
+	return New(ErrorGeneral, reason, externalID, name)
+}
+
 // FailedClusterAuthorization converts the error to a ServiceError and returns a reason and hint for the user.
 func FailedClusterAuthorization(err error) *ServiceError {
 	svcErr := ToServiceError(err)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -735,6 +735,12 @@ func InvalidCloudAccountID(reason string, values ...interface{}) *ServiceError {
 	return New(ErrorInvalidCloudAccountID, message, values...)
 }
 
+// InvalidOCMConnection is raised when the OCM connection is invalid.
+// Root causes for an invalid connection are invalid credentials or OCM base URLs.
+func InvalidOCMConnection() *ServiceError {
+	return New(ErrorGeneral, "invalid OCM connection")
+}
+
 // OrganisationNotFound converts the error to a ServiceError and returns a reason and hint for the user.
 func OrganisationNotFound(externalID string, err error) *ServiceError {
 	svcErr := ToServiceError(err)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -755,8 +755,7 @@ func OrganisationNotFound(externalID string, err error) *ServiceError {
 
 // OrganisationNameInvalid indicates that OCM organisation was found, but its name is invalid.
 func OrganisationNameInvalid(externalID string, name string) *ServiceError {
-	reason := "organisation with external id %s has invalid name %q"
-	return New(ErrorGeneral, reason, externalID, name)
+	return New(ErrorGeneral, "organisation with external id %q has invalid name %q", externalID, name)
 }
 
 // FailedClusterAuthorization converts the error to a ServiceError and returns a reason and hint for the user.

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -1036,6 +1036,8 @@ objects:
             image: ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}
             imagePullPolicy: ${IMAGE_PULL_POLICY}
             volumeMounts:
+            - name: fleet-manager-credentials
+              mountPath: /secrets/fleet-manager-credentials
             - name: service
               mountPath: /secrets/service
             - name: rds

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -1040,6 +1040,9 @@ objects:
               mountPath: /secrets/service
             - name: rds
               mountPath: /secrets/rds
+            env:
+              - name: "OCM_ENV"
+                value: "${ENVIRONMENT}"
             command:
             - /usr/local/bin/fleet-manager
             - migrate
@@ -1051,6 +1054,11 @@ objects:
             - --db-ssl-certificate-file=/secrets/rds/db.ca_cert
             - --db-sslmode=${DB_SSLMODE}
             - --db-max-open-connections=${DB_MAX_OPEN_CONNS}
+            - --ocm-client-id-file=/secrets/fleet-manager-credentials/ocm-service.clientId
+            - --ocm-client-secret-file=/secrets/fleet-manager-credentials/ocm-service.clientSecret
+            - --ocm-base-url=${OCM_URL}
+            - --ams-base-url=${AMS_URL}
+            - --ocm-debug=${OCM_DEBUG}
             - --enable-db-debug=${ENABLE_DB_DEBUG}
             - --alsologtostderr
             - -v=${GLOG_V}


### PR DESCRIPTION
## Description
The organisation name is added to the central request to make the cloud service more observable. The plan is to pass it together with the org id to the data plane, set it as label/annotation and then scrape it with Prometheus. Note that the organisation name is effectively immutable for users - it can only be changed in edge cases by Red Hat IT - however it is not unique. The org id is immutable and unique per account. The org name for existing tenants will be migrated using the OCM client.

* The organisation name is fetched from OCM during the request preparation phase.
* A migration is added to add a column for the org name to the database.
* `GetOrganisationIDFromExternalID` is changed to `GetOrganisationFromExternalID`, which now returns the complete organisation struct instead of just the id.
* Check for `nil` connection in OCM client. This is technically unrelated to this change, but got uncovered by the e2e tests. Previously fleet-manager would run into a nil pointer dereference when OCM was not setup properly - like previously in the e2e tests. Now we return `InvalidOCMConnection` error in this case.
* `org-name` is added to the private API to communicate the name to fleetshard-sync.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] ~Added test description under `Test manual`
- [ ] ~Evaluated and added CHANGELOG.md entry if required~
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual
Tested with local fleet-manager and dev data-plane cluster.
