### PR TITLE
ROX-13092: Add openshift eventrouter to persist kubernetes events to CloudWatch

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/logging/README.md
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/README.md
@@ -1,6 +1,7 @@
 # Data plane terraform logging Helm chart
 
 This chart installs resource into `openshift-logging` namespace. This namespace is Openshift dedicated namespace for logging stack for OSD cluster.
+It installs on top the openshift eventrouter in order to log kubernetes events in the `openshift-logging` namespace.
 
 ## Custom resource definitions
 

--- a/dp-terraform/helm/rhacs-terraform/charts/logging/templates/02-eventrouter-01-rbac.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/templates/02-eventrouter-01-rbac.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eventrouter
+  namespace: openshift-logging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: event-reader
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: event-reader-binding
+subjects:
+- kind: ServiceAccount
+  name: eventrouter
+  namespace: openshift-logging
+roleRef:
+  aoiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: event-reader

--- a/dp-terraform/helm/rhacs-terraform/charts/logging/templates/02-eventrouter-02-configmap.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/templates/02-eventrouter-02-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: eventrouter
+  namespace: openshift-logging
+data:
+  config.json: |-
+    {
+      "sink": "stdout"
+    }

--- a/dp-terraform/helm/rhacs-terraform/charts/logging/templates/02-eventrouter-03-deployment.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/templates/02-eventrouter-03-deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deploy,ent
+kind: Deployment
 metadata:
   name: eventrouter
   namespace: openshift-logging
@@ -31,8 +31,8 @@ spec:
               cpu: "100m"
               memory: "128Mi"
           volumeMounts:
-          - name: config-volume
-            mountPath: /etc/eventrouter
+            - name: config-volume
+              mountPath: /etc/eventrouter
       volumes:
         - name: config-volume
           configMap:

--- a/dp-terraform/helm/rhacs-terraform/charts/logging/templates/02-eventrouter-03-deployment.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/templates/02-eventrouter-03-deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deploy,ent
+metadata:
+  name: eventrouter
+  namespace: openshift-logging
+  labels:
+    component: "eventrouter"
+    logging-infra: "eventrouter"
+    provider: "openshift"
+spec:
+  replicas: 1
+  selector:
+    component: "eventrouter"
+    logging-infra: "eventrouter"
+    provider: "openshift"
+  template:
+    metadata:
+      labels:
+        component: "eventrouter"
+        logging-infra: "eventrouter"
+        provider: "openshift"
+      name: eventrouter
+    spec:
+      serviceAccount: eventrouter
+      containers:
+        - name: kube-eventrouter
+          image: "registry.redhat.io/openshift-logging/eventrouter-rhel8:v0.4"
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+          volumeMounts:
+          - name: config-volume
+            mountPath: /etc/eventrouter
+      volumes:
+        - name: config-volume
+          configMap:
+            name: eventrouter


### PR DESCRIPTION
## Description

The goal here is to persist kubernetes events to cloudwatch in order to ease later troubleshooting of issues.
This relies on the openshift eventrouter component.

## Checklist (Definition of Done)
~~- [ ] Unit and integration tests added~~
- [ ] Added test description under `Test manual`
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
