### PR TITLE
Change RDS DB CA certificate type

### DIFF
--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
@@ -40,7 +40,7 @@ const (
 	dbName                  = "postgres"
 	dbBackupRetentionPeriod = 30
 	dbInstancePromotionTier = 2 // a tier of 2 (or higher) ensures that readers and writers can scale independently
-	dbCACertificateType     = "rds-ca-ecc384-g1"
+	dbCACertificateType     = "rds-ca-rsa4096-g1"
 	dataplaneClusterNameKey = "DataplaneClusterName"
 
 	// The Aurora Serverless v2 DB instance configuration in ACUs (Aurora Capacity Units)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
This PR seems to fix the following incident:
https://redhat.pagerduty.com/alerts/Q1ERBKAIFV2F0K

fleetshard-sync can't connect to new DB instances, with the following error message:
`E0403 09:22:54.265198 1 runtime.go:164] Unexpected error occurred rhacs-cgl99m6d244mjjgq51sg/probe-795ccb9fb7-cc2vd-072a: getting Central DB connection string: initializing managed DB: initializing managed DB: beginning PostgreSQL transaction: remote error: tls: handshake failure`

Not using the ECC CA certificate type seems to solve the problem. Root cause is not known yet, and might be caused by AWS.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

Tested in a local cluster, by running:
INSTALL_OPERATOR=NO MANAGED_DB_ENABLED=TRUE ./dev/env/scripts/up.sh
./scripts/create-central.sh

And then waiting for a Central to start successfully.

To test locally, I had to make the DB publicly accessible. For this purpose, I added a new VPC, security group and DB subnet group in dev on AWS.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
