### PR TITLE
ROX-13692: skip final snapshots for probe

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -322,7 +322,7 @@
         "filename": "fleetshard/pkg/central/cloudprovider/dbclient_moq.go",
         "hashed_secret": "80519927d0f3ce1efe933f46ca9e05e68e491adc",
         "is_verified": false,
-        "line_number": 118
+        "line_number": 124
       }
     ],
     "internal/dinosaur/pkg/api/public/api/openapi.yaml": [
@@ -546,5 +546,5 @@
       }
     ]
   },
-  "generated_at": "2023-03-28T21:54:47Z"
+  "generated_at": "2023-05-10T07:24:16Z"
 }

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -131,7 +131,7 @@ func TestRDSProvisioning(t *testing.T) {
 	err = rdsClient.EnsureDBProvisioned(ctx, dbID, dbMasterPassword)
 	defer func() {
 		// clean-up AWS resources in case the test fails
-		deleteErr := rdsClient.EnsureDBDeprovisioned(dbID)
+		deleteErr := rdsClient.EnsureDBDeprovisioned(dbID, false)
 		assert.NoError(t, deleteErr)
 	}()
 	require.NoError(t, err)
@@ -153,7 +153,7 @@ func TestRDSProvisioning(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, failoverExists)
 
-	err = rdsClient.EnsureDBDeprovisioned(dbID)
+	err = rdsClient.EnsureDBDeprovisioned(dbID, false)
 	assert.NoError(t, err)
 
 	deleteCtx, deleteCancel := context.WithTimeout(context.TODO(), awsTimeoutMinutes*time.Minute)

--- a/fleetshard/pkg/central/cloudprovider/dbclient.go
+++ b/fleetshard/pkg/central/cloudprovider/dbclient.go
@@ -16,7 +16,7 @@ type DBClient interface {
 	EnsureDBProvisioned(ctx context.Context, databaseID, passwordSecretName string) error
 	// EnsureDBDeprovisioned is a non-blocking function that makes sure that a managed DB is deprovisioned (more
 	// specifically, that its deletion was initiated)
-	EnsureDBDeprovisioned(databaseID string) error
+	EnsureDBDeprovisioned(databaseID string, skipFinalSnapshot bool) error
 	// GetDBConnection returns a postgres.DBConnection struct, which contains the data necessary
 	// to construct a PostgreSQL connection string. It expects that the database was already provisioned.
 	GetDBConnection(databaseID string) (postgres.DBConnection, error)

--- a/fleetshard/pkg/central/cloudprovider/dbclient_moq.go
+++ b/fleetshard/pkg/central/cloudprovider/dbclient_moq.go
@@ -19,7 +19,7 @@ var _ DBClient = &DBClientMock{}
 //
 //		// make and configure a mocked DBClient
 //		mockedDBClient := &DBClientMock{
-//			EnsureDBDeprovisionedFunc: func(databaseID string) error {
+//			EnsureDBDeprovisionedFunc: func(databaseID string, skipFinalSnapshot bool) error {
 //				panic("mock out the EnsureDBDeprovisioned method")
 //			},
 //			EnsureDBProvisionedFunc: func(ctx context.Context, databaseID string, passwordSecretName string) error {
@@ -36,7 +36,7 @@ var _ DBClient = &DBClientMock{}
 //	}
 type DBClientMock struct {
 	// EnsureDBDeprovisionedFunc mocks the EnsureDBDeprovisioned method.
-	EnsureDBDeprovisionedFunc func(databaseID string) error
+	EnsureDBDeprovisionedFunc func(databaseID string, skipFinalSnapshot bool) error
 
 	// EnsureDBProvisionedFunc mocks the EnsureDBProvisioned method.
 	EnsureDBProvisionedFunc func(ctx context.Context, databaseID string, passwordSecretName string) error
@@ -50,6 +50,8 @@ type DBClientMock struct {
 		EnsureDBDeprovisioned []struct {
 			// DatabaseID is the databaseID argument value.
 			DatabaseID string
+			// SkipFinalSnapshot is the skipFinalSnapshot argument value.
+			SkipFinalSnapshot bool
 		}
 		// EnsureDBProvisioned holds details about calls to the EnsureDBProvisioned method.
 		EnsureDBProvisioned []struct {
@@ -72,19 +74,21 @@ type DBClientMock struct {
 }
 
 // EnsureDBDeprovisioned calls EnsureDBDeprovisionedFunc.
-func (mock *DBClientMock) EnsureDBDeprovisioned(databaseID string) error {
+func (mock *DBClientMock) EnsureDBDeprovisioned(databaseID string, skipFinalSnapshot bool) error {
 	if mock.EnsureDBDeprovisionedFunc == nil {
 		panic("DBClientMock.EnsureDBDeprovisionedFunc: method is nil but DBClient.EnsureDBDeprovisioned was just called")
 	}
 	callInfo := struct {
-		DatabaseID string
+		DatabaseID        string
+		SkipFinalSnapshot bool
 	}{
-		DatabaseID: databaseID,
+		DatabaseID:        databaseID,
+		SkipFinalSnapshot: skipFinalSnapshot,
 	}
 	mock.lockEnsureDBDeprovisioned.Lock()
 	mock.calls.EnsureDBDeprovisioned = append(mock.calls.EnsureDBDeprovisioned, callInfo)
 	mock.lockEnsureDBDeprovisioned.Unlock()
-	return mock.EnsureDBDeprovisionedFunc(databaseID)
+	return mock.EnsureDBDeprovisionedFunc(databaseID, skipFinalSnapshot)
 }
 
 // EnsureDBDeprovisionedCalls gets all the calls that were made to EnsureDBDeprovisioned.
@@ -92,10 +96,12 @@ func (mock *DBClientMock) EnsureDBDeprovisioned(databaseID string) error {
 //
 //	len(mockedDBClient.EnsureDBDeprovisionedCalls())
 func (mock *DBClientMock) EnsureDBDeprovisionedCalls() []struct {
-	DatabaseID string
+	DatabaseID        string
+	SkipFinalSnapshot bool
 } {
 	var calls []struct {
-		DatabaseID string
+		DatabaseID        string
+		SkipFinalSnapshot bool
 	}
 	mock.lockEnsureDBDeprovisioned.RLock()
 	calls = mock.calls.EnsureDBDeprovisioned

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -432,7 +432,9 @@ func (r *CentralReconciler) ensureCentralDeleted(ctx context.Context, remoteCent
 	globalDeleted = globalDeleted && centralDeleted
 
 	if r.managedDBEnabled {
-		err = r.managedDBProvisioningClient.EnsureDBDeprovisioned(remoteCentral.Id)
+		// skip Snapshot for remoteCentral created by probe
+		skipSnapshot := remoteCentral.Metadata.Internal
+		err = r.managedDBProvisioningClient.EnsureDBDeprovisioned(remoteCentral.Id, skipSnapshot)
 		if err != nil {
 			return false, fmt.Errorf("deprovisioning DB: %v", err)
 		}

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -411,7 +411,7 @@ func TestReconcileDeleteWithManagedDB(t *testing.T) {
 	managedDBProvisioningClient.EnsureDBProvisionedFunc = func(_ context.Context, _ string, _ string) error {
 		return nil
 	}
-	managedDBProvisioningClient.EnsureDBDeprovisionedFunc = func(_ string) error {
+	managedDBProvisioningClient.EnsureDBDeprovisionedFunc = func(_ string, _ bool) error {
 		return nil
 	}
 	managedDBProvisioningClient.GetDBConnectionFunc = func(_ string) (postgres.DBConnection, error) {


### PR DESCRIPTION
## Description
Probes are creating a lot of central tenants and deleting them again. This causes us to hit the limit for manual DB snapshots because every tenant deleted create a final DB snapshot. This PR skips final DB snapshots for centrals created by the probe.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~~[ ] Unit and integration tests added~~
- ~~[ ] Added test description under `Test manual`~~
- ~~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- ~~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- ~~[ ] Add secret to app-interface Vault or Secrets Manager if necessary~~

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
