### PR TITLE
Fix internal user agents config in fleet manager template

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -457,7 +457,7 @@ parameters:
 - name: CENTRAL_REQUEST_INTERNAL_USER_AGENTS
   displayName: Central request internal user agents
   description: List of user agents from internal clients
-  value: "[fleet-manager-probe-service]"
+  value: "fleet-manager-probe-service"
 
 objects:
   - kind: ConfigMap


### PR DESCRIPTION
## Description

The configuration value passed to the CLI argument for `--central-request-internal-user-agents` was malformed. Instead of specifying a single string, the array was passed as `[fleet-manager-probe-service]`. Thus, the central requests coming from the probe service weren't correctly identified as internal, and the telemetry was mistakenly set.

Now, the value is set correctly and the matching succeeds.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
