### PR TITLE
Prefactor: extract central DB reconciliation to dedicated function in fleetshard central reconciler

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -263,31 +263,8 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	}
 
 	if r.managedDBEnabled {
-		centralDBConnectionString, err := r.getCentralDBConnectionString(ctx, remoteCentral)
-		if err != nil {
-			return nil, fmt.Errorf("getting Central DB connection string: %w", err)
-		}
-
-		central.Spec.Central.DB = &v1alpha1.CentralDBSpec{
-			IsEnabled:                v1alpha1.CentralDBEnabledPtr(v1alpha1.CentralDBEnabledTrue),
-			ConnectionStringOverride: pointer.String(centralDBConnectionString),
-			PasswordSecret: &v1alpha1.LocalSecretReference{
-				Name: centralDbSecretName,
-			},
-		}
-
-		dbCA, err := postgres.GetDatabaseCACertificates()
-		if err != nil {
-			glog.Warningf("Could not read DB server CA bundle: %v", err)
-		} else {
-			central.Spec.TLS = &v1alpha1.TLSConfig{
-				AdditionalCAs: []v1alpha1.AdditionalCA{
-					{
-						Name:    postgres.CentralDatabaseCACertificateBaseName,
-						Content: string(dbCA),
-					},
-				},
-			}
+		if err = r.reconcileCentralDBConfig(ctx, remoteCentral, central); err != nil {
+			return nil, err
 		}
 	}
 
@@ -334,6 +311,37 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	}
 
 	return status, nil
+}
+
+func (r *CentralReconciler) reconcileCentralDBConfig(ctx context.Context, remoteCentral private.ManagedCentral, central *v1alpha1.Central) error {
+
+	centralDBConnectionString, err := r.getCentralDBConnectionString(ctx, remoteCentral)
+	if err != nil {
+		return fmt.Errorf("getting Central DB connection string: %w", err)
+	}
+
+	central.Spec.Central.DB = &v1alpha1.CentralDBSpec{
+		IsEnabled:                v1alpha1.CentralDBEnabledPtr(v1alpha1.CentralDBEnabledTrue),
+		ConnectionStringOverride: pointer.String(centralDBConnectionString),
+		PasswordSecret: &v1alpha1.LocalSecretReference{
+			Name: centralDbSecretName,
+		},
+	}
+
+	dbCA, err := postgres.GetDatabaseCACertificates()
+	if err != nil {
+		glog.Warningf("Could not read DB server CA bundle: %v", err)
+	} else {
+		central.Spec.TLS = &v1alpha1.TLSConfig{
+			AdditionalCAs: []v1alpha1.AdditionalCA{
+				{
+					Name:    postgres.CentralDatabaseCACertificateBaseName,
+					Content: string(dbCA),
+				},
+			},
+		}
+	}
+	return nil
 }
 
 func (r *CentralReconciler) reconcileCentral(ctx context.Context, remoteCentral *private.ManagedCentral, central *v1alpha1.Central) error {

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -263,7 +263,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	}
 
 	if r.managedDBEnabled {
-		if err = r.reconcileCentralDBConfig(ctx, remoteCentral, central); err != nil {
+		if err = r.reconcileCentralDBConfig(ctx, &remoteCentral, central); err != nil {
 			return nil, err
 		}
 	}
@@ -313,7 +313,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	return status, nil
 }
 
-func (r *CentralReconciler) reconcileCentralDBConfig(ctx context.Context, remoteCentral private.ManagedCentral, central *v1alpha1.Central) error {
+func (r *CentralReconciler) reconcileCentralDBConfig(ctx context.Context, remoteCentral *private.ManagedCentral, central *v1alpha1.Central) error {
 
 	centralDBConnectionString, err := r.getCentralDBConnectionString(ctx, remoteCentral)
 	if err != nil {
@@ -575,7 +575,7 @@ func (r *CentralReconciler) ensureNamespaceDeleted(ctx context.Context, name str
 	return false, nil
 }
 
-func (r *CentralReconciler) getCentralDBConnectionString(ctx context.Context, remoteCentral private.ManagedCentral) (string, error) {
+func (r *CentralReconciler) getCentralDBConnectionString(ctx context.Context, remoteCentral *private.ManagedCentral) (string, error) {
 	centralDBUserExists, err := r.centralDBUserExists(ctx, remoteCentral.Metadata.Namespace)
 	if err != nil {
 		return "", err
@@ -606,7 +606,7 @@ func generateDBPassword() (string, error) {
 	return password, nil
 }
 
-func (r *CentralReconciler) ensureManagedCentralDBInitialized(ctx context.Context, remoteCentral private.ManagedCentral) error {
+func (r *CentralReconciler) ensureManagedCentralDBInitialized(ctx context.Context, remoteCentral *private.ManagedCentral) error {
 	remoteCentralNamespace := remoteCentral.Metadata.Namespace
 
 	centralDBSecretExists, err := r.centralDBSecretExists(ctx, remoteCentralNamespace)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
