### PR TITLE
ROX-14473: require user org_id to match ACS owner org_id

### DIFF
--- a/fleetshard/pkg/central/reconciler/init_auth.go
+++ b/fleetshard/pkg/central/reconciler/init_auth.go
@@ -163,13 +163,13 @@ func createAuthProviderRequest(central private.ManagedCentral) *storage.AuthProv
 		},
 		ClaimMappings: map[string]string{
 			"realm_access.roles": "groups",
-			"org_id":             "rhOrgId",
+			"org_id":             "rh_org_id",
 		},
 		// TODO: for testing purposes only; remove once host is correctly specified in fleet-manager
 		ExtraUiEndpoints: []string{"localhost:8443"},
 		RequiredAttributes: []*storage.AuthProvider_RequiredAttribute{
 			{
-				AttributeKey:   "rhOrgId",
+				AttributeKey:   "rh_org_id",
 				AttributeValue: central.Spec.Auth.OwnerOrgId,
 			},
 		},

--- a/fleetshard/pkg/central/reconciler/init_auth.go
+++ b/fleetshard/pkg/central/reconciler/init_auth.go
@@ -163,9 +163,16 @@ func createAuthProviderRequest(central private.ManagedCentral) *storage.AuthProv
 		},
 		ClaimMappings: map[string]string{
 			"realm_access.roles": "groups",
+			"org_id":             "rhOrgId",
 		},
 		// TODO: for testing purposes only; remove once host is correctly specified in fleet-manager
 		ExtraUiEndpoints: []string{"localhost:8443"},
+		RequiredAttributes: []*storage.AuthProvider_RequiredAttribute{
+			{
+				AttributeKey:   "rhOrgId",
+				AttributeValue: central.Spec.Auth.OwnerOrgId,
+			},
+		},
 		Traits: &storage.Traits{
 			MutabilityMode: storage.Traits_ALLOW_MUTATE_FORCED,
 		},

--- a/fleetshard/pkg/central/reconciler/init_auth.go
+++ b/fleetshard/pkg/central/reconciler/init_auth.go
@@ -64,6 +64,19 @@ var (
 				RoleName: "Admin",
 			}
 		},
+		func(providerId string, auth private.ManagedCentralAllOfSpecAuth) *storage.Group {
+			return &storage.Group{
+				Props: &storage.GroupProperties{
+					AuthProviderId: providerId,
+					Key:            "rh_is_org_admin",
+					Value:          "true",
+					Traits: &storage.Traits{
+						MutabilityMode: storage.Traits_ALLOW_MUTATE_FORCED,
+					},
+				},
+				RoleName: "Admin",
+			}
+		},
 	}
 )
 
@@ -164,6 +177,7 @@ func createAuthProviderRequest(central private.ManagedCentral) *storage.AuthProv
 		ClaimMappings: map[string]string{
 			"realm_access.roles": "groups",
 			"org_id":             "rh_org_id",
+			"is_org_admin":       "rh_is_org_admin",
 		},
 		// TODO: for testing purposes only; remove once host is correctly specified in fleet-manager
 		ExtraUiEndpoints: []string{"localhost:8443"},


### PR DESCRIPTION
## Description
This pretty much reverts https://issues.redhat.com/browse/ROX-12946. 
For details, refer to the [doc](https://docs.google.com/document/d/1b3ycWWi78s4hllN1S566AzdOPeVXOLzAOekVFa1cKRw/edit?usp=sharing)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Evaluated and added CHANGELOG.md entry if required
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
TBD
