### PR TITLE
add AUTH_TYPE=OCM to fleetshard-sync in quickstart README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ make deploy/bootstrap
 $ make deploy/dev
 
 # Start fleetshard-sync
-$ OCM_TOKEN=$(ocm token --refresh) CLUSTER_ID=1234567890abcdef1234567890abcdef ./fleetshard-sync
+$ OCM_TOKEN=$(ocm token --refresh) AUTH_TYPE=OCM CLUSTER_ID=1234567890abcdef1234567890abcdef ./fleetshard-sync
 
 # To create a central instance
 $ ./scripts/create-central.sh


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Added AUTH_TYPE=OCM to the call to fleetshard-sync in the Quickstart section of the README.md, because the ocm token authentication does not work otherwise.