### PR TITLE
ROX-13408: Use api.iam.clients in dynamic clients API wrapper

### DIFF
--- a/pkg/client/redhatsso/dynamicclients/client.go
+++ b/pkg/client/redhatsso/dynamicclients/client.go
@@ -9,9 +9,7 @@ import (
 
 // NewDynamicClientsAPI returns new instance of dynamic clients sso.redhat.com API client.
 func NewDynamicClientsAPI(realmConfig *iam.IAMRealmConfig) *api.AcsTenantsApiService {
-	// We count that the token being returned will contain api.iam.acs scope by default.
-	// TODO(ROX-13408): switch to explicitly requesting api.iam.clients scope once it's available.
-	httpClient := redhatsso.NewSSOAuthHTTPClient(realmConfig)
+	httpClient := redhatsso.NewSSOAuthHTTPClient(realmConfig, "api.iam.clients")
 	configuration := &api.Configuration{
 		BasePath:  realmConfig.BaseURL + realmConfig.APIEndpointURI,
 		UserAgent: "RHACS-Fleet-Manager/1.0",


### PR DESCRIPTION
## Description
Switch to explicitly requesting `api.iam.clients` scope when getting token for sso.redhat.com dynamic clients API. Currently, the scope is being returned by default.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Evaluated and added CHANGELOG.md entry if required
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

1. Created local fleet-manager with dynamic client configuration
2. POST new central
3. Verified that db contains central with client id and client secret
