### PR TITLE
ROX-13924: provision failover RDS instance

### DIFF
--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -83,6 +83,7 @@ func TestRDSProvisioning(t *testing.T) {
 
 	clusterID := getClusterID(dbID)
 	instanceID := getInstanceID(dbID)
+	failoverID := getFailoverInstanceID(dbID)
 
 	clusterExists, err := rdsClient.clusterExists(clusterID)
 	require.NoError(t, err)
@@ -91,6 +92,10 @@ func TestRDSProvisioning(t *testing.T) {
 	instanceExists, err := rdsClient.instanceExists(instanceID)
 	require.NoError(t, err)
 	require.False(t, instanceExists)
+
+	failoverExists, err := rdsClient.instanceExists(failoverID)
+	require.NoError(t, err)
+	require.False(t, failoverExists)
 
 	err = rdsClient.EnsureDBProvisioned(ctx, dbID, dbMasterPassword)
 	assert.NoError(t, err)
@@ -105,6 +110,10 @@ func TestRDSProvisioning(t *testing.T) {
 	instanceExists, err = rdsClient.instanceExists(instanceID)
 	require.NoError(t, err)
 	require.True(t, instanceExists)
+
+	failoverExists, err = rdsClient.instanceExists(failoverID)
+	require.NoError(t, err)
+	require.True(t, failoverExists)
 
 	clusterStatus, err := rdsClient.clusterStatus(clusterID)
 	require.NoError(t, err)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

For high availability, a failover RDS DB instance is created, in a different Availability Zone (AZ).

This PR implements provisioning logic for the failover instance (also for existing Centrals), and makes sure that both instances are deleted when deprovisioning an ACSCS instance.

Note that during ACSCS provisioning, `fleetshard` does not wait for the failover instance to be completely created, as that would increase our provisioning time.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
~~- [ ] Added test description under `Test manual`~~
~~- [ ] Evaluated and added CHANGELOG.md entry if required~~
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

Tested in a local cluster. Verified in the AWS console that the DB was provisioned and that 2 instances were created, and that the Central was able to connect:
`INSTALL_OPERATOR=NO MANAGED_DB_ENABLED=TRUE ./dev/env/scripts/up.sh`
`./scripts/create-central.sh`

To test locally, I had to make the DB publicly accessible. For this purpose, I added a new VPC, security group and DB subnet group in dev on AWS.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```

