### PR TITLE
ROX-15136: filter aws metrics by cluster name

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/templates/01-operator-03-config-map.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/templates/01-operator-03-config-map.yaml
@@ -4,215 +4,134 @@ metadata:
   name: cloudwatch-exporter-config
   namespace: {{ include "cloudwatch.namespace" . }}
 data:
-  config.yaml: |-
-    region: us-east-1
-    metrics:
-      - aws_metric_name: DatabaseConnections
-        aws_namespace: AWS/RDS
-        aws_dimensions:
-          - DBInstanceIdentifier
-        aws_statistics:
-          - Average
-          - Maximum
-          - Minimum
-        aws_extended_statistics:
-          - p90
-          - p95
-          - p99
-        use_get_metric_data: true
-
-      - aws_metric_name: ServerlessDatabaseCapacity
-        aws_namespace: AWS/RDS
-        aws_dimensions:
-          - DBInstanceIdentifier
-        aws_statistics:
-          - Average
-          - Maximum
-          - Minimum
-        aws_extended_statistics:
-          - p90
-          - p95
-          - p99
-        use_get_metric_data: true
-
-      - aws_metric_name: ACUUtilization
-        aws_namespace: AWS/RDS
-        aws_dimensions:
-          - DBInstanceIdentifier
-        aws_statistics:
-          - Average
-          - Maximum
-          - Minimum
-        aws_extended_statistics:
-          - p90
-          - p95
-          - p99
-        use_get_metric_data: true
-
-      - aws_metric_name: FreeableMemory
-        aws_namespace: AWS/RDS
-        aws_dimensions:
-          - DBInstanceIdentifier
-        aws_statistics:
-          - Average
-          - Maximum
-          - Minimum
-        aws_extended_statistics:
-          - p90
-          - p95
-          - p99
-        use_get_metric_data: true
-
-      - aws_metric_name: CPUUtilization
-        aws_namespace: AWS/RDS
-        aws_dimensions:
-          - DBInstanceIdentifier
-        aws_statistics:
-          - Average
-          - Maximum
-          - Minimum
-        aws_extended_statistics:
-          - p90
-          - p95
-          - p99
-        use_get_metric_data: true
-
-      - aws_metric_name: ReadLatency
-        aws_namespace: AWS/RDS
-        aws_dimensions:
-          - DBInstanceIdentifier
-        aws_statistics:
-          - Average
-          - Maximum
-          - Minimum
-        aws_extended_statistics:
-          - p90
-          - p95
-          - p99
-        use_get_metric_data: true
-
-      - aws_metric_name: ReadThroughput
-        aws_namespace: AWS/RDS
-        aws_dimensions:
-          - DBInstanceIdentifier
-        aws_statistics:
-          - Average
-          - Maximum
-          - Minimum
-        aws_extended_statistics:
-          - p90
-          - p95
-          - p99
-        use_get_metric_data: true
-
-      - aws_metric_name: WriteLatency
-        aws_namespace: AWS/RDS
-        aws_dimensions:
-          - DBInstanceIdentifier
-        aws_statistics:
-          - Average
-          - Maximum
-          - Minimum
-        aws_extended_statistics:
-          - p90
-          - p95
-          - p99
-        use_get_metric_data: true
-
-      - aws_metric_name: WriteThroughput
-        aws_namespace: AWS/RDS
-        aws_dimensions:
-          - DBInstanceIdentifier
-        aws_statistics:
-          - Average
-          - Maximum
-          - Minimum
-        aws_extended_statistics:
-          - p90
-          - p95
-          - p99
-        use_get_metric_data: true
-
-      - aws_metric_name: NetworkThroughput
-        aws_namespace: AWS/RDS
-        aws_dimensions:
-          - DBInstanceIdentifier
-        aws_statistics:
-          - Average
-          - Maximum
-          - Minimum
-        aws_extended_statistics:
-          - p90
-          - p95
-          - p99
-        use_get_metric_data: true
-
-      - aws_metric_name: AuroraReplicaLag
-        aws_namespace: AWS/RDS
-        aws_dimensions:
-          - DBInstanceIdentifier
-        aws_statistics:
-          - Average
-          - Maximum
-          - Minimum
-        aws_extended_statistics:
-          - p90
-          - p95
-          - p99
-        use_get_metric_data: true
-
-      - aws_metric_name: MaximumUsedTransactionIDs
-        aws_namespace: AWS/RDS
-        aws_dimensions:
-          - DBInstanceIdentifier
-        aws_statistics:
-          - Average
-          - Maximum
-          - Minimum
-        aws_extended_statistics:
-          - p90
-          - p95
-          - p99
-        use_get_metric_data: true
-
-      - aws_metric_name: TransactionLogsDiskUsage
-        aws_namespace: AWS/RDS
-        aws_dimensions:
-          - DBInstanceIdentifier
-        aws_statistics:
-          - Average
-          - Maximum
-          - Minimum
-        aws_extended_statistics:
-          - p90
-          - p95
-          - p99
-        use_get_metric_data: true
-
-      - aws_metric_name: Deadlocks
-        aws_namespace: AWS/RDS
-        aws_dimensions:
-          - DBInstanceIdentifier
-        aws_statistics:
-          - Average
-          - Maximum
-          - Minimum
-        aws_extended_statistics:
-          - p90
-          - p95
-          - p99
-        use_get_metric_data: true
-
-      - aws_metric_name: BufferCacheHitRatio
-        aws_namespace: AWS/RDS
-        aws_dimensions:
-          - DBInstanceIdentifier
-        aws_statistics:
-          - Average
-          - Maximum
-          - Minimum
-        aws_extended_statistics:
-          - p90
-          - p95
-          - p99
-        use_get_metric_data: true
+  config.yml: |-
+    apiVersion: v1alpha1
+    discovery:
+      jobs:
+        - type: rds
+          regions:
+            - us-east-1
+          searchTags:
+            - key: DataplaneClusterName
+              value: ^{{ .Values.clusterName }}$
+          metrics:
+            - name: DatabaseConnections
+              statistics:
+                - Average
+                - Maximum
+                - Minimum
+                - p90
+                - p95
+                - p99
+            - name: ServerlessDatabaseCapacity
+              statistics:
+                - Average
+                - Maximum
+                - Minimum
+                - p90
+                - p95
+                - p99
+            - name: ACUUtilization
+              statistics:
+                - Average
+                - Maximum
+                - Minimum
+                - p90
+                - p95
+                - p99
+            - name: FreeableMemory
+              statistics:
+                - Average
+                - Maximum
+                - Minimum
+                - p90
+                - p95
+                - p99
+            - name: CPUUtilization
+              statistics:
+                - Average
+                - Maximum
+                - Minimum
+                - p90
+                - p95
+                - p99
+            - name: ReadLatency
+              statistics:
+                - Average
+                - Maximum
+                - Minimum
+                - p90
+                - p95
+                - p99
+            - name: ReadThroughput
+              statistics:
+                - Average
+                - Maximum
+                - Minimum
+                - p90
+                - p95
+                - p99
+            - name: WriteLatency
+              statistics:
+                - Average
+                - Maximum
+                - Minimum
+                - p90
+                - p95
+                - p99
+            - name: WriteThroughput
+              statistics:
+                - Average
+                - Maximum
+                - Minimum
+                - p90
+                - p95
+                - p99
+            - name: NetworkThroughput
+              statistics:
+                - Average
+                - Maximum
+                - Minimum
+                - p90
+                - p95
+                - p99
+            - name: AuroraReplicaLag
+              statistics:
+                - Average
+                - Maximum
+                - Minimum
+                - p90
+                - p95
+                - p99
+            - name: MaximumUsedTransactionIDs
+              statistics:
+                - Average
+                - Maximum
+                - Minimum
+                - p90
+                - p95
+                - p99
+            - name: TransactionLogsDiskUsage
+              statistics:
+                - Average
+                - Maximum
+                - Minimum
+                - p90
+                - p95
+                - p99
+            - name: Deadlocks
+              statistics:
+                - Average
+                - Maximum
+                - Minimum
+                - p90
+                - p95
+                - p99
+            - name: BufferCacheHitRatio
+              statistics:
+                - Average
+                - Maximum
+                - Minimum
+                - p90
+                - p95
+                - p99

