### PR TITLE
ROX-13593: Store telemetry storage key as secret

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -444,70 +444,70 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "13032f402fed753c2248419ea4f69f99931f6dbc",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 547
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "30025f80f6e22cdafb85db387d50f90ea884576a",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 547
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "355f24fd038bcaf85617abdcaa64af51ed19bbcf",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 547
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "3d8a1dcd2c3c765ce35c9a9552d23273cc4ddace",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 547
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "4ac7b0522761eba972467942cd5cd7499dd2c361",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 547
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "7639ab2a6bcf2ea30a055a99468c9cd844d4c22a",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 547
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "b56360daf4793d2a74991a972b34d95bc00fb2da",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 547
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "c9a73ef9ee8ce9f38437227801c70bcc6740d1a1",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 547
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "14736999d9940728c5294277831a702f7882dece",
         "is_verified": false,
-        "line_number": 589
+        "line_number": 584
       },
       {
         "type": "Secret Keyword",
         "filename": "templates/service-template.yml",
         "hashed_secret": "4e199b4a1c40b497a95fcd1cd896351733849949",
         "is_verified": false,
-        "line_number": 676,
+        "line_number": 671,
         "is_secret": false
       },
       {
@@ -515,7 +515,7 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "9d51dabe59aa776bef2909d3689374ebb93ab2be",
         "is_verified": false,
-        "line_number": 720
+        "line_number": 715
       }
     ],
     "test/support/certs.json": [
@@ -546,5 +546,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-18T17:58:26Z"
+  "generated_at": "2023-01-23T01:51:04Z"
 }

--- a/pkg/client/telemetry/config.go
+++ b/pkg/client/telemetry/config.go
@@ -4,33 +4,45 @@ package telemetry
 import (
 	"os"
 
+	"github.com/golang/glog"
 	"github.com/spf13/pflag"
+	"github.com/stackrox/acs-fleet-manager/pkg/shared"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome"
 )
 
 // TelemetryConfig is a wrapper for the telemetry configuration.
 type TelemetryConfig struct {
 	phonehome.Config
+
+	StorageKeyFile string
 }
 
 // NewTelemetryConfig creates a new telemetry configuration.
 func NewTelemetryConfig() *TelemetryConfig {
 	// HOSTNAME is set to the pod name by K8s.
 	clientID := getEnv("HOSTNAME", "fleet-manager")
-	return &TelemetryConfig{phonehome.Config{
-		ClientID:   clientID,
-		ClientName: "ACS Fleet Manager",
-	}}
+	return &TelemetryConfig{
+		Config: phonehome.Config{
+			ClientID:   clientID,
+			ClientName: "ACS Fleet Manager",
+		},
+		StorageKeyFile: "secrets/telemetry.storageKey",
+	}
 }
 
 // AddFlags adds telemetry CLI flags.
 func (t *TelemetryConfig) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&t.Endpoint, "telemetry-endpoint", t.Config.Endpoint, "The telemetry endpoint")
-	fs.StringVar(&t.StorageKey, "telemetry-storage-key", t.Config.StorageKey, "The telemetry storage key")
+	fs.StringVar(&t.Endpoint, "telemetry-endpoint", t.Endpoint, "The telemetry endpoint")
+	fs.StringVar(&t.StorageKeyFile, "telemetry-storage-key-secret-file", t.StorageKeyFile, "File containing the telemetry storage key")
 }
 
 // ReadFiles reads telemetry secret files.
 func (t *TelemetryConfig) ReadFiles() error {
+	err := shared.ReadFileValueString(t.StorageKeyFile, &t.StorageKey)
+	// Don't fail if telemetry secret key is not found.
+	if err != nil {
+		glog.Warningf("could not read telemetry storage key secret file")
+	}
 	return nil
 }
 

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -454,11 +454,6 @@ parameters:
   description: Endpoint for the telemetry backend
   value: ""
 
-- name: TELEMETRY_STORAGE_KEY
-  displayName: Telemetry storage key
-  description: API token for the telemetry storage backend
-  value: ""
-
 objects:
   - kind: ConfigMap
     apiVersion: v1
@@ -1258,7 +1253,7 @@ objects:
             - --alsologtostderr
             - --central-request-expiration-timeout=${CENTRAL_REQUEST_EXPIRATION_TIMEOUT}
             - --telemetry-endpoint=${TELEMETRY_ENDPONT}
-            - --telemetry-storage-key=${TELEMETRY_STORAGE_KEY}
+            - --telemetry-storage-key-secret-file=/secrets/fleet-manager-credentials/telemetry.storageKey
             - -v=${GLOG_V}
             resources:
               requests:


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
We want to enable loading the telemetry key from the fleet-manager vault. Therefore, the telemetry key is changed from a direct CLI flag to a file mount.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] ~Evaluated and added CHANGELOG.md entry if required~
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual