### PR TITLE
ROX-15980 probe resource requests and limits

### DIFF
--- a/deploy/helm/probe/templates/01-operator-04-deployment.yaml
+++ b/deploy/helm/probe/templates/01-operator-04-deployment.yaml
@@ -55,4 +55,11 @@ spec:
           ports:
             - name: monitoring
               containerPort: 7070
+          resources:
+            requests:
+              cpu: {{ .Values.resources.requests.cpu | quote }}
+              memory: {{ .Values.resources.requests.memory | quote }}
+            limits:
+              cpu: {{ .Values.resources.limits.cpu | quote }}
+              memory: {{ .Values.resources.limits.memory | quote }}
       terminationGracePeriodSeconds: 300

--- a/deploy/helm/probe/values.yaml
+++ b/deploy/helm/probe/values.yaml
@@ -16,3 +16,10 @@ redHatSSO:
   clientSecret: ""
   endpoint: "https://sso.redhat.com"
   realm: "redhat-external"
+resources:
+  limits:
+    cpu: "100m"
+    memory: "128Mi"
+  requests:
+    cpu: "100m"
+    memory: "128Mi"


### PR DESCRIPTION
Sets the resource requests and limits for `probe`

The values were derived from the observed metrics on prometheus/grafana. These resource defaults are a bit overkill for the actual observed usage. I was not comfortable putting less than this for a production deployment.