### PR TITLE
Change secret key to alertmanager.yaml

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-03-secret-alertmanager.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-03-secret-alertmanager.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rhacs-alertmanager-configuration
   namespace: {{ include "observability.namespace" . }}
 stringData:
-  alertmanager.yml: |
+  alertmanager.yaml: |
     global:
       resolve_timeout: 5m
     route:


### PR DESCRIPTION
Prometheus operator specifically looks for `alertmanager.yaml`, NOT `alertmanager.yml`.  If it cannot find that specific key, it will use a default/dummy congiruation instead, effectively disabling alertmanager.

