### PR TITLE
ROX-13666: Split dbclient.EnsureDBProvisioned() into two functions

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -322,7 +322,7 @@
         "filename": "fleetshard/pkg/central/cloudprovider/dbclient_moq.go",
         "hashed_secret": "80519927d0f3ce1efe933f46ca9e05e68e491adc",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 118
       }
     ],
     "internal/dinosaur/pkg/api/public/api/openapi.yaml": [
@@ -546,5 +546,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-13T14:02:09Z"
+  "generated_at": "2023-01-18T17:58:26Z"
 }

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/google/uuid"
@@ -92,6 +93,9 @@ func TestRDSProvisioning(t *testing.T) {
 	err = rdsClient.EnsureDBProvisioned(ctx, dbID, dbMasterPassword)
 	assert.NoError(t, err)
 
+	_, err = rdsClient.GetDBConnection(dbID)
+	assert.NoError(t, err)
+
 	clusterExists, err = rdsClient.clusterExists(clusterID)
 	require.NoError(t, err)
 	require.True(t, clusterExists)
@@ -117,4 +121,18 @@ func TestRDSProvisioning(t *testing.T) {
 	clusterDeleted, err := waitForClusterToBeDeleted(deleteCtx, rdsClient, clusterID)
 	require.NoError(t, err)
 	assert.True(t, clusterDeleted)
+}
+
+func TestGetDBConnection(t *testing.T) {
+	if os.Getenv("RUN_RDS_TESTS") != "true" {
+		t.Skip("Skip RDS tests. Set RUN_RDS_TESTS=true env variable to enable RDS tests.")
+	}
+
+	rdsClient, err := newTestRDS()
+	require.NoError(t, err)
+
+	_, err = rdsClient.GetDBConnection("test-" + uuid.New().String())
+	var awsErr awserr.Error
+	require.ErrorAs(t, err, &awsErr)
+	assert.Equal(t, awsErr.Code(), rds.ErrCodeDBClusterNotFoundFault)
 }

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -89,7 +89,7 @@ func TestRDSProvisioning(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, instanceExists)
 
-	_, err = rdsClient.EnsureDBProvisioned(ctx, dbID, dbMasterPassword)
+	err = rdsClient.EnsureDBProvisioned(ctx, dbID, dbMasterPassword)
 	assert.NoError(t, err)
 
 	clusterExists, err = rdsClient.clusterExists(clusterID)
@@ -108,9 +108,8 @@ func TestRDSProvisioning(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, instanceStatus, dbAvailableStatus)
 
-	deletionStarted, err := rdsClient.EnsureDBDeprovisioned(dbID)
+	err = rdsClient.EnsureDBDeprovisioned(dbID)
 	assert.NoError(t, err)
-	assert.True(t, deletionStarted)
 
 	deleteCtx, deleteCancel := context.WithTimeout(context.TODO(), 10*time.Minute)
 	defer deleteCancel()

--- a/fleetshard/pkg/central/cloudprovider/dbclient.go
+++ b/fleetshard/pkg/central/cloudprovider/dbclient.go
@@ -13,8 +13,11 @@ import (
 type DBClient interface {
 	// EnsureDBProvisioned is a blocking function that makes sure that a database with the given databaseID was provisioned,
 	// using the master password given as parameter
-	EnsureDBProvisioned(ctx context.Context, databaseID, passwordSecretName string) (*postgres.DBConnection, error)
+	EnsureDBProvisioned(ctx context.Context, databaseID, passwordSecretName string) error
 	// EnsureDBDeprovisioned is a non-blocking function that makes sure that a managed DB is deprovisioned (more
 	// specifically, that its deletion was initiated)
-	EnsureDBDeprovisioned(databaseID string) (bool, error)
+	EnsureDBDeprovisioned(databaseID string) error
+	// GetDBConnection returns a postgres.DBConnection struct, which contains the data necessary
+	// to construct a PostgreSQL connection string. It expects that the database was already provisioned.
+	GetDBConnection(databaseID string) (postgres.DBConnection, error)
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

The `EnsureDBProvisioned()` was doing two things:
- ensures that the DB was provisioned
- obtains and returns the data necessary to connect to the DB (host name, etc)

It should be possible to do these things independently of each other, and this PR addresses that.

This will be needed in a follow-up PR, to use non-privileged Postgres users for ACS instances.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [x] Evaluated and added CHANGELOG.md entry if required
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

Tested locally by verifying that a DB was provisioned, and that the Central was able to connect:
INSTALL_OPERATOR=NO MANAGED_DB_ENABLED=TRUE ./dev/env/scripts/up.sh
./scripts/create-central.sh

To test locally, I have to make the DB publicly accessible. I added a new VPC, security group and DB subnet group in dev on AWS for this purpose.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
