### PR TITLE
ROX-14303: Disable telemetry for centrals created by probe service

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -444,70 +444,70 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "13032f402fed753c2248419ea4f69f99931f6dbc",
         "is_verified": false,
-        "line_number": 547
+        "line_number": 552
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "30025f80f6e22cdafb85db387d50f90ea884576a",
         "is_verified": false,
-        "line_number": 547
+        "line_number": 552
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "355f24fd038bcaf85617abdcaa64af51ed19bbcf",
         "is_verified": false,
-        "line_number": 547
+        "line_number": 552
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "3d8a1dcd2c3c765ce35c9a9552d23273cc4ddace",
         "is_verified": false,
-        "line_number": 547
+        "line_number": 552
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "4ac7b0522761eba972467942cd5cd7499dd2c361",
         "is_verified": false,
-        "line_number": 547
+        "line_number": 552
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "7639ab2a6bcf2ea30a055a99468c9cd844d4c22a",
         "is_verified": false,
-        "line_number": 547
+        "line_number": 552
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "b56360daf4793d2a74991a972b34d95bc00fb2da",
         "is_verified": false,
-        "line_number": 547
+        "line_number": 552
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "c9a73ef9ee8ce9f38437227801c70bcc6740d1a1",
         "is_verified": false,
-        "line_number": 547
+        "line_number": 552
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "14736999d9940728c5294277831a702f7882dece",
         "is_verified": false,
-        "line_number": 584
+        "line_number": 589
       },
       {
         "type": "Secret Keyword",
         "filename": "templates/service-template.yml",
         "hashed_secret": "4e199b4a1c40b497a95fcd1cd896351733849949",
         "is_verified": false,
-        "line_number": 671,
+        "line_number": 676,
         "is_secret": false
       },
       {
@@ -515,7 +515,7 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "9d51dabe59aa776bef2909d3689374ebb93ab2be",
         "is_verified": false,
-        "line_number": 715
+        "line_number": 720
       }
     ],
     "test/support/certs.json": [
@@ -546,5 +546,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-23T01:51:04Z"
+  "generated_at": "2023-01-30T16:02:40Z"
 }

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -98,7 +98,9 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	}
 
 	monitoringExposeEndpointEnabled := v1alpha1.ExposeEndpointEnabled
