### PR TITLE
Minor fixes to script output when using Secrets Manager

### DIFF
--- a/dp-terraform/osd-cluster-idp-setup.sh
+++ b/dp-terraform/osd-cluster-idp-setup.sh
@@ -213,4 +213,4 @@ done
 echo "The following cluster parameters are currently stored in AWS Parameter Store:"
 run_chamber list "cluster-${CLUSTER_NAME}"
 echo "The following cluster parameters are currently stored in AWS Secrets Manager:"
-run_chamber list "cluster-${CLUSTER_NAME}" -p secretsmanager
+run_chamber list "cluster-${CLUSTER_NAME}" -b secretsmanager

--- a/scripts/lib/external_config.sh
+++ b/scripts/lib/external_config.sh
@@ -109,8 +109,7 @@ load_external_config() {
     local parameter_store_output
     local secrets_manager_output
     parameter_store_output=$(run_chamber env "$service")
-    [[ -z "$parameter_store_output" ]] && echo "WARNING: no parameters found under '/$service' in AWS Parameter Store of this environment"
     secrets_manager_output=$(run_chamber env "$service" -b secretsmanager)
-    [[ -z "$secrets_manager_output" ]] && echo "WARNING: no parameters found under '/$service' in AWS Secrets Manager of this environment"
+    [[ -z "$parameter_store_output" && -z "$secrets_manager_output" ]] && echo "WARNING: no parameters found under '/$service' of this environment"
     eval "$(printf '%s\n%s' "$parameter_store_output" "$secrets_manager_output" | sed -E "s/(^export +)(.*)/readonly ${prefix}\2/")"
 }


### PR DESCRIPTION
## Description
- Fix incorrect backend flag in `osd-cluster-idp-setup.sh`
- This is the correct situation when there are no parameters in each of the stores. A warning should be raised if both are empty.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
Tested terraforming locally
