### PR TITLE
ROX-13913: Add RDS CA bundle secret

### DIFF
--- a/dev/env/manifests/fleetshard-sync/02-fleetshard-sync-deployment.yaml
+++ b/dev/env/manifests/fleetshard-sync/02-fleetshard-sync-deployment.yaml
@@ -66,6 +66,8 @@ spec:
               name: secrets
             - mountPath: /config
               name: config
+            - mountPath: /rds-ca-bundle
+              name: rds-ca-bundle
       restartPolicy: Always
       volumes:
         - name: secrets
@@ -75,3 +77,7 @@ spec:
         - name: config
           configMap:
             name: config
+        - name: rds-ca-bundle
+          secret:
+            secretName: fleetshard-sync-rds-ca-bundle # pragma: allowlist secret
+            optional: true

--- a/dev/env/scripts/bootstrap.sh
+++ b/dev/env/scripts/bootstrap.sh
@@ -37,6 +37,8 @@ wait_for_default_service_account "$ACSMS_NAMESPACE"
 apply "${MANIFESTS_DIR}/rhacs-operator/00-namespace.yaml"
 wait_for_default_service_account "$STACKROX_OPERATOR_NAMESPACE"
 
+create_rds_ca_bundle_secret
+
 # pragma: allowlist nextline secret
 if [[ "$INHERIT_IMAGEPULLSECRETS" == "true" ]]; then
     create-imagepullsecrets

--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -79,6 +79,7 @@ init() {
 
     export ENABLE_EXTERNAL_CONFIG="${ENABLE_EXTERNAL_CONFIG:-$ENABLE_EXTERNAL_CONFIG_DEFAULT}"
     export AWS_AUTH_HELPER="${AWS_AUTH_HELPER:-$AWS_AUTH_HELPER_DEFAULT}"
+    export AWS_REGION="${AWS_REGION:-"us-east-1"}"
 
     export KUBECTL=${KUBECTL:-$KUBECTL_DEFAULT}
     export ACSMS_NAMESPACE="${ACSMS_NAMESPACE:-$ACSMS_NAMESPACE_DEFAULT}"
@@ -329,4 +330,12 @@ delete_tenant_namespaces() {
         sleep 1
     done
     log "All RHACS tenant namespaces deleted."
+}
+
+create_rds_ca_bundle_secret() {
+    local rds_ca_bundle="rds-ca-bundle.pem"
+    curl https://truststore.pki.rds.amazonaws.com/"${AWS_REGION}"/"${AWS_REGION}"-bundle.pem -o ${rds_ca_bundle}
+    $KUBECTL -n "${ACSMS_NAMESPACE}" delete secret fleetshard-sync-rds-ca-bundle --ignore-not-found
+    $KUBECTL -n "${ACSMS_NAMESPACE}" create secret generic fleetshard-sync-rds-ca-bundle --from-file=${rds_ca_bundle}
+    rm ${rds_ca_bundle}
 }

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-rds-ca-secret.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-rds-ca-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fleetshard-sync-rds-ca-bundle
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: fleetshard-sync
+stringData:
+  rds-ca-bundle.pem: |-
+    {{- .Files.Get .Values.fleetshardSync.aws.rdsCertsBundle | nindent 4 }}

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -80,3 +80,11 @@ spec:
         ports:
         - name: monitoring
           containerPort: 8080
+        volumeMounts:
+          - mountPath: /rds-ca-bundle
+            name: rds-ca-bundle
+      volumes:
+        - name: rds-ca-bundle
+          secret:
+            secretName: fleetshard-sync-rds-ca-bundle # pragma: allowlist secret
+            optional: false

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -85,6 +85,10 @@ if [[ "${OPERATOR_USE_UPSTREAM}" == "true" ]]; then
     OPERATOR_SOURCE="rhacs-operators"
 fi
 
+AWS_REGION="us-east-1" # TODO(ROX-14187): support multiple AWS regions
+RDS_CA_BUNDLE="rds-ca-bundle.pem"
+curl https://truststore.pki.rds.amazonaws.com/${AWS_REGION}/${AWS_REGION}-bundle.pem -o ${RDS_CA_BUNDLE}
+
 # shellcheck disable=SC2086
 helm upgrade rhacs-terraform "${SCRIPT_DIR}" ${HELM_DEBUG_FLAGS:-} \
   --install \
@@ -108,6 +112,7 @@ helm upgrade rhacs-terraform "${SCRIPT_DIR}" ${HELM_DEBUG_FLAGS:-} \
   --set fleetshardSync.managedDB.securityGroup="${CLUSTER_MANAGED_DB_SECURITY_GROUP}" \
   --set fleetshardSync.managedDB.performanceInsights=true \
   --set fleetshardSync.aws.roleARN="${FLEETSHARD_SYNC_AWS_ROLE_ARN}" \
+  --set fleetshardSync.aws.rdsCertsBundle="$RDS_CA_BUNDLE" \
   --set fleetshardSync.telemetry.storage.endpoint="${FLEETSHARD_SYNC_TELEMETRY_STORAGE_ENDPOINT:-}" \
   --set fleetshardSync.telemetry.storage.key="${FLEETSHARD_SYNC_TELEMETRY_STORAGE_KEY:-}" \
   --set cloudwatch.aws.accessKeyId="${CLOUDWATCH_EXPORTER_AWS_ACCESS_KEY_ID:-}" \

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -35,6 +35,7 @@ fleetshardSync:
   aws:
     region: "us-east-1"
     roleARN: ""
+    rdsCertsBundle: ""
   telemetry:
     storage:
       endpoint: ""


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Download the region-specific RDS CA bundle (see https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html) and create a secret, that is then mounted by fleetshard-sync.

These CAs will be used to verify the Postgres connection to our DB instances.  

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
