### PR TITLE
Set ACS Operator CPU request and limit to 2

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/acs-operator.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/acs-operator.yaml
@@ -17,6 +17,13 @@ spec:
   source: {{ .Values.acsOperator.source }}
   sourceNamespace: {{ .Values.acsOperator.sourceNamespace }}
   startingCSV: rhacs-operator.{{ .Values.acsOperator.version }}
+  config:
+    resources:
+      requests:
+        cpu: 2
+      limits:
+        cpu: 2
+
 ---
 {{- if .Values.acsOperator.upstream }}
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
## Description
Set explicit ACS Operator CPU request and limit to 2 (via OLM config).

## Checklist (Definition of Done)
- ~~[ ] Unit and integration tests added~~
- ~~[ ] Added test description under `Test manual`~~
- ~~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- ~~[ ] CI and all relevant tests are passing~~
- ~~[ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~~
- ~~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~

## Test manual

Will test in stage using CD to ensure the config is okay, then push to prod to see if it addresses the issue.