### PR TITLE
ROX-14650- Remove timeout log messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -889,6 +889,21 @@ deploy/bootstrap:
 	./dev/env/scripts/bootstrap.sh
 .PHONY: deploy/bootstrap
 
+deploy/dev-fast: GOOS=linux
+deploy/dev-fast: deploy/dev-fast/fleet-manager deploy/dev-fast/fleetshard-sync
+
+deploy/dev-fast/fleet-manager: GOOS=linux
+deploy/dev-fast/fleet-manager: fleet-manager
+	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) build -t $(SHORT_IMAGE_REF) -f Dockerfile.hybrid .
+	kubectl set image deploy/fleet-manager fleet-manager=$(SHORT_IMAGE_REF)
+	kubectl delete pod -l application=fleet-manager
+
+deploy/dev-fast/fleetshard-sync: GOOS=linux
+deploy/dev-fast/fleetshard-sync: fleetshard-sync
+	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) build -t $(SHORT_IMAGE_REF) -f Dockerfile.hybrid .
+	kubectl set image deploy/fleetshard-sync fleetshard-sync=$(SHORT_IMAGE_REF)
+	kubectl delete pod -l application=fleetshard-sync
+
 tag:
 	@echo "$(image_tag)"
 .PHONY: tag

--- a/Makefile
+++ b/Makefile
@@ -889,21 +889,6 @@ deploy/bootstrap:
 	./dev/env/scripts/bootstrap.sh
 .PHONY: deploy/bootstrap
 
-deploy/dev-fast: GOOS=linux
-deploy/dev-fast: deploy/dev-fast/fleet-manager deploy/dev-fast/fleetshard-sync
-
-deploy/dev-fast/fleet-manager: GOOS=linux
-deploy/dev-fast/fleet-manager: fleet-manager
-	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) build -t $(SHORT_IMAGE_REF) -f Dockerfile.hybrid .
-	kubectl set image deploy/fleet-manager fleet-manager=$(SHORT_IMAGE_REF)
-	kubectl delete pod -l application=fleet-manager
-
-deploy/dev-fast/fleetshard-sync: GOOS=linux
-deploy/dev-fast/fleetshard-sync: fleetshard-sync
-	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) build -t $(SHORT_IMAGE_REF) -f Dockerfile.hybrid .
-	kubectl set image deploy/fleetshard-sync fleetshard-sync=$(SHORT_IMAGE_REF)
-	kubectl delete pod -l application=fleetshard-sync
-
 tag:
 	@echo "$(image_tag)"
 .PHONY: tag

--- a/pkg/workers/reconciler_test.go
+++ b/pkg/workers/reconciler_test.go
@@ -65,12 +65,4 @@ func TestReconciler_Wakeup(t *testing.T) {
 
 	// Next reconcile will take a while since it runs every 30 seconds.. lets timeout after 3 seconds of waiting..
 	Expect(waitForReconcile(3 * time.Second)).Should(Equal(true))
-
-	// Now lets try to wake it up before those 30 seconds have passed...
-	r.Wakeup(false)
-	Expect(waitForReconcile(1 * time.Second)).Should(Equal(false))
-
-	r.Wakeup(true)
-	// We can use a 0 timeout here because Wakeup will wait for the reconcile to occur first.
-	Expect(waitForReconcile(0)).Should(Equal(false))
 }


### PR DESCRIPTION
## Description
Delete it reconcile timeout log messages. Not required because reconcilers already print multiple log messages to indicate that they are running.
Removed wake up channel because it is not used.


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

 - Run fleet-manager
