### PR TITLE
ROX-14955: Remove legacy Central DB migration step

### DIFF
--- a/fleetshard/pkg/central/postgres/dbinit.go
+++ b/fleetshard/pkg/central/postgres/dbinit.go
@@ -45,13 +45,6 @@ func InitializeDatabase(ctx context.Context, con DBConnection, userName, userPas
 		return err
 	}
 
-	// TODO: this step can be removed after this code is deployed to production and
-	// all legacy Centrals are migrated
-	err = migrateLegacyDBs(ctx, con, userName, con.user)
-	if err != nil {
-		return nil
-	}
-
 	con.database = centralDBName // extensions are installed in the newly created DB
 	err = installExtensions(ctx, con)
 	if err != nil {
@@ -146,60 +139,6 @@ func createCentralDB(ctx context.Context, db *sql.DB, databaseName, owner, curre
 		} else {
 			return fmt.Errorf("checking if central_active DB exists: %w", err)
 		}
-	}
-
-	return nil
-}
-
-func migrateLegacyDBs(ctx context.Context, con DBConnection, newOwner, currentOwner string) error {
-	con.database = centralDBName
-	err := changeDBOwner(ctx, con, newOwner, currentOwner)
-	if err != nil {
-		return fmt.Errorf("changing DB %s owner: %w", con.database, err)
-	}
-
-	optionalDatabases := [...]string{stackroxDBClones.PreviousClone, stackroxDBClones.TempClone,
-		stackroxDBClones.BackupClone, stackroxDBClones.RestoreClone}
-
-	for _, dbName := range optionalDatabases {
-		con.database = dbName
-		err = changeDBOwner(ctx, con, newOwner, currentOwner)
-		if err != nil {
-			var pqErr *pq.Error
-			if errors.As(err, &pqErr) {
-				if pqErr.Code.Name() == "invalid_catalog_name" {
-					glog.Infof("DB %s does not exist, migration skipped", con.database)
-					continue
-				}
-			}
-
-			return fmt.Errorf("changing DB %s owner: %w", con.database, err)
-		}
-	}
-
-	return nil
-}
-
-func changeDBOwner(ctx context.Context, con DBConnection, newOwner, currentOwner string) error {
-	db, err := sql.Open("postgres", con.asConnectionStringWithPassword())
-	if err != nil {
-		return fmt.Errorf("opening DB: %w", err)
-	}
-
-	defer func() {
-		if closeErr := db.Close(); closeErr != nil {
-			glog.Errorf("Error closing DB: %v", closeErr)
-		}
-	}()
-
-	_, err = db.ExecContext(ctx, "ALTER DATABASE "+con.database+" OWNER TO "+newOwner)
-	if err != nil {
-		return fmt.Errorf("chaging DB %s owner: %w", con.database, err)
-	}
-
-	_, err = db.ExecContext(ctx, "REASSIGN OWNED BY "+currentOwner+" TO "+newOwner)
-	if err != nil {
-		return fmt.Errorf("reassigning tables from in DB %s: %w", con.database, err)
 	}
 
 	return nil


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This PR removes code that does not need to be executed anymore. All Central DBs in stage and prod have been migrated to not use the `rds_superuser` role anymore, and new Centrals never have access to that user.

The removed code was reassigning the Central DBs owner from `rhacs_master` to `rhacs_central`, but at this point all Centrals are provided the `rhacs_central` user from the beginning, so all DBs belong to this user from the start.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
~~- [ ] Added test description under `Test manual`~~
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
