### PR TITLE
expose instance type as label on Central pod

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -42,6 +42,7 @@ const (
 	envAnnotationKey          = "rhacs.redhat.com/environment"
 	clusterNameAnnotationKey  = "rhacs.redhat.com/cluster-name"
 	orgNameAnnotationKey      = "rhacs.redhat.com/org-name"
+	instanceTypeLabelKey      = "rhacs.redhat.com/instance-type"
 	orgIDLabelKey             = "rhacs.redhat.com/org-id"
 	tenantIDLabelKey          = "rhacs.redhat.com/tenant"
 
@@ -139,6 +140,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 			Labels: map[string]string{
 				k8s.ManagedByLabelKey: k8s.ManagedByFleetshardValue,
 				tenantIDLabelKey:      remoteCentral.Id,
+				instanceTypeLabelKey:  remoteCentral.Spec.Central.InstanceType,
 			},
 			Annotations: map[string]string{managedServicesAnnotation: "true"},
 		},
@@ -185,8 +187,9 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 					orgNameAnnotationKey:     remoteCentral.Spec.Auth.OwnerOrgName,
 				},
 				Labels: map[string]string{
-					orgIDLabelKey:    remoteCentral.Spec.Auth.OwnerOrgId,
-					tenantIDLabelKey: remoteCentral.Id,
+					orgIDLabelKey:        remoteCentral.Spec.Auth.OwnerOrgId,
+					tenantIDLabelKey:     remoteCentral.Id,
+					instanceTypeLabelKey: remoteCentral.Spec.Central.InstanceType,
 				},
 			},
 		},

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -63,6 +63,9 @@ var simpleManagedCentral = private.ManagedCentral{
 		DataEndpoint: private.ManagedCentralAllOfSpecDataEndpoint{
 			Host: fmt.Sprintf("acs-data-%s.acs.rhcloud.test", centralID),
 		},
+		Central: private.ManagedCentralAllOfSpecCentral{
+			InstanceType: "standard",
+		},
 	},
 }
 
@@ -108,6 +111,7 @@ func TestReconcileCreate(t *testing.T) {
 	assert.Equal(t, clusterName, central.Spec.Customize.Annotations[clusterNameAnnotationKey])
 	assert.Equal(t, simpleManagedCentral.Spec.Auth.OwnerOrgName, central.Spec.Customize.Annotations[orgNameAnnotationKey])
 	assert.Equal(t, simpleManagedCentral.Spec.Auth.OwnerOrgId, central.Spec.Customize.Labels[orgIDLabelKey])
+	assert.Equal(t, simpleManagedCentral.Spec.Central.InstanceType, central.Spec.Customize.Labels[instanceTypeLabelKey])
 	assert.Equal(t, "1", central.GetAnnotations()[util.RevisionAnnotationKey])
 	assert.Equal(t, "true", central.GetAnnotations()[managedServicesAnnotation])
 	assert.Equal(t, true, *central.Spec.Central.Exposure.Route.Enabled)

--- a/internal/dinosaur/pkg/api/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/private/api/openapi.yaml
@@ -463,6 +463,11 @@ components:
           type: string
     ManagedCentral_allOf_spec_central:
       properties:
+        instanceType:
+          enum:
+          - eval
+          - standard
+          type: string
         resources:
           $ref: '#/components/schemas/ResourceRequirements'
     ManagedCentral_allOf_spec_scanner_analyzer_scaling:

--- a/internal/dinosaur/pkg/api/private/model_managed_central_all_of_spec_central.go
+++ b/internal/dinosaur/pkg/api/private/model_managed_central_all_of_spec_central.go
@@ -12,5 +12,6 @@ package private
 
 // ManagedCentralAllOfSpecCentral struct for ManagedCentralAllOfSpecCentral
 type ManagedCentralAllOfSpecCentral struct {
-	Resources ResourceRequirements `json:"resources,omitempty"`
+	InstanceType string               `json:"instanceType,omitempty"`
+	Resources    ResourceRequirements `json:"resources,omitempty"`
 }

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -89,6 +89,7 @@ func (c *ManagedCentralPresenter) PresentManagedCentral(from *dbapi.CentralReque
 				CentralOperator: from.DesiredCentralOperatorVersion,
 			},
 			Central: private.ManagedCentralAllOfSpecCentral{
+				InstanceType: from.InstanceType,
 				Resources: private.ResourceRequirements{
 					Requests: map[string]string{
 						corev1.ResourceCPU.String():    orDefaultQty(central.Resources.Requests[corev1.ResourceCPU], defaults.Central.CPURequest).String(),

--- a/openapi/fleet-manager-private.yaml
+++ b/openapi/fleet-manager-private.yaml
@@ -290,6 +290,9 @@ components:
                 central:
                   type: object
                   properties:
+                    instanceType:
+                      type: string
+                      enum: [eval, standard]
                     resources:
                       $ref: "#/components/schemas/ResourceRequirements"
                 scanner:


### PR DESCRIPTION
The label will be scraped by Prometheus as a source for dashboards. This will help increase the observability around eval and standard instances.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] ~Added test description under `Test manual`~
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [ ] ~Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~