### PR TITLE
fix e2e admin tests by reducing required resources

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -319,12 +319,12 @@ var _ = Describe("Central", func() {
 
 		centralResources := private.ResourceRequirements{
 			Requests: map[string]string{
-				corev1.ResourceCPU.String():    "501m",
-				corev1.ResourceMemory.String(): "201M",
+				corev1.ResourceCPU.String():    "210m",
+				corev1.ResourceMemory.String(): "210M",
 			},
 			Limits: map[string]string{
-				corev1.ResourceCPU.String():    "502m",
-				corev1.ResourceMemory.String(): "202M",
+				corev1.ResourceCPU.String():    "310m",
+				corev1.ResourceMemory.String(): "310M",
 			},
 		}
 		centralSpec := private.CentralSpec{
@@ -332,12 +332,12 @@ var _ = Describe("Central", func() {
 		}
 		scannerResources := private.ResourceRequirements{
 			Requests: map[string]string{
-				corev1.ResourceCPU.String():    "301m",
-				corev1.ResourceMemory.String(): "151M",
+				corev1.ResourceCPU.String():    "210m",
+				corev1.ResourceMemory.String(): "310M",
 			},
 			Limits: map[string]string{
-				corev1.ResourceCPU.String():    "302m",
-				corev1.ResourceMemory.String(): "152M",
+				corev1.ResourceCPU.String():    "211m",
+				corev1.ResourceMemory.String(): "311M",
 			},
 		}
 		scannerScaling := private.ScannerSpecAnalyzerScaling{
@@ -422,19 +422,19 @@ var _ = Describe("Central", func() {
 							corev1.ResourceMemory.String(): "199M",
 						},
 						Limits: map[string]string{
-							corev1.ResourceCPU.String(): "505m",
+							corev1.ResourceCPU.String(): "315m",
 						},
 					},
 				},
 			}
 			newCentralResources := corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("501m"),
+					corev1.ResourceCPU:    resource.MustParse("210m"),
 					corev1.ResourceMemory: resource.MustParse("199M"),
 				},
 				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("505m"),
-					corev1.ResourceMemory: resource.MustParse("202M"),
+					corev1.ResourceCPU:    resource.MustParse("315m"),
+					corev1.ResourceMemory: resource.MustParse("310M"),
 				},
 			}
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -320,11 +320,11 @@ var _ = Describe("Central", func() {
 		centralResources := private.ResourceRequirements{
 			Requests: map[string]string{
 				corev1.ResourceCPU.String():    "210m",
-				corev1.ResourceMemory.String(): "201M",
+				corev1.ResourceMemory.String(): "210M",
 			},
 			Limits: map[string]string{
 				corev1.ResourceCPU.String():    "310m",
-				corev1.ResourceMemory.String(): "202M",
+				corev1.ResourceMemory.String(): "310M",
 			},
 		}
 		centralSpec := private.CentralSpec{
@@ -333,11 +333,11 @@ var _ = Describe("Central", func() {
 		scannerResources := private.ResourceRequirements{
 			Requests: map[string]string{
 				corev1.ResourceCPU.String():    "210m",
-				corev1.ResourceMemory.String(): "151M",
+				corev1.ResourceMemory.String(): "310M",
 			},
 			Limits: map[string]string{
 				corev1.ResourceCPU.String():    "211m",
-				corev1.ResourceMemory.String(): "152M",
+				corev1.ResourceMemory.String(): "311M",
 			},
 		}
 		scannerScaling := private.ScannerSpecAnalyzerScaling{
@@ -434,7 +434,7 @@ var _ = Describe("Central", func() {
 				},
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("315m"),
-					corev1.ResourceMemory: resource.MustParse("202M"),
+					corev1.ResourceMemory: resource.MustParse("310M"),
 				},
 			}
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -320,11 +320,11 @@ var _ = Describe("Central", func() {
 		centralResources := private.ResourceRequirements{
 			Requests: map[string]string{
 				corev1.ResourceCPU.String():    "210m",
-				corev1.ResourceMemory.String(): "210M",
+				corev1.ResourceMemory.String(): "201M",
 			},
 			Limits: map[string]string{
 				corev1.ResourceCPU.String():    "310m",
-				corev1.ResourceMemory.String(): "310M",
+				corev1.ResourceMemory.String(): "202M",
 			},
 		}
 		centralSpec := private.CentralSpec{
@@ -333,11 +333,11 @@ var _ = Describe("Central", func() {
 		scannerResources := private.ResourceRequirements{
 			Requests: map[string]string{
 				corev1.ResourceCPU.String():    "210m",
-				corev1.ResourceMemory.String(): "310M",
+				corev1.ResourceMemory.String(): "151M",
 			},
 			Limits: map[string]string{
 				corev1.ResourceCPU.String():    "211m",
-				corev1.ResourceMemory.String(): "311M",
+				corev1.ResourceMemory.String(): "152M",
 			},
 		}
 		scannerScaling := private.ScannerSpecAnalyzerScaling{
@@ -434,7 +434,7 @@ var _ = Describe("Central", func() {
 				},
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("315m"),
-					corev1.ResourceMemory: resource.MustParse("310M"),
+					corev1.ResourceMemory: resource.MustParse("202M"),
 				},
 			}
 


### PR DESCRIPTION
## Description
The e2e admin tests fail because they set resource requests and limits for central to values that did not allow central pods to be created properly. This PR adjusts those resources so that they are close to the default values used in the "non-admin" tests. With this the test should work again.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~~[ ] Unit and integration tests added~~
- ~~[ ] Added test description under `Test manual`~~
- ~~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [ ] CI and all relevant tests are passing
- ~~[ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~~
- ~~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- ~~[ ] Add secret to app-interface Vault or Secrets Manager if necessary~~

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
