### PR TITLE
Add missing AWS_ROLE_ARN parameter in dev script for fleetshard-sync

### DIFF
--- a/dev/env/scripts/exec_fleetshard_sync.sh
+++ b/dev/env/scripts/exec_fleetshard_sync.sh
@@ -12,7 +12,7 @@ fi
 
 if [[ "$ENABLE_EXTERNAL_CONFIG" != "true" ]]; then
     ${ARGS}
-    return
+    exit
 fi
 
 export AWS_AUTH_HELPER="${AWS_AUTH_HELPER:-aws-vault}"

--- a/dev/env/scripts/exec_fleetshard_sync.sh
+++ b/dev/env/scripts/exec_fleetshard_sync.sh
@@ -2,21 +2,30 @@
 
 set -euo pipefail
 
-CLUSTER_NAME="cluster-acs-dev-dp-01"
 GITROOT="$(git rev-parse --show-toplevel)"
-
-export AWS_AUTH_HELPER="${AWS_AUTH_HELPER:-aws-vault}"
-
-# shellcheck source=scripts/lib/external_config.sh
-source "${GITROOT}/scripts/lib/external_config.sh"
-init_chamber
+ENABLE_EXTERNAL_CONFIG="${ENABLE_EXTERNAL_CONFIG:-true}"
 
 ARGS="${GITROOT}/fleetshard-sync"
 if [[ "$#" -gt 0 ]]; then
     ARGS="$*"
 fi
-# shellcheck disable=SC2086
-CLUSTER_ID=$(run_chamber read "${CLUSTER_NAME}" ID -q) \
-MANAGED_DB_SECURITY_GROUP=$(run_chamber read "${CLUSTER_NAME}" MANAGED_DB_SECURITY_GROUP -q) \
-MANAGED_DB_SUBNET_GROUP=$(run_chamber read "${CLUSTER_NAME}" MANAGED_DB_SUBNET_GROUP -q) \
-run_chamber exec fleetshard-sync -b secretsmanager -- ${ARGS}
+
+if [[ "$ENABLE_EXTERNAL_CONFIG" != "true" ]]; then
+    ${ARGS}
+    return
+fi
+
+export AWS_AUTH_HELPER="${AWS_AUTH_HELPER:-aws-vault}"
+# shellcheck source=scripts/lib/external_config.sh
+source "${GITROOT}/scripts/lib/external_config.sh"
+init_chamber
+
+CLUSTER_NAME="cluster-acs-dev-dp-01"
+
+ARGS="CLUSTER_ID=$(run_chamber read ${CLUSTER_NAME} ID -q -b ssm) \
+    MANAGED_DB_SECURITY_GROUP=$(run_chamber read ${CLUSTER_NAME} MANAGED_DB_SECURITY_GROUP -q -b ssm) \
+    MANAGED_DB_SUBNET_GROUP=$(run_chamber read ${CLUSTER_NAME} MANAGED_DB_SUBNET_GROUP -q -b ssm) \
+    AWS_ROLE_ARN=$(run_chamber read fleetshard-sync AWS_ROLE_ARN -q -b ssm) \
+    $ARGS"
+
+run_chamber exec fleetshard-sync -b secretsmanager -- sh -c "$ARGS"

--- a/dev/env/scripts/up.sh
+++ b/dev/env/scripts/up.sh
@@ -70,7 +70,7 @@ if [[ "$SPAWN_LOGGER" == "true" && -n "${LOG_DIR:-}" ]]; then
 fi
 
 log "Deploying fleetshard-sync"
-run_chamber exec "fleetshard-sync" -- apply "${MANIFESTS_DIR}/fleetshard-sync"
+exec_fleetshard_sync.sh apply "${MANIFESTS_DIR}/fleetshard-sync"
 wait_for_container_to_appear "$ACSMS_NAMESPACE" "application=fleetshard-sync" "fleetshard-sync"
 if [[ "$SPAWN_LOGGER" == "true" && -n "${LOG_DIR:-}" ]]; then
     $KUBECTL -n "$ACSMS_NAMESPACE" logs -l application=fleetshard-sync --all-containers --pod-running-timeout=1m --since=1m --tail=100 -f >"${LOG_DIR}/pod-logs_fleetshard-sync_fleetshard-sync.txt" 2>&1 &


### PR DESCRIPTION
## Description
This PR adds loading of `AWS_ROLE_ARN` in dev scripts.
`AWS_ROLE_ARN` stays in Parameter Store for now, which makes it unavailable from the dev scripts, because they are loading the configuration from Secrets Manager only. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
