### PR TITLE
Directly manage Alertmanager configuration

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -316,6 +316,15 @@
         "line_number": 86
       }
     ],
+    "dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml",
+        "hashed_secret": "3e513f12b341ed3327bea645a728401b5d0f9ddb",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
     "fleetshard/pkg/central/cloudprovider/dbclient_moq.go": [
       {
         "type": "Secret Keyword",

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-03-secret-alertmanager.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-03-secret-alertmanager.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhacs-alertmanager-configuration
+  namespace: {{ include "observability.namespace" . }}
+stringData:
+  alertmanager.yml: |
+    global:
+      resolve_timeout: 5m
+    route:
+      receiver: default-receiver
+      repeat_interval: 12h
+      routes:
+      - receiver: managed-rhacs-pagerduty
+        match:
+          observability: managed-rhacs
+          severity: critical
+      - receiver: managed-rhacs-deadmanssnitch
+        repeat_interval: 5m
+        match:
+          alertname: DeadMansSwitch
+          observability: managed-rhacs
+    receivers:
+    - name: default-receiver
+    - name: managed-rhacs-pagerduty
+      pagerduty_configs:
+      - service_key: {{ .Values.pagerduty.key | quote }}
+    - name: managed-rhacs-deadmanssnitch
+      webhook_configs:
+      - url: {{ .Values.deadMansSwitch.url | quote }}
+type: Opaque

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-03-secret-dead-mans-switch.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-03-secret-dead-mans-switch.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rhacs-dead-mans-switch
-  namespace: {{ include "observability.namespace" . }}
-stringData:
-  SNITCH_URL: {{ .Values.deadMansSwitch.url | quote }}
-type: Opaque

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-03-secret-pagerduty.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-03-secret-pagerduty.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rhacs-pagerduty
-  namespace: {{ include "observability.namespace" . }}
-stringData:
-  PAGERDUTY_KEY: {{ .Values.pagerduty.key | quote }}
-type: Opaque

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
@@ -12,6 +12,7 @@ spec:
   resyncPeriod: {{ .Values.resyncPeriod | quote }}
   retention: {{ .Values.retention | quote }}
   selfContained:
+    alertManagerConfigSecret: rhacs-alertmanager-configuration
     disableBlackboxExporter: true
     # Disable logging features of the operator, because we set up the logging operator
     # ourselves via the logging sub-chart.


### PR DESCRIPTION
## Description
This will enable us to set up a Slack receiver for alerts that we don't want going to PagerDuty.

This configuration was pulled directly from the generated version of this secret in one of our data plane clusters and modified to be generated by this Helm chart instead.  There is no functional difference between this config and the one generated by the Observability operator.

The PagerDuty and Dead Man's Snitch secrets are deleted since those secrets are now used directly in the Alertmanager configuration.


<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~Unit and integration tests added~~ Follow up to run `amtool check-config` against `alertmanager.yml` in a github action
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] ~~Add secret to app-interface Vault or Secrets Manager if necessary~~

## Test manual

* Deployed CRC (CodeReady Containers)
* Changed dir to `dp-terraform/helm/rhacs-terraform/charts/observability`
* Created a Github personal token to correctly configure the Obervability operator
* Stuck the token and repo config into `values.yml`
* Ran `helm template . | oc apply -f -`
* Waited until the `Alertmanager` CR was created
* Checked to see that the correct configuration secret name was referenced
* Checked the alertmanager logs to ensure there were no errors loading the configuration

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
