### PR TITLE
ROX-15980 set resource requests and limits to the egress-proxy

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -227,19 +227,20 @@ var _ = Describe("Central", func() {
 			}
 		})
 
-		It("should spin up an egress proxy with one healthy replica", func() {
+		It("should spin up an egress proxy with three healthy replica", func() {
 			if createdCentral == nil {
 				Fail("central not created")
 			}
+			var expected int32 = 3
 			Eventually(func() error {
 				var egressProxyDeployment appsv1.Deployment
 				key := ctrlClient.ObjectKey{Namespace: namespaceName, Name: "egress-proxy"}
 				if err := k8sClient.Get(context.TODO(), key, &egressProxyDeployment); err != nil {
 					return err
 				}
-				if egressProxyDeployment.Status.ReadyReplicas < 1 {
+				if egressProxyDeployment.Status.ReadyReplicas < expected {
 					statusBytes, _ := yaml.Marshal(&egressProxyDeployment.Status)
-					return fmt.Errorf("egress proxy only has %d/%d ready replicas (and %d unavailable ones), expected 1. full status: %s", egressProxyDeployment.Status.ReadyReplicas, egressProxyDeployment.Status.Replicas, egressProxyDeployment.Status.UnavailableReplicas, statusBytes)
+					return fmt.Errorf("egress proxy only has %d/%d ready replicas (and %d unavailable ones), expected %d. full status: %s", egressProxyDeployment.Status.ReadyReplicas, egressProxyDeployment.Status.Replicas, egressProxyDeployment.Status.UnavailableReplicas, expected, statusBytes)
 				}
 				return nil
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Succeed())

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -227,7 +227,7 @@ var _ = Describe("Central", func() {
 			}
 		})
 
-		It("should spin up an egress proxy with three healthy replica", func() {
+		It("should spin up an egress proxy with three healthy replicas", func() {
 			if createdCentral == nil {
 				Fail("central not created")
 			}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -227,7 +227,7 @@ var _ = Describe("Central", func() {
 			}
 		})
 
-		It("should spin up an egress proxy with two healthy replicas", func() {
+		It("should spin up an egress proxy with one healthy replica", func() {
 			if createdCentral == nil {
 				Fail("central not created")
 			}
@@ -237,9 +237,9 @@ var _ = Describe("Central", func() {
 				if err := k8sClient.Get(context.TODO(), key, &egressProxyDeployment); err != nil {
 					return err
 				}
-				if egressProxyDeployment.Status.ReadyReplicas < 2 {
+				if egressProxyDeployment.Status.ReadyReplicas < 1 {
 					statusBytes, _ := yaml.Marshal(&egressProxyDeployment.Status)
-					return fmt.Errorf("egress proxy only has %d/%d ready replicas (and %d unavailable ones), expected 2. full status: %s", egressProxyDeployment.Status.ReadyReplicas, egressProxyDeployment.Status.Replicas, egressProxyDeployment.Status.UnavailableReplicas, statusBytes)
+					return fmt.Errorf("egress proxy only has %d/%d ready replicas (and %d unavailable ones), expected 1. full status: %s", egressProxyDeployment.Status.ReadyReplicas, egressProxyDeployment.Status.Replicas, egressProxyDeployment.Status.UnavailableReplicas, statusBytes)
 				}
 				return nil
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Succeed())

--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
@@ -32,6 +32,15 @@ spec:
       annotations:
         config-hash: {{ .Files.Get "config/squid.conf" | sha256sum | quote }}
     spec:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+              - egress-proxy
+          topologyKey: kubernetes.io/hostname
       containers:
       - name: egress-proxy
         image: {{ .Values.egressProxy.image }}

--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
@@ -49,6 +49,13 @@ spec:
           mountPath: /etc/squid/squid.conf
           subPath: squid.conf
           readOnly: true
+        resources:
+          limits:
+            cpu: {{ .Values.egressProxy.resources.limits.cpu }}
+            memory: {{ .Values.egressProxy.resources.limits.memory }}
+          requests:
+            cpu: {{ .Values.egressProxy.resources.requests.cpu }}
+            memory: {{ .Values.egressProxy.resources.requests.memory }}
       volumes:
       - name: config-volume
         configMap:

--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
@@ -51,11 +51,11 @@ spec:
           readOnly: true
         resources:
           limits:
-            cpu: {{ .Values.egressProxy.resources.limits.cpu }}
-            memory: {{ .Values.egressProxy.resources.limits.memory }}
+            cpu: {{ .Values.egressProxy.resources.limits.cpu | quote }}
+            memory: {{ .Values.egressProxy.resources.limits.memory | quote }}
           requests:
-            cpu: {{ .Values.egressProxy.resources.requests.cpu }}
-            memory: {{ .Values.egressProxy.resources.requests.memory }}
+            cpu: {{ .Values.egressProxy.resources.requests.cpu | quote }}
+            memory: {{ .Values.egressProxy.resources.requests.memory | quote }}
       volumes:
       - name: config-volume
         configMap:

--- a/fleetshard/pkg/central/charts/data/tenant-resources/values.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/values.yaml
@@ -2,6 +2,13 @@
 egressProxy:
   image: ubuntu/squid:5.2-22.04_beta
   replicas: 2
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 200m
+      memory: 256Mi
 
 labels: {}
 annotations: {}

--- a/fleetshard/pkg/central/charts/data/tenant-resources/values.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/values.yaml
@@ -1,6 +1,6 @@
 egressProxy:
   image: ubuntu/squid:5.2-22.04_beta
-  replicas: 1
+  replicas: 3
   resources:
     requests:
       cpu: 100m

--- a/fleetshard/pkg/central/charts/data/tenant-resources/values.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/values.yaml
@@ -1,7 +1,6 @@
-
 egressProxy:
   image: ubuntu/squid:5.2-22.04_beta
-  replicas: 2
+  replicas: 1
   resources:
     limits:
       cpu: 100m
@@ -9,6 +8,5 @@ egressProxy:
     requests:
       cpu: 200m
       memory: 256Mi
-
 labels: {}
 annotations: {}

--- a/fleetshard/pkg/central/charts/data/tenant-resources/values.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/values.yaml
@@ -2,10 +2,10 @@ egressProxy:
   image: ubuntu/squid:5.2-22.04_beta
   replicas: 1
   resources:
-    limits:
+    requests:
       cpu: 100m
       memory: 128Mi
-    requests:
+    limits:
       cpu: 200m
       memory: 256Mi
 labels: {}

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -937,7 +937,7 @@ func (r *CentralReconciler) chartValues(remoteCentral private.ManagedCentral) (c
 		return nil, errors.New("resources chart is not set")
 	}
 	src := r.resourcesChart.Values
-	var dst = map[string]interface{}{
+	dst := map[string]interface{}{
 		"labels": map[string]interface{}{
 			k8s.ManagedByLabelKey: k8s.ManagedByFleetshardValue,
 		},

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -933,18 +933,17 @@ func (r *CentralReconciler) ensureRouteDeleted(ctx context.Context, routeSupplie
 }
 
 func (r *CentralReconciler) chartValues(remoteCentral private.ManagedCentral) (chartutil.Values, error) {
-	vals := chartutil.Values{
-		"labels": map[string]interface{}{
-			k8s.ManagedByLabelKey: k8s.ManagedByFleetshardValue,
-		},
+	vals := r.resourcesChart.Values
+	vals["labels"] = map[string]interface{}{
+		k8s.ManagedByLabelKey: k8s.ManagedByFleetshardValue,
 	}
 	if r.egressProxyImage != "" {
-		override := chartutil.Values{
-			"egressProxy": chartutil.Values{
+		override := map[string]interface{}{
+			"egressProxy": map[string]interface{}{
 				"image": r.egressProxyImage,
 			},
 		}
-		vals = chartutil.CoalesceTables(vals, override)
+		vals = chartutil.CoalesceTables(override, vals)
 	}
 
 	return vals, nil

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -933,20 +933,21 @@ func (r *CentralReconciler) ensureRouteDeleted(ctx context.Context, routeSupplie
 }
 
 func (r *CentralReconciler) chartValues(remoteCentral private.ManagedCentral) (chartutil.Values, error) {
-	vals := r.resourcesChart.Values
-	vals["labels"] = map[string]interface{}{
-		k8s.ManagedByLabelKey: k8s.ManagedByFleetshardValue,
+	if r.resourcesChart == nil {
+		return nil, errors.New("resources chart is not set")
+	}
+	src := r.resourcesChart.Values
+	var dst = map[string]interface{}{
+		"labels": map[string]interface{}{
+			k8s.ManagedByLabelKey: k8s.ManagedByFleetshardValue,
+		},
 	}
 	if r.egressProxyImage != "" {
-		override := map[string]interface{}{
-			"egressProxy": map[string]interface{}{
-				"image": r.egressProxyImage,
-			},
+		dst["egressProxy"] = map[string]interface{}{
+			"image": r.egressProxyImage,
 		}
-		vals = chartutil.CoalesceTables(override, vals)
 	}
-
-	return vals, nil
+	return chartutil.CoalesceTables(dst, src), nil
 }
 
 func (r *CentralReconciler) shouldSkipReadyCentral(remoteCentral private.ManagedCentral) bool {


### PR DESCRIPTION
Sets the resource requests and limits for the egress-proxy.

The values were derived from the observed metrics on prometheus/grafana. These resource defaults are a bit overkill for the actual observed usage. I was not comfortable putting less than this for a production deployment. 

It also seems like the `values.yaml` file was ignored for the `tenant-resources`. This PR also adds changes to use these values by default and apply overrides on top of them. 

The current cluster configuration deploys 1 replica of the `egress-proxy`, so I've changed the value to reflect that as well. 