### PR TITLE
bump observability operator to v4.2.1

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -35,7 +35,7 @@ case $ENVIRONMENT in
     FM_ENDPOINT="https://nonexistent.api.stage.openshift.com"
     OBSERVABILITY_GITHUB_TAG="master"
     OBSERVABILITY_OBSERVATORIUM_GATEWAY="https://observatorium-mst.api.nonexistent.openshift.com"
-    OBSERVABILITY_OPERATOR_VERSION="v4.0.4"
+    OBSERVABILITY_OPERATOR_VERSION="v4.2.1"
     OPERATOR_USE_UPSTREAM="false"
     OPERATOR_VERSION="v3.74.0"
     ;;
@@ -44,7 +44,7 @@ case $ENVIRONMENT in
     FM_ENDPOINT="https://xtr6hh3mg6zc80v.api.stage.openshift.com"
     OBSERVABILITY_GITHUB_TAG="master"
     OBSERVABILITY_OBSERVATORIUM_GATEWAY="https://observatorium-mst.api.stage.openshift.com"
-    OBSERVABILITY_OPERATOR_VERSION="v4.0.4"
+    OBSERVABILITY_OPERATOR_VERSION="v4.2.1"
     OPERATOR_USE_UPSTREAM="false"
     OPERATOR_VERSION="v3.74.0"
     ;;


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Routine update of the observability operator. We benefit mostly from golang deps updates and updates to the operator images. Changelog: https://github.com/redhat-developer/observability-operator/compare/v4.0.4...v4.2.1

The migration should be automatic. Test in stage first, and upgrade in prod if everything goes well.