### PR TITLE
Make `tools_venv` target depend on `tools/requirements.txt`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,13 +117,14 @@ $(GINKGO_BIN): $(TOOLS_DIR)/go.mod $(TOOLS_DIR)/go.sum
 	@cd $(TOOLS_DIR) && GOBIN=${LOCAL_BIN_PATH} $(GO) install github.com/onsi/ginkgo/v2/ginkgo
 
 TOOLS_VENV_DIR := $(LOCAL_BIN_PATH)/tools_venv
-$(TOOLS_VENV_DIR):
+$(TOOLS_VENV_DIR): $(TOOLS_DIR)/requirements.txt
 	@set -e; \
 	trap "rm -rf $(TOOLS_VENV_DIR)" ERR; \
 	python3 -m venv $(TOOLS_VENV_DIR); \
 	. $(TOOLS_VENV_DIR)/bin/activate; \
 	pip install --upgrade pip==22.3.1; \
-	pip install -r $(TOOLS_DIR)/requirements.txt
+	pip install -r $(TOOLS_DIR)/requirements.txt; \
+	touch $(TOOLS_VENV_DIR) # update directory modification timestamp even if no changes were made by pip. This will allow to skip this target if the directory is up-to-date
 
 OPENAPI_GENERATOR ?= ${LOCAL_BIN_PATH}/openapi-generator
 NPM ?= "$(shell which npm 2> /dev/null)"


### PR DESCRIPTION
## Description
Make `tools_venv` target depend on `tools/requirements.txt` changes. Otherwise, the target is always up-to date if I make changes in `requirements.txt` unless I remove `tools_venv` dir manually. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~Unit and integration tests added~
- [x] Added test description under `Test manual`
- [x] ~Evaluated and added CHANGELOG.md entry if required~
- [x] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] ~Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
Tested manually