### PR TITLE
ROX-16161: Change the AWS authentication method in Fleetshard Sync

### DIFF
--- a/dev/env/manifests/fleetshard-sync/01-fleetshard-sync-secrets.yaml
+++ b/dev/env/manifests/fleetshard-sync/01-fleetshard-sync-secrets.yaml
@@ -9,3 +9,4 @@ stringData:
   rhsso-service-account-client-id: "${RHSSO_SERVICE_ACCOUNT_CLIENT_ID}"
   rhsso-service-account-client-secret: "${RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET}"
   aws-role-arn: "${AWS_ROLE_ARN}"
+  aws-token: "${AWS_STATIC_TOKEN}"

--- a/dev/env/manifests/fleetshard-sync/02-fleetshard-sync-deployment.yaml
+++ b/dev/env/manifests/fleetshard-sync/02-fleetshard-sync-deployment.yaml
@@ -56,7 +56,6 @@ spec:
                 secretKeyRef:
                   name: fleetshard-sync
                   key: "aws-role-arn"
-
           image: "${FLEET_MANAGER_IMAGE}"
           imagePullPolicy: IfNotPresent
           name: fleetshard-sync
@@ -66,6 +65,8 @@ spec:
               name: secrets
             - mountPath: /config
               name: config
+            - mountPath: /var/run/secrets/tokens
+              name: aws-token
       restartPolicy: Always
       volumes:
         - name: secrets
@@ -75,3 +76,9 @@ spec:
         - name: config
           configMap:
             name: config
+        - name: aws-token
+          secret:
+            secretName: fleetshard-sync # pragma: allowlist secret
+            items:
+              - key: aws-token
+                path: aws-token

--- a/dev/env/scripts/exec_fleetshard_sync.sh
+++ b/dev/env/scripts/exec_fleetshard_sync.sh
@@ -22,10 +22,10 @@ init_chamber
 
 CLUSTER_NAME="cluster-acs-dev-dp-01"
 
-ARGS="CLUSTER_ID=$(run_chamber read ${CLUSTER_NAME} ID -q -b ssm) \
-    MANAGED_DB_SECURITY_GROUP=$(run_chamber read ${CLUSTER_NAME} MANAGED_DB_SECURITY_GROUP -q -b ssm) \
-    MANAGED_DB_SUBNET_GROUP=$(run_chamber read ${CLUSTER_NAME} MANAGED_DB_SUBNET_GROUP -q -b ssm) \
-    AWS_ROLE_ARN=$(run_chamber read fleetshard-sync AWS_ROLE_ARN -q -b ssm) \
+ARGS="CLUSTER_ID=${CLUSTER_ID:-$(run_chamber read ${CLUSTER_NAME} ID -q -b ssm)} \
+    MANAGED_DB_SECURITY_GROUP=${MANAGED_DB_SECURITY_GROUP:-$(run_chamber read ${CLUSTER_NAME} MANAGED_DB_SECURITY_GROUP -q -b ssm)} \
+    MANAGED_DB_SUBNET_GROUP=${MANAGED_DB_SUBNET_GROUP:-$(run_chamber read ${CLUSTER_NAME} MANAGED_DB_SUBNET_GROUP -q -b ssm)} \
+    AWS_ROLE_ARN=${FLEETSHARD_SYNC_AWS_ROLE_ARN:-$(run_chamber read fleetshard-sync AWS_ROLE_ARN -q -b ssm)} \
     $ARGS"
 
 run_chamber exec fleetshard-sync -b secretsmanager -- sh -c "$ARGS"

