### PR TITLE
ROX-14997: Migrate dev scripts to Secrets Manager

### DIFF
--- a/dev/env/scripts/exec_fleetshard_sync.sh
+++ b/dev/env/scripts/exec_fleetshard_sync.sh
@@ -19,4 +19,4 @@ fi
 CLUSTER_ID=$(run_chamber read "${CLUSTER_NAME}" ID -q) \
 MANAGED_DB_SECURITY_GROUP=$(run_chamber read "${CLUSTER_NAME}" MANAGED_DB_SECURITY_GROUP -q) \
 MANAGED_DB_SUBNET_GROUP=$(run_chamber read "${CLUSTER_NAME}" MANAGED_DB_SUBNET_GROUP -q) \
-run_chamber exec fleetshard-sync -- ${ARGS}
+run_chamber exec fleetshard-sync -b secretsmanager -- ${ARGS}

--- a/dev/env/scripts/up.sh
+++ b/dev/env/scripts/up.sh
@@ -12,7 +12,15 @@ source "${GITROOT}/scripts/lib/external_config.sh"
 source "${GITROOT}/dev/env/scripts/docker.sh"
 
 init
-init_chamber
+
+if [[ "$ENABLE_EXTERNAL_CONFIG" == "true" ]]; then
+    init_chamber
+    export CHAMBER_SECRET_BACKEND=secretsmanager
+else
+    add_bin_to_path
+    ensure_tool_installed chamber
+    export CHAMBER_SECRET_BACKEND=null
+fi
 
 if [[ "$IGNORE_REPOSITORY_DIRTINESS" = "true" ]]; then
     fleet_manager_image_info="${FLEET_MANAGER_IMAGE} (ignoring repository dirtiness)"


### PR DESCRIPTION
## Description
Switch dev scripts to use Secrets Manager instead of Parameter Store.
Scripts are used in local deployment, Openshift CI and RDS tests.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~~Unit and integration tests added~~
- [x] Added test description under `Test manual`
- [x] ~~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
CI
