### PR TITLE
ROX-13692: fix final snapshot creation

### DIFF
--- a/.github/workflows/rds.yaml
+++ b/.github/workflows/rds.yaml
@@ -32,6 +32,7 @@ on:
       - 'docs/**'
       - 'pkg/api/openapi/docs/**'
       - 'pkg/api/openapi/.openapi-generator-ignore'
+      - 'dp-terraform/**'
 
 jobs:
   verify-test:
@@ -67,4 +68,4 @@ jobs:
           AWS_AUTH_HELPER: "none"
         run: |
           ./dev/env/scripts/exec_fleetshard_sync.sh make test/rds
-        timeout-minutes: 35
+        timeout-minutes: 50

--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,7 @@ test: $(GOTESTSUM_BIN)
 # Runs the AWS RDS integration tests.
 test/rds: $(GOTESTSUM_BIN)
 	RUN_RDS_TESTS=true \
-	$(GOTESTSUM_BIN) --junitfile data/results/rds-integration-tests.xml --format $(GOTESTSUM_FORMAT) -- -p 1 -v -timeout 30m -count=1 \
+	$(GOTESTSUM_BIN) --junitfile data/results/rds-integration-tests.xml --format $(GOTESTSUM_FORMAT) -- -p 1 -v -timeout 45m -count=1 \
 		./fleetshard/pkg/central/cloudprovider/awsclient/...
 .PHONY: test/rds
 

--- a/dev/config/dataplane-cluster-configuration-crc.yaml
+++ b/dev/config/dataplane-cluster-configuration-crc.yaml
@@ -15,6 +15,7 @@ clusters:
    provider_type: standalone
    supported_instance_type: "eval,standard"
    cluster_dns: apps-crc.testing
+   multi_az: true
    available_central_operator_versions:
     - version: "0.1.0"
       ready: true

--- a/docs/development/howto-e2e-test-rds.md
+++ b/docs/development/howto-e2e-test-rds.md
@@ -32,7 +32,7 @@ At the point in time this documentation was written AWS RDS DB creation and dele
 
     source <(run_chamber env "fleetshard-sync")
     source <(run_chamber env -b secretsmanager "fleetshard-sync")
-    source <(run_chamber env "cluster-acs-dev-dp-01")
+    source <(run_chamber env "local_cluster")
     export MANAGED_DB_ENABLED=true
 
     ./fleetshard-sync
@@ -46,10 +46,8 @@ At the point in time this documentation was written AWS RDS DB creation and dele
     # Watch the fleetshard-sync logs to tell what's happening in the background.
     # It should print something like this if everything works like expected:
     # RDS instance status: creating (instance ID: rhacs-chcb5m8ah6b2ko6qut0g-db-instance)
-    # At somepoint fleetshard-sync will logs this:
-    Unexpected error occurred rhacs-chcb5m8ah6b2ko6qut0g/test-central-1: getting Central DB connection string: initializing managed DB: initializing managed DB: beginning PostgreSQL transaction: dial tcp 10.1.206.163:5432: connect: operation timed out
 
-    # This is expected because the RDS DB is created within a VPC you can't reach from your local environment, we assume that this test was a success, since the DB got to a avaialble state.
+    # At some point your central instance should become ready
     ```
 
 1. Make sure DB state is available and 2 instances exist in state available

--- a/docs/development/howto-e2e-test-rds.md
+++ b/docs/development/howto-e2e-test-rds.md
@@ -34,9 +34,10 @@ At the point in time this documentation was written AWS RDS DB creation and dele
     source <(run_chamber env -b secretsmanager "fleetshard-sync")
     source <(run_chamber env "local_cluster")
     export MANAGED_DB_ENABLED=true
+    # flip the PublicAcessible flag to true in rds.go line 354
+    make binary
 
     ./fleetshard-sync
-
     ```
 
 1. Create a central instance and wait for DB Creation

--- a/docs/development/howto-e2e-test-rds.md
+++ b/docs/development/howto-e2e-test-rds.md
@@ -51,7 +51,7 @@ At the point in time this documentation was written AWS RDS DB creation and dele
     # At some point your central instance should become ready
     ```
 
-1. Make sure DB state is available and 2 instances exist in state available
+1. Make sure DB state is available and 2 instances exist in state available the central pod is ready
 1. Delete the central
 
     ```

