### PR TITLE
Prefactor: extract status collection to dedicated function in fleetshard central reconciler

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -363,21 +363,33 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		r.hasAuthProvider = true
 	}
 
-	status := readyStatus()
-	// Do not report routes statuses if:
-	// 1. Routes are not used on the cluster
-	// 2. Central request is in status "Ready" - assuming that routes are already reported and saved
-	if r.useRoutes && !isRemoteCentralReady(remoteCentral) {
-		status.Routes, err = r.getRoutesStatuses(ctx, remoteCentralNamespace)
-		if err != nil {
-			return nil, err
-		}
+	status, err := r.collectReconciliationStatus(ctx, remoteCentral)
+	if err != nil {
+		return nil, err
 	}
 
 	// Setting the last central hash must always be executed as the last step.
 	// defer can't be used for this call because it is also executed after the reconcile failed.
 	if err := r.setLastCentralHash(remoteCentral); err != nil {
 		return nil, errors.Wrapf(err, "setting central reconcilation cache")
+	}
+
+	return status, nil
+}
+
+func (r *CentralReconciler) collectReconciliationStatus(ctx context.Context, remoteCentral private.ManagedCentral) (*private.DataPlaneCentralStatus, error) {
+	remoteCentralNamespace := remoteCentral.Metadata.Namespace
+
+	status := readyStatus()
+	// Do not report routes statuses if:
+	// 1. Routes are not used on the cluster
+	// 2. Central request is in status "Ready" - assuming that routes are already reported and saved
+	if r.useRoutes && !isRemoteCentralReady(remoteCentral) {
+		var err error
+		status.Routes, err = r.getRoutesStatuses(ctx, remoteCentralNamespace)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return status, nil

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -363,7 +363,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		r.hasAuthProvider = true
 	}
 
-	status, err := r.collectReconciliationStatus(ctx, remoteCentral)
+	status, err := r.collectReconciliationStatus(ctx, &remoteCentral)
 	if err != nil {
 		return nil, err
 	}
@@ -377,14 +377,14 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	return status, nil
 }
 
-func (r *CentralReconciler) collectReconciliationStatus(ctx context.Context, remoteCentral private.ManagedCentral) (*private.DataPlaneCentralStatus, error) {
+func (r *CentralReconciler) collectReconciliationStatus(ctx context.Context, remoteCentral *private.ManagedCentral) (*private.DataPlaneCentralStatus, error) {
 	remoteCentralNamespace := remoteCentral.Metadata.Namespace
 
 	status := readyStatus()
 	// Do not report routes statuses if:
 	// 1. Routes are not used on the cluster
 	// 2. Central request is in status "Ready" - assuming that routes are already reported and saved
-	if r.useRoutes && !isRemoteCentralReady(remoteCentral) {
+	if r.useRoutes && !isRemoteCentralReady(*remoteCentral) {
 		var err error
 		status.Routes, err = r.getRoutesStatuses(ctx, remoteCentralNamespace)
 		if err != nil {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
