### PR TITLE
ROX-12344: Use dev rhacs org_id in static token

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -305,7 +305,7 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "4e199b4a1c40b497a95fcd1cd896351733849949",
         "is_verified": false,
-        "line_number": 668,
+        "line_number": 666,
         "is_secret": false
       }
     ],

--- a/config/fleetshard-authz-org-ids-development.yaml
+++ b/config/fleetshard-authz-org-ids-development.yaml
@@ -6,7 +6,5 @@
 - "16064548"
 # ACS RH SSO Org Prod
 - "16134752"
-# org_id for the static token
-- "12345678"
 # ACS RH SSO ORG Development
 - "16155304"

--- a/config/static-token-payload.json
+++ b/config/static-token-payload.json
@@ -28,7 +28,7 @@
   "is_org_admin": true,
   "account_id": "12345678",
   "user_id": "12345678",
-  "org_id": "12345678",
+  "org_id": "16155304",
   "first_name": "Test",
   "email": "rhacs-ms-test@redhat.com",
   "username": "rhacs-ms-test@redhat.com"

--- a/dev/env/manifests/shared/03-configmap-config.yaml
+++ b/dev/env/manifests/shared/03-configmap-config.yaml
@@ -26,7 +26,7 @@ data:
     # ACS RH SSO Org Prod
     - "16134752"
     # org_id for the static token
-    - "12345678"
+    - "16155304"
   fleetshard-authz-org-ids-prod.yaml: |-
     # ACS RH SSO Org Prod
     - "16134752"
@@ -205,7 +205,7 @@ data:
         max_allowed_instances: 3
         registered_users: []
         # Static token's org_id, see config/static-token-payload.json
-      - id: 12345678
+      - id: 16155304
         any_user: true
         max_allowed_instances: 100
         registered_users: []

--- a/dev/env/manifests/shared/03-configmap-config.yaml
+++ b/dev/env/manifests/shared/03-configmap-config.yaml
@@ -25,7 +25,7 @@ data:
     - "16064548"
     # ACS RH SSO Org Prod
     - "16134752"
-    # org_id for the static token
+    # org_id for the static token used in E2E tests.
     - "16155304"
   fleetshard-authz-org-ids-prod.yaml: |-
     # ACS RH SSO Org Prod
@@ -204,7 +204,7 @@ data:
         any_user: true
         max_allowed_instances: 3
         registered_users: []
-        # Static token's org_id, see config/static-token-payload.json
+        # Static token's org_id, see config/static-token-payload.json. Used in E2E tests.
       - id: 16155304
         any_user: true
         max_allowed_instances: 100

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -645,8 +645,6 @@ objects:
         - "16064548"
         # ACS RH SSO Org Prod
         - "16134752"
-        # org_id for the static token
-        - "12345678"
         # ACS RH SSO ORG Development
         - "16155304"
       fleetshard-authz-org-ids-prod.yaml: |-


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
This change is in preparation for looking up the org name via OCM in fleet manager.
We need the org in the static token to be real for the lookup to succeed. As the real org
I have chosen the RHACS dev organisation.

Note that the static token is currently used in the e2e tests and is injected via the vault
instance. We therefore have a chicken and egg problem:
* The e2e test of this PR will fail until we change the static token secret in the vault.
* If we change the vault secret without merging this PR, the e2e tests in other PRs will fail.

I suggest to change the secret during a quiet time, wait for a successful build and merge the PR.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~Unit and integration tests added~
- [ ] ~Added test description under `Test manual`~
- [ ] ~Evaluated and added CHANGELOG.md entry if required~
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [ ] ~CI and all relevant tests are passing~
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~
