### PR TITLE
ROX-13692: create final snapshot for tenant db

### DIFF
--- a/.github/workflows/rds.yaml
+++ b/.github/workflows/rds.yaml
@@ -68,4 +68,4 @@ jobs:
           AWS_AUTH_HELPER: "none"
         run: |
           ./dev/env/scripts/exec_fleetshard_sync.sh make test/rds
-        timeout-minutes: 35
+        timeout-minutes: 50

--- a/.github/workflows/rds.yaml
+++ b/.github/workflows/rds.yaml
@@ -32,6 +32,7 @@ on:
       - 'docs/**'
       - 'pkg/api/openapi/docs/**'
       - 'pkg/api/openapi/.openapi-generator-ignore'
+      - 'dp-terraform/**'
 
 jobs:
   verify-test:

--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,7 @@ test: $(GOTESTSUM_BIN)
 # Runs the AWS RDS integration tests.
 test/rds: $(GOTESTSUM_BIN)
 	RUN_RDS_TESTS=true \
-	$(GOTESTSUM_BIN) --junitfile data/results/rds-integration-tests.xml --format $(GOTESTSUM_FORMAT) -- -p 1 -v -timeout 30m -count=1 \
+	$(GOTESTSUM_BIN) --junitfile data/results/rds-integration-tests.xml --format $(GOTESTSUM_FORMAT) -- -p 1 -v -timeout 45m -count=1 \
 		./fleetshard/pkg/central/cloudprovider/awsclient/...
 .PHONY: test/rds
 

--- a/dev/env/defaults/00-defaults.env
+++ b/dev/env/defaults/00-defaults.env
@@ -64,3 +64,4 @@ export RHACS_OPERATOR_RESOURCES_DEFAULTS='{"requests":{"cpu":"200m","memory":"30
 
 export ENABLE_EXTERNAL_CONFIG_DEFAULT=false
 export AWS_AUTH_HELPER_DEFAULT=""
+export WAIT_TIMEOUT="10m"

--- a/dev/env/defaults/00-defaults.env
+++ b/dev/env/defaults/00-defaults.env
@@ -64,4 +64,3 @@ export RHACS_OPERATOR_RESOURCES_DEFAULTS='{"requests":{"cpu":"200m","memory":"30
 
 export ENABLE_EXTERNAL_CONFIG_DEFAULT=false
 export AWS_AUTH_HELPER_DEFAULT=""
