### PR TITLE
ROX-12486: Add support for using existing log groups created by terraform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This Changelog should be updated for:
 ## [NEXT RELEASE]
 ### Added
 ### Changed
+- Collected logs in AWS CloudWatch are grouped by log type instead of namespace
 ### Deprecated
 ### Removed
 

--- a/dp-terraform/helm/rhacs-terraform/charts/logging/templates/01-logging-03-cluster-log-forwarder.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/templates/01-logging-03-cluster-log-forwarder.yaml
@@ -12,7 +12,8 @@ spec:
     - name: cloudwatch-output
       type: cloudwatch
       cloudwatch:
-        groupBy: namespaceName
+        groupBy: "logType"
+        groupPrefix: {{ .Values.groupPrefix | quote }}
         region: {{ .Values.aws.region | quote }}
       secret:
         name: cloudwatch

--- a/dp-terraform/helm/rhacs-terraform/charts/logging/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/values.yaml
@@ -2,6 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+groupPrefix: ""
 aws:
   region: "us-east-1"
   accessKeyId: ""

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -105,6 +105,7 @@ helm upgrade rhacs-terraform "${SCRIPT_DIR}" ${HELM_DEBUG_FLAGS:-} \
   --set fleetshardSync.aws.roleARN="${FLEETSHARD_SYNC_AWS_ROLE_ARN}" \
   --set fleetshardSync.telemetry.storage.endpoint="${FLEETSHARD_SYNC_TELEMETRY_STORAGE_ENDPOINT:-}" \
   --set fleetshardSync.telemetry.storage.key="${FLEETSHARD_SYNC_TELEMETRY_STORAGE_KEY:-}" \
+  --set logging.groupPrefix="${CLUSTER_NAME}" \
   --set logging.aws.accessKeyId="${LOGGING_AWS_ACCESS_KEY_ID}" \
   --set logging.aws.secretAccessKey="${LOGGING_AWS_SECRET_ACCESS_KEY}" \
   --set observability.github.accessToken="${OBSERVABILITY_GITHUB_ACCESS_TOKEN}" \

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -67,6 +67,7 @@ observability:
 # - enabled flag is used to completely enable/disable logging sub-chart
 logging:
   enabled: true
+  groupPrefix: ""
   aws:
     accessKeyId: ""
     secretAccessKey: ""


### PR DESCRIPTION
## Description

This PR is added support to use pre-created AWS CloudWatch Log Groups. This allows us to set the retention period for our logs.

This is tested on the dev environment with cluster "mt-log-0111". And logs can be found on the following AWS CloudWatch Log Group: https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/acs-dev-dp-01.application

This PR is related to the following PR: https://github.com/stackrox/acs-fleet-manager-aws-config/pull/28

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~Unit and integration tests added~~
- [x] Added test description under `Test manual`
- [x] Evaluated and added CHANGELOG.md entry if required
- [ ] ~~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

1. Apply terraform from PR: https://github.com/stackrox/acs-fleet-manager-aws-config/pull/28 - with the following command: `make resources ENV=dev`
2. Create a dev OSD cluster based on documentation: `docs/development/setup-developer-osd-cluster.md`
3. When the cluster is up and running, apply Helm with the following command:
```
  helm upgrade rhacs-terraform \
    --install \
    --namespace rhacs \
    --create-namespace \
    --set acsOperator.enabled=false \
    --set fleetshardSync.authType="STATIC_TOKEN" \
    --set fleetshardSync.image="quay.io/app-sre/acs-fleet-manager:main" \
    --set fleetshardSync.clusterId="${CLUSTER_ID}" \
    --set fleetshardSync.managedDB.enabled=false \
    --set logging.enabled=true \
    --set logging.groupPrefix="acs-dev-dp-01" \
    --set logging.aws.accessKeyId="..." \
    --set logging.aws.secretAccessKey="..." \
    --set observability.enabled=false \
    ./dp-terraform/helm/rhacs-terraform
```

**Note:** It's important to mention here that option used is `--set logging.groupPrefix="acs-dev-dp-01"`, because that's the dummy cluster name used in the dev AWS account.

Existing cluster names will be used for staging and production, as you can see in `dp-terraform/helm/rhacs-terraform/terraform_cluster.sh`.
