### PR TITLE
Build and push probe separately, and on production branch too.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,18 +106,12 @@ jobs:
           export PATH=${PATH}:$GOPATH/bin
           make verify binary test test/integration
         timeout-minutes: 14
-      - name: Build and publish image to quay.io
+      - name: Build and publish fleet* image to quay.io
         if: github.event_name == 'push'
         env:
           QUAY_USER: ${{ secrets.QUAY_RHACS_ENG_FM_RW_USERNAME }}
           QUAY_TOKEN: ${{ secrets.QUAY_RHACS_ENG_FM_RW_PASSWORD }}
           QUAY_IMAGE_REPOSITORY: rhacs-eng/fleet-manager
-
-          QUAY_PROBE_USER: ${{ secrets.QUAY_RHACS_ENG_PROBE_RW_USERNAME }}
-          QUAY_PROBE_TOKEN: ${{ secrets.QUAY_RHACS_ENG_PROBE_RW_PASSWORD }}
-          QUAY_PROBE_IMAGE_REPOSITORY: rhacs-eng/blackbox-monitoring-probe-service
         run: |
           chmod +x ./build_push_fleet_manager.sh
-          chmod +x ./build_push_probe.sh
           ./build_push_fleet_manager.sh
-          ./build_push_probe.sh

--- a/.github/workflows/probe.yaml
+++ b/.github/workflows/probe.yaml
@@ -1,0 +1,38 @@
+name: Build and push probe image.
+
+on:
+  push:
+    branches:
+    - main
+    - production
+
+jobs:
+  build-push:
+    name: "Build & Push Probe"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: n1hility/cancel-previous-runs@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.19"
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+      - name: Cache go module
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Build and publish probe image to quay.io
+        env:
+          QUAY_PROBE_USER: ${{ secrets.QUAY_RHACS_ENG_PROBE_RW_USERNAME }}
+          QUAY_PROBE_TOKEN: ${{ secrets.QUAY_RHACS_ENG_PROBE_RW_PASSWORD }}
+          QUAY_PROBE_IMAGE_REPOSITORY: rhacs-eng/blackbox-monitoring-probe-service
+        run: |
+          chmod +x ./build_push_probe.sh
+          ./build_push_probe.sh


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Problem:
- `acs-fleet-manager` image is built and pushed by jenkins for all `main` and `production` commits.
- probe image is built and pushed by GHA only for `main` commits
- however deployment of both uses the same way to obtain image tag to push
- this obviously leads to image pull failures for prober when cherry-picked commits exist on `production` branch

To fix this quickly without refactoring the whole probe build/push process and repository configuration, this change moves the probe build+push to a separate workflow, and enables this workflow on both `main` and `production`. Once merged and working, this commit will need to be cherry-picked to the `production` branch.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~Unit and integration tests added~
- [x] ~Added test description under `Test manual`~
- [x] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [ ] CI and all relevant tests are passing
- [x] ~Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- [x] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

N/A