### PR TITLE
Bump stackrox operator version to 3.74.0

### DIFF
--- a/Dockerfile.hybrid
+++ b/Dockerfile.hybrid
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 
 ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-ca-global-bundle.pem
 

--- a/dev/env/defaults/00-defaults.env
+++ b/dev/env/defaults/00-defaults.env
@@ -10,10 +10,10 @@ export CLUSTER_ID_DEFAULT="1234567890abcdef1234567890abcdef"
 export CLUSTER_DNS_DEFAULT="cluster.local"
 
 export IMAGE_REGISTRY_DEFAULT="quay.io/rhacs-eng"
-STACKROX_VERSION_TAG="3.73.1" # Note: SCANNER_VERSION_DEFAULT needs to be in sync with this.
+STACKROX_VERSION_TAG="3.74.0" # Note: SCANNER_VERSION_DEFAULT needs to be in sync with this.
 export STACKROX_OPERATOR_VERSION_DEFAULT="${STACKROX_VERSION_TAG}"
 export CENTRAL_VERSION_DEFAULT=$(echo "$STACKROX_VERSION_TAG" | sed -e 's/0-nightly/x-nightly/;')
-export SCANNER_VERSION_DEFAULT="2.27.2" # This one matches the above operator version tag.
+export SCANNER_VERSION_DEFAULT="2.28.2" # This one matches the above operator version tag.
 export STACKROX_OPERATOR_NAMESPACE_DEFAULT="stackrox-operator"
 export FLEET_MANAGER_IMAGE_DEFAULT=""
 export IGNORE_REPOSITORY_DIRTINESS_DEFAULT="false"

--- a/dev/env/manifests/rhacs-operator/marketplace/03-subscription.yaml
+++ b/dev/env/manifests/rhacs-operator/marketplace/03-subscription.yaml
@@ -9,6 +9,6 @@ spec:
   installPlanApproval: Automatic
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: rhacs-operator.v3.73.1
+  startingCSV: rhacs-operator.v${STACKROX_OPERATOR_VERSION}
   config:
     resources: $RHACS_OPERATOR_RESOURCES

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -35,7 +35,7 @@ case $ENVIRONMENT in
     OBSERVABILITY_OBSERVATORIUM_GATEWAY="https://observatorium-mst.api.stage.openshift.com"
     OBSERVABILITY_OPERATOR_VERSION="v4.0.4"
     OPERATOR_USE_UPSTREAM="false"
-    OPERATOR_VERSION="v3.73.2"
+    OPERATOR_VERSION="v3.74.0"
     ;;
 
   prod)
@@ -44,7 +44,7 @@ case $ENVIRONMENT in
     OBSERVABILITY_OBSERVATORIUM_GATEWAY="https://observatorium-mst.api.openshift.com"
     OBSERVABILITY_OPERATOR_VERSION="v4.0.4"
     OPERATOR_USE_UPSTREAM="false"
-    OPERATOR_VERSION="v3.73.2"
+    OPERATOR_VERSION="v3.74.0"
     ;;
 
   *)


### PR DESCRIPTION
## Description
Bump stackrox operator version to 3.74.0.
ubi version bump is unrelated.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
CI
