### PR TITLE
Use a released operator in stage, to test before ACSCS release.

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -35,7 +35,7 @@ case $ENVIRONMENT in
     OBSERVABILITY_OBSERVATORIUM_GATEWAY="https://observatorium-mst.api.stage.openshift.com"
     OBSERVABILITY_OPERATOR_VERSION="v4.0.4"
     OPERATOR_USE_UPSTREAM="true"
-    OPERATOR_VERSION="v3.74.0-nightly-20230213"
+    OPERATOR_VERSION="v3.73.2"
     ;;
 
   prod)
@@ -43,6 +43,7 @@ case $ENVIRONMENT in
     OBSERVABILITY_GITHUB_TAG="production"
     OBSERVABILITY_OBSERVATORIUM_GATEWAY="https://observatorium-mst.api.openshift.com"
     OBSERVABILITY_OPERATOR_VERSION="v4.0.4"
+    OPERATOR_USE_UPSTREAM="false"
     OPERATOR_VERSION="v3.73.1"
     ;;
 

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -34,7 +34,7 @@ case $ENVIRONMENT in
     OBSERVABILITY_GITHUB_TAG="master"
     OBSERVABILITY_OBSERVATORIUM_GATEWAY="https://observatorium-mst.api.stage.openshift.com"
     OBSERVABILITY_OPERATOR_VERSION="v4.0.4"
-    OPERATOR_USE_UPSTREAM="true"
+    OPERATOR_USE_UPSTREAM="false"
     OPERATOR_VERSION="v3.73.2"
     ;;
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

The nightly build currently deployed to staging points to not-yet-existing docs, so we do not want to push that to production.
So we revert the operator version in staging to the version that we intend to push to production, to be able to validate everything is OK before proceeding with ACS CS release.

Also (no impact) explicitly set `OPERATOR_USE_UPSTREAM="false"` in the `prod` case for now to make the distinction more clear.

I *suppose* the existing centrals in staging might not like this downgrade, but I think they are disposable. I plan to post an announcement about this when merging this change.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~Unit and integration tests added~
- [x] ~Added test description under `Test manual`~
- [x] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [ ] CI and all relevant tests are passing
- [x] ~Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- [x] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

None.