-export WAIT_TIMEOUT="10m"

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const awsTimeoutMinutes = 15
+const awsTimeoutMinutes = 30
 
 func newTestRDS() (*RDS, error) {
 	rdsClient, err := newTestRDSClient()

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -78,7 +78,7 @@ func waitForFinalSnapshotToExist(ctx context.Context, rdsClient *RDS, clusterID 
 
 			if err != nil {
 				if awsErr, ok := err.(awserr.Error); ok {
-					if awsErr.Code() != rds.ErrCodeDBClusterSnapshotNotFoundFault {
+					if awsErr.Code() != rds.ErrCodeDBSnapshotNotFoundFault {
 						return false, err
 					}
 

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -133,7 +133,9 @@ func TestRDSProvisioning(t *testing.T) {
 	assert.True(t, clusterDeleted)
 
 	// test that final snapshot was created
-	snapshotOut, err := rdsClient.rdsClient.DescribeDBSnapshots(&rds.DescribeDBSnapshotsInput{DBSnapshotIdentifier: aws.String(fmt.Sprintf("%s-%s", clusterID, "final"))})
+	snapshotOut, err := rdsClient.rdsClient.DescribeDBSnapshots(&rds.DescribeDBSnapshotsInput{
+		DBSnapshotIdentifier: aws.String(fmt.Sprintf("%s-%s", clusterID, "final")),
+	})
 	require.NoError(t, err)
 	require.NotNil(t, snapshotOut)
 	require.NotEmpty(t, snapshotOut.DBSnapshots)

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -136,6 +136,12 @@ func TestRDSProvisioning(t *testing.T) {
 	clusterDeleted, err := waitForClusterToBeDeleted(deleteCtx, rdsClient, clusterID)
 	require.NoError(t, err)
 	assert.True(t, clusterDeleted)
+
+	// test that final snapshot was created
+	snapshotOut, err := rdsClient.rdsClient.DescribeDBSnapshots(&rds.DescribeDBSnapshotsInput{DBSnapshotIdentifier: aws.String(fmt.Sprintf("%s-%s", clusterID, "final"))})
+	require.NoError(t, err)
+	require.NotNil(t, snapshotOut)
+	require.NotEmpty(t, snapshotOut.DBSnapshots)
 }
 
 func TestGetDBConnection(t *testing.T) {

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -72,13 +72,13 @@ func waitForFinalSnapshotToExist(ctx context.Context, rdsClient *RDS, clusterID 
 	for {
 		select {
 		case <-ticker.C:
-			snapshotOut, err := rdsClient.rdsClient.DescribeDBSnapshots(&rds.DescribeDBSnapshotsInput{
-				DBSnapshotIdentifier: aws.String(fmt.Sprintf("%s-%s", clusterID, "final")),
+			snapshotOut, err := rdsClient.rdsClient.DescribeDBClusterSnapshots(&rds.DescribeDBClusterSnapshotsInput{
+				DBClusterSnapshotIdentifier: aws.String(fmt.Sprintf("%s-%s", clusterID, "final")),
 			})
 
 			if err != nil {
 				if awsErr, ok := err.(awserr.Error); ok {
-					if awsErr.Code() != rds.ErrCodeDBSnapshotNotFoundFault {
+					if awsErr.Code() != rds.ErrCodeDBClusterSnapshotNotFoundFault {
 						return false, err
 					}
 
@@ -87,7 +87,7 @@ func waitForFinalSnapshotToExist(ctx context.Context, rdsClient *RDS, clusterID 
 			}
 
 			if snapshotOut != nil {
-				return len(snapshotOut.DBSnapshots) == 1, nil
+				return len(snapshotOut.DBClusterSnapshots) == 1, nil
 			}
 		case <-ctx.Done():
 			return false, fmt.Errorf("waiting for final DB snapshot: %w", ctx.Err())

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -163,7 +163,15 @@ func TestRDSProvisioning(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, clusterDeleted)
 
-	// test that final snapshot was created
+	// Always attemt to delete the final snapshot if it exists
+	defer func() {
+		_, err := rdsClient.rdsClient.DeleteDBClusterSnapshot(
+			&rds.DeleteDBClusterSnapshotInput{DBClusterSnapshotIdentifier: getFinalSnapshotID(clusterID)},
+		)
+
+		assert.NoError(t, err)
+	}()
+
 	snapshotExists, err := waitForFinalSnapshotToExist(deleteCtx, rdsClient, clusterID)
 	require.NoError(t, err)
 	require.True(t, snapshotExists)

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -47,17 +47,12 @@ func newTestRDSClient() (*rds.RDS, error) {
 
 func waitForClusterToBeDeleted(ctx context.Context, rdsClient *RDS, clusterID string) (bool, error) {
 	for {
-		clusterExists, clusterStatus, err := rdsClient.clusterStatus(clusterID)
+		clusterExists, _, err := rdsClient.clusterStatus(clusterID)
 		if err != nil {
 			return false, err
 		}
 
 		if !clusterExists {
-			return true, nil
-		}
-
-		// exit early if cluster is marked as deleting
-		if clusterStatus == dbDeletingStatus {
 			return true, nil
 		}
 

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -73,7 +73,7 @@ func waitForFinalSnapshotToExist(ctx context.Context, rdsClient *RDS, clusterID 
 		select {
 		case <-ticker.C:
 			snapshotOut, err := rdsClient.rdsClient.DescribeDBClusterSnapshots(&rds.DescribeDBClusterSnapshotsInput{
-				DBClusterSnapshotIdentifier: aws.String(fmt.Sprintf("%s-%s", clusterID, "final")),
+				DBClusterSnapshotIdentifier: getFinalSnapshotID(clusterID),
 			})
 
 			if err != nil {


### PR DESCRIPTION
## Description
This PR changes the central tenant DB deletion for RDS so that it always creates a final snapshot this is required in order to restore the tenant in case it has been deleted accidentally by a customer, an engineer or an error in the code.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [x] Add secret to app-interface Vault or Secrets Manager if necessary

## Test manual

Adding test case and running rds tests locally and in CI.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
