### PR TITLE
ROX-14997: Add Secrets Manager support

### DIFF
--- a/docs/development/secret-management.md
+++ b/docs/development/secret-management.md
@@ -1,8 +1,8 @@
 # Secret Management
 
 ## Overview / Tools
-Application Secrets are stored in AWS Parameter Store.
-The following tools are used to integrate with Parameter Store:
+Application Secrets are stored in AWS Secrets Manager.
+The following tools are used to integrate with Secrets Manager:
 - [chamber](https://github.com/segmentio/chamber) - CLI for managing secrets
 - [aws-vault](https://github.com/99designs/aws-vault) - supplementary tool to store AWS credentials in the secure local storage
 - [aws-saml.py](https://gitlab.corp.redhat.com/compute/aws-automation) - helper tool for authenticating in AWS using SAML
@@ -22,7 +22,7 @@ Secrets are divided to subgroups per each service. The following services are cu
 
 ## Instructions
 - `AWS_AUTH_HELPER` environment variable selects the appropriate authentication method within the deployment scripts. Possible options are:
-  - `aws-vault`
+  - `aws-vault` (deprecated)
   - `aws-saml`
   - `none` (default)
 - Depending on the environment, the following choices are set:
@@ -49,18 +49,18 @@ Without the alias you have to load the session token manually or always add `aws
 
 ### Write secret
 ```shell
-chamber write <service> <KEY> -
+chamber write -b secretsmanager <service> <KEY> -
 <value>
 ^D # end-of-stdin
 ```
 for example:
 ```shell
-chamber write fleetshard-sync RHSSO_SERVICE_ACCOUNT_CLIENT_ID -
+chamber write -b secretsmanager fleetshard-sync RHSSO_SERVICE_ACCOUNT_CLIENT_ID -
 changeme
 ^D
 ```
 
 ### Print environment
 ```shell
-chamber env fleetshard-sync
+chamber env -b secretsmanager fleetshard-sync
 ```

--- a/docs/development/setup-osd-cluster-idp.md
+++ b/docs/development/setup-osd-cluster-idp.md
@@ -27,13 +27,13 @@ Afterwards, you can call the script and adjust the parameters based on your need
 
 The script will handle the following (again, split by environments):
 - stage:
-  1. Fetch required credentials from AWS Parameter Store. The first time it runs, it will ask for AWS credentials.
+  1. Fetch required parameters from AWS Parameter Store and credentials from AWS Secrets Manager. The first time it runs, it will ask for AWS credentials.
   2. Create the OIDC IdP for the cluster.
   3. Create the user <-> group mapping for cluster-admins.
   4. Create the HTPasswd IdP for the cluster.
   5. Create the `acsms-stage-admin` user and map it to cluster-admins group.
 - prod:
-  1. Fetch required credentials from AWS Parameter Store. The first time it runs, it will ask for AWS credentials.
+  1. Fetch required parameters from AWS Parameter Store and credentials from AWS Secrets Manager. The first time it runs, it will ask for AWS credentials.
   2. Create the HTPasswd IdP for the cluster.
   3. Create the `acsms-prod-admin` user and map it to cluster-admins group.
 

--- a/dp-terraform/osd-cluster-idp-setup.sh
+++ b/dp-terraform/osd-cluster-idp-setup.sh
@@ -49,7 +49,7 @@ export_cluster_environment() {
     load_external_config "cluster-$CLUSTER_NAME" STORED_
 
     if [[ -z ${STORED_ADMIN_USERNAME:-} ]]; then
-        echo "Cluster admin user is missing from Secrets Manager."
+        echo "Cluster admin user not specified in Secrets Manager nor Parameter Store."
         echo "Enter cluster admin username:"
         read -r STORED_ADMIN_USERNAME
         save_cluster_secret "admin_username" "$STORED_ADMIN_USERNAME"

--- a/dp-terraform/osd-cluster-idp-setup.sh
+++ b/dp-terraform/osd-cluster-idp-setup.sh
@@ -36,21 +36,28 @@ save_cluster_parameter() {
     run_chamber write "cluster-${CLUSTER_NAME}" "${key}" "${value}" --skip-unchanged
 }
 
+save_cluster_secret() {
+    local key="$1"
+    local value="$2"
+    echo "Saving parameter '/cluster-${CLUSTER_NAME}/${key}' in AWS Secrets Manager..."
+    run_chamber write -b secretsmanager "cluster-${CLUSTER_NAME}" "${key}" "${value}" --skip-unchanged
+}
+
 export_cluster_environment() {
     init_chamber
     load_external_config "osd" OSD_
     load_external_config "cluster-$CLUSTER_NAME" STORED_
 
     if [[ -z ${STORED_ADMIN_USERNAME:-} ]]; then
-        echo "Cluster admin user is missing from Parameter Store."
+        echo "Cluster admin user is missing from Secrets Manager."
         echo "Enter cluster admin username:"
         read -r STORED_ADMIN_USERNAME
-        save_cluster_parameter "admin_username" "$STORED_ADMIN_USERNAME"
+        save_cluster_secret "admin_username" "$STORED_ADMIN_USERNAME"
     fi
     if [[ -z ${STORED_ADMIN_PASSWORD:-} ]]; then
         echo "Enter cluster admin password:"
         read -r -s STORED_ADMIN_PASSWORD
-        save_cluster_parameter "admin_password" "$STORED_ADMIN_PASSWORD"
+        save_cluster_secret "admin_password" "$STORED_ADMIN_PASSWORD"
     fi
 }
 
@@ -193,7 +200,7 @@ do
   attempt=$((attempt+1))
   ROBOT_TOKEN="$(oc get secret "${ROBOT_TOKEN_RESOURCE}" -n "$ROBOT_NS" -o json | jq -r 'if (has("data") and (.data|has("token"))) then (.data.token|@base64d) else "" end')"
   if [[ -n $ROBOT_TOKEN ]]; then
-    save_cluster_parameter "robot_oc_token" "$ROBOT_TOKEN"
+    save_cluster_secret "robot_oc_token" "$ROBOT_TOKEN"
     break
   fi
   if [[ $attempt -gt 30 ]]; then
@@ -205,3 +212,5 @@ done
 
 echo "The following cluster parameters are currently stored in AWS Parameter Store:"
 run_chamber list "cluster-${CLUSTER_NAME}"
+echo "The following cluster parameters are currently stored in AWS Secrets Manager:"
+run_chamber list "cluster-${CLUSTER_NAME}" -p secretsmanager

--- a/scripts/lib/external_config.sh
+++ b/scripts/lib/external_config.sh
@@ -111,8 +111,11 @@ run_chamber() {
 load_external_config() {
     local service="$1"
     local prefix="${2:-}"
-    local env_output
-    env_output=$(run_chamber env "$service")
-    [[ -z "$env_output" ]] && echo "WARNING: no parameters found under '/$service' in AWS parameter store of this environment"
-    eval "$(echo "$env_output" | sed -E "s/(^export +)(.*)/readonly ${prefix}\2/")"
+    local parameter_store_output
+    local secrets_manager_output
+    parameter_store_output=$(run_chamber env "$service")
+    [[ -z "$parameter_store_output" ]] && echo "WARNING: no parameters found under '/$service' in AWS Parameter Store of this environment"
+    secrets_manager_output=$(run_chamber env "$service" -b secretsmanager)
+    [[ -z "$secrets_manager_output" ]] && echo "WARNING: no parameters found under '/$service' in AWS Secrets Manager of this environment"
+    eval "$(printf '%s\n%s' "$parameter_store_output" "$secrets_manager_output" | sed -E "s/(^export +)(.*)/readonly ${prefix}\2/")"
 }


### PR DESCRIPTION
## Description
To cover resilience requirements and prepare for disaster recovery in case of failure, it was decided to switch from Parameter Store to Secrets Manager. Parameter Store does not provide DR or backup out of the box, and the implemented S3 backup prototype looks cumbersome and not worth the effort to maintain it. On the other hand, Secret Manager supports replication across regions out of the box and it can be used for disaster recovery. 

The change is backward compatible. Parameters can be still loaded from Parameter Store. After merging this PR, I'm going to move the secured parameters.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~~Unit and integration tests added~~
- [x] ~~Added test description under `Test manual`~~
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
CI
