### PR TITLE
ROX-10918: use rhacs label selectors

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-02-no-init.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-02-no-init.yaml
@@ -1,0 +1,6 @@
+# This config map prevents the operator from creating a Observability custom resoruce on start up.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: observability-operator-no-init
+  namespace: {{ include "observability.namespace" . }}

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
@@ -1,0 +1,34 @@
+apiVersion: observability.redhat.com/v1
+kind: Observability
+metadata:
+  name: observability-stack
+  namespace: {{ include "observability.namespace" . }}
+spec:
+  # The cluster ID is added as a label to all metrics when interacting with external services.
+  clusterId: {{ .Values.clusterName | quote }}
+  configurationSelector:
+    matchLabels:
+      configures: observability-operator
+  resyncPeriod: {{ .Values.resyncPeriod | quote }}
+  retention: {{ .Values.retention | quote }}
+  selfContained:
+    disableBlackboxExporter: true
+    # Disable logging features of the operator, because we set up the logging operator
+    # ourselves via the logging sub-chart.
+    disableLogging: true
+    podMonitorLabelSelector:
+      matchLabels:
+        app: rhacs
+    serviceMonitorLabelSelector:
+      matchLabels:
+        app: rhacs
+  storage:
+    prometheus:
+      volumeClaimTemplate:
+        metadata:
+          name: managed-services
+        spec:
+          resources:
+            requests:
+              storage: 250Gi
+        status: {}

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
@@ -17,11 +17,19 @@ spec:
     # ourselves via the logging sub-chart.
     disableLogging: true
     podMonitorLabelSelector:
-      matchLabels:
-        app: rhacs
+      matchExpressions:
+        - key: app
+          operator: In
+          values:
+            - rhacs
+            - strimzi
     serviceMonitorLabelSelector:
-      matchLabels:
-        app: rhacs
+      matchExpressions:
+        - key: app
+          operator: In
+          values:
+            - rhacs
+            - strimzi
   storage:
     prometheus:
       volumeClaimTemplate:

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
@@ -14,6 +14,10 @@ github:
   repository: ""
   tag: "master"
 
+clusterName: ""
+resyncPeriod: "1h"
+retention: "45d"
+
 # Credentials for Observatorium https://observatorium.io/ instance
 observatorium:
   tenant: "rhacs"

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -118,6 +118,7 @@ helm upgrade rhacs-terraform "${SCRIPT_DIR}" ${HELM_DEBUG_FLAGS:-} \
   --set logging.groupPrefix="${CLUSTER_NAME}" \
   --set logging.aws.accessKeyId="${LOGGING_AWS_ACCESS_KEY_ID}" \
   --set logging.aws.secretAccessKey="${LOGGING_AWS_SECRET_ACCESS_KEY}" \
+  --set observability.clusterName="${CLUSTER_NAME}" \
   --set observability.github.accessToken="${OBSERVABILITY_GITHUB_ACCESS_TOKEN}" \
   --set observability.github.repository=https://api.github.com/repos/stackrox/rhacs-observability-resources/contents \
   --set observability.github.tag="${OBSERVABILITY_GITHUB_TAG}" \

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -63,6 +63,7 @@ cloudwatch:
 # - enabled flag is used to completely enable/disable observability sub-chart
 observability:
   enabled: true
+  clusterName: ""
   github:
     accessToken: ""
     repository: ""


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
We want to get rid of the default `strimzi` selector label, and replace it with `rhacs`. The observability operator allows such customizations via the `Observability` custom resource. We need to make sure the operator does not auto create one with default settings.

The CR is created with the current default settings, except:
* Set the cluster id to the cluster name - it's currently a UUID of the OpenShift cluster. The cluster is set by the operator as an external metric label.
* Disable logging explicitly. This shouldn't make a difference in most cases, because the operator ignores logging if the logging operator already exists in the cluster.
* Overwrite the selector labels and set them to `rhacs`.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~Unit and integration tests added~
- [x] Added test description under `Test manual`
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Tested the Helm chart on dev cluster.