### PR TITLE
ROX-13666: Refactor DB connection string

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -322,7 +322,7 @@
         "filename": "fleetshard/pkg/central/cloudprovider/dbclient_moq.go",
         "hashed_secret": "80519927d0f3ce1efe933f46ca9e05e68e491adc",
         "is_verified": false,
-        "line_number": 105
+        "line_number": 106
       }
     ],
     "internal/dinosaur/pkg/api/public/api/openapi.yaml": [
@@ -546,5 +546,5 @@
       }
     ]
   },
-  "generated_at": "2022-12-21T09:23:54Z"
+  "generated_at": "2023-01-13T14:02:09Z"
 }

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/golang/glog"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/config"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/postgres"
 	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
 )
 
@@ -54,16 +55,16 @@ type RDS struct {
 }
 
 // EnsureDBProvisioned is a blocking function that makes sure that an RDS database was provisioned for a Central
-func (r *RDS) EnsureDBProvisioned(ctx context.Context, databaseID, masterPassword string) (string, error) {
+func (r *RDS) EnsureDBProvisioned(ctx context.Context, databaseID, masterPassword string) (*postgres.DBConnection, error) {
 	clusterID := getClusterID(databaseID)
 	instanceID := getInstanceID(databaseID)
 
 	if err := r.ensureDBClusterCreated(clusterID, masterPassword); err != nil {
-		return "", fmt.Errorf("ensuring DB cluster %s exists: %w", clusterID, err)
+		return nil, fmt.Errorf("ensuring DB cluster %s exists: %w", clusterID, err)
 	}
 
 	if err := r.ensureDBInstanceCreated(instanceID, clusterID); err != nil {
-		return "", fmt.Errorf("ensuring DB instance %s exists in cluster %s: %w", instanceID, clusterID, err)
+		return nil, fmt.Errorf("ensuring DB instance %s exists in cluster %s: %w", instanceID, clusterID, err)
 	}
 
 	return r.waitForInstanceToBeAvailable(ctx, instanceID, clusterID)
@@ -233,23 +234,27 @@ func (r *RDS) describeDBCluster(clusterID string) (*rds.DBCluster, error) {
 	return result.DBClusters[0], nil
 }
 
-func (r *RDS) waitForInstanceToBeAvailable(ctx context.Context, instanceID string, clusterID string) (string, error) {
+func (r *RDS) waitForInstanceToBeAvailable(ctx context.Context, instanceID string, clusterID string) (*postgres.DBConnection, error) {
 	for {
 		dbInstanceStatus, err := r.instanceStatus(instanceID)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
 		if dbInstanceStatus == dbAvailableStatus {
 			dbCluster, err := r.describeDBCluster(clusterID)
 			if err != nil {
-				return "", err
+				return nil, err
 			}
 
-			connectionString := fmt.Sprintf("host=%s port=%d user=%s dbname=%s sslmode=require",
-				*dbCluster.Endpoint, dbPostgresPort, dbUser, dbName)
+			connection := &postgres.DBConnection{
+				Host:     *dbCluster.Endpoint,
+				Port:     dbPostgresPort,
+				User:     dbUser,
+				Database: dbName,
+			}
 
-			return connectionString, nil
+			return connection, nil
 		}
 
 		glog.Infof("RDS instance status: %s (instance ID: %s)", dbInstanceStatus, instanceID)
@@ -258,7 +263,7 @@ func (r *RDS) waitForInstanceToBeAvailable(ctx context.Context, instanceID strin
 		case <-ticker.C:
 			continue
 		case <-ctx.Done():
-			return "", fmt.Errorf("waiting for RDS instance to be available: %w", ctx.Err())
+			return nil, fmt.Errorf("waiting for RDS instance to be available: %w", ctx.Err())
 		}
 	}
 }

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
@@ -247,14 +247,12 @@ func (r *RDS) waitForInstanceToBeAvailable(ctx context.Context, instanceID strin
 				return nil, err
 			}
 
-			connection := &postgres.DBConnection{
-				Host:     *dbCluster.Endpoint,
-				Port:     dbPostgresPort,
-				User:     dbUser,
-				Database: dbName,
+			connection, err := postgres.NewDBConnection(*dbCluster.Endpoint, dbPostgresPort, dbUser, dbName)
+			if err != nil {
+				return nil, fmt.Errorf("incorrect DB connection parameters: %w", err)
 			}
 
-			return connection, nil
+			return &connection, nil
 		}
 
 		glog.Infof("RDS instance status: %s (instance ID: %s)", dbInstanceStatus, instanceID)

--- a/fleetshard/pkg/central/cloudprovider/dbclient.go
+++ b/fleetshard/pkg/central/cloudprovider/dbclient.go
@@ -3,6 +3,8 @@ package cloudprovider
 
 import (
 	"context"
+
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/postgres"
 )
 
 // DBClient defines an interface for clients that can provision and deprovision databases on cloud providers
@@ -11,7 +13,7 @@ import (
 type DBClient interface {
 	// EnsureDBProvisioned is a blocking function that makes sure that a database with the given databaseID was provisioned,
 	// using the master password given as parameter
-	EnsureDBProvisioned(ctx context.Context, databaseID, passwordSecretName string) (string, error)
+	EnsureDBProvisioned(ctx context.Context, databaseID, passwordSecretName string) (*postgres.DBConnection, error)
 	// EnsureDBDeprovisioned is a non-blocking function that makes sure that a managed DB is deprovisioned (more
 	// specifically, that its deletion was initiated)
 	EnsureDBDeprovisioned(databaseID string) (bool, error)

--- a/fleetshard/pkg/central/cloudprovider/dbclient_moq.go
+++ b/fleetshard/pkg/central/cloudprovider/dbclient_moq.go
@@ -5,6 +5,7 @@ package cloudprovider
 
 import (
 	"context"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/postgres"
 	"sync"
 )
 
@@ -21,7 +22,7 @@ var _ DBClient = &DBClientMock{}
 //			EnsureDBDeprovisionedFunc: func(databaseID string) (bool, error) {
 //				panic("mock out the EnsureDBDeprovisioned method")
 //			},
-//			EnsureDBProvisionedFunc: func(ctx context.Context, databaseID string, passwordSecretName string) (string, error) {
+//			EnsureDBProvisionedFunc: func(ctx context.Context, databaseID string, passwordSecretName string) (*postgres.DBConnection, error) {
 //				panic("mock out the EnsureDBProvisioned method")
 //			},
 //		}
@@ -35,7 +36,7 @@ type DBClientMock struct {
 	EnsureDBDeprovisionedFunc func(databaseID string) (bool, error)
 
 	// EnsureDBProvisionedFunc mocks the EnsureDBProvisioned method.
-	EnsureDBProvisionedFunc func(ctx context.Context, databaseID string, passwordSecretName string) (string, error)
+	EnsureDBProvisionedFunc func(ctx context.Context, databaseID string, passwordSecretName string) (*postgres.DBConnection, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -91,7 +92,7 @@ func (mock *DBClientMock) EnsureDBDeprovisionedCalls() []struct {
 }
 
 // EnsureDBProvisioned calls EnsureDBProvisionedFunc.
-func (mock *DBClientMock) EnsureDBProvisioned(ctx context.Context, databaseID string, passwordSecretName string) (string, error) {
+func (mock *DBClientMock) EnsureDBProvisioned(ctx context.Context, databaseID string, passwordSecretName string) (*postgres.DBConnection, error) {
 	if mock.EnsureDBProvisionedFunc == nil {
 		panic("DBClientMock.EnsureDBProvisionedFunc: method is nil but DBClient.EnsureDBProvisioned was just called")
 	}

--- a/fleetshard/pkg/central/postgres/postgres.go
+++ b/fleetshard/pkg/central/postgres/postgres.go
@@ -7,27 +7,37 @@ import (
 
 // DBConnection stores the data necessary to connect to a PostgreSQL server
 type DBConnection struct {
-	Host     string
-	Port     int
-	User     string
-	Database string
+	host     string
+	port     int
+	user     string
+	database string
 }
 
-// CreatePostgresConnectionString generates a connection string from a DBConnection struct
-func CreatePostgresConnectionString(connection DBConnection) (string, error) {
-	if connection.Host == "" {
-		return "", fmt.Errorf("host parameter cannot be empty")
+// NewDBConnection constructs a new DBConnection struct
+func NewDBConnection(host string, port int, user, database string) (DBConnection, error) {
+	if host == "" {
+		return DBConnection{}, fmt.Errorf("host parameter cannot be empty")
 	}
-	if connection.Port == 0 {
-		return "", fmt.Errorf("port parameter cannot be 0")
+	if port == 0 {
+		return DBConnection{}, fmt.Errorf("port parameter cannot be 0")
 	}
-	if connection.User == "" {
-		return "", fmt.Errorf("user parameter cannot be empty")
+	if user == "" {
+		return DBConnection{}, fmt.Errorf("user parameter cannot be empty")
 	}
-	if connection.Database == "" {
-		return "", fmt.Errorf("database parameter cannot be empty")
+	if database == "" {
+		return DBConnection{}, fmt.Errorf("database parameter cannot be empty")
 	}
 
+	return DBConnection{
+		host:     host,
+		port:     port,
+		user:     user,
+		database: database,
+	}, nil
+}
+
+// AsConnectionString returns a string that can be used to connect to a PostgreSQL server
+func (c DBConnection) AsConnectionString() string {
 	return fmt.Sprintf("host=%s port=%d user=%s dbname=%s sslmode=require",
-		connection.Host, connection.Port, connection.User, connection.Database), nil
+		c.host, c.port, c.user, c.database)
 }

--- a/fleetshard/pkg/central/postgres/postgres.go
+++ b/fleetshard/pkg/central/postgres/postgres.go
@@ -1,0 +1,33 @@
+// Package postgres provides utility functions related to PostreSQL
+package postgres
+
+import (
+	"fmt"
+)
+
+// DBConnection stores the data necessary to connect to a PostgreSQL server
+type DBConnection struct {
+	Host     string
+	Port     int
+	User     string
+	Database string
+}
+
+// CreatePostgresConnectionString generates a connection string from a DBConnection struct
+func CreatePostgresConnectionString(connection DBConnection) (string, error) {
+	if connection.Host == "" {
+		return "", fmt.Errorf("host parameter cannot be empty")
+	}
+	if connection.Port == 0 {
+		return "", fmt.Errorf("port parameter cannot be 0")
+	}
+	if connection.User == "" {
+		return "", fmt.Errorf("user parameter cannot be empty")
+	}
+	if connection.Database == "" {
+		return "", fmt.Errorf("database parameter cannot be empty")
+	}
+
+	return fmt.Sprintf("host=%s port=%d user=%s dbname=%s sslmode=require",
+		connection.Host, connection.Port, connection.User, connection.Database), nil
+}

--- a/fleetshard/pkg/central/postgres/postgres_test.go
+++ b/fleetshard/pkg/central/postgres/postgres_test.go
@@ -1,0 +1,39 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgresConnectionString(t *testing.T) {
+	dbConnection := DBConnection{
+		Host:     "localhost",
+		Port:     14543,
+		User:     "test-user",
+		Database: "postgresdb",
+	}
+
+	dbConnectionString, err := CreatePostgresConnectionString(dbConnection)
+	require.NoError(t, err)
+	require.Equal(t, dbConnectionString, "host=localhost port=14543 user=test-user dbname=postgresdb sslmode=require")
+
+	dbConnection.Host = ""
+	_, err = CreatePostgresConnectionString(dbConnection)
+	require.Error(t, err)
+
+	dbConnection.Host = "host"
+	dbConnection.Port = 0
+	_, err = CreatePostgresConnectionString(dbConnection)
+	require.Error(t, err)
+
+	dbConnection.Port = 5432
+	dbConnection.User = ""
+	_, err = CreatePostgresConnectionString(dbConnection)
+	require.Error(t, err)
+
+	dbConnection.User = "postgres"
+	dbConnection.Database = ""
+	_, err = CreatePostgresConnectionString(dbConnection)
+	require.Error(t, err)
+}

--- a/fleetshard/pkg/central/postgres/postgres_test.go
+++ b/fleetshard/pkg/central/postgres/postgres_test.go
@@ -3,37 +3,28 @@ package postgres
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPostgresConnectionString(t *testing.T) {
-	dbConnection := DBConnection{
-		Host:     "localhost",
-		Port:     14543,
-		User:     "test-user",
-		Database: "postgresdb",
-	}
-
-	dbConnectionString, err := CreatePostgresConnectionString(dbConnection)
+	dbConnection, err := NewDBConnection("localhost", 14543, "test-user", "postgresdb")
 	require.NoError(t, err)
-	require.Equal(t, dbConnectionString, "host=localhost port=14543 user=test-user dbname=postgresdb sslmode=require")
 
-	dbConnection.Host = ""
-	_, err = CreatePostgresConnectionString(dbConnection)
-	require.Error(t, err)
+	require.Equal(t, dbConnection.AsConnectionString(), "host=localhost port=14543 user=test-user dbname=postgresdb sslmode=require")
+}
 
-	dbConnection.Host = "host"
-	dbConnection.Port = 0
-	_, err = CreatePostgresConnectionString(dbConnection)
-	require.Error(t, err)
+func TestNewDBConnection(t *testing.T) {
+	_, err := NewDBConnection("", 14543, "test-user", "postgresdb")
+	assert.EqualErrorf(t, err, "host parameter cannot be empty", "incorrect error message")
 
-	dbConnection.Port = 5432
-	dbConnection.User = ""
-	_, err = CreatePostgresConnectionString(dbConnection)
-	require.Error(t, err)
+	_, err = NewDBConnection("localhost", 0, "test-user", "postgresdb")
+	assert.EqualErrorf(t, err, "port parameter cannot be 0"+
+		"", "incorrect error message")
 
-	dbConnection.User = "postgres"
-	dbConnection.Database = ""
-	_, err = CreatePostgresConnectionString(dbConnection)
-	require.Error(t, err)
+	_, err = NewDBConnection("localhost", 14543, "", "postgresdb")
+	assert.EqualErrorf(t, err, "user parameter cannot be empty", "incorrect error message")
+
+	_, err = NewDBConnection("localhost", 14543, "test-user", "")
+	assert.EqualErrorf(t, err, "database parameter cannot be empty", "incorrect error message")
 }

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stackrox/acs-fleet-manager/fleetshard/config"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/charts"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/cloudprovider"
-	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/postgres"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/util"
 	centralConstants "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
@@ -224,14 +223,10 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		if err != nil {
 			return nil, fmt.Errorf("provisioning RDS DB: %w", err)
 		}
-		dbConnectionString, err := postgres.CreatePostgresConnectionString(*dbConnection)
-		if err != nil {
-			return nil, fmt.Errorf("creating RDS DB connection string: %w", err)
-		}
 
 		central.Spec.Central.DB = &v1alpha1.CentralDBSpec{
 			IsEnabled:                v1alpha1.CentralDBEnabledPtr(v1alpha1.CentralDBEnabledTrue),
-			ConnectionStringOverride: pointer.String(dbConnectionString),
+			ConnectionStringOverride: pointer.String(dbConnection.AsConnectionString()),
 			PasswordSecret: &v1alpha1.LocalSecretReference{
 				Name: centralDbSecretName,
 			},

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -108,12 +108,11 @@ func TestReconcileCreateWithManagedDB(t *testing.T) {
 
 	managedDBProvisioningClient := &cloudprovider.DBClientMock{}
 	managedDBProvisioningClient.EnsureDBProvisionedFunc = func(_ context.Context, _ string, _ string) (*postgres.DBConnection, error) {
-		return &postgres.DBConnection{
-			Host:     "localhost",
-			Port:     5432,
-			User:     "rhacs",
-			Database: "postgres",
-		}, nil
+		connection, err := postgres.NewDBConnection("localhost", 5432, "rhacs", "postgres")
+		if err != nil {
+			return nil, err
+		}
+		return &connection, nil
 	}
 	r := NewCentralReconciler(fakeClient, private.ManagedCentral{}, managedDBProvisioningClient,
 		CentralReconcilerOptions{
@@ -314,12 +313,11 @@ func TestReconcileDeleteWithManagedDB(t *testing.T) {
 
 	managedDBProvisioningClient := &cloudprovider.DBClientMock{}
 	managedDBProvisioningClient.EnsureDBProvisionedFunc = func(_ context.Context, _ string, _ string) (*postgres.DBConnection, error) {
-		return &postgres.DBConnection{
-			Host:     "localhost",
-			Port:     5432,
-			User:     "rhacs",
-			Database: "postgres",
-		}, nil
+		connection, err := postgres.NewDBConnection("localhost", 5432, "rhacs", "postgres")
+		if err != nil {
+			return nil, err
+		}
+		return &connection, nil
 	}
 	managedDBProvisioningClient.EnsureDBDeprovisionedFunc = func(_ string) (bool, error) {
 		return true, nil


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

In preparation for supporting multiple DB users (i.e. the initial `rds_superuser`, and a non-privileged user for Centrals) , this PR refactors the RDS provisioning client so that it returns the connection parameters as a struct, instead of a string. 

This will make it easier to generate connection strings for different users.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [x] Evaluated and added CHANGELOG.md entry if required
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

Tested locally by verifying that a DB was provisioned, and that the Central was able to connect:
`INSTALL_OPERATOR=NO MANAGED_DB_ENABLED=TRUE ./dev/env/scripts/up.sh`
`./scripts/create-central.sh`

To test locally, I have to make the DB publicly accessible. I added a new VPC, security group and DB subnet group in dev on AWS for this purpose.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
