### PR TITLE
Avoid using `which`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ all: openapi/generate binary
 .PHONY: setup/git/hooks
 setup/git/hooks:
 	-git config --unset-all core.hooksPath
-	@if which -s pre-commit; then \
+	@if command -v pre-commit >/dev/null 2>&1; then \
 		echo "Installing pre-commit hooks"; \
 		pre-commit install; \
 	else \

--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -8,9 +8,9 @@ source "$GITROOT/scripts/lib/log.sh"
 
 try_kubectl() {
     local kubectl
-    if which kubectl >/dev/null 2>&1; then
+    if command -v kubectl >/dev/null 2>&1; then
         kubectl="kubectl"
-    elif which oc >/dev/null 2>&1; then
+    elif command -v oc >/dev/null 2>&1; then
         kubectl="oc"
     else
         log "Error: Neither 'kubectl' nor 'oc' found." >&2
@@ -63,7 +63,7 @@ init() {
         source "$env_file"
     done
 
-    if ! which bootstrap.sh >/dev/null 2>&1; then
+    if ! command -v bootstrap.sh >/dev/null 2>&1; then
         export PATH="$GITROOT/dev/env/scripts:${PATH}"
     fi
 

--- a/dp-terraform/add-on/rhacs-terraform/Makefile
+++ b/dp-terraform/add-on/rhacs-terraform/Makefile
@@ -193,7 +193,7 @@ $(ENVTEST): $(LOCALBIN)
 HELM_OPERATOR = $(shell pwd)/bin/helm-operator
 helm-operator: ## Download helm-operator locally if necessary, preferring the $(pwd)/bin path over global if both exist.
 ifeq (,$(wildcard $(HELM_OPERATOR)))
-ifeq (,$(shell which helm-operator 2>/dev/null))
+ifeq (,$(shell command -v helm-operator 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(HELM_OPERATOR)) ;\
@@ -201,7 +201,7 @@ ifeq (,$(shell which helm-operator 2>/dev/null))
 	chmod +x $(HELM_OPERATOR) ;\
 	}
 else
-HELM_OPERATOR = $(shell which helm-operator)
+HELM_OPERATOR = $(shell command -v helm-operator)
 endif
 endif
 
@@ -225,7 +225,7 @@ bundle-push: ## Push the bundle image.
 OPM = ./bin/opm
 opm: ## Download opm locally if necessary.
 ifeq (,$(wildcard $(OPM)))
-ifeq (,$(shell which opm 2>/dev/null))
+ifeq (,$(shell command -v opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
@@ -233,7 +233,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	chmod +x $(OPM) ;\
 	}
 else
-OPM = $(shell which opm)
+OPM = $(shell command -v opm)
 endif
 endif
 

--- a/pr_check_docker.sh
+++ b/pr_check_docker.sh
@@ -8,7 +8,7 @@ export TEST_SUMMARY_FORMAT="standard-verbose"
 # go version
 
 # start postgres
-which pg_ctl
+command -v pg_ctl
 # shellcheck disable=SC2037,SC2211
 PGDATA=/var/lib/postgresql/data /usr/lib/postgresql/*/bin/pg_ctl -w stop
 # shellcheck disable=SC2037,SC2211


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This started as a way to fix this error that I encountered a while ago:
```
[mowsiany@mowsiany acs-fleet-manager]$ make setup/git/hooks
[...]
/usr/bin/which: invalid option -- 's'
/nix/store/fsg2hsj457wm29d6gvxg2giw1d6nic2l-python3.10-pre-commit-2.19.0/bin/pre-commit
Installing pre-commit hooks
pre-commit installed at .git/hooks/pre-commit
```

After [some googling](https://unix.stackexchange.com/questions/404146/what-is-the-best-method-to-test-if-a-program-exists-for-a-shell-script) I decided to eradicate all uses of `which` in the repo in exchange for a portable way, to seed any future cargo-culting in the desired direction. :wink:

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~Unit and integration tests added~
- [x] Added test description under `Test manual`
- [x] Evaluated and added CHANGELOG.md entry if required
- [x] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] ~Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- [x] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Ran the target and it was fine this time:
```
[mowsiany@mowsiany acs-fleet-manager]$ make setup/git/hooks 
git config --unset-all core.hooksPath
make: [Makefile:249: setup/git/hooks] Error 5 (ignored)
Installing pre-commit hooks
pre-commit installed at .git/hooks/pre-commit
```