### PR TITLE
import rpm gpg key for CentOS

### DIFF
--- a/.openshift-ci/e2e-runtime/Dockerfile
+++ b/.openshift-ci/e2e-runtime/Dockerfile
@@ -1,5 +1,8 @@
 FROM quay.io/centos/centos:stream9
 
+# Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2184640
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+
 RUN dnf update -y --disablerepo=\* --enablerepo=baseos,appstream && dnf -y install make which git gettext jq gcc && dnf clean all && rm -rf /var/cache/dnf
 
 COPY --from=registry.ci.openshift.org/openshift/release:golang-1.19 /usr/local/go /usr/local/go

--- a/.openshift-ci/e2e-runtime/Dockerfile
+++ b/.openshift-ci/e2e-runtime/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/centos/centos:stream9
 
 # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2184640
-rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
 RUN dnf update -y --disablerepo=\* --enablerepo=baseos,appstream && dnf -y install make which git gettext jq gcc && dnf clean all && rm -rf /var/cache/dnf
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
This is a workaround to the issue https://bugzilla.redhat.com/show_bug.cgi?id=2184640. This should fix the e2e tests in CI.