--- a/docs/development/setup-aws-idp-on-osd.md
+++ b/docs/development/setup-aws-idp-on-osd.md
@@ -1,0 +1,70 @@
+# Authenticate ACSCS services on AWS using OSD cluster Identity Provider
+
+## Overview
+The goal is to authenticate ACSCS applications (pods) to AWS. The recommended approach is to use STS so that each application assumes an IAM role with policies describing what that application is allowed to do.
+Every Openshift cluster (OCP) has a built-in OAuth server that is used to authenticate service accounts within the cluster. OSD is no exception. This document describes how to add an Identity Provider to the AWS IAM configuration to use the OAuth server to authenticate ACSCS pods to AWS.
+
+## Implementation
+In scope are the environments that run on OSD clusters, namely _stage_ and _prod_. Engineers may want to set up their own OSD cluster to make experiments. The setup procedure is described  [below](#manual-setup-dev).
+The main idea is the following: The OAuth server has been added to the AWS IAM configuration as an Identity Provider. Each cluster has its own server, so each must be declared in the AWS IAM configuration. AWS has a limit of 100 identity providers per account [1].
+The complication is that server is not reachable from AWS STS, therefore, it couldn't load the public keys to verify a JWT token. The recommended approach is to expose OAuth server's public keys in a **public** S3 bucket [2].
+
+S3 bucket name has the following pattern: `<osdClusterName>-<randomAlphanumeric>-oidc`
+- `osdClusterName` is to identify the cluster associated with this bucket
+- `randomAlphanumeric` - 32-character random string to ensure uniqueness of the S3 bucket
+- `oidc` suffix is chosen to indicate that bucket corresponds to an OAuth server. This suffix also corresponds to the pattern used in the `ccoctl` tool [3].
+
+## Manual setup (dev)
+> ❗️This instruction is intended only for OSD clusters. For local clusters, it is recommended to use the OCM token for authentication.
+
+1. Prepare the environment
+    ```shell
+    ENVIRONMENT=dev
+    AWS_REGION=us-east-1
+    GITROOT=$(git rev-parse --show-toplevel)
+    CLUSTER_ID="<ID of the cluster>"
+    CLUSTER_NAME="<name of the cluster>"
+    IDP_NAME="${CLUSTER_NAME}-${CLUSTER_ID}"
+    OUTPUT_DIR="${IDP_NAME}"
+    cd $GITROOT/tmp
+    mkdir $OUTPUT_DIR
+    ```
+1. Login into the osd cluster
+    ```shell
+    ocm cluster login $CLUSTER_ID
+    # follow instructions to login
+    ```
+1. Retrieve a public key from the cluster
+    ```shell
+    oc get configmap --namespace openshift-kube-apiserver bound-sa-token-signing-certs --output json | jq --raw-output '.data["service-account-001.pub"]' > "${OUTPUT_DIR}/serviceaccount-signer.public"
+    ```
+1. Authenticate in AWS
+    ```saml
+    make -C $GITROOT $GITROOT/bin/tools_venv
+    source $GITROOT/bin/tools_venv/bin/activate
+    aws-saml.py
+    ```
+1. Create an Identity Provider
+    ```shell
+    ccoctl aws create-identity-provider --output-dir $OUTPUT_DIR --name $IDP_NAME --region $AWS_REGION
+    ```
+1. Change the cluster authentication
+    ```shell
+    oc apply -f ./dev-dp-idp/manifests/cluster-authentication-02-config.yaml
+    ```
+1. Make sure that the cluster authentication has an appropriate url pointing to the S3 bucket
+    ```shell
+    oc get authentication -o yaml
+    ```
+
+## Tear down
+```shell
+ccoctl aws delete --name $IDP_NAME --region $AWS_REGION
+deactivate
+```
+
+## Links
+1. https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html
+1. https://github.com/openshift/enhancements/blob/master/enhancements/cloud-integration/aws/aws-pod-identity.md
+1. https://github.com/openshift/cloud-credential-operator/blob/master/docs/ccoctl.md
+1. https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/authentication_and_authorization/index#bound-sa-tokens-about_bound-service-account-tokens

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -80,6 +80,16 @@ spec:
           value: {{ .Values.fleetshardSync.telemetry.storage.endpoint | quote }}
         - name: TELEMETRY_STORAGE_KEY
           value: {{ .Values.fleetshardSync.telemetry.storage.key | quote }}
+        volumeMounts:
+          - mountPath: /var/run/secrets/tokens
+            name: aws-token
         ports:
         - name: monitoring
           containerPort: 8080
+      volumes:
+        - name: aws-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: aws-token
+                  audience: sts.amazonaws.com

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -36,8 +36,9 @@ type Config struct {
 
 // AWS for configuring AWS specific parameters
 type AWS struct {
-	Region  string `env:"AWS_REGION" envDefault:"us-east-1"`
-	RoleARN string `env:"AWS_ROLE_ARN"`
+	Region    string `env:"AWS_REGION" envDefault:"us-east-1"`
+	RoleARN   string `env:"AWS_ROLE_ARN"`
+	TokenFile string `env:"AWS_STS_TOKEN_FILE" envDefault:"/var/run/secrets/tokens/aws-token"`
 }
 
 // ManagedDB for configuring managed DB specific parameters

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"embed"
 	"fmt"
-	"net/http"
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
-	"github.com/aws/aws-sdk-go/service/sts"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	openshiftRouteV1 "github.com/openshift/api/route/v1"
 	"github.com/pkg/errors"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/config"
@@ -23,7 +22,6 @@ import (
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/util"
 	centralConstants "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
-	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
 	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -203,8 +201,7 @@ func TestReconcileCreateWithManagedDBNoCredentials(t *testing.T) {
 				SecurityGroup: "security-group",
 				SubnetGroup:   "db-group",
 			},
-		},
-		&fakeAuth{})
+		})
 	require.NoError(t, err)
 
 	r := NewCentralReconciler(fakeClient, private.ManagedCentral{}, managedDBProvisioningClient, centralDBInitFunc,
@@ -214,11 +211,9 @@ func TestReconcileCreateWithManagedDBNoCredentials(t *testing.T) {
 		})
 
 	_, err = r.Reconcile(context.TODO(), simpleManagedCentral)
