### PR TITLE
ROX-16894: Enable CloudWatch log exports for new RDS DBs

### DIFF
--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds.go
@@ -318,13 +318,14 @@ func getFailoverInstanceID(databaseID string) string {
 
 func newCreateCentralDBClusterInput(clusterID, dbPassword, securityGroup, subnetGroup, dataplaneClusterName string) *rds.CreateDBClusterInput {
 	return &rds.CreateDBClusterInput{
-		DBClusterIdentifier: aws.String(clusterID),
-		Engine:              aws.String(dbEngine),
-		EngineVersion:       aws.String(dbEngineVersion),
-		MasterUsername:      aws.String(dbUser),
-		MasterUserPassword:  aws.String(dbPassword),
-		VpcSecurityGroupIds: aws.StringSlice([]string{securityGroup}),
-		DBSubnetGroupName:   aws.String(subnetGroup),
+		DBClusterIdentifier:         aws.String(clusterID),
+		Engine:                      aws.String(dbEngine),
+		EngineVersion:               aws.String(dbEngineVersion),
+		EnableCloudwatchLogsExports: aws.StringSlice([]string{"postgresql"}),
+		MasterUsername:              aws.String(dbUser),
+		MasterUserPassword:          aws.String(dbPassword),
+		VpcSecurityGroupIds:         aws.StringSlice([]string{securityGroup}),
+		DBSubnetGroupName:           aws.String(subnetGroup),
 		ServerlessV2ScalingConfiguration: &rds.ServerlessV2ScalingConfiguration{
 			MinCapacity: aws.Float64(dbMinCapacityACU),
 			MaxCapacity: aws.Float64(dbMaxCapacityACU),


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This PR enables exporting of PostgreSQL logs to CloudWatch, for newly created RDS clusters. 

Existing instances will be modified separately.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~Unit and integration tests added~~
- [ ] ~~Added test description under `Test manual`~~
- [ ] ~~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [] ~~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- [ ] ~~Add secret to app-interface Vault or Secrets Manager if necessary~~

## Test manual

Tested in a local cluster, by running:
INSTALL_OPERATOR=NO MANAGED_DB_ENABLED=TRUE ./dev/env/scripts/up.sh
./scripts/create-central.sh

And then waiting for a Central to start successfully.

To test locally, I had to make the DB publicly accessible. For this purpose, I added a new VPC, security group and DB subnet group in dev on AWS.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
