### PR TITLE
ROX-13593: Use account id as user in track events

### DIFF
--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -74,7 +74,7 @@ func (h adminDinosaurHandler) Create(w http.ResponseWriter, r *http.Request) {
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
 			svcErr := h.service.RegisterDinosaurJob(&convDinosaur)
-			h.telemetry.TrackCreationRequested(convDinosaur.ID, convDinosaur.OrganisationID, true, svcErr.AsError())
+			h.telemetry.TrackCreationRequested(convDinosaur.ID, convDinosaur.OwnerAccountID, true, svcErr.AsError())
 			if svcErr != nil {
 				return nil, svcErr
 			}
@@ -158,8 +158,8 @@ func (h adminDinosaurHandler) Delete(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 
 			err := h.service.RegisterDinosaurDeprovisionJob(ctx, id)
-			if orgID, orgErr := getOrgIDFromContext(ctx); orgErr == nil {
-				h.telemetry.TrackDeletionRequested(id, orgID, true, err.AsError())
+			if accountID, orgErr := getAccountIDFromContext(ctx); orgErr == nil {
+				h.telemetry.TrackDeletionRequested(id, accountID, true, err.AsError())
 			}
 			return nil, err
 		},

--- a/internal/dinosaur/pkg/handlers/dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/dinosaur.go
@@ -82,7 +82,7 @@ func (h dinosaurHandler) Create(w http.ResponseWriter, r *http.Request) {
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
 			svcErr := h.service.RegisterDinosaurJob(convDinosaur)
-			h.telemetry.TrackCreationRequested(convDinosaur.ID, convDinosaur.OrganisationID, false, svcErr.AsError())
+			h.telemetry.TrackCreationRequested(convDinosaur.ID, convDinosaur.OwnerAccountID, false, svcErr.AsError())
 			if svcErr != nil {
 				return nil, svcErr
 			}
@@ -122,8 +122,8 @@ func (h dinosaurHandler) Delete(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 
 			err := h.service.RegisterDinosaurDeprovisionJob(ctx, id)
-			if orgID, orgErr := getOrgIDFromContext(ctx); orgErr == nil {
-				h.telemetry.TrackDeletionRequested(id, orgID, false, err.AsError())
+			if accountID, orgErr := getAccountIDFromContext(ctx); orgErr == nil {
+				h.telemetry.TrackDeletionRequested(id, accountID, false, err.AsError())
 			}
 			return nil, err
 		},
@@ -168,14 +168,14 @@ func (h dinosaurHandler) List(w http.ResponseWriter, r *http.Request) {
 	handlers.HandleList(w, r, cfg)
 }
 
-func getOrgIDFromContext(ctx context.Context) (string, error) {
+func getAccountIDFromContext(ctx context.Context) (string, error) {
 	claims, err := auth.GetClaimsFromContext(ctx)
 	if err != nil {
 		return "", goerr.Wrap(err, "cannot obtain claims from context")
 	}
-	orgID, err := claims.GetOrgID()
+	accountID, err := claims.GetAccountID()
 	if err != nil {
-		return "", goerr.Wrap(err, "no org id in claims")
+		return "", goerr.Wrap(err, "no account id in claims")
 	}
-	return orgID, nil
+	return accountID, nil
 }

--- a/internal/dinosaur/pkg/services/telemetry.go
+++ b/internal/dinosaur/pkg/services/telemetry.go
@@ -35,7 +35,7 @@ func (t *Telemetry) RegisterTenant(central *dbapi.CentralRequest) {
 }
 
 // TrackCreationRequested emits a track event that signals the creation request of a Central instance.
-func (t *Telemetry) TrackCreationRequested(id string, orgID string, isAdmin bool, err error) {
+func (t *Telemetry) TrackCreationRequested(id string, user string, isAdmin bool, err error) {
 	if t.enabled() {
 		var errMsg string
 		if err != nil {
@@ -47,12 +47,12 @@ func (t *Telemetry) TrackCreationRequested(id string, orgID string, isAdmin bool
 			"Success":          err == nil,
 			"Is Admin Request": isAdmin,
 		}
-		t.config.Telemeter().Track("Central Creation Requested", orgID, props)
+		t.config.Telemeter().Track("Central Creation Requested", user, props)
 	}
 }
 
 // TrackDeletionRequested emits a track event that signals the deletion request of a Central instance.
-func (t *Telemetry) TrackDeletionRequested(id string, orgID string, isAdmin bool, err error) {
+func (t *Telemetry) TrackDeletionRequested(id string, user string, isAdmin bool, err error) {
 	if t.enabled() {
 		var errMsg string
 		if err != nil {
@@ -64,7 +64,7 @@ func (t *Telemetry) TrackDeletionRequested(id string, orgID string, isAdmin bool
 			"Success":          err == nil,
 			"Is Admin Request": isAdmin,
 		}
-		t.config.Telemeter().Track("Central Deletion Requested", orgID, props)
+		t.config.Telemeter().Track("Central Deletion Requested", user, props)
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Use the `acount_id` claim from the Red Hat SSO token as the user id in telemetry events. This aligns with the user id that is used by the ACS front end console plugin.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] ~Added test description under `Test manual`~
- [ ] ~Evaluated and added CHANGELOG.md entry if required~
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

