### PR TITLE
ROX-16355: Do not run RDS tests from forks

### DIFF
--- a/.github/workflows/rds.yaml
+++ b/.github/workflows/rds.yaml
@@ -37,7 +37,7 @@ jobs:
   verify-test:
     name: "Test RDS Provisioning"
     runs-on: ubuntu-latest
-    if: github.repository == 'stackrox/acs-fleet-manager' # do not run in forks
+    if: ${{ !github.event.pull_request.head.repo.fork }} # do not run for PRs from forks
     permissions:
       id-token: write
       contents: read

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
@@ -1,4 +1,4 @@
-// Package awsclient provides AWS-specific implementations of the interfaces in cloudprovider test
+// Package awsclient provides AWS-specific implementations of the interfaces in cloudprovider
 package awsclient
 
 import (

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
@@ -1,4 +1,4 @@
-// Package awsclient provides AWS-specific implementations of the interfaces in cloudprovider
+// Package awsclient provides AWS-specific implementations of the interfaces in cloudprovider test
 package awsclient
 
 import (


### PR DESCRIPTION
## Description
Do not run RDS tests from forks. Second try. The first one was made in #930.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
GHA