### PR TITLE
Allow DB instances to scale independently of each other

### DIFF
--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
@@ -38,6 +38,7 @@ const (
 	dbPostgresPort          = 5432
 	dbName                  = "postgres"
 	dbBackupRetentionPeriod = 30
+	dbInstancePromotionTier = 2 // a tier of 2 (or higher) ensures that readers and writers can scale independently
 
 	// The Aurora Serverless v2 DB instance configuration in ACUs (Aurora Capacity Units)
 	// 1 ACU = 1 vCPU + 2GB RAM
@@ -350,6 +351,7 @@ func newCreateCentralDBInstanceInput(clusterID, instanceID string, performanceIn
 		Engine:                    aws.String(dbEngine),
 		PubliclyAccessible:        aws.Bool(false),
 		EnablePerformanceInsights: aws.Bool(performanceInsights),
+		PromotionTier:             aws.Int64(dbInstancePromotionTier),
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Creating DB instance in a cluster with Promotion Tier 1 (which the default value) causes our backup instance to scale together with the main instance, even if it has 0 connections to it. More information can be found [here](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.how-it-works.html#aurora-serverless-v2.how-it-works.scaling).

The reason we have a backup instance is to have automatic failover, if the main instance fails. As these instances are normally not used at all, it's cheaper to not have them scale together with the writer instance.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
~~- [ ] Added test description under `Test manual`~~
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
~~- [ ] CI and all relevant tests are passing~~
~~- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~~
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~

## Test manual

CI should be enough. Checked in the AWS Console that the DB instances created by "AWS integration tests / Test RDS Provisioning" have a failover priority of 2.