### PR TITLE
send actual and desired version to fleetshard in private API

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -111,11 +111,12 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		return nil, errors.Wrapf(err, "checking if central changed")
 	}
 
-	remoteCentralName := remoteCentral.Metadata.Name
-	remoteCentralNamespace := remoteCentral.Metadata.Namespace
-	if !changed && r.wantsAuthProvider == r.hasAuthProvider && isRemoteCentralReady(remoteCentral) {
+	if !changed && r.shouldSkipReadyCentral(remoteCentral) {
 		return nil, ErrCentralNotChanged
 	}
+
+	remoteCentralName := remoteCentral.Metadata.Name
+	remoteCentralNamespace := remoteCentral.Metadata.Namespace
 
 	monitoringExposeEndpointEnabled := v1alpha1.ExposeEndpointEnabled
 	// Telemetry will only be enabled if the storage key is set _and_ the central is not an "internal" central created
@@ -944,6 +945,12 @@ func (r *CentralReconciler) chartValues(remoteCentral private.ManagedCentral) (c
 	}
 
 	return vals, nil
+}
+
+func (r *CentralReconciler) shouldSkipReadyCentral(remoteCentral private.ManagedCentral) bool {
+	return r.wantsAuthProvider == r.hasAuthProvider &&
+		isRemoteCentralReady(remoteCentral) &&
+		remoteCentral.Spec.Versions.ActualVersion == remoteCentral.Spec.Versions.DesiredVersion
 }
 
 var resourcesChart = charts.MustGetChart("tenant-resources")

--- a/internal/dinosaur/pkg/api/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/private/api/openapi.yaml
@@ -296,9 +296,9 @@ components:
       type: object
     ManagedCentralVersions:
       properties:
-        central:
+        desiredVersion:
           type: string
-        centralOperator:
+        actualVersion:
           type: string
       type: object
     ManagedCentral:

--- a/internal/dinosaur/pkg/api/private/model_managed_central_versions.go
+++ b/internal/dinosaur/pkg/api/private/model_managed_central_versions.go
@@ -12,6 +12,6 @@ package private
 
 // ManagedCentralVersions struct for ManagedCentralVersions
 type ManagedCentralVersions struct {
-	Central         string `json:"central,omitempty"`
-	CentralOperator string `json:"centralOperator,omitempty"`
+	DesiredVersion string `json:"desiredVersion,omitempty"`
+	ActualVersion  string `json:"actualVersion,omitempty"`
 }

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -85,8 +85,8 @@ func (c *ManagedCentralPresenter) PresentManagedCentral(from *dbapi.CentralReque
 				Host: from.GetDataHost(),
 			},
 			Versions: private.ManagedCentralVersions{
-				Central:         from.DesiredCentralVersion,
-				CentralOperator: from.DesiredCentralOperatorVersion,
+				DesiredVersion: from.DesiredCentralVersion,
+				ActualVersion:  from.ActualCentralVersion,
 			},
 			Central: private.ManagedCentralAllOfSpecCentral{
 				InstanceType: from.InstanceType,

--- a/openapi/fleet-manager-private.yaml
+++ b/openapi/fleet-manager-private.yaml
@@ -211,9 +211,9 @@ components:
     ManagedCentralVersions:
       type: object
       properties:
-        central:
+        desiredVersion:
           type: string
-        centralOperator:
+        actualVersion:
           type: string
 
     ManagedCentral:


### PR DESCRIPTION
## Description
This PR changes the internal private API so that Fleet-Manager sends actual and desired version information to fleetshard-sync. It also modifies the reconcile cache of fleetshard-sync so that centrals reconciles are not skipped if actual version does not match desired version.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~[ ] Unit and integration tests added~
- [x] Added test description under `Test manual`
- ~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

Manual testing:

- create a central in local cluster with fleet-manager/fleet-shard-sync

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
