### PR TITLE
add grafana and prometheus rule label selectors

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
@@ -16,6 +16,20 @@ spec:
     # Disable logging features of the operator, because we set up the logging operator
     # ourselves via the logging sub-chart.
     disableLogging: true
+    grafanaDashboardLabelSelector:
+      matchExpressions:
+        - key: app
+          operator: In
+          values:
+            - rhacs
+            - strimzi
+    ruleLabelSelector:
+      matchExpressions:
+        - key: app
+          operator: In
+          values:
+            - rhacs
+            - strimzi
     podMonitorLabelSelector:
       matchExpressions:
         - key: app


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

I realized that we need to add additional label selectors for the Grafana and Prometheus rule resources - currently these still default to `strimzi`. After these selectors have been deployed to stage and prod envs, we may finally switch the labels to `rhacs` to get rid of Kafka naming.

Note that the first attempt to do this has been reverted via https://github.com/stackrox/rhacs-observability-resources/pull/68, precisely because the selectors in this PR are needed.