### PR TITLE
ROX-16561: Do not export RDS/Postgres logs to CloudWatch for Probe instances

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -322,7 +322,7 @@
         "filename": "fleetshard/pkg/central/cloudprovider/dbclient_moq.go",
         "hashed_secret": "80519927d0f3ce1efe933f46ca9e05e68e491adc",
         "is_verified": false,
-        "line_number": 124
+        "line_number": 127
       }
     ],
     "internal/dinosaur/pkg/api/public/api/openapi.yaml": [
@@ -546,5 +546,5 @@
       }
     ]
   },
-  "generated_at": "2023-05-10T07:24:16Z"
+  "generated_at": "2023-05-10T10:12:08Z"
 }

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -128,7 +128,7 @@ func TestRDSProvisioning(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, failoverExists)
 
-	err = rdsClient.EnsureDBProvisioned(ctx, dbID, dbMasterPassword)
+	err = rdsClient.EnsureDBProvisioned(ctx, dbID, dbMasterPassword, false)
 	defer func() {
 		// clean-up AWS resources in case the test fails
 		deleteErr := rdsClient.EnsureDBDeprovisioned(dbID, false)

--- a/fleetshard/pkg/central/cloudprovider/dbclient.go
+++ b/fleetshard/pkg/central/cloudprovider/dbclient.go
@@ -13,7 +13,7 @@ import (
 type DBClient interface {
 	// EnsureDBProvisioned is a blocking function that makes sure that a database with the given databaseID was provisioned,
 	// using the master password given as parameter
-	EnsureDBProvisioned(ctx context.Context, databaseID, passwordSecretName string) error
+	EnsureDBProvisioned(ctx context.Context, databaseID, passwordSecretName string, exportLogs bool) error
 	// EnsureDBDeprovisioned is a non-blocking function that makes sure that a managed DB is deprovisioned (more
 	// specifically, that its deletion was initiated)
 	EnsureDBDeprovisioned(databaseID string, skipFinalSnapshot bool) error

--- a/fleetshard/pkg/central/cloudprovider/dbclient_moq.go
+++ b/fleetshard/pkg/central/cloudprovider/dbclient_moq.go
@@ -22,7 +22,7 @@ var _ DBClient = &DBClientMock{}
 //			EnsureDBDeprovisionedFunc: func(databaseID string, skipFinalSnapshot bool) error {
 //				panic("mock out the EnsureDBDeprovisioned method")
 //			},
-//			EnsureDBProvisionedFunc: func(ctx context.Context, databaseID string, passwordSecretName string) error {
+//			EnsureDBProvisionedFunc: func(ctx context.Context, databaseID string, passwordSecretName string, exportLogs bool) error {
 //				panic("mock out the EnsureDBProvisioned method")
 //			},
 //			GetDBConnectionFunc: func(databaseID string) (postgres.DBConnection, error) {
@@ -39,7 +39,7 @@ type DBClientMock struct {
 	EnsureDBDeprovisionedFunc func(databaseID string, skipFinalSnapshot bool) error
 
 	// EnsureDBProvisionedFunc mocks the EnsureDBProvisioned method.
-	EnsureDBProvisionedFunc func(ctx context.Context, databaseID string, passwordSecretName string) error
+	EnsureDBProvisionedFunc func(ctx context.Context, databaseID string, passwordSecretName string, exportLogs bool) error
 
 	// GetDBConnectionFunc mocks the GetDBConnection method.
 	GetDBConnectionFunc func(databaseID string) (postgres.DBConnection, error)
@@ -61,6 +61,8 @@ type DBClientMock struct {
 			DatabaseID string
 			// PasswordSecretName is the passwordSecretName argument value.
 			PasswordSecretName string
+			// ExportLogs is the exportLogs argument value.
+			ExportLogs bool
 		}
 		// GetDBConnection holds details about calls to the GetDBConnection method.
 		GetDBConnection []struct {
@@ -110,7 +112,7 @@ func (mock *DBClientMock) EnsureDBDeprovisionedCalls() []struct {
 }
 
 // EnsureDBProvisioned calls EnsureDBProvisionedFunc.
-func (mock *DBClientMock) EnsureDBProvisioned(ctx context.Context, databaseID string, passwordSecretName string) error {
+func (mock *DBClientMock) EnsureDBProvisioned(ctx context.Context, databaseID string, passwordSecretName string, exportLogs bool) error {
 	if mock.EnsureDBProvisionedFunc == nil {
 		panic("DBClientMock.EnsureDBProvisionedFunc: method is nil but DBClient.EnsureDBProvisioned was just called")
 	}
@@ -118,15 +120,17 @@ func (mock *DBClientMock) EnsureDBProvisioned(ctx context.Context, databaseID st
 		Ctx                context.Context
 		DatabaseID         string
 		PasswordSecretName string
+		ExportLogs         bool
 	}{
 		Ctx:                ctx,
 		DatabaseID:         databaseID,
 		PasswordSecretName: passwordSecretName,
+		ExportLogs:         exportLogs,
 	}
 	mock.lockEnsureDBProvisioned.Lock()
 	mock.calls.EnsureDBProvisioned = append(mock.calls.EnsureDBProvisioned, callInfo)
 	mock.lockEnsureDBProvisioned.Unlock()
-	return mock.EnsureDBProvisionedFunc(ctx, databaseID, passwordSecretName)
+	return mock.EnsureDBProvisionedFunc(ctx, databaseID, passwordSecretName, exportLogs)
 }
 
 // EnsureDBProvisionedCalls gets all the calls that were made to EnsureDBProvisioned.
@@ -137,11 +141,13 @@ func (mock *DBClientMock) EnsureDBProvisionedCalls() []struct {
 	Ctx                context.Context
 	DatabaseID         string
 	PasswordSecretName string
+	ExportLogs         bool
 } {
 	var calls []struct {
 		Ctx                context.Context
 		DatabaseID         string
 		PasswordSecretName string
+		ExportLogs         bool
 	}
 	mock.lockEnsureDBProvisioned.RLock()
 	calls = mock.calls.EnsureDBProvisioned

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -587,7 +587,8 @@ func (r *CentralReconciler) ensureManagedCentralDBInitialized(ctx context.Contex
 		return fmt.Errorf("getting DB password from secret: %w", err)
 	}
 
-	err = r.managedDBProvisioningClient.EnsureDBProvisioned(ctx, remoteCentral.Id, dbMasterPassword)
+	exportLogs := !remoteCentral.Metadata.Internal // do not export DB logs of internal instances (e.g. Probes)
+	err = r.managedDBProvisioningClient.EnsureDBProvisioned(ctx, remoteCentral.Id, dbMasterPassword, exportLogs)
 	if err != nil {
 		return fmt.Errorf("provisioning RDS DB: %w", err)
 	}

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -128,7 +128,7 @@ func TestReconcileCreateWithManagedDB(t *testing.T) {
 	fakeClient := testutils.NewFakeClientBuilder(t).Build()
 
 	managedDBProvisioningClient := &cloudprovider.DBClientMock{}
-	managedDBProvisioningClient.EnsureDBProvisionedFunc = func(_ context.Context, _ string, _ string) error {
+	managedDBProvisioningClient.EnsureDBProvisionedFunc = func(_ context.Context, _ string, _ string, _ bool) error {
 		return nil
 	}
 	managedDBProvisioningClient.GetDBConnectionFunc = func(_ string) (postgres.DBConnection, error) {
@@ -408,7 +408,7 @@ func TestReconcileDeleteWithManagedDB(t *testing.T) {
 	fakeClient := testutils.NewFakeClientBuilder(t).Build()
 
 	managedDBProvisioningClient := &cloudprovider.DBClientMock{}
-	managedDBProvisioningClient.EnsureDBProvisionedFunc = func(_ context.Context, _ string, _ string) error {
+	managedDBProvisioningClient.EnsureDBProvisionedFunc = func(_ context.Context, _ string, _ string, _ bool) error {
 		return nil
 	}
 	managedDBProvisioningClient.EnsureDBDeprovisionedFunc = func(_ string, _ bool) error {
@@ -436,7 +436,7 @@ func TestReconcileDeleteWithManagedDB(t *testing.T) {
 	deletedCentral.Metadata.DeletionTimestamp = "2006-01-02T15:04:05Z07:00"
 
 	// trigger deletion
-	managedDBProvisioningClient.EnsureDBProvisionedFunc = func(_ context.Context, _ string, _ string) error {
+	managedDBProvisioningClient.EnsureDBProvisionedFunc = func(_ context.Context, _ string, _ string, _ bool) error {
 		return nil
 	}
 	statusTrigger, err := r.Reconcile(context.TODO(), deletedCentral)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Inspired by https://github.com/stackrox/acs-fleet-manager/pull/1018 this PR does not export RDS logs to CloudWatch for Centrals created by the Probe service.

These instances are creating a lot of useless log groups and basically spamming CloudWatch.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~Unit and integration tests added~~
- [ ] ~~Added test description under `Test manual`~~
- [ ] ~~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- [ ] ~~Add secret to app-interface Vault or Secrets Manager if necessary~~

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
