### PR TITLE
ROX-15980 observability resource requests and limits

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
@@ -44,6 +44,41 @@ spec:
           values:
             - rhacs
             - strimzi
+    alertManagerResourceRequirement:
+      requests:
+        cpu: {{ .Values.alertManager.resources.cpu.requests | quote }}
+        memory: {{ .Values.alertManager.resources.memory.requests | quote }}
+      limits:
+        cpu: {{ .Values.alertManager.resources.cpu.limits | quote }}
+        memory: {{ .Values.alertManager.resources.memory.limits | quote }}
+    prometheusResourceRequirement:
+      requests:
+        cpu: {{ .Values.prometheus.resources.cpu.requests | quote }}
+        memory: {{ .Values.prometheus.resources.memory.requests | quote }}
+      limits:
+        cpu: {{ .Values.prometheus.resources.cpu.limits | quote }}
+        memory: {{ .Values.prometheus.resources.memory.limits | quote }}
+    prometheusOperatorResourceRequirement:
+      requests:
+        cpu: {{ .Values.prometheusOperator.resources.cpu.requests | quote }}
+        memory: {{ .Values.prometheusOperator.resources.memory.requests | quote }}
+      limits:
+        cpu: {{ .Values.prometheusOperator.resources.cpu.limits | quote }}
+        memory: {{ .Values.prometheusOperator.resources.memory.limits | quote }}
+    grafanaResourceRequirement:
+      requests:
+        cpu: {{ .Values.grafana.resources.cpu.requests | quote }}
+        memory: {{ .Values.grafana.resources.memory.requests | quote }}
+      limits:
+        cpu: {{ .Values.grafana.resources.cpu.limits | quote }}
+        memory: {{ .Values.grafana.resources.memory.limits | quote }}
+    grafanaOperatorResourceRequirement:
+      requests:
+        cpu: {{ .Values.grafanaOperator.resources.cpu.requests | quote }}
+        memory: {{ .Values.grafanaOperator.resources.memory.requests | quote }}
+      limits:
+        cpu: {{ .Values.grafanaOperator.resources.cpu.limits | quote }}
+        memory: {{ .Values.grafanaOperator.resources.memory.limits | quote }}
   storage:
     prometheus:
       volumeClaimTemplate:

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
@@ -46,39 +46,39 @@ spec:
             - strimzi
     alertManagerResourceRequirement:
       requests:
-        cpu: {{ .Values.alertManager.resources.cpu.requests | quote }}
-        memory: {{ .Values.alertManager.resources.memory.requests | quote }}
+        cpu: {{ .Values.alertManager.resources.requests.cpu | quote }}
+        memory: {{ .Values.alertManager.resources.requests.memory | quote }}
       limits:
-        cpu: {{ .Values.alertManager.resources.cpu.limits | quote }}
-        memory: {{ .Values.alertManager.resources.memory.limits | quote }}
+        cpu: {{ .Values.alertManager.resources.limits.cpu | quote }}
+        memory: {{ .Values.alertManager.resources.limits.memory | quote }}
     prometheusResourceRequirement:
       requests:
-        cpu: {{ .Values.prometheus.resources.cpu.requests | quote }}
-        memory: {{ .Values.prometheus.resources.memory.requests | quote }}
+        cpu: {{ .Values.prometheus.resources.requests.cpu | quote }}
+        memory: {{ .Values.prometheus.resources.requests.memory | quote }}
       limits:
-        cpu: {{ .Values.prometheus.resources.cpu.limits | quote }}
-        memory: {{ .Values.prometheus.resources.memory.limits | quote }}
+        cpu: {{ .Values.prometheus.resources.limits.cpu | quote }}
+        memory: {{ .Values.prometheus.resources.limits.memory | quote }}
     prometheusOperatorResourceRequirement:
       requests:
-        cpu: {{ .Values.prometheusOperator.resources.cpu.requests | quote }}
-        memory: {{ .Values.prometheusOperator.resources.memory.requests | quote }}
+        cpu: {{ .Values.prometheusOperator.resources.requests.cpu | quote }}
+        memory: {{ .Values.prometheusOperator.resources.requests.memory | quote }}
       limits:
-        cpu: {{ .Values.prometheusOperator.resources.cpu.limits | quote }}
-        memory: {{ .Values.prometheusOperator.resources.memory.limits | quote }}
+        cpu: {{ .Values.prometheusOperator.resources.limits.cpu | quote }}
+        memory: {{ .Values.prometheusOperator.resources.limits.memory | quote }}
     grafanaResourceRequirement:
       requests:
-        cpu: {{ .Values.grafana.resources.cpu.requests | quote }}
-        memory: {{ .Values.grafana.resources.memory.requests | quote }}
+        cpu: {{ .Values.grafana.resources.requests.cpu | quote }}
+        memory: {{ .Values.grafana.resources.requests.memory | quote }}
       limits:
-        cpu: {{ .Values.grafana.resources.cpu.limits | quote }}
-        memory: {{ .Values.grafana.resources.memory.limits | quote }}
+        cpu: {{ .Values.grafana.resources.limits.cpu | quote }}
+        memory: {{ .Values.grafana.resources.limits.memory | quote }}
     grafanaOperatorResourceRequirement:
       requests:
-        cpu: {{ .Values.grafanaOperator.resources.cpu.requests | quote }}
-        memory: {{ .Values.grafanaOperator.resources.memory.requests | quote }}
+        cpu: {{ .Values.grafanaOperator.resources.requests.cpu | quote }}
+        memory: {{ .Values.grafanaOperator.resources.requests.memory | quote }}
       limits:
-        cpu: {{ .Values.grafanaOperator.resources.cpu.limits | quote }}
-        memory: {{ .Values.grafanaOperator.resources.memory.limits | quote }}
+        cpu: {{ .Values.grafanaOperator.resources.limits.cpu | quote }}
+        memory: {{ .Values.grafanaOperator.resources.limits.memory | quote }}
   storage:
     prometheus:
       volumeClaimTemplate:

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
@@ -57,8 +57,8 @@ prometheusOperator:
 grafana:
   resources:
     requests:
-      cpu: 100m
-      memory: 512Mi
+      cpu: 500m
+      memory: 1024Mi
     limits:
       cpu: 500m
       memory: 1024Mi
@@ -66,10 +66,10 @@ grafana:
 grafanaOperator:
   resources:
     requests:
-      cpu: 100m
+      cpu: 200m
       memory: 256Mi
     limits:
-      cpu: 500m
+      cpu: 200m
       memory: 256Mi
 
 alertManager:

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
@@ -35,3 +35,48 @@ pagerduty:
 deadMansSwitch:
   # Webhook URL of the dead man's switch provider.
   url: ""
+
+prometheus:
+  resources:
+    requests:
+      cpu: 1500m
+      memory: 18Gi
+    limits:
+      cpu: 1500m
+      memory: 18Gi
+
+prometheusOperator:
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
+grafana:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 1024Mi
+
+grafanaOperator:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
+alertManager:
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi


### PR DESCRIPTION
Sets the resource requests and limits for observability components

The values were derived from the observed metrics on prometheus/grafana. 