### PR TITLE
ROX-16791: Increase route timeout to 10m to allow for longer operations

### DIFF
--- a/fleetshard/pkg/k8s/route.go
+++ b/fleetshard/pkg/k8s/route.go
@@ -19,6 +19,9 @@ const (
 	centralReencryptRouteName   = "managed-central-reencrypt"
 	centralPassthroughRouteName = "managed-central-passthrough"
 	centralTLSSecretName        = "central-tls" // pragma: allowlist secret
+
+	centralReencryptTimeoutAnnotationKey   = "router.openshift.io/haproxy.health.check.interval"
+	centralReencryptTimeoutAnnotationValue = "10m"
 )
 
 // ErrCentralTLSSecretNotFound returned when central-tls secret is not found during creation of the reencrypt route
@@ -120,9 +123,10 @@ func (s *RouteService) CreatePassthroughRoute(ctx context.Context, remoteCentral
 func (s *RouteService) createCentralRoute(ctx context.Context, name string, namespace string, host string, tls *openshiftRouteV1.TLSConfig) error {
 	route := &openshiftRouteV1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels:    map[string]string{ManagedByLabelKey: ManagedByFleetshardValue},
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      map[string]string{ManagedByLabelKey: ManagedByFleetshardValue},
+			Annotations: map[string]string{centralReencryptTimeoutAnnotationKey: centralReencryptTimeoutAnnotationValue},
 		},
 		Spec: openshiftRouteV1.RouteSpec{
 			Host: host,

--- a/fleetshard/pkg/k8s/route.go
+++ b/fleetshard/pkg/k8s/route.go
@@ -20,7 +20,7 @@ const (
 	centralPassthroughRouteName = "managed-central-passthrough"
 	centralTLSSecretName        = "central-tls" // pragma: allowlist secret
 
-	centralReencryptTimeoutAnnotationKey   = "router.openshift.io/haproxy.health.check.interval"
+	centralReencryptTimeoutAnnotationKey   = "haproxy.router.openshift.io/timeout"
 	centralReencryptTimeoutAnnotationValue = "10m"
 )
 

--- a/fleetshard/pkg/k8s/route.go
+++ b/fleetshard/pkg/k8s/route.go
@@ -97,6 +97,10 @@ func (s *RouteService) CreateReencryptRoute(ctx context.Context, remoteCentral p
 		return errors.Errorf("could not find centrals ca certificate 'ca.pem' in secret/%s", centralTLSSecretName)
 	}
 
+	annotations := map[string]string{
+		centralReencryptTimeoutAnnotationKey: centralReencryptTimeoutAnnotationValue,
+	}
+
 	return s.createCentralRoute(ctx,
 		centralReencryptRouteName,
 		remoteCentral.Metadata.Namespace,
@@ -106,7 +110,8 @@ func (s *RouteService) CreateReencryptRoute(ctx context.Context, remoteCentral p
 			Key:                      remoteCentral.Spec.UiEndpoint.Tls.Key,
 			Certificate:              remoteCentral.Spec.UiEndpoint.Tls.Cert,
 			DestinationCACertificate: string(centralCA),
-		})
+		},
+		annotations)
 }
 
 // CreatePassthroughRoute creates a new managed central passthrough route.
@@ -117,16 +122,16 @@ func (s *RouteService) CreatePassthroughRoute(ctx context.Context, remoteCentral
 		remoteCentral.Spec.DataEndpoint.Host,
 		&openshiftRouteV1.TLSConfig{
 			Termination: openshiftRouteV1.TLSTerminationPassthrough,
-		})
+		}, nil)
 }
 
-func (s *RouteService) createCentralRoute(ctx context.Context, name string, namespace string, host string, tls *openshiftRouteV1.TLSConfig) error {
+func (s *RouteService) createCentralRoute(ctx context.Context, name, namespace, host string, tls *openshiftRouteV1.TLSConfig, annotations map[string]string) error {
 	route := &openshiftRouteV1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
 			Labels:      map[string]string{ManagedByLabelKey: ManagedByFleetshardValue},
-			Annotations: map[string]string{centralReencryptTimeoutAnnotationKey: centralReencryptTimeoutAnnotationValue},
+			Annotations: annotations,
 		},
 		Spec: openshiftRouteV1.RouteSpec{
 			Host: host,


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

https://issues.redhat.com/browse/ROX-16791

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary

## Test manual

Manually edited the route in staging
```
time curl 'https://<url>/api/graphql?opname=triggerScan' --data-raw $'{"operationName":"triggerScan","variables":{"clusterId":"*","standardId":"*"},"query":"mutation triggerScan($clusterId: ID\u0021, $standardId: ID\u0021) {\\n  complianceTriggerRuns(clusterId: $clusterId, standardId: $standardId) {\\n    id\\n    standardId\\n    clusterId\\n    state\\n    errorMessage\\n    __typename\\n  }\\n}\\n"}'   --compressed

real	5m56.838s
user	0m0.019s
sys	0m0.018s
```

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
