### PR TITLE
Rename Central command to centrals to align with API resource naming

### DIFF
--- a/cmd/fleet-manager/main.go
+++ b/cmd/fleet-manager/main.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/cmd/admin"
-	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/cmd/central"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/cmd/centrals"
 	"github.com/stackrox/acs-fleet-manager/pkg/cmd/migrate"
 	"github.com/stackrox/acs-fleet-manager/pkg/cmd/serve"
 
@@ -48,7 +48,7 @@ func main() {
 
 	rootCmd.AddCommand(migrate.NewMigrateCommand(env))
 	rootCmd.AddCommand(serve.NewServeCommand(env))
-	rootCmd.AddCommand(central.NewCentralCommand())
+	rootCmd.AddCommand(centrals.NewCentralsCommand())
 	rootCmd.AddCommand(admin.NewAdminCommand())
 	// Unsupported CLI commands. Eventually some of them can be removed.
 	// rootCmd.AddCommand(cluster.NewClusterCommand(env))

--- a/internal/dinosaur/pkg/cmd/admin/centrals/cmd.go
+++ b/internal/dinosaur/pkg/cmd/admin/centrals/cmd.go
@@ -11,6 +11,7 @@ const (
 func NewAdminCentralsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:              "centrals",
+		Aliases:          []string{"central"},
 		Short:            "Perform admin central API calls.",
 		Long:             "Perform admin central API calls.",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {},

--- a/internal/dinosaur/pkg/cmd/centrals/cmd.go
+++ b/internal/dinosaur/pkg/cmd/centrals/cmd.go
@@ -1,6 +1,6 @@
 // Package central contains commands for interacting with central logic of the service directly instead of through the
 // REST API exposed via the serve command.
-package central
+package centrals
 
 import (
 	"github.com/spf13/cobra"
@@ -10,10 +10,11 @@ const (
 	apiErrorMsg = "%s Central failed: To fix this ensure you are authenticated, fleet-manager endpoint is configured and reachable. Status Code: %s."
 )
 
-// NewCentralCommand ...
-func NewCentralCommand() *cobra.Command {
+// NewCentralsCommand ...
+func NewCentralsCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:              "central",
+		Use:              "centrals",
+		Aliases:          []string{"central"},
 		Short:            "Perform central CRUD actions directly",
 		Long:             "Perform central CRUD actions directly.",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {},

--- a/internal/dinosaur/pkg/cmd/centrals/create.go
+++ b/internal/dinosaur/pkg/cmd/centrals/create.go
@@ -1,4 +1,4 @@
-package central
+package centrals
 
 import (
 	"encoding/json"

--- a/internal/dinosaur/pkg/cmd/centrals/delete.go
+++ b/internal/dinosaur/pkg/cmd/centrals/delete.go
@@ -1,4 +1,4 @@
-package central
+package centrals
 
 import (
 	"fmt"

--- a/internal/dinosaur/pkg/cmd/centrals/flags.go
+++ b/internal/dinosaur/pkg/cmd/centrals/flags.go
@@ -1,4 +1,4 @@
-package central
+package centrals
 
 // FlagID ...
 const (

--- a/internal/dinosaur/pkg/cmd/centrals/get.go
+++ b/internal/dinosaur/pkg/cmd/centrals/get.go
@@ -1,4 +1,4 @@
-package central
+package centrals
 
 import (
 	"encoding/json"

--- a/internal/dinosaur/pkg/cmd/centrals/list.go
+++ b/internal/dinosaur/pkg/cmd/centrals/list.go
@@ -1,4 +1,4 @@
-package central
+package centrals
 
 import (
 	"encoding/json"


### PR DESCRIPTION
## Description
Rename Central command to centrals to align with API resource naming

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary

## Test manual

 - /
