### PR TITLE
ROX-17083: Send stage alerts directly to Slack

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/observability/slack-receiver-config.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/slack-receiver-config.yaml
@@ -1,0 +1,18 @@
+# Due to nested go template syntax, this section needs to be moved to a separate file
+# The alternative is quite unreadable escaping, e.g.:
+# title_link: '{{ "{{" }} template "slack.default.titlelink" . {{ "}}" }}'
+title_link: '{{ template "slack.default.titlelink" . }}'
+fallback: '{{ template "slack.default.fallback" . }}'
+title: '[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ index .CommonLabels "alertname" }}'
+text: |
+  *Cluster*: {{ index .CommonLabels "rhacs_cluster_name" }}
+  *Namespace*: {{ index .CommonLabels "namespace" }}
+  *Summary*: {{(index .Alerts 0).Annotations.summary }}
+  *Description*: {{ (index .Alerts 0).Annotations.description }}
+actions:
+- type: button
+  text: 'SOP :green_book:'
+  url: '{{ (index .Alerts 0).Annotations.sop_url }}'
+- type: button
+  text: 'Prometheus :prometheus:'
+  url: '{{ (index .Alerts 0).GeneratorURL}}'

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-03-secret-alertmanager.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-03-secret-alertmanager.yaml
@@ -8,24 +8,30 @@ stringData:
     global:
       resolve_timeout: 5m
     route:
-      receiver: default-receiver
+      receiver: slack
       repeat_interval: 12h
       routes:
       - receiver: managed-rhacs-pagerduty
         match:
           observability: managed-rhacs
           severity: critical
+          rhacs_environment: prod
       - receiver: managed-rhacs-deadmanssnitch
         repeat_interval: 5m
         match:
           alertname: DeadMansSwitch
           observability: managed-rhacs
     receivers:
-    - name: default-receiver
     - name: managed-rhacs-pagerduty
       pagerduty_configs:
       - service_key: {{ .Values.pagerduty.key | quote }}
     - name: managed-rhacs-deadmanssnitch
       webhook_configs:
       - url: {{ .Values.deadMansSwitch.url | quote }}
+    - name: slack
+      slack_configs:
+      - send_resolved: true
+        api_url: {{ .Values.slack.apiURL | quote }}
+        title_link: '{{ "{{" }} template "slack.default.titlelink" . {{ "}}" }}'
+{{ .Files.Get "slack-receiver-config.yaml" | indent 8 }}
 type: Opaque

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
@@ -28,6 +28,9 @@ observatorium:
   metricsClientId: ""
   metricsSecret: ""
 
+slack:
+  apiURL: ""
+
 pagerduty:
   # PagerDuty integration key, which is generated within a Ruleset.
   key: ""

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -157,7 +157,9 @@ invoke_helm "${SCRIPT_DIR}" rhacs-terraform \
   --set observability.observatorium.metricsClientId="${OBSERVABILITY_OBSERVATORIUM_METRICS_CLIENT_ID}" \
   --set observability.observatorium.metricsSecret="${OBSERVABILITY_OBSERVATORIUM_METRICS_SECRET}" \
   --set observability.pagerduty.key="${OBSERVABILITY_PAGERDUTY_SERVICE_KEY}" \
-  --set observability.deadMansSwitch.url="${OBSERVABILITY_DEAD_MANS_SWITCH_URL}"
+  --set observability.deadMansSwitch.url="${OBSERVABILITY_DEAD_MANS_SWITCH_URL}" \
+  --set observability.slack.apiURL="${OBSERVABILITY_SLACK_API_URL}"
+
 
 # To uninstall an existing release:
 # helm uninstall rhacs-terraform --namespace rhacs


### PR DESCRIPTION
## Description
Only critical production alerts get sent to PagerDuty.

This commit sets up the Slack receiver, which includes formatting the Slack messages.  A few notes on the format:

* Due to the use of a shared webhook config, the icon, bot name, and target channel are not configurable.
* Only the alert name is in the message title (as well as whether the alert is firing or resolved)
* The message body has four sections:
  * Cluster name
  * Namespace
  * Summary
  * Description
* Two action buttons: SOP and Prometheus URL

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~ alertmanager config linter to come
- [x] Added test description under `Test manual`
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [x] Add secret to app-interface Vault or Secrets Manager if necessary

## Test manual

Created a very simple prometheus exporter that increments a counter when an enpoint is invoked:

```python
from flask import Flask, make_response, request, redirect, url_for, abort, session, jsonify
from prometheus_client import Counter, make_wsgi_app
from werkzeug.middleware.dispatcher import DispatcherMiddleware

c = Counter('calls', 'Count of calls to endpoint')
app = Flask(__name__)

@app.route("/inc")
def inc():
    c.inc()
    return ""

# Add prometheus wsgi middleware to route /metrics requests
app.wsgi_app = DispatcherMiddleware(app.wsgi_app, {
    '/metrics': make_wsgi_app()
})
```

Ran a local prometheus with this config:

```yaml
# my global config
global:
  scrape_interval: 1s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
  evaluation_interval: 5s # Evaluate rules every 15 seconds. The default is every 1 minute.
  # scrape_timeout is set to the global default (10s).

# Alertmanager configuration
alerting:
  alertmanagers:
  - static_configs:
    - targets:
      - localhost:9093

# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
rule_files:
- "rules.yml"

# A scrape configuration containing exactly one endpoint to scrape:
# Here it's Prometheus itself.
scrape_configs:
  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
  - job_name: "prometheus"

    # metrics_path defaults to '/metrics'
    # scheme defaults to 'http'.

    static_configs:
    - targets: ["localhost:5000"]
```

and rules file 

```yaml
groups:
  - name: rules
    rules:
      - alert: FAKE-RateTooHigh
        expr: rate(calls_total[15s]) > 0.5
        for: 15s
        labels:
          severity: critical
          observability: managed-rhacs
          rhacs_environment: stage
          rhacs_cluster_name: fake-acs-stage-dp-03
          namespace: test
        annotations:
          summary: "Counter rate too high"
          description: "THIS IS A FAKE ALERT to test slack alerting.  Count rate is at {{ $value }}. This is a longer message because the description is supposed to be longer!"
          sop_url: "dummy"
```

Ran a local alertmanager with a config pulled from the changes in the PR and the Slack API URL.

Once the receiver config was finalized, I needed to validate the helm chart would render the secret correctly.  To do this, I added to the `slack_api_url` secret to the `observability` secret in the dev AWS account.  I then ran `terraform_cluster.sh` to see that the chart was rendered correctly with the value pulled from AWS Secret Manager.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
