### PR TITLE
Provide utility to disable/enable admin password for specific central CR

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -97,7 +97,7 @@ func TestReconcileCreate(t *testing.T) {
 	assert.Equal(t, simpleManagedCentral.Id, central.Spec.Customize.Labels[tenantIDLabelKey])
 	assert.Equal(t, simpleManagedCentral.Spec.Auth.OwnerOrgName, central.Spec.Customize.Annotations[orgNameAnnotationKey])
 	assert.Equal(t, simpleManagedCentral.Spec.Auth.OwnerOrgId, central.Spec.Customize.Labels[orgIDLabelKey])
-	assert.Equal(t, "1", central.GetAnnotations()[revisionAnnotationKey])
+	assert.Equal(t, "1", central.GetAnnotations()[util.RevisionAnnotationKey])
 	assert.Equal(t, "true", central.GetAnnotations()[managedServicesAnnotation])
 	assert.Equal(t, true, *central.Spec.Central.Exposure.Route.Enabled)
 
@@ -188,7 +188,7 @@ func TestReconcileUpdateSucceeds(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        centralName,
 			Namespace:   centralNamespace,
-			Annotations: map[string]string{revisionAnnotationKey: "3"},
+			Annotations: map[string]string{util.RevisionAnnotationKey: "3"},
 		},
 	}, centralDeploymentObject()).Build()
 
@@ -203,7 +203,7 @@ func TestReconcileUpdateSucceeds(t *testing.T) {
 	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralName, Namespace: centralNamespace}, central)
 	require.NoError(t, err)
 	assert.Equal(t, centralName, central.GetName())
-	assert.Equal(t, "4", central.GetAnnotations()[revisionAnnotationKey])
+	assert.Equal(t, "4", central.GetAnnotations()[util.RevisionAnnotationKey])
 }
 
 func TestReconcileLastHashNotUpdatedOnError(t *testing.T) {
@@ -211,7 +211,7 @@ func TestReconcileLastHashNotUpdatedOnError(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        centralName,
 			Namespace:   centralNamespace,
-			Annotations: map[string]string{revisionAnnotationKey: "invalid annotation"},
+			Annotations: map[string]string{util.RevisionAnnotationKey: "invalid annotation"},
 		},
 	}, centralDeploymentObject()).Build()
 
@@ -233,7 +233,7 @@ func TestReconcileLastHashSetOnSuccess(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        centralName,
 			Namespace:   centralNamespace,
-			Annotations: map[string]string{revisionAnnotationKey: "3"},
+			Annotations: map[string]string{util.RevisionAnnotationKey: "3"},
 		},
 	}, centralDeploymentObject()).Build()
 
@@ -257,7 +257,7 @@ func TestReconcileLastHashSetOnSuccess(t *testing.T) {
 	central := &v1alpha1.Central{}
 	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralName, Namespace: centralNamespace}, central)
 	require.NoError(t, err)
-	assert.Equal(t, "4", central.Annotations[revisionAnnotationKey])
+	assert.Equal(t, "4", central.Annotations[util.RevisionAnnotationKey])
 }
 
 func TestIgnoreCacheForCentralNotReady(t *testing.T) {
@@ -265,7 +265,7 @@ func TestIgnoreCacheForCentralNotReady(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        centralName,
 			Namespace:   centralNamespace,
-			Annotations: map[string]string{revisionAnnotationKey: "3"},
+			Annotations: map[string]string{util.RevisionAnnotationKey: "3"},
 		},
 	}, centralDeploymentObject()).Build()
 

