### PR TITLE
Revert "Bump stage Central version to nightly-2023-01-09 build (#717)"

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -33,7 +33,7 @@ case $ENVIRONMENT in
     OBSERVABILITY_GITHUB_TAG="master"
     OBSERVABILITY_OBSERVATORIUM_GATEWAY="https://observatorium-mst.api.stage.openshift.com"
     OPERATOR_USE_UPSTREAM="true"
-    OPERATOR_VERSION="v3.73.0-nightly-20230109"
+    OPERATOR_VERSION="v3.73.0-286-g76dd12e8fd"
     ;;
 
   prod)


### PR DESCRIPTION
This reverts commit 1553ab728f9c74b30b283764abaaf135c030382b.

## Description
The ACS operator install of `rhacs-operator.v3.73.0-nightly-20230109` fails with

```
bundle unpacking failed. Reason: DeadlineExceeded, and Message: Job was active longer than specified deadline
```

Revert to restore stage environment. Will need to investigate why this fails even when uninstalling/installing the ACS operator.