### PR TITLE
update prod observability operator to v4.0.4

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
@@ -4,7 +4,7 @@
 
 # Version of observability operator
 # https://github.com/redhat-developer/observability-operator/releases
-observabilityOperatorVersion: "v3.0.16"
+observabilityOperatorVersion: "v4.0.4"
 
 github:
   # You can generate a new one at https://github.com/settings/tokens/new, for a user

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -42,7 +42,7 @@ case $ENVIRONMENT in
     FM_ENDPOINT="https://api.openshift.com"
     OBSERVABILITY_GITHUB_TAG="production"
     OBSERVABILITY_OBSERVATORIUM_GATEWAY="https://observatorium-mst.api.openshift.com"
-    OBSERVABILITY_OPERATOR_VERSION="v3.0.16"
+    OBSERVABILITY_OPERATOR_VERSION="v4.0.4"
     OPERATOR_VERSION="v3.73.1"
     ;;
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Update observability operator to `v4.0.4`. This version has been live in stage for some time, and brings security updates and a change to the resource naming (`kafka` -> `obs`).