--- a/fleetshard/pkg/util/revision.go
+++ b/fleetshard/pkg/util/revision.go
@@ -16,8 +16,18 @@ const (
 // IncrementCentralRevision will increment the central's revision within its annotations.
 // In case no revision annotation exists, the revision will be set to 1.
 func IncrementCentralRevision(central *v1alpha1.Central) error {
+	if central == nil {
+		return errors.New("no central given to increment revision")
+	}
+	if central.GetAnnotations() == nil {
+		central.Annotations = map[string]string{
+			RevisionAnnotationKey: "1",
+		}
+		return nil
+	}
+
 	revisionString, ok := central.GetAnnotations()[RevisionAnnotationKey]
-	// Annotation does not exist yet, create the initial revision of 1.
+
 	if !ok {
 		central.GetAnnotations()[RevisionAnnotationKey] = "1"
 		return nil

--- a/fleetshard/pkg/util/revision.go
+++ b/fleetshard/pkg/util/revision.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
+)
+
+const (
+	// RevisionAnnotationKey corresponds to the annotation key that holds the current revision number.
+	RevisionAnnotationKey = "rhacs.redhat.com/revision"
+)
+
+// IncrementCentralRevision will increment the central's revision within its annotations.
+// In case no revision annotation exists, the revision will be set to 1.
+func IncrementCentralRevision(central *v1alpha1.Central) error {
+	revisionString, ok := central.GetAnnotations()[RevisionAnnotationKey]
+	// Annotation does not exist yet, create the initial revision of 1.
+	if !ok {
+		central.GetAnnotations()[RevisionAnnotationKey] = "1"
+		return nil
+	}
+
+	revision, err := strconv.Atoi(revisionString)
+	if err != nil {
+		return errors.Wrapf(err, "failed to increment central revision %s", central.GetName())
+	}
+	revision++
+	central.Annotations[RevisionAnnotationKey] = fmt.Sprintf("%d", revision)
+	return nil
+}

--- a/fleetshard/pkg/util/revision_test.go
+++ b/fleetshard/pkg/util/revision_test.go
@@ -1,0 +1,51 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIncrementCentralRevision(t *testing.T) {
+	cases := map[string]struct {
+		annotations      map[string]string
+		expectedRevision string
+		shouldFail       bool
+	}{
+		"empty revision should lead to revision == 1": {
+			annotations:      map[string]string{},
+			expectedRevision: "1",
+		},
+		"revision == 1 should increment to revision == 2": {
+			annotations: map[string]string{
+				RevisionAnnotationKey: "1",
+			},
+			expectedRevision: "2",
+		},
+		"non-integer string for revision should fail to increment": {
+			annotations: map[string]string{
+				RevisionAnnotationKey: "something",
+			},
+			shouldFail: true,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			central := &v1alpha1.Central{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: c.annotations,
+				},
+			}
+			err := IncrementCentralRevision(central)
+			if c.shouldFail {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, c.expectedRevision, central.GetAnnotations()[RevisionAnnotationKey])
+			}
+		})
+	}
+}

--- a/fleetshard/pkg/util/revision_test.go
+++ b/fleetshard/pkg/util/revision_test.go
@@ -30,6 +30,10 @@ func TestIncrementCentralRevision(t *testing.T) {
 			},
 			shouldFail: true,
 		},
