### PR TITLE
ROX-13472: Mark parameters loaded from Parameter Store as read-only

### DIFF
--- a/scripts/lib/external_config.sh
+++ b/scripts/lib/external_config.sh
@@ -114,5 +114,5 @@ load_external_config() {
     local env_output
     env_output=$(run_chamber env "$service")
     [[ -z "$env_output" ]] && echo "WARNING: no parameters found under '/$service' in AWS parameter store of this environment"
-    eval "$(echo "$env_output" | sed -E "s/(^export +)(.*)/\1${prefix}\2/")"
+    eval "$(echo "$env_output" | sed -E "s/(^export +)(.*)/readonly ${prefix}\2/")"
 }


### PR DESCRIPTION
## Description
Mark parameters loaded from Parameter Store as read-only to avoid unnecessary overrides in the script.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~Unit and integration tests added~
- [x] Added test description under `Test manual`
- [x] ~Evaluated and added CHANGELOG.md entry if required~
- [x] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
Manual testing
