### PR TITLE
enable OCM mock in fleet-manager

### DIFF
--- a/internal/dinosaur/pkg/environments/development.go
+++ b/internal/dinosaur/pkg/environments/development.go
@@ -10,7 +10,7 @@ func NewDevelopmentEnvLoader() environments.EnvLoader {
 		"ocm-debug":                                       "false",
 		"ams-base-url":                                    "https://api.stage.openshift.com",
 		"ocm-base-url":                                    "https://api.stage.openshift.com",
-		"enable-ocm-mock":                                 "false",
+		"enable-ocm-mock":                                 "true",
 		"enable-https":                                    "false",
 		"enable-metrics-https":                            "false",
 		"enable-terms-acceptance":                         "false",


### PR DESCRIPTION
## Description

Enable ocm mock and fleet manager development mode.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Evaluated and added CHANGELOG.md entry if required
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

