### PR TITLE
Skip tracking deletion for centrals from probe service

### DIFF
--- a/internal/dinosaur/pkg/handlers/dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/dinosaur.go
@@ -131,8 +131,14 @@ func (h dinosaurHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		Action: func() (i interface{}, serviceError *errors.ServiceError) {
 			id := mux.Vars(r)["id"]
 			ctx := r.Context()
-			err := h.service.RegisterDinosaurDeprovisionJob(ctx, id)
-			h.telemetry.TrackDeletionRequested(ctx, id, false, err.AsError())
+			centralRequest, err := h.service.Get(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+			err = h.service.RegisterDinosaurDeprovisionJob(ctx, id)
+			if !centralRequest.Internal {
+				h.telemetry.TrackDeletionRequested(ctx, id, false, err.AsError())
+			}
 			return nil, err
 		},
 	}


### PR DESCRIPTION
## Description

We currently skip setting the telemetry key as well as tracking events from central requests that are `Internal`, i.e. coming from services such as the probe service.

Within the initial PR, the condition was missed for the deletion request, which is now fixed within this PR.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
