### PR TITLE
Increase RDS integration tests timeout

### DIFF
--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const awsTimeoutMinutes = 15
+
 func newTestRDS() (*RDS, error) {
 	rdsClient, err := newTestRDSClient()
 	if err != nil {
@@ -72,7 +74,7 @@ func TestRDSProvisioning(t *testing.T) {
 	rdsClient, err := newTestRDS()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.TODO(), 15*time.Minute)
+	ctx, cancel := context.WithTimeout(context.TODO(), awsTimeoutMinutes*time.Minute)
 	defer cancel()
 
 	dbID := "test-" + uuid.New().String()
@@ -115,7 +117,7 @@ func TestRDSProvisioning(t *testing.T) {
 	err = rdsClient.EnsureDBDeprovisioned(dbID)
 	assert.NoError(t, err)
 
-	deleteCtx, deleteCancel := context.WithTimeout(context.TODO(), 10*time.Minute)
+	deleteCtx, deleteCancel := context.WithTimeout(context.TODO(), awsTimeoutMinutes*time.Minute)
 	defer deleteCancel()
 
 	clusterDeleted, err := waitForClusterToBeDeleted(deleteCtx, rdsClient, clusterID)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

RDS DB usually takes ~3 minutes, and the timeout was set to 10 minutes. It looks like sometimes it actually takes around 10 minutes, so this PR increases that time limit to 14 minutes.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
~~- [ ] Added test description under `Test manual`~~
~~- [ ] Evaluated and added CHANGELOG.md entry if required~~
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [ ] CI and all relevant tests are passing

~~- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~~
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~

## Test manual

CI only.
