### PR TITLE
Remove acs-stage-eu-01 from Helm bootstrapping CI

### DIFF
--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -12,5 +12,5 @@ jobs:
     with:
       acs_environment: stage
       github_environment: stage
-      deploy_clusters: "acs-stage-dp-02 acs-stage-eu-01 acs-stage-eu-02"
+      deploy_clusters: "acs-stage-dp-02 acs-stage-eu-02"
       probe_clusters: "acs-stage-dp-02 acs-stage-eu-02"


### PR DESCRIPTION
Nico and I are going to use acs-stage-eu-01 for Addon Package testing. To do so we need to make sure the Helm chart is removed from that cluster and will not be reinstalled there.