--- a/docs/development/howto-e2e-test-rds.md
+++ b/docs/development/howto-e2e-test-rds.md
@@ -1,0 +1,61 @@
+# How to e2e test RDS
+
+At the point in time this documentation was written AWS RDS DB creation and deletion is not e2e tested with a full setup of fleet-manager and fleetshard-sync. Everytime a change to the RDS provisioning logic is introduced we need to e2e test that change manually using the steps described here.
+
+**Prerequisites:**
+
+- A K8s cluster to create central resources on (using CRC as an example here)
+- Kubeconfig configured with access to that cluster
+- Setup personal AWS access through `aws-saml.py` (see [secret-management.md](./secret-management.md))
+- RHACS Operator running or installed in the cluster
+
+1. Run local fleet-manager
+
+    ```
+    make db/teardown db/setup db/migrate
+
+    make binary
+
+    ./fleet-manager serve --dataplane-cluster-config-file ./dev/config
+    ```
+
+1. Run local fleetshard-sync
+
+    ```
+    # Prepare environment and secrets
+    export PATH="$PATH:$(pwd)/bin"
+    source ./scripts/lib/external_config.sh
+    kinit # get a kerberos ticket
+    export AWS_AUTH_HELPER=aws-saml
+    init_chamber
+    # When prompted select your profile for the dev AWS account arn:aws:iam::047735621815:role/047735621815-poweruser
+
+    source <(run_chamber env "fleetshard-sync")
+    source <(run_chamber env -b secretsmanager "fleetshard-sync")
+    source <(run_chamber env "cluster-acs-dev-dp-01")
+    export MANAGED_DB_ENABLED=true
+
+    ./fleetshard-sync
+
+    ```
+
+1. Create a central instance and wait for DB Creation
+
+    ```
+    central_id=$(./scripts/create-centrals.sh | jq '.id' -r)
+    # Watch the fleetshard-sync logs to tell what's happening in the background.
+    # It should print something like this if everything works like expected:
+    # RDS instance status: creating (instance ID: rhacs-chcb5m8ah6b2ko6qut0g-db-instance)
+    # At somepoint fleetshard-sync will logs this:
+    Unexpected error occurred rhacs-chcb5m8ah6b2ko6qut0g/test-central-1: getting Central DB connection string: initializing managed DB: initializing managed DB: beginning PostgreSQL transaction: dial tcp 10.1.206.163:5432: connect: operation timed out
+
+    # This is expected because the RDS DB is created within a VPC you can't reach from your local environment, we assume that this test was a success, since the DB got to a avaialble state.
+    ```
+
+1. Make sure DB state is available and 2 instances exist in state available
+1. Delete the central
+
+    ```
+    export OCM_TOKEN=$(ocm token)
+    ./scripts/fmcurl "rhacs/v1/centrals/$central_id?async=true" -XDELETE  
+    ```

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
@@ -189,7 +189,7 @@ func (r *RDS) ensureClusterDeleted(clusterID string) error {
 		_, err := r.rdsClient.DeleteDBCluster(newDeleteCentralDBClusterInput(clusterID, false))
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {
-				// This assumes that if a final snapshot exists, a deletion for the RDS cluster was already trigger
+				// This assumes that if a final snapshot exists, a deletion for the RDS cluster was already triggered
 				// and we can move on with deprovisioning,
 				if awsErr.Code() == rds.ErrCodeDBClusterSnapshotAlreadyExistsFault {
 					return nil

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
@@ -23,13 +23,13 @@ import (
 const (
 	dbAvailableStatus = "available"
 	dbDeletingStatus  = "deleting"
-
-	dbUser           = "rhacs_master"
-	dbPrefix         = "rhacs-"
-	dbInstanceSuffix = "-db-instance"
-	dbFailoverSuffix = "-db-failover"
-	dbClusterSuffix  = "-db-cluster"
-	awsRetrySeconds  = 30
+	dbBackingUpStatus = "backing-up"
+	dbUser            = "rhacs_master"
+	dbPrefix          = "rhacs-"
+	dbInstanceSuffix  = "-db-instance"
+	dbFailoverSuffix  = "-db-failover"
+	dbClusterSuffix   = "-db-cluster"
+	awsRetrySeconds   = 30
 
 	// DB cluster / instance configuration parameters
 	dbEngine                = "aurora-postgresql"
@@ -184,7 +184,7 @@ func (r *RDS) ensureClusterDeleted(clusterID string) error {
 		return nil
 	}
 
-	if clusterStatus != dbDeletingStatus {
+	if clusterStatus != dbDeletingStatus && clusterStatus != dbBackingUpStatus {
 		glog.Infof("Initiating deprovisioning of RDS database cluster %s.", clusterID)
 		_, err := r.rdsClient.DeleteDBCluster(newDeleteCentralDBClusterInput(clusterID, false))
 		if err != nil {

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -163,7 +163,7 @@ func TestRDSProvisioning(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, clusterDeleted)
 
-	// Always attemt to delete the final snapshot if it exists
+	// Always attempt to delete the final snapshot if it exists
 	defer func() {
 		_, err := rdsClient.rdsClient.DeleteDBClusterSnapshot(
 			&rds.DeleteDBClusterSnapshotInput{DBClusterSnapshotIdentifier: getFinalSnapshotID(clusterID)},

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const awsTimeoutMinutes = 15
+const awsTimeoutMinutes = 30
 
 func newTestRDS() (*RDS, error) {
 	rdsClient, err := newTestRDSClient()
@@ -47,17 +47,12 @@ func newTestRDSClient() (*rds.RDS, error) {
 
 func waitForClusterToBeDeleted(ctx context.Context, rdsClient *RDS, clusterID string) (bool, error) {
 	for {
-		clusterExists, clusterStatus, err := rdsClient.clusterStatus(clusterID)
+		clusterExists, _, err := rdsClient.clusterStatus(clusterID)
 		if err != nil {
 			return false, err
 		}
 
 		if !clusterExists {
-			return true, nil
-		}
-
-		// exit early if cluster is marked as deleting
-		if clusterStatus == dbDeletingStatus {
 			return true, nil
 		}
 
@@ -69,6 +64,37 @@ func waitForClusterToBeDeleted(ctx context.Context, rdsClient *RDS, clusterID st
 			return false, fmt.Errorf("waiting for RDS cluster to be deleted: %w", ctx.Err())
 		}
 	}
+}
+
+func waitForFinalSnapshotToExist(ctx context.Context, rdsClient *RDS, clusterID string) (bool, error) {
+
+	ticker := time.NewTicker(awsRetrySeconds * time.Second)
+	for {
+		select {
+		case <-ticker.C:
+			snapshotOut, err := rdsClient.rdsClient.DescribeDBClusterSnapshots(&rds.DescribeDBClusterSnapshotsInput{
+				DBClusterSnapshotIdentifier: getFinalSnapshotID(clusterID),
+			})
+
+			if err != nil {
+				if awsErr, ok := err.(awserr.Error); ok {
+					if awsErr.Code() != rds.ErrCodeDBClusterSnapshotNotFoundFault {
+						return false, err
+					}
+
+					continue
+				}
+			}
+
+			if snapshotOut != nil {
+				return len(snapshotOut.DBClusterSnapshots) == 1, nil
+			}
+		case <-ctx.Done():
+			return false, fmt.Errorf("waiting for final DB snapshot: %w", ctx.Err())
+		}
+
+	}
+
 }
 
 func TestRDSProvisioning(t *testing.T) {
@@ -136,6 +162,19 @@ func TestRDSProvisioning(t *testing.T) {
 	clusterDeleted, err := waitForClusterToBeDeleted(deleteCtx, rdsClient, clusterID)
 	require.NoError(t, err)
 	assert.True(t, clusterDeleted)
+
+	// Always attemt to delete the final snapshot if it exists
+	defer func() {
+		_, err := rdsClient.rdsClient.DeleteDBClusterSnapshot(
+			&rds.DeleteDBClusterSnapshotInput{DBClusterSnapshotIdentifier: getFinalSnapshotID(clusterID)},
+		)
+
+		assert.NoError(t, err)
+	}()
+
+	snapshotExists, err := waitForFinalSnapshotToExist(deleteCtx, rdsClient, clusterID)
+	require.NoError(t, err)
+	require.True(t, snapshotExists)
 }
 
 func TestGetDBConnection(t *testing.T) {


### PR DESCRIPTION
The first PR  #994 was causing errors in the stage environment because the reconciler would proceed to run delete DB calls to AWS even though the deletion was already in progress. The ad-hoc fix for staging was to revert the PR. This PR is the new attempt to implement the feature without breaking reconciliation logic.

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [x] Add secret to app-interface Vault or Secrets Manager if necessary

## Test manual

See the new file `howto-e2e-test-rds.md`.

Also running local RDS integration tests.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
