### PR TITLE
ROX-16099: new DBs will use a LTS aurora-postgresql version

### DIFF
--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
@@ -33,7 +33,8 @@ const (
 
 	// DB cluster / instance configuration parameters
 	dbEngine                = "aurora-postgresql"
-	dbEngineVersion         = "13.7"
+	dbEngineVersion         = "13.9" // 13.9 is a LTS Aurora PostgreSQL version
+	dbAutoVersionUpgrade    = false  // disable auto upgrades while on LTS version (see ROX-16099)
 	dbInstanceClass         = "db.serverless"
 	dbPostgresPort          = 5432
 	dbName                  = "postgres"
@@ -348,6 +349,7 @@ func newCreateCentralDBInstanceInput(clusterID, instanceID, dataplaneClusterName
 		EnablePerformanceInsights: aws.Bool(performanceInsights),
 		PromotionTier:             aws.Int64(dbInstancePromotionTier),
 		CACertificateIdentifier:   aws.String(dbCACertificateType),
+		AutoMinorVersionUpgrade:   aws.Bool(dbAutoVersionUpgrade),
 		Tags: []*rds.Tag{
 			{
 				Key:   aws.String(dataplaneClusterNameKey),


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

New DBs will be provisioned with aurora-sqlpostgres engine version 13.9, which is a LTS (long term support) version. To stay on the LTS version, the auto upgrade minor version feature is now turned off.

This does not change existing DBs. As part of [ROX-16099](https://issues.redhat.com//browse/ROX-16099), I will monitor the upgrade state on AWS and disable auto upgrade on all instances, when they are all on v13.9. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

Tested in a local cluster, by running:
INSTALL_OPERATOR=NO MANAGED_DB_ENABLED=TRUE ./dev/env/scripts/up.sh
./scripts/create-central.sh

And then waiting for a Central to start successfully.

To test locally, I had to make the DB publicly accessible. For this purpose, I added a new VPC, security group and DB subnet group in dev on AWS.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```