-	telemetryEnabled := r.telemetry.StorageKey != ""
+	// Telemetry will only be enabled if the storage key is set _and_ the central is not an "internal" central created
+	// from internal clients such as probe service or others.
+	telemetryEnabled := r.telemetry.StorageKey != "" && !remoteCentral.Metadata.Internal
 
 	centralResources, err := converters.ConvertPrivateResourceRequirementsToCoreV1(&remoteCentral.Spec.Central.Resources)
 	if err != nil {
@@ -131,7 +133,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 			Central: &v1alpha1.CentralComponentSpec{
 				Exposure: &v1alpha1.Exposure{
 					Route: &v1alpha1.ExposureRoute{
-						Enabled: pointer.BoolPtr(r.useRoutes),
+						Enabled: pointer.Bool(r.useRoutes),
 					},
 				},
 				Monitoring: &v1alpha1.Monitoring{
@@ -141,7 +143,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 					Resources: &centralResources,
 				},
 				Telemetry: &v1alpha1.Telemetry{
-					Enabled: pointer.BoolPtr(telemetryEnabled),
+					Enabled: pointer.Bool(telemetryEnabled),
 					Storage: &v1alpha1.TelemetryStorage{
 						Endpoint: &r.telemetry.StorageEndpoint,
 						Key:      &r.telemetry.StorageKey,
@@ -190,7 +192,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	}
 
 	if r.hasAuthProvider {
-		central.Spec.Central.AdminPasswordGenerationDisabled = pointer.BoolPtr(true)
+		central.Spec.Central.AdminPasswordGenerationDisabled = pointer.Bool(true)
 	}
 
 	if remoteCentral.Metadata.DeletionTimestamp != "" {

--- a/internal/dinosaur/pkg/api/dbapi/central_request_types.go
+++ b/internal/dinosaur/pkg/api/dbapi/central_request_types.go
@@ -63,6 +63,12 @@ type CentralRequest struct {
 	// DeletionTimestamp stores the timestamp of the DELETE api call for the resource
 	DeletionTimestamp *time.Time `json:"deletionTimestamp"`
 
+	// Internal will be set for instances created by internal services, such as the probe service.
+	// If Internal is set to true, telemetry will be disabled for this particular instance.
+	// Note: Internal cannot be set via API, but instead will be set based on the User-Agent for the central creation
+	// request (see pkg/handlers/dinosaur.go).
+	Internal bool `json:"internal"`
+
 	// All we need to integrate Central with an IdP.
 	AuthConfig
 }

--- a/internal/dinosaur/pkg/api/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/private/api/openapi.yaml
@@ -421,6 +421,8 @@ components:
           type: string
         namespace:
           type: string
+        internal:
+          type: boolean
         annotations:
           $ref: '#/components/schemas/ManagedCentral_allOf_metadata_annotations'
         deletionTimestamp:

--- a/internal/dinosaur/pkg/api/private/model_managed_central_all_of_metadata.go
+++ b/internal/dinosaur/pkg/api/private/model_managed_central_all_of_metadata.go
@@ -14,6 +14,7 @@ package private
 type ManagedCentralAllOfMetadata struct {
 	Name              string                                 `json:"name,omitempty"`
 	Namespace         string                                 `json:"namespace,omitempty"`
+	Internal          bool                                   `json:"internal,omitempty"`
 	Annotations       ManagedCentralAllOfMetadataAnnotations `json:"annotations,omitempty"`
 	DeletionTimestamp string                                 `json:"deletionTimestamp,omitempty"`
 }

--- a/internal/dinosaur/pkg/config/central.go
+++ b/internal/dinosaur/pkg/config/central.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
@@ -33,10 +32,6 @@ type CentralConfig struct {
 	CentralIDPClientSecret     string `json:"central_idp_client_secret"`
 	CentralIDPClientSecretFile string `json:"central_idp_client_secret_file"`
 	CentralIDPIssuer           string `json:"central_idp_issuer"`
-
-	// TODO: this parameter does not belong here, as it's configuration of central request, not central.
-	// TODO: However, for the time being there's no better place to put this parameter.
-	CentralRequestExpirationTimeout time.Duration `json:"central_request_expiration_timeout"`
 }
 
 // NewCentralConfig ...
@@ -50,7 +45,6 @@ func NewCentralConfig() *CentralConfig {
 		Quota:                            NewCentralQuotaConfig(),
 		CentralIDPClientSecretFile:       "secrets/central.idp-client-secret", //pragma: allowlist secret
 		CentralIDPIssuer:                 "https://sso.redhat.com/auth/realms/redhat-external",
-		CentralRequestExpirationTimeout:  60 * time.Minute,
 	}
 }
 
@@ -68,7 +62,6 @@ func (c *CentralConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.CentralIDPClientID, "central-idp-client-id", c.CentralIDPClientID, "OIDC client_id to pass to Central's auth config")
 	fs.StringVar(&c.CentralIDPClientSecretFile, "central-idp-client-secret-file", c.CentralIDPClientSecretFile, "File containing OIDC client_secret to pass to Central's auth config")
 	fs.StringVar(&c.CentralIDPIssuer, "central-idp-issuer", c.CentralIDPIssuer, "OIDC issuer URL to pass to Central's auth config")
-	fs.DurationVar(&c.CentralRequestExpirationTimeout, "central-request-expiration-timeout", c.CentralRequestExpirationTimeout, "Timeout for central requests")
 }
 
 // ReadFiles ...

--- a/internal/dinosaur/pkg/config/central_request.go
+++ b/internal/dinosaur/pkg/config/central_request.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+// CentralRequestConfig holds all configuration for CentralRequests, e.g. expiration timeouts.
+type CentralRequestConfig struct {
+	CentralRequestExpirationTimeout  time.Duration `json:"central_request_expiration_timeout"`
+	CentralRequestInternalUserAgents []string      `json:"central_request_internal_user_agents"`
+}
+
+// NewCentralRequestConfig creates a new CentralRequestConfig with default values.
+func NewCentralRequestConfig() *CentralRequestConfig {
+	return &CentralRequestConfig{
+		CentralRequestExpirationTimeout:  60 * time.Minute,
+		CentralRequestInternalUserAgents: []string{"fleet-manager-probe-service"},
+	}
+}
+
+// AddFlags adds flags for all configuration settings within CentralRequestConfig to the flag set.
+func (c *CentralRequestConfig) AddFlags(fs *pflag.FlagSet) {
+	fs.DurationVar(&c.CentralRequestExpirationTimeout, "central-request-expiration-timeout",
+		c.CentralRequestExpirationTimeout, "Timeout for central requests")
+	fs.StringSliceVar(&c.CentralRequestInternalUserAgents, "central-request-internal-user-agents",
+		c.CentralRequestInternalUserAgents,
+		"HTTP User-Agents for central requests coming from internal services such as the probe service")
+}
+
+// ReadFiles will read any files specified via flags.
+// Note: this is required to satisfy the environment.ConfigModule interface and will be a no-op for this struct.
+func (c *CentralRequestConfig) ReadFiles() error {
+	return nil
+}

--- a/internal/dinosaur/pkg/config/central_request.go
+++ b/internal/dinosaur/pkg/config/central_request.go
@@ -8,24 +8,24 @@ import (
 
 // CentralRequestConfig holds all configuration for CentralRequests, e.g. expiration timeouts.
 type CentralRequestConfig struct {
-	CentralRequestExpirationTimeout  time.Duration `json:"central_request_expiration_timeout"`
-	CentralRequestInternalUserAgents []string      `json:"central_request_internal_user_agents"`
+	ExpirationTimeout  time.Duration `json:"expiration_timeout"`
+	InternalUserAgents []string      `json:"internal_user_agents"`
 }
 
 // NewCentralRequestConfig creates a new CentralRequestConfig with default values.
 func NewCentralRequestConfig() *CentralRequestConfig {
 	return &CentralRequestConfig{
-		CentralRequestExpirationTimeout:  60 * time.Minute,
-		CentralRequestInternalUserAgents: []string{"fleet-manager-probe-service"},
+		ExpirationTimeout:  60 * time.Minute,
+		InternalUserAgents: []string{"fleet-manager-probe-service"},
 	}
 }
 
 // AddFlags adds flags for all configuration settings within CentralRequestConfig to the flag set.
 func (c *CentralRequestConfig) AddFlags(fs *pflag.FlagSet) {
-	fs.DurationVar(&c.CentralRequestExpirationTimeout, "central-request-expiration-timeout",
-		c.CentralRequestExpirationTimeout, "Timeout for central requests")
-	fs.StringSliceVar(&c.CentralRequestInternalUserAgents, "central-request-internal-user-agents",
-		c.CentralRequestInternalUserAgents,
+	fs.DurationVar(&c.ExpirationTimeout, "central-request-expiration-timeout",
+		c.ExpirationTimeout, "Timeout for central requests")
+	fs.StringSliceVar(&c.InternalUserAgents, "central-request-internal-user-agents",
+		c.InternalUserAgents,
 		"HTTP User-Agents for central requests coming from internal services such as the probe service")
 }
 

--- a/internal/dinosaur/pkg/handlers/dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/dinosaur.go
@@ -86,7 +86,7 @@ func (h dinosaurHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Action: func() (interface{}, *errors.ServiceError) {
 			// Set the central request as internal, **iff** the user agent used within the creation request is contained
 			// within the list of user agents for internal services / clients, such as the probe service.
-			if arrays.Contains(h.centralRequestConfig.CentralRequestInternalUserAgents, r.UserAgent()) {
+			if arrays.Contains(h.centralRequestConfig.InternalUserAgents, r.UserAgent()) {
 				convCentral.Internal = true
 			}
 			svcErr := h.service.RegisterDinosaurJob(convCentral)

--- a/internal/dinosaur/pkg/migrations/202301301200_add_internal_to_central_request.go
+++ b/internal/dinosaur/pkg/migrations/202301301200_add_internal_to_central_request.go
@@ -1,0 +1,79 @@
+package migrations
+
+import (
+	"time"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/pkg/errors"
+	"github.com/stackrox/acs-fleet-manager/pkg/api"
+	"gorm.io/gorm"
+)
+
+func addInternalToCentralRequest() *gormigrate.Migration {
+	type AuthConfig struct {
+		ClientID     string `json:"idp_client_id"`
+		ClientSecret string `json:"idp_client_secret"`
+		Issuer       string `json:"idp_issuer"`
+		ClientOrigin string `json:"client_origin"`
+	}
+
+	type CentralRequest struct {
+		api.Meta
+		Region           string   `json:"region"`
+		ClusterID        string   `json:"cluster_id" gorm:"index"`
+		CloudProvider    string   `json:"cloud_provider"`
+		CloudAccountID   string   `json:"cloud_account_id"`
+		MultiAZ          bool     `json:"multi_az"`
+		Name             string   `json:"name" gorm:"index"`
+		Status           string   `json:"status" gorm:"index"`
+		SubscriptionID   string   `json:"subscription_id"`
+		Owner            string   `json:"owner" gorm:"index"`
+		OwnerAccountID   string   `json:"owner_account_id"`
+		OwnerUserID      string   `json:"owner_user_id"`
+		Host             string   `json:"host"`
+		OrganisationID   string   `json:"organisation_id" gorm:"index"`
+		OrganisationName string   `json:"organisation_name"`
+		FailedReason     string   `json:"failed_reason"`
+		PlacementID      string   `json:"placement_id"`
+		Central          api.JSON `json:"central"`
+		Scanner          api.JSON `json:"scanner"`
+
+		DesiredCentralVersion         string     `json:"desired_central_version"`
+		ActualCentralVersion          string     `json:"actual_central_version"`
+		DesiredCentralOperatorVersion string     `json:"desired_central_operator_version"`
+		ActualCentralOperatorVersion  string     `json:"actual_central_operator_version"`
+		CentralUpgrading              bool       `json:"central_upgrading"`
+		CentralOperatorUpgrading      bool       `json:"central_operator_upgrading"`
+		InstanceType                  string     `json:"instance_type"`
+		QuotaType                     string     `json:"quota_type"`
+		Routes                        api.JSON   `json:"routes"`
+		RoutesCreated                 bool       `json:"routes_created"`
+		Namespace                     string     `json:"namespace"`
+		RoutesCreationID              string     `json:"routes_creation_id"`
+		DeletionTimestamp             *time.Time `json:"deletionTimestamp"`
+		Internal                      bool       `json:"internal"`
+		AuthConfig
+	}
+
+	id := "202301301200"
+	colName := "Internal"
+	return &gormigrate.Migration{
+		ID: id,
+		Migrate: func(tx *gorm.DB) error {
+			if !tx.Migrator().HasColumn(&CentralRequest{}, colName) {
+				if err := tx.Migrator().AddColumn(&CentralRequest{}, colName); err != nil {
+					return errors.Wrapf(err, "adding column %s in migration %s", colName, id)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			if tx.Migrator().HasColumn(&CentralRequest{}, colName) {
+				if err := tx.Migrator().DropColumn(&CentralRequest{}, colName); err != nil {
+					return errors.Wrapf(err, "rolling back from column %s in migration %s", colName, id)
+				}
+			}
+			return nil
+		},
+	}
+}

--- a/internal/dinosaur/pkg/migrations/202301301200_add_internal_to_central_request.go
+++ b/internal/dinosaur/pkg/migrations/202301301200_add_internal_to_central_request.go
@@ -3,6 +3,8 @@ package migrations
 import (
 	"time"
 
+	"github.com/golang/glog"
+
 	"github.com/go-gormigrate/gormigrate/v2"
 	"github.com/pkg/errors"
 	"github.com/stackrox/acs-fleet-manager/pkg/api"
@@ -64,6 +66,7 @@ func addInternalToCentralRequest() *gormigrate.Migration {
 				if err := tx.Migrator().AddColumn(&CentralRequest{}, colName); err != nil {
 					return errors.Wrapf(err, "adding column %s in migration %s", colName, id)
 				}
+				glog.Infof("Successfully added the %s column", colName)
 			}
 			return nil
 		},
@@ -72,6 +75,7 @@ func addInternalToCentralRequest() *gormigrate.Migration {
 				if err := tx.Migrator().DropColumn(&CentralRequest{}, colName); err != nil {
 					return errors.Wrapf(err, "rolling back from column %s in migration %s", colName, id)
 				}
+				glog.Infof("Successfully removed the %s column", colName)
 			}
 			return nil
 		},

--- a/internal/dinosaur/pkg/migrations/migrations.go
+++ b/internal/dinosaur/pkg/migrations/migrations.go
@@ -40,6 +40,7 @@ func getMigrations(ocmConfig *ocm.OCMConfig) []*gormigrate.Migration {
 		changeCentralClientOrigin(),
 		addCloudAccountIDToCentralRequest(),
 		addOrganisationNameToCentralRequest(ocmConfig),
+		addInternalToCentralRequest(),
 	}
 }
 

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -59,6 +59,7 @@ func (c *ManagedCentralPresenter) PresentManagedCentral(from *dbapi.CentralReque
 				MasId:          from.ID,
 				MasPlacementId: from.PlacementID,
 			},
+			Internal: from.Internal,
 		},
 		Spec: private.ManagedCentralAllOfSpec{
 			Owners: []string{

--- a/internal/dinosaur/pkg/routes/route_loader.go
+++ b/internal/dinosaur/pkg/routes/route_loader.go
@@ -39,10 +39,11 @@ import (
 
 type options struct {
 	di.Inject
-	ServerConfig   *server.ServerConfig
-	OCMConfig      *ocm.OCMConfig
-	ProviderConfig *config.ProviderConfig
-	IAMConfig      *iam.IAMConfig
+	ServerConfig         *server.ServerConfig
+	OCMConfig            *ocm.OCMConfig
+	ProviderConfig       *config.ProviderConfig
+	IAMConfig            *iam.IAMConfig
+	CentralRequestConfig *config.CentralRequestConfig
 
 	AMSClient                ocm.AMSClient
 	Dinosaur                 services.DinosaurService
@@ -86,7 +87,8 @@ func (s *options) buildAPIBaseRouter(mainRouter *mux.Router, basePath string, op
 		return pkgerrors.Wrapf(err, "can't load OpenAPI specification")
 	}
 
-	dinosaurHandler := handlers.NewDinosaurHandler(s.Dinosaur, s.ProviderConfig, s.AuthService, s.Telemetry)
+	dinosaurHandler := handlers.NewDinosaurHandler(s.Dinosaur, s.ProviderConfig, s.AuthService, s.Telemetry,
+		s.CentralRequestConfig)
 	cloudProvidersHandler := handlers.NewCloudProviderHandler(s.CloudProviders, s.ProviderConfig)
 	errorsHandler := coreHandlers.NewErrorsHandler()
 	metricsHandler := handlers.NewMetricsHandler(s.Observatorium)

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/accepted_centrals_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/accepted_centrals_mgr.go
@@ -45,7 +45,7 @@ func NewAcceptedCentralManager(centralService services.DinosaurService, quotaSer
 		quotaServiceFactory:    quotaServiceFactory,
 		clusterPlmtStrategy:    clusterPlmtStrategy,
 		dataPlaneClusterConfig: dataPlaneClusterConfig,
-		centralRequestTimeout:  centralRequestConfig.CentralRequestExpirationTimeout,
+		centralRequestTimeout:  centralRequestConfig.ExpirationTimeout,
 	}
 }
 

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/accepted_centrals_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/accepted_centrals_mgr.go
@@ -33,7 +33,7 @@ type AcceptedCentralManager struct {
 }
 
 // NewAcceptedCentralManager creates a new manager
-func NewAcceptedCentralManager(centralService services.DinosaurService, quotaServiceFactory services.QuotaServiceFactory, clusterPlmtStrategy services.ClusterPlacementStrategy, dataPlaneClusterConfig *config.DataplaneClusterConfig, centralConfig *config.CentralConfig) *AcceptedCentralManager {
+func NewAcceptedCentralManager(centralService services.DinosaurService, quotaServiceFactory services.QuotaServiceFactory, clusterPlmtStrategy services.ClusterPlacementStrategy, dataPlaneClusterConfig *config.DataplaneClusterConfig, centralRequestConfig *config.CentralRequestConfig) *AcceptedCentralManager {
 	metrics.InitReconcilerMetricsForType(acceptedCentralWorkerType)
 	return &AcceptedCentralManager{
 		BaseWorker: workers.BaseWorker{
@@ -45,7 +45,7 @@ func NewAcceptedCentralManager(centralService services.DinosaurService, quotaSer
 		quotaServiceFactory:    quotaServiceFactory,
 		clusterPlmtStrategy:    clusterPlmtStrategy,
 		dataPlaneClusterConfig: dataPlaneClusterConfig,
-		centralRequestTimeout:  centralConfig.CentralRequestExpirationTimeout,
+		centralRequestTimeout:  centralRequestConfig.CentralRequestExpirationTimeout,
 	}
 }
 

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/preparing_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/preparing_dinosaurs_mgr.go
@@ -29,7 +29,7 @@ type PreparingDinosaurManager struct {
 }
 
 // NewPreparingDinosaurManager creates a new dinosaur manager
-func NewPreparingDinosaurManager(dinosaurService services.DinosaurService, centralConfig *config.CentralConfig) *PreparingDinosaurManager {
+func NewPreparingDinosaurManager(dinosaurService services.DinosaurService, centralRequestConfig *config.CentralRequestConfig) *PreparingDinosaurManager {
 	metrics.InitReconcilerMetricsForType(preparingCentralWorkerType)
 	return &PreparingDinosaurManager{
 		BaseWorker: workers.BaseWorker{
@@ -38,7 +38,7 @@ func NewPreparingDinosaurManager(dinosaurService services.DinosaurService, centr
 			Reconciler: workers.Reconciler{},
 		},
 		dinosaurService:       dinosaurService,
-		centralRequestTimeout: centralConfig.CentralRequestExpirationTimeout,
+		centralRequestTimeout: centralRequestConfig.CentralRequestExpirationTimeout,
 	}
 }
 

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/preparing_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/preparing_dinosaurs_mgr.go
@@ -38,7 +38,7 @@ func NewPreparingDinosaurManager(dinosaurService services.DinosaurService, centr
 			Reconciler: workers.Reconciler{},
 		},
 		dinosaurService:       dinosaurService,
-		centralRequestTimeout: centralRequestConfig.CentralRequestExpirationTimeout,
+		centralRequestTimeout: centralRequestConfig.ExpirationTimeout,
 	}
 }
 

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/provisioning_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/provisioning_dinosaurs_mgr.go
@@ -27,7 +27,7 @@ type ProvisioningDinosaurManager struct {
 }
 
 // NewProvisioningDinosaurManager creates a new dinosaur manager
-func NewProvisioningDinosaurManager(dinosaurService services.DinosaurService, observatoriumService services.ObservatoriumService, centralConfig *config.CentralConfig) *ProvisioningDinosaurManager {
+func NewProvisioningDinosaurManager(dinosaurService services.DinosaurService, observatoriumService services.ObservatoriumService, centralRequestConfig *config.CentralRequestConfig) *ProvisioningDinosaurManager {
 	metrics.InitReconcilerMetricsForType(provisioningCentralWorkerType)
 	return &ProvisioningDinosaurManager{
 		BaseWorker: workers.BaseWorker{
@@ -37,7 +37,7 @@ func NewProvisioningDinosaurManager(dinosaurService services.DinosaurService, ob
 		},
 		dinosaurService:       dinosaurService,
 		observatoriumService:  observatoriumService,
-		centralRequestTimeout: centralConfig.CentralRequestExpirationTimeout,
+		centralRequestTimeout: centralRequestConfig.CentralRequestExpirationTimeout,
 	}
 }
 

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/provisioning_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/provisioning_dinosaurs_mgr.go
@@ -37,7 +37,7 @@ func NewProvisioningDinosaurManager(dinosaurService services.DinosaurService, ob
 		},
 		dinosaurService:       dinosaurService,
 		observatoriumService:  observatoriumService,
-		centralRequestTimeout: centralRequestConfig.CentralRequestExpirationTimeout,
+		centralRequestTimeout: centralRequestConfig.ExpirationTimeout,
 	}
 }
 

--- a/internal/dinosaur/providers.go
+++ b/internal/dinosaur/providers.go
@@ -50,7 +50,7 @@ func ConfigProviders() di.Option {
 		di.Provide(config.NewCentralConfig, di.As(new(environments2.ConfigModule))),
 		di.Provide(config.NewDataplaneClusterConfig, di.As(new(environments2.ConfigModule))),
 		di.Provide(config.NewFleetshardConfig, di.As(new(environments2.ConfigModule))),
-		di.Provide(config.NewCentralRequestConfig(), di.As(new(environments2.ConfigModule))),
+		di.Provide(config.NewCentralRequestConfig, di.As(new(environments2.ConfigModule))),
 
 		// Additional CLI subcommands
 		di.Provide(cluster.NewClusterCommand),

--- a/internal/dinosaur/providers.go
+++ b/internal/dinosaur/providers.go
@@ -50,6 +50,7 @@ func ConfigProviders() di.Option {
 		di.Provide(config.NewCentralConfig, di.As(new(environments2.ConfigModule))),
 		di.Provide(config.NewDataplaneClusterConfig, di.As(new(environments2.ConfigModule))),
 		di.Provide(config.NewFleetshardConfig, di.As(new(environments2.ConfigModule))),
+		di.Provide(config.NewCentralRequestConfig(), di.As(new(environments2.ConfigModule))),
 
 		// Additional CLI subcommands
 		di.Provide(cluster.NewClusterCommand),

--- a/openapi/fleet-manager-private.yaml
+++ b/openapi/fleet-manager-private.yaml
@@ -228,6 +228,8 @@ components:
                   type: string
                 namespace:
                   type: string
+                internal:
+                  type: boolean
                 annotations:
                   type: object
                   required:

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -454,6 +454,11 @@ parameters:
   description: Endpoint for the telemetry backend
   value: ""
 
+- name: CENTRAL_REQUEST_INTERNAL_USER_AGENTS
+  displayName: Central request internal user agents
+  description: List of user agents from internal clients
+  value: "[fleet-manager-probe-service]"
+
 objects:
   - kind: ConfigMap
     apiVersion: v1
@@ -1252,6 +1257,7 @@ objects:
             - --fleetshard-addon-id=${FLEETSHARD_ADDON_ID}
             - --alsologtostderr
             - --central-request-expiration-timeout=${CENTRAL_REQUEST_EXPIRATION_TIMEOUT}
+            - --central-request-internal-user-agents=${CENTRAL_REQUEST_INTERNAL_USER_AGENTS}
             - --telemetry-endpoint=${TELEMETRY_ENDPONT}
             - --telemetry-storage-key-secret-file=/secrets/fleet-manager-credentials/telemetry.storageKey
             - -v=${GLOG_V}


### PR DESCRIPTION
## Description

This PR provides the ability to disable telemetry for central created by the probe service.

Currently, the probe service will create centrals in a continous interval (each 15 minutes). Since we track the central creation requests in our telemetry (specifically via segment and visualizing via amplitude), this means we get unneccessary information there.

Instead, we want to disable these central instances specifically for telemetry collection.

To achieve this, the following has been done in this PR:
- A new configuration for CentralRequests has been introduced as a `ConfigModule` for fleet manager. It will hold the list of user-agents that should be seen as coming from "internal" clients.
- During this introduction, the CentralRequestsExpirationTime has been refactored to move out of the CentralConfig, as it has now found a more appropriate place.
- A new field has been added to CentralRequest: `Internal`. In addition, a migration has been added to add the new column to the database.
- The central creation handler now sets the `Internal` field to `true` _iff_ the user-agent associated with the HTTP request is contained in the list of internal user-agents of the central request config.
- The private API now propagates the `internal` field in its metadata to fleetshard synchronizer.
- The fleetshard synchronizer will explicitly disable telemetry for centrals where `internal == true`.


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
~~- [ ] Evaluated and added CHANGELOG.md entry if required~~
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~

## Test manual

```
TODO dhaus:
# Run the fleet manager.
make deploy/bootstrap && make deploy/dev

# Run the probe service in a single execution
./probe/bin/probe run

# See within the logs of the user agent that the fleet-manager-probe-service header is found
{"request_method":"POST","request_url":"/api/rhacs/v1/centrals?async=true","request_header":{"Accept":["application/json"],"Accept-Encoding":["gzip"],"Authorization":["REDACTED"],"Content-Length":["184"],"Content-Type":["application/json"],"User-Agent":["fleet-manager-probe-service"]},"request_body":{"Reader":{},"Closer":{}},"request_remote_ip":"127.0.0.1:50981"}

```
