### PR TITLE
ROX-14997: Add prefix to secrets in the deployment scripts

### DIFF
--- a/deploy/helm/probe/deploy.sh
+++ b/deploy/helm/probe/deploy.sh
@@ -26,7 +26,7 @@ export AWS_PROFILE="$ENVIRONMENT"
 
 init_chamber
 
-load_external_config probe PROBE_
+load_external_config "$ENVIRONMENT/acscs/probe" PROBE_
 
 case $ENVIRONMENT in
   stage)
@@ -55,7 +55,7 @@ else
     "${SCRIPT_DIR}/../../../scripts/check_image_exists.sh" "${PROBE_IMAGE_ORG}" "${PROBE_IMAGE_NAME}" "${PROBE_IMAGE_TAG}"
 fi
 
-load_external_config "cluster-${CLUSTER_NAME}" CLUSTER_
+load_external_config "$ENVIRONMENT/acscs/cluster-${CLUSTER_NAME}" CLUSTER_
 oc login --token="${CLUSTER_ROBOT_OC_TOKEN}" --server="$CLUSTER_URL"
 
 NAMESPACE="rhacs-probe"

--- a/dev/env/scripts/exec_fleetshard_sync.sh
+++ b/dev/env/scripts/exec_fleetshard_sync.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-CLUSTER_NAME="cluster-acs-dev-dp-01"
+CLUSTER_KEY="dev/acscs/cluster-acs-dev-dp-01"
 GITROOT="$(git rev-parse --show-toplevel)"
 
 export AWS_AUTH_HELPER="${AWS_AUTH_HELPER:-aws-vault}"
@@ -16,7 +16,7 @@ if [[ "$#" -gt 0 ]]; then
     ARGS="$*"
 fi
 # shellcheck disable=SC2086
-CLUSTER_ID=$(run_chamber read "${CLUSTER_NAME}" ID -q) \
-MANAGED_DB_SECURITY_GROUP=$(run_chamber read "${CLUSTER_NAME}" MANAGED_DB_SECURITY_GROUP -q) \
-MANAGED_DB_SUBNET_GROUP=$(run_chamber read "${CLUSTER_NAME}" MANAGED_DB_SUBNET_GROUP -q) \
-run_chamber exec fleetshard-sync -- ${ARGS}
+CLUSTER_ID=$(run_chamber read "${CLUSTER_KEY}" ID -q) \
+MANAGED_DB_SECURITY_GROUP=$(run_chamber read "${CLUSTER_KEY}" MANAGED_DB_SECURITY_GROUP -q) \
+MANAGED_DB_SUBNET_GROUP=$(run_chamber read "${CLUSTER_KEY}" MANAGED_DB_SUBNET_GROUP -q) \
+run_chamber exec dev/acscs/fleetshard-sync -b secretsmanager -- ${ARGS}

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -23,10 +23,10 @@ fi
 
 init_chamber
 
-load_external_config fleetshard-sync FLEETSHARD_SYNC_
-load_external_config cloudwatch-exporter CLOUDWATCH_EXPORTER_
-load_external_config logging LOGGING_
-load_external_config observability OBSERVABILITY_
+load_external_config "$ENVIRONMENT/acscs/fleetshard-sync" FLEETSHARD_SYNC_
+load_external_config "$ENVIRONMENT/acscs/cloudwatch-exporter" CLOUDWATCH_EXPORTER_
+load_external_config "$ENVIRONMENT/acscs/logging" LOGGING_
+load_external_config "$ENVIRONMENT/acscs/observability" OBSERVABILITY_
 
 case $ENVIRONMENT in
   stage)
@@ -71,7 +71,7 @@ else
     "${SCRIPT_DIR}/../../../scripts/check_image_exists.sh" "${FLEETSHARD_SYNC_ORG}" "${FLEETSHARD_SYNC_IMAGE}" "${FLEETSHARD_SYNC_TAG}"
 fi
 
-load_external_config "cluster-${CLUSTER_NAME}" CLUSTER_
+load_external_config "$ENVIRONMENT/acscs/cluster-${CLUSTER_NAME}" CLUSTER_
 oc login --token="${CLUSTER_ROBOT_OC_TOKEN}" --server="$CLUSTER_URL"
 
 OPERATOR_SOURCE="redhat-operators"

--- a/dp-terraform/osd-cluster-idp-setup.sh
+++ b/dp-terraform/osd-cluster-idp-setup.sh
@@ -32,21 +32,21 @@ fi
 save_cluster_parameter() {
     local key="$1"
     local value="$2"
-    echo "Saving parameter '/cluster-${CLUSTER_NAME}/${key}' in AWS parameter store..."
-    run_chamber write "cluster-${CLUSTER_NAME}" "${key}" "${value}" --skip-unchanged
+    echo "Saving parameter '/$ENVIRONMENT/acscs/cluster-${CLUSTER_NAME}/${key}' in AWS Parameter Store..."
+    run_chamber write "$ENVIRONMENT/acscs/cluster-${CLUSTER_NAME}" "${key}" "${value}" --skip-unchanged
 }
 
 save_cluster_secret() {
     local key="$1"
     local value="$2"
-    echo "Saving parameter '/cluster-${CLUSTER_NAME}/${key}' in AWS Secrets Manager..."
-    run_chamber write -b secretsmanager "cluster-${CLUSTER_NAME}" "${key}" "${value}" --skip-unchanged
+    echo "Saving parameter '$ENVIRONMENT/acscs/cluster-${CLUSTER_NAME}/${key}' in AWS Secrets Manager..."
+    run_chamber write -b secretsmanager "$ENVIRONMENT/acscs/cluster-${CLUSTER_NAME}" "${key}" "${value}" --skip-unchanged
 }
 
 export_cluster_environment() {
     init_chamber
-    load_external_config "osd" OSD_
-    load_external_config "cluster-$CLUSTER_NAME" STORED_
+    load_external_config "$ENVIRONMENT/acscs/osd" OSD_
+    load_external_config "$ENVIRONMENT/acscs/cluster-$CLUSTER_NAME" STORED_
 
     if [[ -z ${STORED_ADMIN_USERNAME:-} ]]; then
         echo "Cluster admin user not specified in Secrets Manager nor Parameter Store."


### PR DESCRIPTION
## Description
In order to grant fine-grained access to secrets I decided to add a prefix to our secrets, i.e. `${ENVIRONMENT}/acscs/fleetshard-sync` instead of `fleetshard-sync`. This will also help to introduce new environments using the same AWS accounts.

I also changed the logic when `ENABLE_EXTERNAL_CONFIG=false`, because, as implemented before, flags `-b null` and `-b secretsmanager` could conflict with each other and give unexpected results.  

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~~Unit and integration tests added~~
- [x] ~~Added test description under `Test manual`~~
- [x] ~~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
- [x] `./dev/env/scripts/up.sh`
- [x] `./dev/env/scripts/exec_fleetshard_sync.sh`
- [ ] Check terraforming on stage with `HELM_PRINT_ONLY=true`
- [ ] RDS tests green
- [ ] Openshift CI green