### PR TITLE
ROX-14696: Add terraforming and probe deployment to acs-stage-eu-01.

### DIFF
--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -7,6 +7,12 @@ on:
     branches:
       - main
 
+env:
+  # Credentials are populated by explicit `configure-aws-credentials` jobs in
+  # the workflow, so loading additional credentials in the terraform_cluster.sh
+  # script is not necessary.
+  AWS_AUTH_HELPER: none
+
 jobs:
   terraform:
     name: Re-terraform stage clusters
@@ -31,15 +37,11 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github
       - name: Run terraforming on acs-stage-dp-02
         working-directory: ./dp-terraform/helm/rhacs-terraform
-        env:
-          AWS_AUTH_HELPER: none # credentials are populated by the above action
         run: |
           set -euo pipefail
           ./terraform_cluster.sh stage acs-stage-dp-02
       - name: Run terraforming on acs-stage-eu-01
         working-directory: ./dp-terraform/helm/rhacs-terraform
-        env:
-          AWS_AUTH_HELPER: none # credentials are populated by the above action
         run: |
           set -euo pipefail
           ./terraform_cluster.sh stage acs-stage-eu-01
@@ -67,8 +69,6 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github
       - name: Deploy probe on acs-stage-dp-02
         working-directory: ./deploy/helm/probe
-        env:
-          AWS_AUTH_HELPER: none # credentials are populated by the above action
         run: |
           set -euo pipefail
           ./deploy.sh stage acs-stage-dp-02

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -29,13 +29,20 @@ jobs:
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github
-      - name: Run terraforming on THE stage cluster
+      - name: Run terraforming on acs-stage-dp-02
         working-directory: ./dp-terraform/helm/rhacs-terraform
         env:
           AWS_AUTH_HELPER: none # credentials are populated by the above action
         run: |
           set -euo pipefail
           ./terraform_cluster.sh stage acs-stage-dp-02
+      - name: Run terraforming on acs-stage-eu-01
+        working-directory: ./dp-terraform/helm/rhacs-terraform
+        env:
+          AWS_AUTH_HELPER: none # credentials are populated by the above action
+        run: |
+          set -euo pipefail
+          ./terraform_cluster.sh stage acs-stage-eu-01
 
   deploy-probe:
     name: Deploy blackbox monitoring probe service to stage
@@ -58,10 +65,17 @@ jobs:
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github
-      - name: Deploy probe
+      - name: Deploy probe on acs-stage-dp-02
         working-directory: ./deploy/helm/probe
         env:
           AWS_AUTH_HELPER: none # credentials are populated by the above action
         run: |
           set -euo pipefail
           ./deploy.sh stage acs-stage-dp-02
+      - name: Deploy probe on acs-stage-eu-01
+        working-directory: ./deploy/helm/probe
+        env:
+          AWS_AUTH_HELPER: none # credentials are populated by the above action
+        run: |
+          set -euo pipefail
+          ./deploy.sh stage acs-stage-eu-01

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -72,10 +72,3 @@ jobs:
         run: |
           set -euo pipefail
           ./deploy.sh stage acs-stage-dp-02
-      - name: Deploy probe on acs-stage-eu-01
-        working-directory: ./deploy/helm/probe
-        env:
-          AWS_AUTH_HELPER: none # credentials are populated by the above action
-        run: |
-          set -euo pipefail
-          ./deploy.sh stage acs-stage-eu-01


### PR DESCRIPTION
## Description
Adds acs-stage-eu-01 terraforming to the CD pipeline.

https://issues.redhat.com/browse/ROX-14696

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~Unit and integration tests added~~
- [ ] ~~Added test description under `Test manual`~~
- [ ] ~~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [ ] ~~CI and all relevant tests are passing~~
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~

## Test manual

I could manually CD the cluster but I want to ensure adding it to CD is a supported way to do the initial bootstrapping. Per https://github.com/stackrox/acs-fleet-manager/blob/main/.github/workflows/deploy-stage.yaml#L5-L8 that means we need to merge to main and fix it if it's broken.
