### PR TITLE
Add `sleep(6s)` before tracking central creation

### DIFF
--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -4,7 +4,6 @@ package handlers
 import (
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/stackrox/acs-fleet-manager/pkg/services/account"
 	corev1 "k8s.io/api/core/v1"
@@ -82,13 +81,7 @@ func (h adminCentralHandler) Create(w http.ResponseWriter, r *http.Request) {
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
 			svcErr := h.service.RegisterDinosaurJob(&convCentral)
-			h.telemetry.RegisterTenant(r.Context(), &convCentral)
-			go func() {
-				// This is to raise the chances for the group properties to
-				// be procesed by Segment:
-				time.Sleep(6 * time.Second)
-				h.telemetry.TrackCreationRequested(r.Context(), convCentral.ID, true, svcErr.AsError())
-			}()
+			h.telemetry.RegisterTenant(ctx, &convCentral, true, svcErr.AsError())
 
 			if svcErr != nil {
 				return nil, svcErr

--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -4,6 +4,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/stackrox/acs-fleet-manager/pkg/services/account"
 	corev1 "k8s.io/api/core/v1"
@@ -82,7 +83,13 @@ func (h adminCentralHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Action: func() (interface{}, *errors.ServiceError) {
 			svcErr := h.service.RegisterDinosaurJob(&convCentral)
 			h.telemetry.RegisterTenant(r.Context(), &convCentral)
-			h.telemetry.TrackCreationRequested(r.Context(), convCentral.ID, true, svcErr.AsError())
+			go func() {
+				// This is to raise the chances for the group properties to
+				// be procesed by Segment:
+				time.Sleep(6 * time.Second)
+				h.telemetry.TrackCreationRequested(r.Context(), convCentral.ID, true, svcErr.AsError())
+			}()
+
 			if svcErr != nil {
 				return nil, svcErr
 			}

--- a/internal/dinosaur/pkg/handlers/dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/dinosaur.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/stackrox/acs-fleet-manager/pkg/shared/utils/arrays"
 
@@ -93,7 +94,12 @@ func (h dinosaurHandler) Create(w http.ResponseWriter, r *http.Request) {
 			// Do not track centrals created from internal services.
 			if !convCentral.Internal {
 				h.telemetry.RegisterTenant(r.Context(), convCentral)
-				h.telemetry.TrackCreationRequested(r.Context(), convCentral.ID, false, svcErr.AsError())
+				go func() {
+					// This is to raise the chances for the group properties to
+					// be procesed by Segment:
+					time.Sleep(6 * time.Second)
+					h.telemetry.TrackCreationRequested(r.Context(), convCentral.ID, false, svcErr.AsError())
+				}()
 			}
 			if svcErr != nil {
 				return nil, svcErr

--- a/internal/dinosaur/pkg/handlers/dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/dinosaur.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/stackrox/acs-fleet-manager/pkg/shared/utils/arrays"
 
@@ -93,13 +92,7 @@ func (h dinosaurHandler) Create(w http.ResponseWriter, r *http.Request) {
 			svcErr := h.service.RegisterDinosaurJob(convCentral)
 			// Do not track centrals created from internal services.
 			if !convCentral.Internal {
-				h.telemetry.RegisterTenant(r.Context(), convCentral)
-				go func() {
-					// This is to raise the chances for the group properties to
-					// be procesed by Segment:
-					time.Sleep(6 * time.Second)
-					h.telemetry.TrackCreationRequested(r.Context(), convCentral.ID, false, svcErr.AsError())
-				}()
+				h.telemetry.RegisterTenant(ctx, convCentral, false, svcErr.AsError())
 			}
 			if svcErr != nil {
 				return nil, svcErr

--- a/internal/dinosaur/pkg/services/telemetry.go
+++ b/internal/dinosaur/pkg/services/telemetry.go
@@ -120,6 +120,8 @@ func (t *Telemetry) trackCreationRequested(ctx context.Context, tenantID string,
 	)
 }
 
+// RegisterTenant initializes the tenant group with the associated properties
+// and issues a following event tracking the central creation request.
 func (t *Telemetry) RegisterTenant(ctx context.Context, convCentral *dbapi.CentralRequest, isAdmin bool, err error) {
 	t.setTenantProperties(ctx, convCentral)
 	go func() {

--- a/internal/dinosaur/pkg/services/telemetry_test.go
+++ b/internal/dinosaur/pkg/services/telemetry_test.go
@@ -22,7 +22,7 @@ func TestTelemetryTrackRequests(t *testing.T) {
 	ctx := context.Background()
 	tenantID := "tenant-id"
 	createFunc := func(t *Telemetry, tt testCase) {
-		t.TrackCreationRequested(ctx, tenantID, tt.isAdmin, tt.requestErr)
+		t.trackCreationRequested(ctx, tenantID, tt.isAdmin, tt.requestErr)
 	}
 	deleteFunc := func(t *Telemetry, tt testCase) {
 		t.TrackDeletionRequested(ctx, tenantID, tt.isAdmin, tt.requestErr)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Our Segment framework sends several group properties requests to raise chances for the following events to catch the group properties. Unfortunately, as this is done asynchronously, Fleet Manager didn't have a chance to get the properties.

The PR introduces a 6 seconds pause before issuing the central creation tracking event.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] ~Added test description under `Test manual`~
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [ ] ~CI and all relevant tests are passing~
- [ ] ~Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- [ ] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~
- [ ] ~Add secret to app-interface Vault or Secrets Manager if necessary~

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
