### PR TITLE
ROX-13593: Use `user_id` and `rh-user-id` claims in telemetry events

### DIFF
--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -74,11 +74,11 @@ func (h adminDinosaurHandler) Create(w http.ResponseWriter, r *http.Request) {
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
 			svcErr := h.service.RegisterDinosaurJob(&convDinosaur)
+			h.telemetry.RegisterTenant(r.Context(), &convDinosaur)
 			h.telemetry.TrackCreationRequested(r.Context(), convDinosaur.ID, true, svcErr.AsError())
 			if svcErr != nil {
 				return nil, svcErr
 			}
-			h.telemetry.RegisterTenant(r.Context(), &convDinosaur)
 			// TODO(mclasmeier): Do we need PresentDinosaurRequestAdminEndpoint?
 			return presenters.PresentCentralRequest(&convDinosaur), nil
 		},

--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -74,11 +74,11 @@ func (h adminDinosaurHandler) Create(w http.ResponseWriter, r *http.Request) {
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
 			svcErr := h.service.RegisterDinosaurJob(&convDinosaur)
-			h.telemetry.TrackCreationRequested(convDinosaur.ID, convDinosaur.OwnerAccountID, true, svcErr.AsError())
+			h.telemetry.TrackCreationRequested(r.Context(), convDinosaur.ID, true, svcErr.AsError())
 			if svcErr != nil {
 				return nil, svcErr
 			}
-			h.telemetry.RegisterTenant(&convDinosaur)
+			h.telemetry.RegisterTenant(r.Context(), &convDinosaur)
 			// TODO(mclasmeier): Do we need PresentDinosaurRequestAdminEndpoint?
 			return presenters.PresentCentralRequest(&convDinosaur), nil
 		},
@@ -156,11 +156,8 @@ func (h adminDinosaurHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		Action: func() (i interface{}, serviceError *errors.ServiceError) {
 			id := mux.Vars(r)["id"]
 			ctx := r.Context()
-
 			err := h.service.RegisterDinosaurDeprovisionJob(ctx, id)
-			if accountID, orgErr := getAccountIDFromContext(ctx); orgErr == nil {
-				h.telemetry.TrackDeletionRequested(id, accountID, true, err.AsError())
-			}
+			h.telemetry.TrackDeletionRequested(ctx, id, true, err.AsError())
 			return nil, err
 		},
 	}
