### PR TITLE
check that probe image exists before deployment

### DIFF
--- a/deploy/helm/probe/deploy.sh
+++ b/deploy/helm/probe/deploy.sh
@@ -15,10 +15,12 @@ fi
 
 ENVIRONMENT=$1
 CLUSTER_NAME=$2
+PROBE_IMAGE_ORG="rhacs-eng"
+PROBE_IMAGE_NAME="blackbox-monitoring-probe-service"
 # Get the first non-merge commit, starting with HEAD.
 # On main this should be HEAD, on production, the latest merged main commit.
 PROBE_IMAGE_TAG="$(git rev-list --no-merges --max-count 1 --abbrev-commit --abbrev=7 HEAD)"
-PROBE_IMAGE="quay.io/rhacs-eng/blackbox-monitoring-probe-service:${PROBE_IMAGE_TAG}"
+PROBE_IMAGE="quay.io/${PROBE_IMAGE_ORG}/${PROBE_IMAGE_NAME}:${PROBE_IMAGE_TAG}"
 
 export AWS_PROFILE="$ENVIRONMENT"
 
@@ -47,6 +49,12 @@ if [[ $CLUSTER_ENVIRONMENT != "$ENVIRONMENT" ]]; then
     exit 2
 fi
 
+if [[ "${HELM_PRINT_ONLY:-}" == "true" ]]; then
+    HELM_DEBUG_FLAGS="--debug --dry-run"
+else
+    "${SCRIPT_DIR}/../../../scripts/check_image_exists.sh" "${PROBE_IMAGE_ORG}" "${PROBE_IMAGE_NAME}" "${PROBE_IMAGE_TAG}"
+fi
+
 load_external_config "cluster-${CLUSTER_NAME}" CLUSTER_
 oc login --token="${CLUSTER_ROBOT_OC_TOKEN}" --server="$CLUSTER_URL"
 
@@ -54,7 +62,7 @@ NAMESPACE="rhacs-probe"
 AUTH_TYPE="OCM"
 
 # helm template --debug ... to debug changes
-helm upgrade rhacs-probe "${SCRIPT_DIR}" \
+helm upgrade rhacs-probe "${SCRIPT_DIR}" "${HELM_DEBUG_FLAGS:-}" \
   --install \
   --namespace "${NAMESPACE}" \
   --create-namespace \

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -59,6 +59,8 @@ if [[ $CLUSTER_ENVIRONMENT != "$ENVIRONMENT" ]]; then
     exit 2
 fi
 
+FLEETSHARD_SYNC_ORG="app-sre"
+FLEETSHARD_SYNC_IMAGE="acs-fleet-manager"
 # Get the first non-merge commit, starting with HEAD.
 # On main this should be HEAD, on production, the latest merged main commit.
 FLEETSHARD_SYNC_TAG="$(git rev-list --no-merges --max-count 1 --abbrev-commit --abbrev=7 HEAD)"
@@ -66,7 +68,7 @@ FLEETSHARD_SYNC_TAG="$(git rev-list --no-merges --max-count 1 --abbrev-commit --
 if [[ "${HELM_PRINT_ONLY:-}" == "true" ]]; then
     HELM_DEBUG_FLAGS="--debug --dry-run"
 else
-    "${SCRIPT_DIR}/check_image_exists.sh" "${FLEETSHARD_SYNC_TAG}"
+    "${SCRIPT_DIR}/../../../scripts/check_image_exists.sh" "${FLEETSHARD_SYNC_ORG}" "${FLEETSHARD_SYNC_IMAGE}" "${FLEETSHARD_SYNC_TAG}"
 fi
 
 load_external_config "cluster-${CLUSTER_NAME}" CLUSTER_
@@ -96,7 +98,7 @@ helm upgrade rhacs-terraform "${SCRIPT_DIR}" ${HELM_DEBUG_FLAGS:-} \
   --set acsOperator.sourceNamespace=openshift-marketplace \
   --set acsOperator.version="${OPERATOR_VERSION}" \
   --set acsOperator.upstream="${OPERATOR_USE_UPSTREAM}" \
-  --set fleetshardSync.image="quay.io/app-sre/acs-fleet-manager:${FLEETSHARD_SYNC_TAG}" \
+  --set fleetshardSync.image="quay.io/${FLEETSHARD_SYNC_ORG}/${FLEETSHARD_SYNC_IMAGE}:${FLEETSHARD_SYNC_TAG}" \
   --set fleetshardSync.authType="RHSSO" \
   --set fleetshardSync.clusterId="${CLUSTER_ID}" \
   --set fleetshardSync.clusterName="${CLUSTER_NAME}" \

--- a/scripts/check_image_exists.sh
+++ b/scripts/check_image_exists.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-org="app-sre"
-image="acs-fleet-manager"
-tag="$1"
+org="$1"
+image="$2"
+tag="$3"
 # 40*15s = 10 minutes
 retry_attempts=40
 sleep_time_sec=15


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Make sure that the probe image exists before we deploy, similar to what we already do for fleetshard-sync. This should address problems with deploying the probe service even though no new image has been built.

I refactored the image check script args and moved the script to the global scripts folder.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~Unit and integration tests added~
- [ ] ~Added test description under `Test manual`~
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [ ] ~Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~