### PR TITLE
ROX-12462: add env to fleetshard-sync, probe, cloudwatch-exporter

### DIFF
--- a/deploy/helm/probe/deploy.sh
+++ b/deploy/helm/probe/deploy.sh
@@ -59,6 +59,8 @@ helm upgrade rhacs-probe "${SCRIPT_DIR}" \
   --namespace "${NAMESPACE}" \
   --create-namespace \
   --set authType="${AUTH_TYPE}" \
+  --set clusterName="${CLUSTER_NAME}" \
+  --set environment="${ENVIRONMENT}" \
   --set fleetManagerEndpoint="${FM_ENDPOINT}" \
   --set image="${PROBE_IMAGE}" \
   --set ocm.token="${PROBE_OCM_TOKEN}" \

--- a/deploy/helm/probe/templates/01-operator-04-deployment.yaml
+++ b/deploy/helm/probe/templates/01-operator-04-deployment.yaml
@@ -14,6 +14,9 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        rhacs.redhat.com/cluster-name: {{ .Values.clusterName | quote }}
+        rhacs.redhat.com/environment: {{ .Values.environment | quote }}
       labels:
         app: probe
     spec:

--- a/deploy/helm/probe/values.yaml
+++ b/deploy/helm/probe/values.yaml
@@ -1,6 +1,8 @@
 image: "quay.io/rhacs-eng/blackbox-monitoring-probe-service:main"
 namespace: "rhacs-probe"
 fleetManagerEndpoint: ""
+clusterName: ""
+environment: ""
 # Must be either 'RHSSO' or 'OCM'.
 authType: "RHSSO"
 ocm:

--- a/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/templates/01-operator-04-deployment.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/templates/01-operator-04-deployment.yaml
@@ -12,6 +12,9 @@ spec:
       app: cloudwatch-exporter
   template:
     metadata:
+      annotations:
+        rhacs.redhat.com/cluster-name: {{ .Values.clusterName | quote }}
+        rhacs.redhat.com/environment: {{ .Values.environment | quote }}
       labels:
         app: cloudwatch-exporter
     spec:

--- a/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/values.yaml
@@ -3,4 +3,6 @@ aws:
   accessKeyId: ""
   secretAccessKey: ""
 
+clusterName: ""
+environment: ""
 image: "quay.io/prometheus/cloudwatch-exporter:v0.15.1"

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -14,6 +14,9 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        rhacs.redhat.com/cluster-name: {{ .Values.fleetshardSync.clusterName | quote }}
+        rhacs.redhat.com/environment: {{ .Values.fleetshardSync.environment | quote }}
       labels:
         app: fleetshard-sync
     spec:

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -112,6 +112,8 @@ helm upgrade rhacs-terraform "${SCRIPT_DIR}" ${HELM_DEBUG_FLAGS:-} \
   --set fleetshardSync.telemetry.storage.key="${FLEETSHARD_SYNC_TELEMETRY_STORAGE_KEY:-}" \
   --set cloudwatch.aws.accessKeyId="${CLOUDWATCH_EXPORTER_AWS_ACCESS_KEY_ID:-}" \
   --set cloudwatch.aws.secretAccessKey="${CLOUDWATCH_EXPORTER_AWS_SECRET_ACCESS_KEY:-}" \
+  --set cloudwatch.clusterName="${CLUSTER_NAME}" \
+  --set cloudwatch.environment="${ENVIRONMENT}" \
   --set logging.groupPrefix="${CLUSTER_NAME}" \
   --set logging.aws.accessKeyId="${LOGGING_AWS_ACCESS_KEY_ID}" \
   --set logging.aws.secretAccessKey="${LOGGING_AWS_SECRET_ACCESS_KEY}" \

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -56,6 +56,8 @@ cloudwatch:
   aws:
     accessKeyId: ""
     secretAccessKey: ""
+  clusterName: ""
+  environment: ""
 
 # See available parameters in charts/observability/values.yaml
 # - enabled flag is used to completely enable/disable observability sub-chart


### PR DESCRIPTION
## Description
Follow up to #822 to make sure fleetshard-sync, probe and cloudwatch exporter metrics are also labelled in the same way as Central/Scanner metrics.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~Unit and integration tests added~
- [ ] ~Added test description under `Test manual`~
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~