### PR TITLE
Pass the region from the parameter store to the fleetshard sync

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -110,7 +110,7 @@ helm upgrade rhacs-terraform "${SCRIPT_DIR}" ${HELM_DEBUG_FLAGS:-} \
   --set fleetshardSync.managedDB.subnetGroup="${CLUSTER_MANAGED_DB_SUBNET_GROUP}" \
   --set fleetshardSync.managedDB.securityGroup="${CLUSTER_MANAGED_DB_SECURITY_GROUP}" \
   --set fleetshardSync.managedDB.performanceInsights=true \
-  --set fleetshardSync.aws.region="${FLEETSHARD_SYNC_AWS_REGION}" \
+  --set fleetshardSync.aws.region="${CLUSTER_REGION}" \
   --set fleetshardSync.aws.roleARN="${FLEETSHARD_SYNC_AWS_ROLE_ARN}" \
   --set fleetshardSync.telemetry.storage.endpoint="${FLEETSHARD_SYNC_TELEMETRY_STORAGE_ENDPOINT:-}" \
   --set fleetshardSync.telemetry.storage.key="${FLEETSHARD_SYNC_TELEMETRY_STORAGE_KEY:-}" \

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -110,6 +110,7 @@ helm upgrade rhacs-terraform "${SCRIPT_DIR}" ${HELM_DEBUG_FLAGS:-} \
   --set fleetshardSync.managedDB.subnetGroup="${CLUSTER_MANAGED_DB_SUBNET_GROUP}" \
   --set fleetshardSync.managedDB.securityGroup="${CLUSTER_MANAGED_DB_SECURITY_GROUP}" \
   --set fleetshardSync.managedDB.performanceInsights=true \
+  --set fleetshardSync.aws.region="${FLEETSHARD_SYNC_AWS_REGION}" \
   --set fleetshardSync.aws.roleARN="${FLEETSHARD_SYNC_AWS_ROLE_ARN}" \
   --set fleetshardSync.telemetry.storage.endpoint="${FLEETSHARD_SYNC_TELEMETRY_STORAGE_ENDPOINT:-}" \
   --set fleetshardSync.telemetry.storage.key="${FLEETSHARD_SYNC_TELEMETRY_STORAGE_KEY:-}" \

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -33,7 +33,7 @@ fleetshardSync:
     securityGroup: ""
     performanceInsights: true
   aws:
-    region: "us-east-1"
+    region: "us-east-1"  # TODO(2023-05-01): Remove the default value here as we now set it explicitly
     roleARN: ""
   telemetry:
     storage:


### PR DESCRIPTION
## Description
Pass the cluster's region from parameter store to the Fleetshard Sync so that it creates RDS instances in the correct (local) region.

## Checklist (Definition of Done)
- ~~[ ] Unit and integration tests added~~
- [x] Added test description under `Test manual`
- ~~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- ~~[ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~~
- ~~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~

## Test manual

Waited for https://github.com/stackrox/acs-fleet-manager-aws-config/pull/66 to merge.
Checked that parameter existed in Parameter Store.
Did *not* test the terraforming - we should push this commit to actually test the change using GHA, instead of trying to push the change locally using the script.
