### PR TITLE
Disable OCM logger by default

### DIFF
--- a/pkg/client/fleetmanager/auth.go
+++ b/pkg/client/fleetmanager/auth.go
@@ -46,6 +46,7 @@ type RHSSOOption struct {
 // OCMOption for the OCM Auth type.
 type OCMOption struct {
 	RefreshToken string `env:"OCM_TOKEN"`
+	EnableLogger bool   `env:"OCM_ENABLE_LOGGER"`
 }
 
 // StaticOption for the Static Auth type.

--- a/pkg/client/fleetmanager/auth_ocm.go
+++ b/pkg/client/fleetmanager/auth_ocm.go
@@ -39,15 +39,17 @@ func (f *ocmAuthFactory) CreateAuth(o Option) (Auth, error) {
 		return nil, errors.New("empty ocm token")
 	}
 
-	l, err := sdk.NewGlogLoggerBuilder().Build()
-	if err != nil {
-		return nil, fmt.Errorf("creating Glog logger: %w", err)
-	}
-
 	builder := sdk.NewConnectionBuilder().
 		Client(ocmClientID, "").
-		Tokens(initialToken).
-		Logger(l)
+		Tokens(initialToken)
+
+	if o.Ocm.EnableLogger {
+		l, err := sdk.NewGlogLoggerBuilder().Build()
+		if err != nil {
+			return nil, fmt.Errorf("creating Glog logger: %w", err)
+		}
+		builder.Logger(l)
+	}
 
 	// Check if the connection can be established and tokens can be retrieved.
 	conn, err := builder.Build()


### PR DESCRIPTION
## Description

The OCM logger creates a lot of noise, especially on CLI environments.
This PR disables the OCM logger by default.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary

## Test manual

 - CI
 - Compile fleet-manager and connect to OCM
