### PR TITLE
expand cloudwatch exports to eu region

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/templates/01-operator-03-config-map.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/templates/01-operator-03-config-map.yaml
@@ -10,128 +10,33 @@ data:
       jobs:
         - type: rds
           regions:
+            - eu-west-1
             - us-east-1
           searchTags:
             - key: DataplaneClusterName
               value: ^{{ .Values.clusterName }}$
+          dimensionNameRequirements:
+            - DBInstanceIdentifier
+          statistics:
+            - Average
+            - Maximum
+            - Minimum
+            - p90
+            - p95
+            - p99
           metrics:
             - name: DatabaseConnections
-              statistics:
-                - Average
-                - Maximum
-                - Minimum
-                - p90
-                - p95
-                - p99
             - name: ServerlessDatabaseCapacity
-              statistics:
-                - Average
-                - Maximum
-                - Minimum
-                - p90
-                - p95
-                - p99
             - name: ACUUtilization
-              statistics:
-                - Average
-                - Maximum
-                - Minimum
-                - p90
-                - p95
-                - p99
             - name: FreeableMemory
-              statistics:
-                - Average
-                - Maximum
-                - Minimum
-                - p90
-                - p95
-                - p99
             - name: CPUUtilization
-              statistics:
-                - Average
-                - Maximum
-                - Minimum
-                - p90
-                - p95
-                - p99
             - name: ReadLatency
-              statistics:
-                - Average
-                - Maximum
-                - Minimum
-                - p90
-                - p95
-                - p99
             - name: ReadThroughput
-              statistics:
-                - Average
-                - Maximum
-                - Minimum
-                - p90
-                - p95
-                - p99
             - name: WriteLatency
-              statistics:
-                - Average
-                - Maximum
-                - Minimum
-                - p90
-                - p95
-                - p99
             - name: WriteThroughput
-              statistics:
-                - Average
-                - Maximum
-                - Minimum
-                - p90
-                - p95
-                - p99
             - name: NetworkThroughput
-              statistics:
-                - Average
-                - Maximum
-                - Minimum
-                - p90
-                - p95
-                - p99
             - name: AuroraReplicaLag
-              statistics:
-                - Average
-                - Maximum
-                - Minimum
-                - p90
-                - p95
-                - p99
             - name: MaximumUsedTransactionIDs
-              statistics:
-                - Average
-                - Maximum
-                - Minimum
-                - p90
-                - p95
-                - p99
             - name: TransactionLogsDiskUsage
-              statistics:
-                - Average
-                - Maximum
-                - Minimum
-                - p90
-                - p95
-                - p99
             - name: Deadlocks
-              statistics:
-                - Average
-                - Maximum
-                - Minimum
-                - p90
-                - p95
-                - p99
             - name: BufferCacheHitRatio
-              statistics:
-                - Average
-                - Maximum
-                - Minimum
-                - p90
-                - p95
-                - p99


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
A few improvements to the cloudwatch exporter configuration.
* Add `eu-west-1` to AWS regions to search for resources to export.
* Use global `statistics` block to reduce config bloat.
* Restrict to metric series with `DBInstanceIdentifier` dimension to avoid exporting RDS cluster metrics (only export RDS instance metrics).

## Test manual

Tested config with local cloudwatch exporter running against our stage AWS account.