-	var awsErr, awsOrigErr awserr.Error
+	var awsErr awserr.Error
 	require.ErrorAs(t, err, &awsErr)
-	assert.Equal(t, awsErr.Code(), stscreds.ErrCodeWebIdentity)
-	require.ErrorAs(t, awsErr.OrigErr(), &awsOrigErr)
-	assert.Equal(t, awsOrigErr.Code(), sts.ErrCodeInvalidIdentityTokenException)
+	assert.Equal(t, stscreds.ErrCodeWebIdentity, awsErr.Code())
 }
 
 func TestReconcileUpdateSucceeds(t *testing.T) {
@@ -697,18 +692,6 @@ func TestNoRoutesSentWhenOneNotCreatedYet(t *testing.T) {
 
 func centralDeploymentObject() *appsv1.Deployment {
 	return testutils.NewCentralDeployment(centralNamespace)
-}
-
-var _ fleetmanager.Auth = &fakeAuth{}
-
-type fakeAuth struct{}
-
-func (*fakeAuth) AddAuth(_ *http.Request) error {
-	return nil
-}
-
-func (*fakeAuth) RetrieveIDToken() (string, error) {
-	return "fake.token", nil // minimum field size of 20
 }
 
 func TestTelemetryOptionsAreSetInCR(t *testing.T) {

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -54,7 +54,7 @@ type Runtime struct {
 
 // NewRuntime creates a new runtime
 func NewRuntime(config *config.Config, k8sClient ctrlClient.Client) (*Runtime, error) {
-	auth, err := fleetmanager.NewAuth(config.AuthType, fleetmanager.Option{
+	authOption := fleetmanager.Option{
 		Sso: fleetmanager.RHSSOOption{
 			ClientID:     config.RHSSOClientID,
 			ClientSecret: config.RHSSOClientSecret, // pragma: allowlist secret
@@ -67,7 +67,8 @@ func NewRuntime(config *config.Config, k8sClient ctrlClient.Client) (*Runtime, e
 		Static: fleetmanager.StaticOption{
 			StaticToken: config.StaticToken,
 		},
-	})
+	}
+	auth, err := fleetmanager.NewAuth(config.AuthType, authOption)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create fleet manager authentication")
 	}
@@ -79,7 +80,7 @@ func NewRuntime(config *config.Config, k8sClient ctrlClient.Client) (*Runtime, e
 	}
 	var dbProvisionClient cloudprovider.DBClient
 	if config.ManagedDB.Enabled {
-		dbProvisionClient, err = awsclient.NewRDSClient(config, auth)
+		dbProvisionClient, err = awsclient.NewRDSClient(config)
 		if err != nil {
 			return nil, fmt.Errorf("creating managed DB provisioning client: %v", err)
 		}

--- a/pkg/client/fleetmanager/auth.go
+++ b/pkg/client/fleetmanager/auth.go
@@ -8,19 +8,14 @@ import (
 	"strings"
 
 	"github.com/caarlos0/env/v6"
-	"github.com/stackrox/rox/pkg/utils"
-
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/utils"
 )
 
 // Auth will handle adding authentication information to HTTP requests.
 type Auth interface {
 	// AddAuth will add authentication information to the request, e.g. in the form of the Authorization header.
 	AddAuth(req *http.Request) error
-
-	// RetrieveIDToken will return the ID token, if available.
-	// If the ID token cannot be retrieved, an error will be returned.
-	RetrieveIDToken() (string, error)
 }
 
 type authFactory interface {

--- a/pkg/client/fleetmanager/auth_ocm.go
+++ b/pkg/client/fleetmanager/auth_ocm.go
@@ -78,14 +78,3 @@ func (o *ocmAuth) AddAuth(req *http.Request) error {
 	setBearer(req, access)
 	return nil
 }
-
-func (o *ocmAuth) RetrieveIDToken() (string, error) {
-	// Our internal definition of the ID token is to have a `aud` claim set.
-	// The OCM bearer token, by default, has the `aud` claim set, hence we can just return it here.
-	access, _, err := o.conn.Tokens(ocmTokenExpirationMargin)
-	if err != nil {
-		return "", errors.Wrap(err, "retrieving access token via OCM auth type")
-	}
-
-	return access, nil
-}

--- a/pkg/client/fleetmanager/auth_rhsso.go
+++ b/pkg/client/fleetmanager/auth_rhsso.go
@@ -61,20 +61,3 @@ func (r *rhSSOAuth) AddAuth(req *http.Request) error {
 	setBearer(req, token.AccessToken)
 	return nil
 }
-
-func (r *rhSSOAuth) RetrieveIDToken() (string, error) {
-	t, err := r.tokenSource.Token()
-	if err != nil {
-		return "", errors.Wrap(err, "retrieving token from token source")
-	}
-
-	idTokenRaw := t.Extra("id_token")
-	if idTokenRaw == nil {
-		return "", errors.New("no ID token could be retrieved")
-	}
-	idToken, ok := idTokenRaw.(string)
-	if !ok {
-		return "", errors.New("ID token was in an unsupported format")
-	}
-	return idToken, nil
-}

--- a/pkg/client/fleetmanager/auth_static_token.go
+++ b/pkg/client/fleetmanager/auth_static_token.go
@@ -43,9 +43,3 @@ func (s *staticTokenAuth) AddAuth(req *http.Request) error {
 	setBearer(req, s.token)
 	return nil
 }
-
-func (s *staticTokenAuth) RetrieveIDToken() (string, error) {
-	// Since we plan to minimize the usage of the static token auth type, potentially removing it going forward,
-	// we skip implementing the `id_token` interface for it.
-	return "", errors.New("retrieving ID tokens using the static token auth type is currently not supported")
-}


### PR DESCRIPTION
## Description
This PR changes the authentication method in AWS for Fleetshard Sync from RHSSO to Service Account tokens issued by the OAuth Server built-in to the Data Plane cluster. This will allow to grant more granular permission to apps, be independent from RHSSO and use STS for another apps, where we don't want to use IAM User access keys (like cloudwatch-exporter).

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
