### PR TITLE
Fix dubious ownership error in CI

### DIFF
--- a/.openshift-ci/e2e-runtime/Dockerfile
+++ b/.openshift-ci/e2e-runtime/Dockerfile
@@ -36,6 +36,6 @@ RUN mkdir /src $GOPATH
 WORKDIR /src
 
 COPY . .
-RUN chmod 775 -R /src && chmod 775 -R $GOPATH
+RUN chmod 775 -R /src && chmod 775 -R $GOPATH && git config --global --add safe.directory /src
 
 CMD ./.openshift-ci/tests/e2e.sh

--- a/.openshift-ci/e2e-runtime/Dockerfile
+++ b/.openshift-ci/e2e-runtime/Dockerfile
@@ -36,6 +36,6 @@ RUN mkdir /src $GOPATH
 WORKDIR /src
 
 COPY . .
-RUN chmod 775 -R /src && chmod 775 -R $GOPATH && git config --global --add safe.directory /src
+RUN chmod 775 -R /src && chmod 775 -R $GOPATH && git config --system --add safe.directory /src
 
 CMD ./.openshift-ci/tests/e2e.sh


### PR DESCRIPTION
## Description
Starting from today our CI fails with error:
```
fatal: detected dubious ownership in repository at '/src'
To add an exception for this directory, call:

	git config --global --add safe.directory /src
./.openshift-ci/tests/e2e.sh: line 10: /dev/env/scripts/lib.sh: No such file or directory
```
I think it may be caused by a `git` version update in the yum repo. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~Unit and integration tests added~
- [x] Added test description under `Test manual`
- [x] Evaluated and added CHANGELOG.md entry if required
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] ~Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
CI green
