### PR TITLE
Fix central count log message deduplication

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -194,12 +194,18 @@ var cache = sync.Map{}
 
 // InfoChangedInt32 logs whenever the value of the passed counter reference changes when it is called.
 func InfoChangedInt32(counter *int32, msg string, args ...interface{}) {
-	val, loaded := cache.LoadOrStore(counter, *counter)
-	if loaded && val == *counter {
+	doIfChangedInt32(counter, func() {
+		glog.InfoDepth(logDepth, fmt.Sprintf(msg, args...))
+	})
+}
+
+func doIfChangedInt32(counter *int32, f func()) {
+	prev, loaded := cache.Swap(counter, *counter)
+	if loaded && prev == *counter {
 		return // counter not changed, do not log
 	}
 
-	glog.InfoDepth(logDepth, fmt.Sprintf(msg, args...))
+	f()
 }
 
 // Warningf ...

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,24 @@
+package logger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInfoChangedInt32(t *testing.T) {
+	times := 0
+
+	increment := func() { times = times + 1 }
+
+	counter := int32(42)
+	doIfChangedInt32(&counter, increment) // log
+
+	counter = int32(43)
+	doIfChangedInt32(&counter, increment) // log
+
+	counter = int32(43)
+	doIfChangedInt32(&counter, increment) // skip
+
+	assert.Equal(t, 2, times)
+}


### PR DESCRIPTION
## Description
Fixed incorrect behavior of `logger.InfoChangedInt32`. The previous implementation used `cache.LoadOrStore` which stored only the first value for the key. This resulted in filtering only messages with the number of central instances stored right after starting fleetshard-sync, i.e.:
```
fleetshard starts
36 centrals -> Message: Received central count changed: received 36 centrals
36 centrals -> filtered
36 centrals -> filtered
37 centrals -> Message: Received central count changed: received 37 centrals
37 centrals -> Message: Received central count changed: received 37 centrals
37 centrals -> Message: Received central count changed: received 37 centrals
37 centrals -> Message: Received central count changed: received 37 centrals
36 centrals -> filtered
36 centrals -> filtered
36 centrals -> filtered
37 centrals -> Message: Received central count changed: received 37 centrals
37 centrals -> Message: Received central count changed: received 37 centrals
37 centrals -> Message: Received central count changed: received 37 centrals
38 centrals -> Message: Received central count changed: received 38 centrals
```
This is typical scenario on stage/prod where the probe service is running.

## Checklist (Definition of Done)
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [x] ~~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- [ ] ~~Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~~
- [x] ~~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- [x] ~~Add secret to app-interface Vault or Secrets Manager if necessary~~
- [x] ~~RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
- [x] ~~Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual
Unit tests