@@ -322,7 +319,6 @@ func updateCentralRequest(request *dbapi.CentralRequest, updateRequest *private.
 
 // Update a Central instance.
 func (h adminDinosaurHandler) Update(w http.ResponseWriter, r *http.Request) {
-
 	var dinosaurUpdateReq private.CentralUpdateRequest
 	cfg := &handlers.HandlerConfig{
 		MarshalInto: &dinosaurUpdateReq,

--- a/internal/dinosaur/pkg/handlers/dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/dinosaur.go
@@ -82,11 +82,11 @@ func (h dinosaurHandler) Create(w http.ResponseWriter, r *http.Request) {
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
 			svcErr := h.service.RegisterDinosaurJob(convDinosaur)
+			h.telemetry.RegisterTenant(r.Context(), convDinosaur)
 			h.telemetry.TrackCreationRequested(r.Context(), convDinosaur.ID, false, svcErr.AsError())
 			if svcErr != nil {
 				return nil, svcErr
 			}
-			h.telemetry.RegisterTenant(r.Context(), convDinosaur)
 			return presenters.PresentCentralRequest(convDinosaur), nil
 		},
 	}

--- a/internal/dinosaur/pkg/handlers/dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/dinosaur.go
@@ -82,11 +82,11 @@ func (h dinosaurHandler) Create(w http.ResponseWriter, r *http.Request) {
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
 			svcErr := h.service.RegisterDinosaurJob(convDinosaur)
-			h.telemetry.TrackCreationRequested(convDinosaur.ID, convDinosaur.OwnerAccountID, false, svcErr.AsError())
+			h.telemetry.TrackCreationRequested(r.Context(), convDinosaur.ID, false, svcErr.AsError())
 			if svcErr != nil {
 				return nil, svcErr
 			}
-			h.telemetry.RegisterTenant(convDinosaur)
+			h.telemetry.RegisterTenant(r.Context(), convDinosaur)
 			return presenters.PresentCentralRequest(convDinosaur), nil
 		},
 	}
@@ -120,11 +120,8 @@ func (h dinosaurHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		Action: func() (i interface{}, serviceError *errors.ServiceError) {
 			id := mux.Vars(r)["id"]
 			ctx := r.Context()
-
 			err := h.service.RegisterDinosaurDeprovisionJob(ctx, id)
-			if accountID, orgErr := getAccountIDFromContext(ctx); orgErr == nil {
-				h.telemetry.TrackDeletionRequested(id, accountID, false, err.AsError())
-			}
+			h.telemetry.TrackDeletionRequested(ctx, id, false, err.AsError())
 			return nil, err
 		},
 	}

--- a/internal/dinosaur/pkg/handlers/validation.go
+++ b/internal/dinosaur/pkg/handlers/validation.go
@@ -112,7 +112,7 @@ func ValidateDinosaurClaims(ctx context.Context, dinosaurRequestPayload *public.
 		dinosaurRequest.Owner, _ = claims.GetUsername()
 		dinosaurRequest.OrganisationID, _ = claims.GetOrgID()
 		dinosaurRequest.OwnerAccountID, _ = claims.GetAccountID()
-		dinosaurRequest.OwnerUserID, _ = claims.GetUserID()
+		dinosaurRequest.OwnerUserID, _ = claims.GetSubject()
 
 		return nil
 	}

--- a/internal/dinosaur/pkg/services/telemetry.go
+++ b/internal/dinosaur/pkg/services/telemetry.go
@@ -45,7 +45,7 @@ func (t *Telemetry) RegisterTenant(ctx context.Context, central *dbapi.CentralRe
 
 	user, err := getUserFromContext(ctx)
 	if err != nil {
-		glog.Warning(errors.Wrap(err, "cannot get telemetry user from context claims"))
+		glog.Error(errors.Wrap(err, "cannot get telemetry user from context claims"))
 		return
 	}
 	props := map[string]any{
@@ -72,7 +72,7 @@ func (t *Telemetry) TrackCreationRequested(ctx context.Context, tenantID string,
 
 	user, err := getUserFromContext(ctx)
 	if err != nil {
-		glog.Warning(errors.Wrap(err, "cannot get telemetry user from context claims"))
+		glog.Error(errors.Wrap(err, "cannot get telemetry user from context claims"))
 		return
 	}
 
@@ -98,7 +98,7 @@ func (t *Telemetry) TrackDeletionRequested(ctx context.Context, tenantID string,
 
 	user, err := getUserFromContext(ctx)
 	if err != nil {
-		glog.Warning(errors.Wrap(err, "cannot get telemetry user from context claims"))
+		glog.Error(errors.Wrap(err, "cannot get telemetry user from context claims"))
 		return
 	}
 

--- a/internal/dinosaur/pkg/services/telemetry.go
+++ b/internal/dinosaur/pkg/services/telemetry.go
@@ -39,70 +39,76 @@ func getUserFromContext(ctx context.Context) (string, error) {
 // RegisterTenant emits a group event that captures meta data of the input central instance.
 // Adds the token user to the tenant group.
 func (t *Telemetry) RegisterTenant(ctx context.Context, central *dbapi.CentralRequest) {
-	if t.enabled() {
-		user, err := getUserFromContext(ctx)
-		if err != nil {
-			glog.Warning(errors.Wrap(err, "cannot get telemetry user from context claims"))
-			return
-		}
-		props := map[string]any{
-			"Cloud Account":   central.CloudAccountID,
-			"Cloud Provider":  central.CloudProvider,
-			"Instance Type":   central.InstanceType,
-			"Organisation ID": central.OrganisationID,
-			"Region":          central.Region,
-			"Tenant ID":       central.ID,
-		}
-		t.config.Telemeter().Group(central.ID, user, props)
+	if !t.enabled() {
+		return
 	}
+
+	user, err := getUserFromContext(ctx)
+	if err != nil {
+		glog.Warning(errors.Wrap(err, "cannot get telemetry user from context claims"))
+		return
+	}
+	props := map[string]any{
+		"Cloud Account":   central.CloudAccountID,
+		"Cloud Provider":  central.CloudProvider,
+		"Instance Type":   central.InstanceType,
+		"Organisation ID": central.OrganisationID,
+		"Region":          central.Region,
+		"Tenant ID":       central.ID,
+	}
+	t.config.Telemeter().Group(central.ID, user, props)
 }
 
 // TrackCreationRequested emits a track event that signals the creation request of a Central instance.
 func (t *Telemetry) TrackCreationRequested(ctx context.Context, tenantID string, isAdmin bool, requestErr error) {
-	if t.enabled() {
-		var errMsg string
-		if requestErr != nil {
-			errMsg = requestErr.Error()
-		}
-
-		user, err := getUserFromContext(ctx)
-		if err != nil {
-			glog.Warning(errors.Wrap(err, "cannot get telemetry user from context claims"))
-			return
-		}
-
-		props := map[string]any{
-			"Tenant ID":        tenantID,
-			"Error":            errMsg,
-			"Success":          err == nil,
-			"Is Admin Request": isAdmin,
-		}
-		t.config.Telemeter().Track("Central Creation Requested", user, props)
+	if !t.enabled() {
+		return
 	}
+
+	var errMsg string
+	if requestErr != nil {
+		errMsg = requestErr.Error()
+	}
+
+	user, err := getUserFromContext(ctx)
+	if err != nil {
+		glog.Warning(errors.Wrap(err, "cannot get telemetry user from context claims"))
+		return
+	}
+
+	props := map[string]any{
+		"Tenant ID":        tenantID,
+		"Error":            errMsg,
+		"Success":          err == nil,
+		"Is Admin Request": isAdmin,
+	}
+	t.config.Telemeter().Track("Central Creation Requested", user, props)
 }
 
 // TrackDeletionRequested emits a track event that signals the deletion request of a Central instance.
 func (t *Telemetry) TrackDeletionRequested(ctx context.Context, tenantID string, isAdmin bool, requestErr error) {
-	if t.enabled() {
-		var errMsg string
-		if requestErr != nil {
-			errMsg = requestErr.Error()
-		}
-
-		user, err := getUserFromContext(ctx)
-		if err != nil {
-			glog.Warning(errors.Wrap(err, "cannot get telemetry user from context claims"))
-			return
-		}
-
-		props := map[string]any{
-			"Tenant ID":        tenantID,
-			"Error":            errMsg,
-			"Success":          err == nil,
-			"Is Admin Request": isAdmin,
-		}
-		t.config.Telemeter().Track("Central Deletion Requested", user, props)
+	if !t.enabled() {
+		return
 	}
+
+	var errMsg string
+	if requestErr != nil {
+		errMsg = requestErr.Error()
+	}
+
+	user, err := getUserFromContext(ctx)
+	if err != nil {
+		glog.Warning(errors.Wrap(err, "cannot get telemetry user from context claims"))
+		return
+	}
+
+	props := map[string]any{
+		"Tenant ID":        tenantID,
+		"Error":            errMsg,
+		"Success":          err == nil,
+		"Is Admin Request": isAdmin,
+	}
+	t.config.Telemeter().Track("Central Deletion Requested", user, props)
 }
 
 // Start the telemetry service.

--- a/pkg/auth/acs_claims.go
+++ b/pkg/auth/acs_claims.go
@@ -40,8 +40,8 @@ func (c *ACSClaims) GetAccountID() (string, error) {
 func (c *ACSClaims) GetUserID() (string, error) {
 	if idx, val := arrays.FindFirst(func(x interface{}) bool { return x != nil },
 		(*c)[tenantUserIDClaim], (*c)[alternateTenantUserIDClaim]); idx != -1 {
-		if orgID, ok := val.(string); ok {
-			return orgID, nil
+		if userID, ok := val.(string); ok {
+			return userID, nil
 		}
 	}
 

--- a/pkg/auth/acs_claims.go
+++ b/pkg/auth/acs_claims.go
@@ -30,10 +30,23 @@ func (c *ACSClaims) GetUsername() (string, error) {
 
 // GetAccountID ...
 func (c *ACSClaims) GetAccountID() (string, error) {
-	if accountID, ok := (*c)[tenantUserIDClaim].(string); ok {
+	if accountID, ok := (*c)[tenantAccountIDClaim].(string); ok {
 		return accountID, nil
 	}
-	return "", fmt.Errorf("can't find %q attribute in claims", tenantUserIDClaim)
+	return "", fmt.Errorf("can't find %q attribute in claims", tenantAccountIDClaim)
+}
+
+// GetUserID returns the user id of the Red Hat account associated to the token.
+func (c *ACSClaims) GetUserID() (string, error) {
+	if idx, val := arrays.FindFirst(func(x interface{}) bool { return x != nil },
+		(*c)[tenantUserIDClaim], (*c)[alternateTenantUserIDClaim]); idx != -1 {
+		if orgID, ok := val.(string); ok {
+			return orgID, nil
+		}
+	}
+
+	return "", fmt.Errorf("can't find neither %q or %q attribute in claims",
+		tenantUserIDClaim, alternateTenantUserIDClaim)
 }
 
 // GetOrgID ...
@@ -49,8 +62,8 @@ func (c *ACSClaims) GetOrgID() (string, error) {
 		tenantIDClaim, alternateTenantIDClaim)
 }
 
-// GetUserID ...
-func (c *ACSClaims) GetUserID() (string, error) {
+// GetSubject returns the subject claim of the token. It identifies the principal authenticated by the token.
+func (c *ACSClaims) GetSubject() (string, error) {
 	if sub, ok := (*c)[tenantSubClaim].(string); ok {
 		return sub, nil
 	}

--- a/pkg/auth/acs_claims_test.go
+++ b/pkg/auth/acs_claims_test.go
@@ -203,7 +203,7 @@ func TestACSClaims_GetUserId(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			userID, err := tt.claims.GetUserID()
+			userID, err := tt.claims.GetSubject()
 
 			assert.Equal(t, tt.error, err != nil)
 			assert.Equal(t, tt.userID, userID)

--- a/pkg/auth/context_config.go
+++ b/pkg/auth/context_config.go
@@ -12,15 +12,19 @@ var (
 
 	// sso.redhat.com token claim keys.
 	alternateTenantUsernameClaim = "preferred_username"
-	tenantUserIDClaim            = "account_id"
-	tenantSubClaim               = "sub"
-	// Only service accounts that have been created via the service_accounts API have this claim set.
-	alternateTenantIDClaim = "rh-org-id"
+	// This is the EBS account id.
+	tenantAccountIDClaim = "account_id"
+	// This is the Red Hat user id.
+	tenantUserIDClaim = "user_id"
+	tenantSubClaim    = "sub"
+	// Only service accounts that have been created via the service_accounts API have these claims set.
+	// The claims relate to the Red Hat organisation and user that created the service account.
+	alternateTenantIDClaim     = "rh-org-id"
+	alternateTenantUserIDClaim = "rh-user-id"
 )
 
 // ContextConfig ...
-type ContextConfig struct {
-}
+type ContextConfig struct{}
 
 // NewContextConfig ...
 func NewContextConfig() *ContextConfig {
@@ -39,9 +43,12 @@ func (c *ContextConfig) AddFlags(fs *pflag.FlagSet) {
 		"Token claims key to retrieve the corresponding organisation admin role.")
 	fs.StringVar(&alternateTenantUsernameClaim, "alternate-tenant-username-claim", alternateTenantUsernameClaim,
 		"Token claims key to retrieve the corresponding user principal using an alternative claim.")
+	fs.StringVar(&tenantAccountIDClaim, "tenant-account-id-claim", tenantAccountIDClaim,
+		"Token claims key to retrieve the corresponding EBS account ID.")
 	fs.StringVar(&tenantUserIDClaim, "tenant-user-id-claim", tenantUserIDClaim,
-		"Token claims key to retrieve the corresponding  Account ID.")
-
+		"Token claims key to retrieve the corresponding Red Hat user ID.")
+	fs.StringVar(&alternateTenantUserIDClaim, "alternate-tenant-user-id-claim", alternateTenantUserIDClaim,
+		"Token claims key to retrieve the corresponding Red Hat user ID using an alternative claim.")
 }
 
 // ReadFiles ...

--- a/pkg/auth/context_test.go
+++ b/pkg/auth/context_test.go
@@ -14,16 +14,16 @@ func TestContext_GetAccountIdFromClaims(t *testing.T) {
 		want   string
 	}{
 		{
-			name:   "Should return empty when tenantUserIdClaim is empty",
+			name:   "Should return empty when tenantAccountIdClaim is empty",
 			claims: ACSClaims{},
 			want:   "",
 		},
 		{
-			name: "Should return when tenantUserIdClaim is not empty",
+			name: "Should return when tenantAccountIdClaim is not empty",
 			claims: ACSClaims{
-				tenantUserIDClaim: "Test_user_id",
+				tenantAccountIDClaim: "Test_account_id",
 			},
-			want: "Test_user_id",
+			want: "Test_account_id",
 		},
 	}
 
@@ -33,6 +33,87 @@ func TestContext_GetAccountIdFromClaims(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			accountID, _ := tt.claims.GetAccountID()
 			Expect(accountID).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestContext_GetUserIdFromClaims(t *testing.T) {
+	tests := []struct {
+		name    string
+		claims  ACSClaims
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Should return empty when tenantUserIDClaim and alternateUserIDClaim empty",
+			claims:  ACSClaims{},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Should return when tenantUserIDClaim is not empty",
+			claims: ACSClaims{
+				tenantUserIDClaim: "12345678",
+			},
+			want: "12345678",
+		},
+		{
+			name: "Should return when alternateUserIDClaim is not empty",
+			claims: ACSClaims{
+				alternateTenantUserIDClaim: "87654321",
+			},
+			want: "87654321",
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userID, err := tt.claims.GetUserID()
+			Expect(userID).To(Equal(tt.want))
+			if tt.wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).To(Not(HaveOccurred()))
+			}
+		})
+	}
+}
+
+func TestContext_GetSubjectFromClaims(t *testing.T) {
+	tests := []struct {
+		name    string
+		claims  ACSClaims
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Should return empty when tenantSubClaim empty",
+			claims:  ACSClaims{},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Should return when tenantSubClaim is not empty",
+			claims: ACSClaims{
+				tenantSubClaim: "12345678",
+			},
+			want: "12345678",
+		},
+	}
+
+	RegisterTestingT(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sub, err := tt.claims.GetSubject()
+			Expect(sub).To(Equal(tt.want))
+			if tt.wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).To(Not(HaveOccurred()))
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Description
Extract the `user_id` or `rh-user-id` (human user token vs service account token) and emit them as part of the telemetry events. Group the telemetry user together with the tenant group.

I tried to clean up the claim naming without changing too much. In particular, I tried to distinguish more clearly between the subject claim, account id claim and the new user id claims. However no changes to the Central request schema have been made.

The plan going forward is to deprecate and eventually remove the `OwnerAccountID` column all together, removing the need for the `account_id` token.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] ~Evaluated and added CHANGELOG.md entry if required~
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Manual test of the telemetry events.
