### PR TITLE
ROX-16205: Add Operator Version label to Centrals

### DIFF
--- a/fleetshard/main.go
+++ b/fleetshard/main.go
@@ -35,6 +35,7 @@ func main() {
 	glog.Infof("ClusterID: %s", config.ClusterID)
 	glog.Infof("RuntimePollPeriod: %s", config.RuntimePollPeriod.String())
 	glog.Infof("AuthType: %s", config.AuthType)
+	glog.Infof("FeatureFlagUpgradeOperatorEnabled: %t", config.FeatureFlagUpgradeOperatorEnabled)
 
 	glog.Infof("ManagedDB.Enabled: %t", config.ManagedDB.Enabled)
 	glog.Infof("ManagedDB.SecurityGroup: %s", config.ManagedDB.SecurityGroup)

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -107,13 +107,14 @@ func (r *Runtime) Start() error {
 	routesAvailable := r.routesAvailable()
 
 	reconcilerOpts := centralReconciler.CentralReconcilerOptions{
-		UseRoutes:         routesAvailable,
-		WantsAuthProvider: r.config.CreateAuthProvider,
-		EgressProxyImage:  r.config.EgressProxyImage,
-		ManagedDBEnabled:  r.config.ManagedDB.Enabled,
-		Telemetry:         r.config.Telemetry,
-		ClusterName:       r.config.ClusterName,
-		Environment:       r.config.Environment,
+		UseRoutes:                         routesAvailable,
+		WantsAuthProvider:                 r.config.CreateAuthProvider,
+		EgressProxyImage:                  r.config.EgressProxyImage,
+		ManagedDBEnabled:                  r.config.ManagedDB.Enabled,
+		Telemetry:                         r.config.Telemetry,
+		ClusterName:                       r.config.ClusterName,
+		Environment:                       r.config.Environment,
+		FeatureFlagUpgradeOperatorEnabled: r.config.FeatureFlagUpgradeOperatorEnabled,
 	}
 
 	if r.config.FeatureFlagUpgradeOperatorEnabled {


### PR DESCRIPTION
## Description
Add an Operator Version label to Central instances. It will be used for Canary Upgrades.

Additional note: [k8s Label, selector, and annotation conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#label-selector-and-annotation-conventions)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~

## Test manual

1. Build and deploy

```
make deploy/dev
```

2. Create ACS instance
3. Check Labels:
```
kubectl get pods -l 'stackrox.io/operator-version=rhacs-operator.v3.74.0' -n ascms
```

