### PR TITLE
Prefactor: extract auth provider configuration reconciliation to dedicated function in fleetshard central reconciler

### DIFF
--- a/fleetshard/pkg/central/reconciler/init_auth.go
+++ b/fleetshard/pkg/central/reconciler/init_auth.go
@@ -126,7 +126,7 @@ func existsRHSSOAuthProvider(ctx context.Context, central *private.ManagedCentra
 
 // createRHSSOAuthProvider initialises sso.redhat.com auth provider in a deployed Central instance.
 func createRHSSOAuthProvider(ctx context.Context, central *private.ManagedCentral, client ctrlClient.Client) error {
-	pass, err := getAdminPassword(ctx, *central, client)
+	pass, err := getAdminPassword(ctx, central, client)
 	if err != nil {
 		return err
 	}
@@ -245,7 +245,7 @@ func getHTTPSServicePort(service *core.Service) (int32, error) {
 	return 0, errors.Errorf("no `https` port is present in %s/%s service", service.Namespace, service.Name)
 }
 
-func getAdminPassword(ctx context.Context, central private.ManagedCentral, client ctrlClient.Client) (string, error) {
+func getAdminPassword(ctx context.Context, central *private.ManagedCentral, client ctrlClient.Client) (string, error) {
 	// pragma: allowlist nextline secret
 	secretRef := ctrlClient.ObjectKey{
 		Name:      centralHtpasswdSecretName,

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -218,7 +218,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		central.ObjectMeta.Labels = labels
 	}
 
-	if err = r.reconcileAuthProviderConfig(ctx, remoteCentral, central); err != nil {
+	if err = r.reconcileAuthProviderConfig(ctx, &remoteCentral, central); err != nil {
 		return nil, err
 	}
 
@@ -263,7 +263,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	}
 
 	// Check whether deployment is ready.
-	centralDeploymentReady, err := isCentralDeploymentReady(ctx, r.client, remoteCentral)
+	centralDeploymentReady, err := isCentralDeploymentReady(ctx, r.client, &remoteCentral)
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +292,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	return status, nil
 }
 
-func (r *CentralReconciler) reconcileAuthProviderConfig(ctx context.Context, remoteCentral private.ManagedCentral, central *v1alpha1.Central) error {
+func (r *CentralReconciler) reconcileAuthProviderConfig(ctx context.Context, remoteCentral *private.ManagedCentral, central *v1alpha1.Central) error {
 	remoteCentralName := remoteCentral.Metadata.Name
 	remoteCentralNamespace := remoteCentral.Metadata.Namespace
 
@@ -412,7 +412,7 @@ func (r *CentralReconciler) reconcileAuthProvider(ctx context.Context, remoteCen
 	// 2. OR reconciler creator specified auth provider not to be created
 	// 3. OR Central request is in status "Ready" - meaning auth provider should've been initialised earlier
 	if r.wantsAuthProvider && !r.hasAuthProvider && !isRemoteCentralReady(remoteCentral) {
-		err := createRHSSOAuthProvider(ctx, *remoteCentral, r.client)
+		err := createRHSSOAuthProvider(ctx, remoteCentral, r.client)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
