### PR TITLE
ROX-12462: add env annotations

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -31,6 +31,10 @@ spec:
           value: {{ .Values.fleetshardSync.fleetManagerEndpoint }}
         - name: CLUSTER_ID
           value: {{ .Values.fleetshardSync.clusterId }}
+        - name: CLUSTER_NAME
+          value: {{ .Values.fleetshardSync.clusterName }}
+        - name: ENVIRONMENT
+          value: {{ .Values.fleetshardSync.environment }}
         - name: CREATE_AUTH_PROVIDER
           value: "{{ .Values.fleetshardSync.createAuthProvider }}"
         - name: AUTH_TYPE

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -98,6 +98,8 @@ helm upgrade rhacs-terraform "${SCRIPT_DIR}" ${HELM_DEBUG_FLAGS:-} \
   --set fleetshardSync.image="quay.io/app-sre/acs-fleet-manager:${FLEETSHARD_SYNC_TAG}" \
   --set fleetshardSync.authType="RHSSO" \
   --set fleetshardSync.clusterId="${CLUSTER_ID}" \
+  --set fleetshardSync.clusterName="${CLUSTER_NAME}" \
+  --set fleetshardSync.environment="${ENVIRONMENT}" \
   --set fleetshardSync.fleetManagerEndpoint="${FM_ENDPOINT}" \
   --set fleetshardSync.redHatSSO.clientId="${FLEETSHARD_SYNC_RHSSO_SERVICE_ACCOUNT_CLIENT_ID}" \
   --set fleetshardSync.redHatSSO.clientSecret="${FLEETSHARD_SYNC_RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET}" \

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -10,6 +10,8 @@ fleetshardSync:
   ocmToken: ""
   fleetManagerEndpoint: ""
   clusterId: ""
+  clusterName: ""
+  environment: ""
   # Flag controlling whether tenant's sso.redhat.com auth provider will be initialised by fleetshard-sync.
   # Currently this functionality is supported only when fleetshard-sync is deployed in the same k8s cluster as tenant.
   createAuthProvider: true

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -14,6 +14,8 @@ import (
 type Config struct {
 	FleetManagerEndpoint string        `env:"FLEET_MANAGER_ENDPOINT" envDefault:"http://127.0.0.1:8000"`
 	ClusterID            string        `env:"CLUSTER_ID"`
+	ClusterName          string        `env:"CLUSTER_NAME"`
+	Environment          string        `env:"ENVIRONMENT"`
 	RuntimePollPeriod    time.Duration `env:"RUNTIME_POLL_PERIOD" envDefault:"5s"`
 	AuthType             string        `env:"AUTH_TYPE" envDefault:"RHSSO"`
 	RHSSOClientID        string        `env:"RHSSO_SERVICE_ACCOUNT_CLIENT_ID"`

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -51,7 +51,7 @@ func NewRuntime(config *config.Config, k8sClient ctrlClient.Client) (*Runtime, e
 	auth, err := fleetmanager.NewAuth(config.AuthType, fleetmanager.Option{
 		Sso: fleetmanager.RHSSOOption{
 			ClientID:     config.RHSSOClientID,
-			ClientSecret: config.RHSSOClientSecret, //pragma: allowlist secret
+			ClientSecret: config.RHSSOClientSecret, // pragma: allowlist secret
 			Realm:        config.RHSSORealm,
 			Endpoint:     config.RHSSOEndpoint,
 		},
@@ -106,6 +106,8 @@ func (r *Runtime) Start() error {
 		EgressProxyImage:  r.config.EgressProxyImage,
 		ManagedDBEnabled:  r.config.ManagedDB.Enabled,
 		Telemetry:         r.config.Telemetry,
+		ClusterName:       r.config.ClusterName,
+		Environment:       r.config.Environment,
 	}
 
 	ticker := concurrency.NewRetryTicker(func(ctx context.Context) (timeToNextTick time.Duration, err error) {


### PR DESCRIPTION
## Description
Add environment and cluster name annotations to Central pods. The annotations can be read by Prometheus, and will be attached to any metrics scraped from Central. This will make it easier to identify the environment in alerts, both to distinguish between stage/prod and between different data plane clusters (us, eu).

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

CI