+		"nil annotations should lead to revision == 1": {
+			annotations:      nil,
+			expectedRevision: "1",
+		},
 	}
 
 	for name, c := range cases {
@@ -48,4 +52,9 @@ func TestIncrementCentralRevision(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIncrementCentralRevisionNilCentral(t *testing.T) {
+	err := IncrementCentralRevision(nil)
+	assert.Error(t, err)
 }

--- a/pkg/shared/central_admin_password.go
+++ b/pkg/shared/central_admin_password.go
@@ -1,0 +1,172 @@
+package shared
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/util"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	centralClient "github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/client"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/httputil"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// EnableAdminPassword enables the admin password for the given central instance.
+// This will be done by changing the central CR, and requires appropriate access to K8S.
+// The generated password will be returned, and the basic auth provider will be
+// NOTE: It's the callers responsibility to reset the admin password afterwards!
+func EnableAdminPassword(ctx context.Context, centralID, centralName string, centralUIEndpoint string) (string, error) {
+	k8sClient := k8s.CreateClientOrDie()
+	centralNamespace := fmt.Sprintf("rhacs-%s", centralID)
+
+	// Retrieve existing central.
+	central := v1alpha1.Central{}
+	err := k8sClient.Get(ctx,
+		ctrlClient.ObjectKey{Namespace: centralNamespace, Name: centralName},
+		&central,
+	)
+	if err != nil {
+		return "", errors.Wrapf(err, "retrieving central instance %s/%s", centralNamespace, centralName)
+	}
+
+	glog.Infof("Found central CR %s in namespace %s", centralName, centralNamespace)
+
+	// If admin password generation disabled is not set, the admin password will be generated, hence no need to update
+	// in that case and the default value false.
+	if pointer.BoolDeref(central.Spec.Central.AdminPasswordGenerationDisabled, false) {
+		// Enable admin password generation, increase the revision, and update the central CR.
+		glog.Infof("Setting disable admin password generation to false for central %s/%s",
+			centralNamespace, centralName)
+		central.Spec.Central.AdminPasswordGenerationDisabled = pointer.Bool(false)
+		if err := util.IncrementCentralRevision(&central); err != nil {
+			return "", errors.Wrapf(err, "increasing central revision for central instance %s/%s",
+				centralNamespace, centralName)
+		}
+		if err := k8sClient.Update(ctx, &central); err != nil {
+			return "", errors.Wrapf(err, "updating central instance %s/%s", centralNamespace, centralName)
+		}
+		glog.Infof("Updating admin password generation finished for central %s/%s", centralNamespace, centralName)
+	}
+
+	// Wait for the secret to be created with a timeout of 5 minutes, polling in 10 seconds intervals.
+	secret, err := waitForSecret(ctx, k8sClient, centralNamespace)
+	if err != nil {
+		return "", errors.Wrapf(err, "waiting for secret containing admin password for central %s/%s",
+			centralNamespace, centralName)
+	}
+
+	// Retrieve the "password" key, additionally make sure to trim all spaces from the value.
+	password := strings.TrimSpace(string(secret.Data["password"]))
+	if password == "" {
+		return "", errors.Errorf("admin password was empty for central instance %s/%s",
+			centralNamespace, centralName)
+	}
+	glog.Infof("Retrieved the admin password for central %s/%s", centralNamespace, centralName)
+
+	// Wait for the first successful response from the central API using the basic auth provider.
+	if err := waitForBasicAuthProvider(centralUIEndpoint, centralName, centralNamespace, password); err != nil {
+		return "", errors.Wrapf(err, "waiting for basic auth provider for central %s/%s",
+			centralNamespace, centralName)
+	}
+	return password, nil
+}
+
+// DisableAdminPassword disables the admin password for the given central instance.
+// This will be done by changing the central CR, and requires appropriate access to K8S.
+func DisableAdminPassword(ctx context.Context, centralID, centralName string) error {
+	client := k8s.CreateClientOrDie()
+
+	centralNamespace := fmt.Sprintf("rhacs-%s", centralID)
+
+	// Retrieve existing central.
+	central := v1alpha1.Central{}
+	err := client.Get(ctx,
+		ctrlClient.ObjectKey{Namespace: centralNamespace, Name: centralName},
+		&central,
+	)
+	if err != nil {
+		return errors.Wrapf(err, "retrieving central instance %s/%s", centralNamespace, centralName)
+	}
+
+	glog.Infof("Found central CR %s in namespace %s", centralName, centralNamespace)
+
+	// If admin password generation disabled is not set, default to true, since we need to explicitly set it in this
+	// case to disable it.
+	if !pointer.BoolDeref(central.Spec.Central.AdminPasswordGenerationDisabled, false) {
+		glog.Infof("Setting disable admin password generation to true for central %s/%s",
+			centralNamespace, centralName)
+		// Disable admin password generation, increase the revision, and update the central CR.
+		central.Spec.Central.AdminPasswordGenerationDisabled = pointer.Bool(true)
+		if err := util.IncrementCentralRevision(&central); err != nil {
+			return errors.Wrapf(err, "increasing central revision for central instance %s/%s",
+				centralNamespace, centralName)
+		}
+		if err := client.Update(ctx, &central); err != nil {
+			return errors.Wrapf(err, "updating central instance %s/%s", centralNamespace, centralName)
+		}
+		glog.Infof("Updating admin password finished for central %s/%s", centralNamespace, centralName)
+	}
+
+	return nil
+}
+
+func waitForSecret(ctx context.Context, client ctrlClient.Client, namespace string) (*corev1.Secret, error) {
+	glog.Info("Waiting until secret with admin password is created")
+	exists := concurrency.PollWithTimeout(
+		func() bool {
+			secret := corev1.Secret{} // pragma: allowlist secret
+			err := client.Get(ctx, ctrlClient.ObjectKey{Namespace: namespace, Name: "central-htpasswd"}, &secret)
+			return err == nil
+		}, 10*time.Second, 5*time.Minute)
+	if !exists {
+		return nil, errors.Errorf(
+			"timed out waiting for admin password secret %s/central-htpwass to be created", namespace)
+	}
+
+	glog.Infof("Secret with admin password was created successfully")
+	secret := corev1.Secret{} // pragma: allowlist secret
+	if err := client.Get(ctx, ctrlClient.ObjectKey{Namespace: namespace, Name: "central-htpasswd"}, &secret); err != nil {
+		return nil, errors.Wrapf(err, "retrieving secret %s/central-htpasswd", namespace)
+	}
+	return &secret, nil
+}
+
+func waitForBasicAuthProvider(uiEndpoint, name, namespace, password string) error {
+	centralClient := centralClient.NewCentralClient(
+		private.ManagedCentral{
+			Metadata: private.ManagedCentralAllOfMetadata{Name: name, Namespace: namespace},
+		}, uiEndpoint, password)
+
+	glog.Infof("Waiting until authentication with basic auth provider works for central %s/%s",
+		namespace, name)
+	succeeded := concurrency.PollWithTimeout(
+		func() bool {
+			resp, err := centralClient.SendRequestToCentralRaw(context.Background(), &v1.GetGroupsRequest{},
+				http.MethodGet, "/v1/groups")
+			if err != nil {
+				return false
+			}
+			return httputil.Is2xxStatusCode(resp.StatusCode)
+		},
+		10*time.Second, 5*time.Minute)
+
+	if !succeeded {
+		return errors.Errorf(
+			"no successful request could be done with basic auth provider for central instance %s/%s",
+			namespace, name)
+	}
+	glog.Infof("Authentication with basic auth provider works for central %s/%s", namespace, name)
+	return nil
+}

--- a/pkg/shared/central_admin_password.go
+++ b/pkg/shared/central_admin_password.go
@@ -128,7 +128,7 @@ func DisableAdminPassword(ctx context.Context, centralID, centralName string) er
 }
 
 func getSecretWithWait(ctx context.Context, client ctrlClient.Client, namespace string, secretName string) (*corev1.Secret, error) {
-	glog.Info("Waiting until secret with admin password is created")
+	glog.Info("Waiting until secret is created")
 	exists := concurrency.PollWithTimeout(
 		func() bool {
 			secret := corev1.Secret{} // pragma: allowlist secret
@@ -137,10 +137,10 @@ func getSecretWithWait(ctx context.Context, client ctrlClient.Client, namespace 
 		}, 10*time.Second, 5*time.Minute)
 	if !exists {
 		return nil, errors.Errorf(
-			"timed out waiting for admin password secret %s/%s to be created", namespace, secretName)
+			"timed out waiting for secret %s/%s to be created", namespace, secretName)
 	}
 
-	glog.Infof("Secret with admin password was created successfully")
+	glog.Infof("Secret was created successfully")
 	secret := corev1.Secret{} // pragma: allowlist secret
 	if err := client.Get(ctx, ctrlClient.ObjectKey{Namespace: namespace, Name: secretName}, &secret); err != nil {
 		return nil, errors.Wrapf(err, "retrieving secret %s/%s", namespace, secretName)


### PR DESCRIPTION
## Description

This PR provides utility functions to enable / disable admin password generation for specific central CRs.

Internally, it will set the `adminPasswordGeneration` field on the central CR to either `false`, i.e. enabling basic authentication with username password, or to `true`, i.e. disabling basic authentication with username password.

This was especially useful in creating migration scripts for a previous incident, where admin access to the central instance was required.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
~~- [ ] Evaluated and added CHANGELOG.md entry if required~~
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
~~- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~~
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
