### PR TITLE
ROX-16338 Add central label selector to operator helm chart

### DIFF
--- a/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-deployment.yaml
+++ b/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-deployment.yaml
@@ -80,6 +80,10 @@ spec:
                   divisor: '0'
             - name: OPERATOR_CONDITION_NAME
               value: rhacs-operator.v3.74.0
+            {{ if .Values.operator.centralLabelSelector -}}
+            - name: CENTRAL_LABEL_SELECTOR
+              value: {{ .Values.operator.centralLabelSelector | quote }}
+            {{- end }}
           image: {{ .Values.operator.image }}
           imagePullPolicy: IfNotPresent
           livenessProbe:


### PR DESCRIPTION
Adds an optional helm chart value so that we can pass the central label selector to the operator using the helm chart