### PR TITLE
add FM_URL env variable for fmcurl script

### DIFF
--- a/scripts/fmcurl
+++ b/scripts/fmcurl
@@ -13,5 +13,5 @@ shift
 
 # Normalize
 resource=$(echo "$resource" | sed -e 's/^\///;')
-
-curl -LH "Authorization: Bearer ${OCM_TOKEN}" "http://localhost:8000/api/${resource}" "$@" | jq .
+FM_URL="${FM_URL:-http://localhost:8000}"
+curl -LH "Authorization: Bearer ${OCM_TOKEN}" "$FM_URL/api/${resource}" "$@" | jq .


### PR DESCRIPTION
## Description
Add the FM_URL variable to fmcurl script. To also use it for easy access to fleet-manager on other urls.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~~[ ] Unit and integration tests added~~
- ~~[ ] Added test description under `Test manual`~~
- ~~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- ~~[ ] CI and all relevant tests are passing~~
- ~~[ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~~
- ~~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- ~~[ ] Add secret to app-interface Vault or Secrets Manager if necessary~~

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
