### PR TITLE
ROX-15954: Setup non-admin access to observability resources

### DIFF
--- a/dp-terraform/osd-cluster-idp-setup.sh
+++ b/dp-terraform/osd-cluster-idp-setup.sh
@@ -112,6 +112,52 @@ trap 'rm -f "${KUBECONFIG}"' EXIT
 echo "Logging into cluster ${CLUSTER_NAME}..."
 oc login "${CLUSTER_URL}" --token="${CLUSTER_TOKEN}"
 
+# This set of commands modifies OIDC provider to include "groups" claim mapping.
+CLUSTER_IDP_ID=$(ocm get /api/clusters_mgmt/v1/clusters/"$CLUSTER_ID"/identity_providers | jq '.items[0].id' | tr -d '"')
+tmpfile=$(mktemp /tmp/dataplane-idp-setup-tmp-patch-body.XXXXXX)
+cat <<END >"$tmpfile"
+{
+  "type": "OpenIDIdentityProvider",
+  "open_id": {
+    "claims": {
+      "email": [
+        "email"
+      ],
+      "groups": [
+        "groups"
+      ],
+      "name": [
+        "preferred_username"
+      ],
+      "preferred_username": [
+        "preferred_username"
+      ]
+    },
+    "client_id": "${OSD_OIDC_CLIENT_ID}",
+    "client_secret": "${OSD_OIDC_CLIENT_SECRET}",
+    "issuer": "https://auth.redhat.com/auth/realms/EmployeeIDP"
+  }
+}
+END
+ocm patch /api/clusters_mgmt/v1/clusters/"$CLUSTER_ID"/identity_providers/"$CLUSTER_IDP_ID" --body="$tmpfile"
+rm "$tmpfile"
+
+# This command grants access to all RH employees to access cluster monitoring.
+oc apply -f - <<END
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: acs-general-observability
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: Employee
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+END
+
 ROBOT_NS="acscs-dataplane-cd"
 ROBOT_SA="acscs-cd-robot"
 ROBOT_TOKEN_RESOURCE="robot-token"

--- a/dp-terraform/osd-cluster-idp-setup.sh
+++ b/dp-terraform/osd-cluster-idp-setup.sh
@@ -113,7 +113,7 @@ echo "Logging into cluster ${CLUSTER_NAME}..."
 oc login "${CLUSTER_URL}" --token="${CLUSTER_TOKEN}"
 
 # This set of commands modifies OIDC provider to include "groups" claim mapping.
-CLUSTER_IDP_ID=$(ocm get /api/clusters_mgmt/v1/clusters/"$CLUSTER_ID"/identity_providers | jq '.items[0].id' | tr -d '"')
+CLUSTER_IDP_ID=$(ocm get /api/clusters_mgmt/v1/clusters/"$CLUSTER_ID"/identity_providers | jq -r '.items[0].id')
 tmpfile=$(mktemp /tmp/dataplane-idp-setup-tmp-patch-body.XXXXXX)
 cat <<END >"$tmpfile"
 {


### PR DESCRIPTION
## Description
This PR adds commands necessary to give all RH employees access to our monitoring stack(Prometheus, Alertmanager, Grafana) in dataplane clusters.

All existing dataplane clusters are already updated, this PR is in case we would want to use new dataplane cluster.

Important limitation that we faced during work on this feature is that creating IdP via `ocm` command does not allow for `groups` claim mapping. Thus we patch IdP resource later in the setup via `ocm patch`.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary

## Test manual

1. All commands were used during modification of existing clusters
