### PR TITLE
use HEAD as tag for fleetshard-sync image

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -62,7 +62,7 @@ fi
 FLEETSHARD_SYNC_ORG="app-sre"
 FLEETSHARD_SYNC_IMAGE="acs-fleet-manager"
 # Get HEAD for both main and production. This is the latest merged commit.
-FLEETSHARD_SYNC_TAG="$(git rev-list --max-count 1 --abbrev-commit --abbrev=7 HEAD)"
+FLEETSHARD_SYNC_TAG="$(git rev-parse --short=7 HEAD)"
 
 if [[ "${HELM_PRINT_ONLY:-}" == "true" ]]; then
     HELM_DEBUG_FLAGS="--debug --dry-run"

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -61,9 +61,8 @@ fi
 
 FLEETSHARD_SYNC_ORG="app-sre"
 FLEETSHARD_SYNC_IMAGE="acs-fleet-manager"
-# Get the first non-merge commit, starting with HEAD.
-# On main this should be HEAD, on production, the latest merged main commit.
-FLEETSHARD_SYNC_TAG="$(git rev-list --no-merges --max-count 1 --abbrev-commit --abbrev=7 HEAD)"
+# Get HEAD for both main and production. This is the latest merged commit.
+FLEETSHARD_SYNC_TAG="$(git rev-list --max-count 1 --abbrev-commit --abbrev=7 HEAD)"
 
 if [[ "${HELM_PRINT_ONLY:-}" == "true" ]]; then
     HELM_DEBUG_FLAGS="--debug --dry-run"


### PR DESCRIPTION
## Description

We switch the deployment tag to HEAD, instead of the last non-merge commit. The reason behind this change is to better enable cherry-picks onto the production branch, which are added to the branch via a new merge commit. Since cherry-picks modify the commit hash, we cannot reuse the image built from `main` commits. The images are produced by app-interface, which only builds images for the latest merge commit of the `main` and `production` branches.

With this change we lose the ability to deploy the exact same image to both stage and production during regular releases, because a new image is build for the production HEAD. However, the contents as calculated by git between the stage and production image will be identical, which is considered sufficient at this time.

In particular, this change is urgently needed to merge a bugfix cherry-pick to resolve the RDS certificate incident (see https://redhat-internal.slack.com/archives/C051DKRQ2NR). The plan is to cherry-pick this change onto the production branch, which then allows us to deploy the fix.