### PR TITLE
add group name to traits

### DIFF
--- a/internal/dinosaur/pkg/services/telemetry.go
+++ b/internal/dinosaur/pkg/services/telemetry.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter"
 )
 
+const tenantGroupName = "Tenant"
+
 // TelemetryAuth is a wrapper around the user claim extraction.
 //
 //go:generate moq -out telemetry_moq.go . TelemetryAuth
@@ -66,6 +68,7 @@ func (t *Telemetry) RegisterTenant(ctx context.Context, central *dbapi.CentralRe
 		return
 	}
 	props := map[string]any{
+		"name":            tenantGroupName,
 		"Cloud Account":   central.CloudAccountID,
 		"Cloud Provider":  central.CloudProvider,
 		"Instance Type":   central.InstanceType,
@@ -107,7 +110,7 @@ func (t *Telemetry) TrackCreationRequested(ctx context.Context, tenantID string,
 		"Central Creation Requested",
 		props,
 		telemeter.WithUserID(user),
-		telemeter.WithGroups("Tenant", tenantID),
+		telemeter.WithGroups(tenantGroupName, tenantID),
 	)
 }
 
@@ -138,7 +141,7 @@ func (t *Telemetry) TrackDeletionRequested(ctx context.Context, tenantID string,
 		"Central Deletion Requested",
 		props,
 		telemeter.WithUserID(user),
-		telemeter.WithGroups("Tenant", tenantID),
+		telemeter.WithGroups(tenantGroupName, tenantID),
 	)
 }
 


### PR DESCRIPTION
## Description
`name` is a reserved trait for the Segment name (see https://segment.com/docs/connections/spec/group/#traits). The hope is that attaching the group name to the traits, will help with the group -> tenant association.

The tenant grouping of the first creation events got broken after #804. In my local testing specifying the group name explicitly seems to help. So with the last change + this, we are at "sometimes the grouping works, sometimes not, but if it works it's the correct group".