### PR TITLE
improve probe logging

### DIFF
--- a/probe/pkg/probe/probe.go
+++ b/probe/pkg/probe/probe.go
@@ -64,7 +64,11 @@ func (p *ProbeImpl) newCentralName() (string, error) {
 
 // Execute the probe of the fleet manager API.
 func (p *ProbeImpl) Execute(ctx context.Context) error {
-	glog.Info("probe run has been started")
+	glog.Infof("probe run has been started: fleetManagerEndpoint=%q, provider=%q, region=%q",
+		p.config.FleetManagerEndpoint,
+		p.config.DataCloudProvider,
+		p.config.DataPlaneRegion,
+	)
 	defer glog.Info("probe run has ended")
 	defer recordElapsedTime(time.Now())
 
@@ -192,7 +196,6 @@ func (p *ProbeImpl) ensureStateFunc(ctx context.Context, centralRequest *public.
 		return &centralResp, nil
 	}
 	err = errors.Errorf("central instance %s not in target state %q", centralRequest.Id, targetState)
-	glog.Warning(err)
 	return nil, err
 }
 
@@ -219,7 +222,6 @@ func (p *ProbeImpl) ensureDeletedFunc(ctx context.Context, centralRequest *publi
 		return err
 	}
 	err = errors.Errorf("central instance %s not deleted", centralRequest.Id)
-	glog.Warning(err)
 	return err
 }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Small improvement of the probe logging:
* Remove warnings emitted frequently while the probe is waiting for the instance to be ready/deleted. This warning creates a lot of spam in the logs.
* Log target configuration when a probe run starts.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~Unit and integration tests added~
- [ ] ~Added test description under `Test manual`~
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [ ] ~Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~