### PR TITLE
Hardcode Fleet-Manager CLI command registration

### DIFF
--- a/cmd/fleet-manager/main.go
+++ b/cmd/fleet-manager/main.go
@@ -4,6 +4,14 @@ package main
 import (
 	"flag"
 
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/cmd/central"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/cmd/cloudprovider"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/cmd/cluster"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/cmd/errors"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/cmd/observatorium"
+	"github.com/stackrox/acs-fleet-manager/pkg/cmd/migrate"
+	"github.com/stackrox/acs-fleet-manager/pkg/cmd/serve"
+
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur"
@@ -41,14 +49,18 @@ func main() {
 		glog.Fatalf("Unable to add global flags: %s", err.Error())
 	}
 
-	env.MustInvoke(func(subcommands []*cobra.Command) {
-		rootCmd.AddCommand(subcommands...)
+	rootCmd.AddCommand(migrate.NewMigrateCommand(env))
+	rootCmd.AddCommand(serve.NewServeCommand(env))
+	rootCmd.AddCommand(central.NewCentralCommand(env))
+	rootCmd.AddCommand(cluster.NewClusterCommand(env))
+	rootCmd.AddCommand(cloudprovider.NewCloudProviderCommand(env))
+	rootCmd.AddCommand(observatorium.NewRunObservatoriumCommand(env))
+	rootCmd.AddCommand(errors.NewErrorsCommand(env))
 
-		if err := rootCmd.Execute(); err != nil {
-			glog.Fatalf("error running command: %v", err)
-		}
+	if err := rootCmd.Execute(); err != nil {
+		glog.Fatalf("error running command: %v", err)
+	}
 
-	})
 	if err != nil {
 		glog.Fatalf("Unable to initialize environment: %s", err.Error())
 	}

--- a/internal/dinosaur/providers.go
+++ b/internal/dinosaur/providers.go
@@ -4,11 +4,6 @@ package dinosaur
 import (
 	"github.com/goava/di"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/clusters"
-	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/cmd/central"
-	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/cmd/cloudprovider"
-	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/cmd/cluster"
-	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/cmd/errors"
-	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/cmd/observatorium"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/config"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/environments"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/handlers"
@@ -52,12 +47,6 @@ func ConfigProviders() di.Option {
 		di.Provide(config.NewFleetshardConfig, di.As(new(environments2.ConfigModule))),
 		di.Provide(config.NewCentralRequestConfig, di.As(new(environments2.ConfigModule))),
 
-		// Additional CLI subcommands
-		di.Provide(cluster.NewClusterCommand),
-		di.Provide(central.NewCentralCommand),
-		di.Provide(cloudprovider.NewCloudProviderCommand),
-		di.Provide(observatorium.NewRunObservatoriumCommand),
-		di.Provide(errors.NewErrorsCommand),
 		di.Provide(environments2.Func(ServiceProviders)),
 		di.Provide(migrations.New),
 

--- a/pkg/providers/core.go
+++ b/pkg/providers/core.go
@@ -11,8 +11,6 @@ import (
 	"github.com/stackrox/acs-fleet-manager/pkg/client/observatorium"
 	"github.com/stackrox/acs-fleet-manager/pkg/client/ocm"
 	"github.com/stackrox/acs-fleet-manager/pkg/client/telemetry"
-	"github.com/stackrox/acs-fleet-manager/pkg/cmd/migrate"
-	"github.com/stackrox/acs-fleet-manager/pkg/cmd/serve"
 	"github.com/stackrox/acs-fleet-manager/pkg/db"
 	"github.com/stackrox/acs-fleet-manager/pkg/environments"
 	"github.com/stackrox/acs-fleet-manager/pkg/handlers"
@@ -46,10 +44,6 @@ func CoreConfigProviders() di.Option {
 		di.Provide(auth.NewFleetShardAuthZConfig, di.As(new(environments.ConfigModule))),
 		di.Provide(auth.NewAdminAuthZConfig, di.As(new(environments.ConfigModule))),
 		di.Provide(telemetry.NewTelemetryConfig, di.As(new(environments.ConfigModule))),
-
-		// Add common CLI sub commands
-		di.Provide(serve.NewServeCommand),
-		di.Provide(migrate.NewMigrateCommand),
 
 		// Add other core config providers..
 		sentry.ConfigProviders(),


### PR DESCRIPTION
## Description
Hardcoding the fleet-manager CLI command registration instead of using the DI container registration.
This removes the need of reflection and cleans up error logs dramatically.
The DI container is still passed to all commands.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

 - run CLI should work