### PR TITLE
add migration resets to fleet-manager init container

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -119,6 +119,11 @@ parameters:
   description: framework's debug mode
   value: "false"
 
+- name: DB_MIGRATION_RESET
+  displayName: DB migration reset
+  description: If true, all database migrations are rolled back and re-applied on start up
+  value: "false"
+
 - name: ENABLE_METRICS_HTTPS
   displayName: Enable Metrics HTTPS
   description: Enable HTTPS for metrics server
@@ -1040,20 +1045,39 @@ objects:
               mountPath: /secrets/service
             - name: rds
               mountPath: /secrets/rds
-            command:
-            - /usr/local/bin/fleet-manager
-            - migrate
-            - --db-host-file=/secrets/rds/db.host
-            - --db-port-file=/secrets/rds/db.port
-            - --db-user-file=/secrets/rds/db.user
-            - --db-password-file=/secrets/rds/db.password
-            - --db-name-file=/secrets/rds/db.name
-            - --db-ssl-certificate-file=/secrets/rds/db.ca_cert
-            - --db-sslmode=${DB_SSLMODE}
-            - --db-max-open-connections=${DB_MAX_OPEN_CONNS}
-            - --enable-db-debug=${ENABLE_DB_DEBUG}
-            - --alsologtostderr
-            - -v=${GLOG_V}
+            command: ["/bin/sh"]
+            args:
+            - -c
+            - >-
+              if [ "$DB_MIGRATION_RESET" = true ];
+              then
+              /usr/local/bin/fleet-manager
+                migrate rollback-all
+                --db-host-file=/secrets/rds/db.host
+                --db-port-file=/secrets/rds/db.port
+                --db-user-file=/secrets/rds/db.user
+                --db-password-file=/secrets/rds/db.password
+                --db-name-file=/secrets/rds/db.name
+                --db-ssl-certificate-file=/secrets/rds/db.ca_cert
+                --db-sslmode=${DB_SSLMODE}
+                --db-max-open-connections=${DB_MAX_OPEN_CONNS}
+                --enable-db-debug=${ENABLE_DB_DEBUG}
+                --alsologtostderr
+                -v=${GLOG_V};
+              fi &&
+              /usr/local/bin/fleet-manager
+                migrate
+                --db-host-file=/secrets/rds/db.host
+                --db-port-file=/secrets/rds/db.port
+                --db-user-file=/secrets/rds/db.user
+                --db-password-file=/secrets/rds/db.password
+                --db-name-file=/secrets/rds/db.name
+                --db-ssl-certificate-file=/secrets/rds/db.ca_cert
+                --db-sslmode=${DB_SSLMODE}
+                --db-max-open-connections=${DB_MAX_OPEN_CONNS}
+                --enable-db-debug=${ENABLE_DB_DEBUG}
+                --alsologtostderr
+                -v=${GLOG_V};
           containers:
           - name: service
             image: ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}


### PR DESCRIPTION
## Description
Add a migration reset toggle via app-interface flag. This allows us to rollback migrations in an idempotent way. Consider the following scenario:

0. Fleet-manager is on commit A and DB migration 9.
1. Column is added to DB via migration 10 by commit B.
2. Commit B is reverted, fleet-manager is now on again commit A. We now need to rollback the DB schema from migration 10 -> 9.
4. Instead of using `fleet-manager migrate rollback-last`, we enable migration reset. When the container with image A is started, all migrations are rolled back (10 -> 0), and A's migrations are re-applied (0 -> 9).
5. Fleet-manager is now again on commit A and DB migration 9.
6. Migration reset can now be disabled again.

The assumption here is that we can perform the DB schema migrations without data loss.

Edit: Nvm this doesn't work either because we need to rollback on commit B and re-apply on commit A.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Evaluated and added CHANGELOG.md entry if required
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
