### PR TITLE
add region label to probe metrics

### DIFF
--- a/probe/pkg/metrics/server_test.go
+++ b/probe/pkg/metrics/server_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
@@ -25,7 +26,16 @@ func TestMetricsServerServesDefaultMetrics(t *testing.T) {
 }
 
 func TestMetricsServerServesCustomMetrics(t *testing.T) {
-	metrics := serveMetrics(t, newMetrics())
+	// Initialize metric series such that they are not empty.
+	customMetrics := newMetrics()
+	customMetrics.IncStartedRuns(regionValue)
+	customMetrics.IncSucceededRuns(regionValue)
+	customMetrics.IncFailedRuns(regionValue)
+	customMetrics.SetLastStartedTimestamp(regionValue)
+	customMetrics.SetLastSuccessTimestamp(regionValue)
+	customMetrics.SetLastFailureTimestamp(regionValue)
+	customMetrics.ObserveTotalDuration(time.Minute, regionValue)
+	metrics := serveMetrics(t, customMetrics)
 
 	expectedKeys := []string{
 		"acs_probe_runs_started_total",

--- a/probe/pkg/probe/probe.go
+++ b/probe/pkg/probe/probe.go
@@ -47,10 +47,10 @@ func New(config *config.Config, fleetManagerPublicAPI fleetmanager.PublicAPI, ht
 	}
 }
 
-func recordElapsedTime(start time.Time) {
+func recordElapsedTime(start time.Time, region string) {
 	elapsedTime := time.Since(start)
 	glog.Infof("elapsed time: %v", elapsedTime)
-	metrics.MetricsInstance().ObserveTotalDuration(elapsedTime)
+	metrics.MetricsInstance().ObserveTotalDuration(elapsedTime, region)
 }
 
 func (p *ProbeImpl) newCentralName() (string, error) {
@@ -70,7 +70,7 @@ func (p *ProbeImpl) Execute(ctx context.Context) error {
 		p.config.DataPlaneRegion,
 	)
 	defer glog.Info("probe run has ended")
-	defer recordElapsedTime(time.Now())
+	defer recordElapsedTime(time.Now(), p.config.DataPlaneRegion)
 
 	central, err := p.createCentral(ctx)
 	if err != nil {

--- a/probe/pkg/runtime/runtime.go
+++ b/probe/pkg/runtime/runtime.go
@@ -49,8 +49,8 @@ func (r *Runtime) RunLoop(ctx context.Context) error {
 
 // RunSingle executes a single probe run.
 func (r *Runtime) RunSingle(ctx context.Context) (errReturn error) {
-	metrics.MetricsInstance().IncStartedRuns()
-	metrics.MetricsInstance().SetLastStartedTimestamp()
+	metrics.MetricsInstance().IncStartedRuns(r.Config.DataPlaneRegion)
+	metrics.MetricsInstance().SetLastStartedTimestamp(r.Config.DataPlaneRegion)
 
 	probeRunCtx, cancel := context.WithTimeout(ctx, r.Config.ProbeRunTimeout)
 	defer cancel()
@@ -72,11 +72,11 @@ func (r *Runtime) RunSingle(ctx context.Context) (errReturn error) {
 	}()
 
 	if err := r.probe.Execute(probeRunCtx); err != nil {
-		metrics.MetricsInstance().IncFailedRuns()
-		metrics.MetricsInstance().SetLastFailureTimestamp()
+		metrics.MetricsInstance().IncFailedRuns(r.Config.DataPlaneRegion)
+		metrics.MetricsInstance().SetLastFailureTimestamp(r.Config.DataPlaneRegion)
 		return errors.Wrap(err, "probe run failed")
 	}
-	metrics.MetricsInstance().IncSucceededRuns()
-	metrics.MetricsInstance().SetLastSuccessTimestamp()
+	metrics.MetricsInstance().IncSucceededRuns(r.Config.DataPlaneRegion)
+	metrics.MetricsInstance().SetLastSuccessTimestamp(r.Config.DataPlaneRegion)
 	return nil
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Add region label to indicate in the metrics what data plane region the probe requested an instance in. For example, the counter `acs_probe_runs_started_total` will become `acs_probe_runs_started_total{region="us-east-1"}`. This will be especially useful if we add a regional round robin to the probe in the future.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [ ] ~Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

CI