### PR TITLE
ROX-16108: Remove Targeted Cluster Placement Strategy

### DIFF
--- a/internal/dinosaur/pkg/config/dataplane_cluster_config.go
+++ b/internal/dinosaur/pkg/config/dataplane_cluster_config.go
@@ -30,7 +30,6 @@ type DataplaneClusterConfig struct {
 	// 'none' to disabled scaling all together, useful in testing
 	DataPlaneClusterScalingType string `json:"dataplane_cluster_scaling_type"`
 	DataPlaneClusterConfigFile  string `json:"dataplane_cluster_config_file"`
-	DataPlaneClusterTarget      string `json:"dataplane_cluster_target"`
 	ReadOnlyUserList            userv1.OptionalNames
 	ReadOnlyUserListFile        string
 	// TODO ROX-11294 adjust or drop sre user list
@@ -318,7 +317,6 @@ func (c *DataplaneClusterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.FleetshardOperatorOLMConfig.Namespace, "fleetshard-operator-namespace", c.FleetshardOperatorOLMConfig.Namespace, "fleetshard operator namespace")
 	fs.StringVar(&c.FleetshardOperatorOLMConfig.Package, "fleetshard-operator-package", c.FleetshardOperatorOLMConfig.Package, "fleetshard operator package")
 	fs.StringVar(&c.FleetshardOperatorOLMConfig.SubscriptionChannel, "fleetshard-operator-sub-channel", c.FleetshardOperatorOLMConfig.SubscriptionChannel, "fleetshard operator subscription channel")
-	fs.StringVar(&c.DataPlaneClusterTarget, "dataplane-cluster-target", "", "specify cluster by ID on which new centrals should be created")
 }
 
 // ReadFiles ...

--- a/internal/dinosaur/pkg/services/cluster_placement_strategy_test.go
+++ b/internal/dinosaur/pkg/services/cluster_placement_strategy_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestPlacementStrategyType(t *testing.T) {
-
 	tt := []struct {
 		description          string
 		createClusterService func() ClusterService
@@ -27,20 +26,8 @@ func TestPlacementStrategyType(t *testing.T) {
 			createClusterService: func() ClusterService {
 				return &ClusterServiceMock{}
 			},
-			dataPlaneConfig: &config.DataplaneClusterConfig{
-				DataPlaneClusterTarget: "",
-			},
-			expectedType: FirstReadyPlacementStrategy{},
-		},
-		{
-			description: "TargetClusterPlacementStrategy",
-			createClusterService: func() ClusterService {
-				return &ClusterServiceMock{}
-			},
-			dataPlaneConfig: &config.DataplaneClusterConfig{
-				DataPlaneClusterTarget: "test-cluster-id",
-			},
-			expectedType: TargetClusterPlacementStrategy{},
+			dataPlaneConfig: &config.DataplaneClusterConfig{},
+			expectedType:    FirstReadyPlacementStrategy{},
 		},
 	}
 

--- a/internal/dinosaur/pkg/services/cluster_placement_strategy_test.go
+++ b/internal/dinosaur/pkg/services/cluster_placement_strategy_test.go
@@ -27,7 +27,7 @@ func TestPlacementStrategyType(t *testing.T) {
 				return &ClusterServiceMock{}
 			},
 			dataPlaneConfig: &config.DataplaneClusterConfig{},
-			expectedType:    FirstReadyPlacementStrategy{},
+			expectedType:    &FirstReadyPlacementStrategy{},
 		},
 	}
 


### PR DESCRIPTION
## Description
Removes the TargetedClusterPlacementStrategy.

This placement strategy was a breakglass mechanism that was added before in ServicePreview to enable forcing cluster selection to a single specific cluster. It is not currently used and will immediately be replaced by disabling Schedulable field for all non-desired clusters once https://github.com/stackrox/acs-fleet-manager/pull/904 is merged.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~~[ ] Unit and integration tests added~~
- ~~[ ] Added test description under `Test manual`~~
- ~~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- ~~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~

## Test manual

Ran the local tests per instructions below, all passing.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
