### PR TITLE
ROX-13913: Verify RDS certificates in Postgres connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS build
 
 ENV GOFLAGS="-mod=mod"
 
+RUN mkdir /rds_ca
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /rds_ca/aws-rds-ca-global-bundle.pem
+
 RUN mkdir /src
 WORKDIR /src
 RUN CGO_ENABLED=0 go install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@latest
@@ -16,15 +19,16 @@ FROM build as build-standard
 RUN make binary
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7 as debug
-ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-ca-global-bundle.pem
 COPY --from=build-debug /go/bin/dlv /src/fleet-manager /src/fleetshard-sync /usr/local/bin/
 COPY --from=build-debug /src /src
+COPY --from=build /rds_ca /usr/local/share/ca-certificates
 EXPOSE 8000
 WORKDIR /
 ENTRYPOINT [ "/usr/local/bin/dlv" , "--listen=:40000", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "/usr/local/bin/fleet-manager", "serve"]
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7 as standard
 COPY --from=build-standard /src/fleet-manager /src/fleetshard-sync /usr/local/bin/
+COPY --from=build /rds_ca /usr/local/share/ca-certificates
 EXPOSE 8000
 WORKDIR /
 ENTRYPOINT ["/usr/local/bin/fleet-manager", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ FROM build as build-standard
 RUN make binary
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7 as debug
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-ca-global-bundle.pem
 COPY --from=build-debug /go/bin/dlv /src/fleet-manager /src/fleetshard-sync /usr/local/bin/
 COPY --from=build-debug /src /src
 EXPOSE 8000

--- a/Dockerfile.hybrid
+++ b/Dockerfile.hybrid
@@ -1,5 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-ca-global-bundle.pem
+
 COPY \
     fleet-manager \
     fleetshard-sync \

--- a/fleetshard/pkg/central/postgres/db_ca_certs.go
+++ b/fleetshard/pkg/central/postgres/db_ca_certs.go
@@ -1,0 +1,31 @@
+package postgres
+
+import (
+	"fmt"
+	"os"
+)
+
+const (
+	// CentralDatabaseCACertificateBaseName is the name of the additional CA that is passed to Central
+	CentralDatabaseCACertificateBaseName = "rds-ca-bundle"
+	caPath                               = "/usr/local/share/ca-certificates/"
+	// DatabaseCACertificatePathFleetshard stores the location where the RDS CA bundle is mounted in the fleetshard image
+	DatabaseCACertificatePathFleetshard = caPath + "aws-rds-ca-global-bundle.pem"
+	// DatabaseCACertificatePathCentral stores the location where the RDS CA bundle is mounted in the Central image
+	DatabaseCACertificatePathCentral = caPath + "00-" + CentralDatabaseCACertificateBaseName + ".crt"
+)
+
+// GetDatabaseCACertificates loads the DB server CA certificates from the filesystem, and returns them as a string
+// Because the certificates are bundled with the fleetshard-sync image, they are loaded only once.
+func GetDatabaseCACertificates() ([]byte, error) {
+	var err error
+	once.Do(func() {
+		rdsCertificateData, err = os.ReadFile(DatabaseCACertificatePathFleetshard)
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("reading DB server CA file: %w", err)
+	}
+
+	return rdsCertificateData, nil
+}

--- a/fleetshard/pkg/central/postgres/dbconnection.go
+++ b/fleetshard/pkg/central/postgres/dbconnection.go
@@ -62,9 +62,9 @@ func (c DBConnection) AsConnectionStringForCentral() string {
 		c.host, c.port, c.user, c.database, sslMode, rdsCertificatePathCentral)
 }
 
-// asConnectionForFleetshard returns a string that can be used by fleetshard to connect to a PostgreSQL server. This function
+// asConnectionStringForFleetshard returns a string that can be used by fleetshard to connect to a PostgreSQL server. This function
 // exposes the password in plain-text, so its output should be used with care.
-func (c DBConnection) asConnectionForFleetshard() string {
+func (c DBConnection) asConnectionStringForFleetshard() string {
 	return fmt.Sprintf("host=%s port=%d user=%s dbname=%s sslmode=%s sslrootcert=%s password=%s",
 		c.host, c.port, c.user, c.database, sslMode, RDSCertificatePath, c.password)
 }

--- a/fleetshard/pkg/central/postgres/dbconnection_test.go
+++ b/fleetshard/pkg/central/postgres/dbconnection_test.go
@@ -11,14 +11,19 @@ func TestPostgresConnectionString(t *testing.T) {
 	dbConnection, err := NewDBConnection("localhost", 14543, "test-user", "postgresdb")
 	require.NoError(t, err)
 
-	require.Equal(t, dbConnection.AsConnectionStringForCentral(),
-		"host=localhost port=14543 user=test-user dbname=postgresdb sslmode=verify-full sslrootcert=/usr/local/share/ca-certificates/00-rds-ca-bundle.crt")
+	require.Equal(t, "host=localhost port=14543 user=test-user dbname=postgresdb sslmode=verify-full", dbConnection.AsConnectionString())
 
 	dbConnectionWithPassword := dbConnection.WithPassword("test_pass")
-	require.Equal(t, dbConnectionWithPassword.AsConnectionStringForCentral(),
-		"host=localhost port=14543 user=test-user dbname=postgresdb sslmode=verify-full sslrootcert=/usr/local/share/ca-certificates/00-rds-ca-bundle.crt")
-	require.Equal(t, dbConnectionWithPassword.asConnectionStringForFleetshard(),
-		"host=localhost port=14543 user=test-user dbname=postgresdb sslmode=verify-full sslrootcert=/usr/local/share/ca-certificates/aws-rds-ca-global-bundle.pem password=test_pass") // pragma: allowlist secret
+	require.Equal(t, "host=localhost port=14543 user=test-user dbname=postgresdb sslmode=verify-full",
+		dbConnectionWithPassword.AsConnectionString())
+	require.Equal(t, "host=localhost port=14543 user=test-user dbname=postgresdb sslmode=verify-full password=test_pass", // pragma: allowlist secret
+		dbConnectionWithPassword.asConnectionStringWithPassword())
+
+	dbConnectionWithSSLRootCert := dbConnectionWithPassword.WithSSLRootCert("/tmp/ssl-root-cert.pem")
+	require.Equal(t, "host=localhost port=14543 user=test-user dbname=postgresdb sslmode=verify-full sslrootcert=/tmp/ssl-root-cert.pem",
+		dbConnectionWithSSLRootCert.AsConnectionString())
+	require.Equal(t, "host=localhost port=14543 user=test-user dbname=postgresdb sslmode=verify-full sslrootcert=/tmp/ssl-root-cert.pem password=test_pass", // pragma: allowlist secret
+		dbConnectionWithSSLRootCert.asConnectionStringWithPassword())
 }
 
 func TestNewDBConnection(t *testing.T) {

--- a/fleetshard/pkg/central/postgres/dbconnection_test.go
+++ b/fleetshard/pkg/central/postgres/dbconnection_test.go
@@ -17,7 +17,7 @@ func TestPostgresConnectionString(t *testing.T) {
 	dbConnectionWithPassword := dbConnection.WithPassword("test_pass")
 	require.Equal(t, dbConnectionWithPassword.AsConnectionStringForCentral(),
 		"host=localhost port=14543 user=test-user dbname=postgresdb sslmode=verify-full sslrootcert=/usr/local/share/ca-certificates/00-rds-ca-bundle.crt")
-	require.Equal(t, dbConnectionWithPassword.asConnectionForFleetshard(),
+	require.Equal(t, dbConnectionWithPassword.asConnectionStringForFleetshard(),
 		"host=localhost port=14543 user=test-user dbname=postgresdb sslmode=verify-full sslrootcert=/usr/local/share/ca-certificates/aws-rds-ca-global-bundle.pem password=test_pass") // pragma: allowlist secret
 }
 

--- a/fleetshard/pkg/central/postgres/dbconnection_test.go
+++ b/fleetshard/pkg/central/postgres/dbconnection_test.go
@@ -11,12 +11,14 @@ func TestPostgresConnectionString(t *testing.T) {
 	dbConnection, err := NewDBConnection("localhost", 14543, "test-user", "postgresdb")
 	require.NoError(t, err)
 
-	require.Equal(t, dbConnection.AsConnectionString(), "host=localhost port=14543 user=test-user dbname=postgresdb sslmode=require")
+	require.Equal(t, dbConnection.AsConnectionStringForCentral(),
+		"host=localhost port=14543 user=test-user dbname=postgresdb sslmode=verify-full sslrootcert=/usr/local/share/ca-certificates/00-rds-ca-bundle.crt")
 
 	dbConnectionWithPassword := dbConnection.WithPassword("test_pass")
-	require.Equal(t, dbConnectionWithPassword.AsConnectionString(), "host=localhost port=14543 user=test-user dbname=postgresdb sslmode=require")
-	require.Equal(t, dbConnectionWithPassword.asConnectionStringWithPassword(),
-		"host=localhost port=14543 user=test-user dbname=postgresdb sslmode=require password=test_pass") // pragma: allowlist secret
+	require.Equal(t, dbConnectionWithPassword.AsConnectionStringForCentral(),
+		"host=localhost port=14543 user=test-user dbname=postgresdb sslmode=verify-full sslrootcert=/usr/local/share/ca-certificates/00-rds-ca-bundle.crt")
+	require.Equal(t, dbConnectionWithPassword.asConnectionForFleetshard(),
+		"host=localhost port=14543 user=test-user dbname=postgresdb sslmode=verify-full sslrootcert=/usr/local/share/ca-certificates/aws-rds-ca-global-bundle.pem password=test_pass") // pragma: allowlist secret
 }
 
 func TestNewDBConnection(t *testing.T) {

--- a/fleetshard/pkg/central/postgres/dbinit.go
+++ b/fleetshard/pkg/central/postgres/dbinit.go
@@ -22,7 +22,7 @@ type CentralDBInitFunc func(ctx context.Context, con DBConnection, userName, use
 // - creates a user for Central, with appropriate privileges
 // - creates the central_active DB and installs extensions
 func InitializeDatabase(ctx context.Context, con DBConnection, userName, userPassword string) error {
-	db, err := sql.Open("postgres", con.asConnectionStringForFleetshard())
+	db, err := sql.Open("postgres", con.asConnectionStringWithPassword())
 	if err != nil {
 		return fmt.Errorf("opening DB: %w", err)
 	}
@@ -181,7 +181,7 @@ func migrateLegacyDBs(ctx context.Context, con DBConnection, newOwner, currentOw
 }
 
 func changeDBOwner(ctx context.Context, con DBConnection, newOwner, currentOwner string) error {
-	db, err := sql.Open("postgres", con.asConnectionStringForFleetshard())
+	db, err := sql.Open("postgres", con.asConnectionStringWithPassword())
 	if err != nil {
 		return fmt.Errorf("opening DB: %w", err)
 	}
@@ -206,7 +206,7 @@ func changeDBOwner(ctx context.Context, con DBConnection, newOwner, currentOwner
 }
 
 func installExtensions(ctx context.Context, con DBConnection) error {
-	db, err := sql.Open("postgres", con.asConnectionStringForFleetshard())
+	db, err := sql.Open("postgres", con.asConnectionStringWithPassword())
 	if err != nil {
 		return fmt.Errorf("opening DB: %w", err)
 	}

--- a/fleetshard/pkg/central/postgres/dbinit.go
+++ b/fleetshard/pkg/central/postgres/dbinit.go
@@ -22,7 +22,7 @@ type CentralDBInitFunc func(ctx context.Context, con DBConnection, userName, use
 // - creates a user for Central, with appropriate privileges
 // - creates the central_active DB and installs extensions
 func InitializeDatabase(ctx context.Context, con DBConnection, userName, userPassword string) error {
-	db, err := sql.Open("postgres", con.asConnectionForFleetshard())
+	db, err := sql.Open("postgres", con.asConnectionStringForFleetshard())
 	if err != nil {
 		return fmt.Errorf("opening DB: %w", err)
 	}
@@ -181,7 +181,7 @@ func migrateLegacyDBs(ctx context.Context, con DBConnection, newOwner, currentOw
 }
 
 func changeDBOwner(ctx context.Context, con DBConnection, newOwner, currentOwner string) error {
-	db, err := sql.Open("postgres", con.asConnectionForFleetshard())
+	db, err := sql.Open("postgres", con.asConnectionStringForFleetshard())
 	if err != nil {
 		return fmt.Errorf("opening DB: %w", err)
 	}
@@ -206,7 +206,7 @@ func changeDBOwner(ctx context.Context, con DBConnection, newOwner, currentOwner
 }
 
 func installExtensions(ctx context.Context, con DBConnection) error {
-	db, err := sql.Open("postgres", con.asConnectionForFleetshard())
+	db, err := sql.Open("postgres", con.asConnectionStringForFleetshard())
 	if err != nil {
 		return fmt.Errorf("opening DB: %w", err)
 	}

--- a/fleetshard/pkg/central/postgres/dbinit.go
+++ b/fleetshard/pkg/central/postgres/dbinit.go
@@ -22,7 +22,7 @@ type CentralDBInitFunc func(ctx context.Context, con DBConnection, userName, use
 // - creates a user for Central, with appropriate privileges
 // - creates the central_active DB and installs extensions
 func InitializeDatabase(ctx context.Context, con DBConnection, userName, userPassword string) error {
-	db, err := sql.Open("postgres", con.asConnectionStringWithPassword())
+	db, err := sql.Open("postgres", con.asConnectionForFleetshard())
 	if err != nil {
 		return fmt.Errorf("opening DB: %w", err)
 	}
@@ -181,7 +181,7 @@ func migrateLegacyDBs(ctx context.Context, con DBConnection, newOwner, currentOw
 }
 
 func changeDBOwner(ctx context.Context, con DBConnection, newOwner, currentOwner string) error {
-	db, err := sql.Open("postgres", con.asConnectionStringWithPassword())
+	db, err := sql.Open("postgres", con.asConnectionForFleetshard())
 	if err != nil {
 		return fmt.Errorf("opening DB: %w", err)
 	}
@@ -206,7 +206,7 @@ func changeDBOwner(ctx context.Context, con DBConnection, newOwner, currentOwner
 }
 
 func installExtensions(ctx context.Context, con DBConnection) error {
-	db, err := sql.Open("postgres", con.asConnectionStringWithPassword())
+	db, err := sql.Open("postgres", con.asConnectionForFleetshard())
 	if err != nil {
 		return fmt.Errorf("opening DB: %w", err)
 	}

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"sync/atomic"
 
 	"github.com/golang/glog"
@@ -248,15 +247,15 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 			},
 		}
 
-		additionalCa, err := os.ReadFile(postgres.RDSCertificatePath)
+		rdsCA, err := postgres.GetRDSCertificate()
 		if err != nil {
-			glog.Warningf("Could not read RDS CA bundle at %s: %v", postgres.RDSCertificatePath, err)
+			glog.Warningf("Could not read RDS CA bundle: %v", err)
 		} else {
 			central.Spec.TLS = &v1alpha1.TLSConfig{
 				AdditionalCAs: []v1alpha1.AdditionalCA{
 					{
 						Name:    postgres.CentralRDSCertificateBaseName,
-						Content: string(additionalCa),
+						Content: string(rdsCA),
 					},
 				},
 			}

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -250,16 +250,16 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 
 		additionalCa, err := os.ReadFile(postgres.RDSCertificatePath)
 		if err != nil {
-			return nil, fmt.Errorf("reading RDS CA bundle: %w", err)
-		}
-
-		central.Spec.TLS = &v1alpha1.TLSConfig{
-			AdditionalCAs: []v1alpha1.AdditionalCA{
-				{
-					Name:    postgres.CentralRDSCertificateBaseName,
-					Content: string(additionalCa),
+			glog.Warningf("Could not read RDS CA bundle at %s: %v", postgres.RDSCertificatePath, err)
+		} else {
+			central.Spec.TLS = &v1alpha1.TLSConfig{
+				AdditionalCAs: []v1alpha1.AdditionalCA{
+					{
+						Name:    postgres.CentralRDSCertificateBaseName,
+						Content: string(additionalCa),
+					},
 				},
-			},
+			}
 		}
 	}
 

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -247,15 +247,15 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 			},
 		}
 
-		rdsCA, err := postgres.GetRDSCACertificate()
+		dbCA, err := postgres.GetDatabaseCACertificates()
 		if err != nil {
-			glog.Warningf("Could not read RDS CA bundle: %v", err)
+			glog.Warningf("Could not read DB server CA bundle: %v", err)
 		} else {
 			central.Spec.TLS = &v1alpha1.TLSConfig{
 				AdditionalCAs: []v1alpha1.AdditionalCA{
 					{
-						Name:    postgres.CentralRDSCACertificateBaseName,
-						Content: string(rdsCA),
+						Name:    postgres.CentralDatabaseCACertificateBaseName,
+						Content: string(dbCA),
 					},
 				},
 			}
@@ -523,7 +523,7 @@ func (r *CentralReconciler) getCentralDBConnectionString(ctx context.Context, re
 	if err != nil {
 		return "", fmt.Errorf("getting RDS DB connection data: %w", err)
 	}
-	return dbConnection.GetConnectionForUser(dbCentralUserName).AsConnectionStringForCentral(), nil
+	return dbConnection.GetConnectionForUser(dbCentralUserName).WithSSLRootCert(postgres.DatabaseCACertificatePathCentral).AsConnectionString(), nil
 }
 
 func generateDBPassword() (string, error) {
@@ -572,7 +572,8 @@ func (r *CentralReconciler) ensureManagedCentralDBInitialized(ctx context.Contex
 	if err != nil {
 		return fmt.Errorf("generating Central DB password: %w", err)
 	}
-	err = r.managedDBInitFunc(ctx, dbConnection.WithPassword(dbMasterPassword), dbCentralUserName, dbCentralPassword)
+	err = r.managedDBInitFunc(ctx, dbConnection.WithPassword(dbMasterPassword).WithSSLRootCert(postgres.DatabaseCACertificatePathFleetshard),
+		dbCentralUserName, dbCentralPassword)
 	if err != nil {
 		return fmt.Errorf("initializing managed DB: %w", err)
 	}

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -247,14 +247,14 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 			},
 		}
 
-		rdsCA, err := postgres.GetRDSCertificate()
+		rdsCA, err := postgres.GetRDSCACertificate()
 		if err != nil {
 			glog.Warningf("Could not read RDS CA bundle: %v", err)
 		} else {
 			central.Spec.TLS = &v1alpha1.TLSConfig{
 				AdditionalCAs: []v1alpha1.AdditionalCA{
 					{
-						Name:    postgres.CentralRDSCertificateBaseName,
+						Name:    postgres.CentralRDSCACertificateBaseName,
 						Content: string(rdsCA),
 					},
 				},


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This PR adds the AWS RDS CA certificates to the fleetshard-sync image, which are then:
* used verify the Postgres connection from fleetshard to RDS
* passed to Central as additionalCAs, so that also Central can verify its Postgres connections

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
~~- [ ] Added test description under `Test manual`~~
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

Tested in a local cluster, by running:
INSTALL_OPERATOR=NO MANAGED_DB_ENABLED=TRUE ./dev/env/scripts/up.sh
./scripts/create-central.sh

And then waiting for a Central to start successfully.

To test locally, I had to make the DB publicly accessible. For this purpose, I added a new VPC, security group and DB subnet group in dev on AWS.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