--- a/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/templates/01-operator-04-deployment.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/templates/01-operator-04-deployment.yaml
@@ -29,6 +29,8 @@ spec:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+          args:
+            - "--config.file=/tmp/config.yml"
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
@@ -41,12 +43,11 @@ spec:
                   name: rhacs-cloudwatch-exporter
                   key: AWS_SECRET_ACCESS_KEY
           volumeMounts:
-            - mountPath: /config/config.yml
+            - mountPath: /tmp
               name: config
-              subPath: config.yaml
           ports:
             - name: monitoring
-              containerPort: 9106
+              containerPort: 5000
       volumes:
         - name: config
           configMap:

--- a/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/values.yaml
@@ -5,4 +5,4 @@ aws:
 
 clusterName: ""
 environment: ""
-image: "quay.io/prometheus/cloudwatch-exporter:v0.15.1"
+image: "ghcr.io/nerdswords/yet-another-cloudwatch-exporter:v0.48.0-alpha"


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
This is a follow up to #846, which added cluster name tags to the Central RDS instances. Now we want to filter the exported metrics based on these cluster names in the cloudwatch exporter. This is done to allow us to only export metrics for RDS instances which belong to a specific ACS data plane region.

I decided to switch the exporter from https://github.com/prometheus/cloudwatch_exporter to https://github.com/nerdswords/yet-another-cloudwatch-exporter, because it has better filter and region support.

The metrics themselves are not changed by this, only the labels change slightly. Most notably, the dimension label will change from `dbinstance_identifier` to `dimension_DBInstanceIdentifier`. We will have to change this in the alerts and dashboards.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~Unit and integration tests added~
- [x] Added test description under `Test manual`
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

Tested the exporter on dev cluster.