### PR TITLE
ROX-15234: Prometheus metric for pause-reconcile instances

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -36,10 +36,11 @@ const (
 	FreeStatus int32 = iota
 	BlockedStatus
 
+	PauseReconcileAnnotation = "stackrox.io/pause-reconcile"
+
 	helmReleaseName = "tenant-resources"
 
 	managedServicesAnnotation = "platform.stackrox.io/managed-services"
-	pauseReconcileAnnotation  = "stackrox.io/pause-reconcile"
 	envAnnotationKey          = "rhacs.redhat.com/environment"
 	clusterNameAnnotationKey  = "rhacs.redhat.com/cluster-name"
 	orgNameAnnotationKey      = "rhacs.redhat.com/org-name"
@@ -767,11 +768,11 @@ func (r *CentralReconciler) disablePauseReconcileIfPresent(ctx context.Context, 
 		return nil
 	}
 
-	if value, exists := central.Annotations[pauseReconcileAnnotation]; !exists || value != "true" {
+	if value, exists := central.Annotations[PauseReconcileAnnotation]; !exists || value != "true" {
 		return nil
 	}
 
-	central.Annotations[pauseReconcileAnnotation] = "false"
+	central.Annotations[PauseReconcileAnnotation] = "false"
 	err := r.client.Update(ctx, central)
 	if err != nil {
 		return fmt.Errorf("removing pause reconcile annotation: %v", err)

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -387,7 +387,7 @@ func TestDisablePauseAnnotation(t *testing.T) {
 	central := &v1alpha1.Central{}
 	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralName, Namespace: centralNamespace}, central)
 	require.NoError(t, err)
-	central.Annotations[pauseReconcileAnnotation] = "true"
+	central.Annotations[PauseReconcileAnnotation] = "true"
 	err = fakeClient.Update(context.TODO(), central)
 	require.NoError(t, err)
 
@@ -396,7 +396,7 @@ func TestDisablePauseAnnotation(t *testing.T) {
 
 	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralName, Namespace: centralNamespace}, central)
 	require.NoError(t, err)
-	require.Equal(t, "false", central.Annotations[pauseReconcileAnnotation])
+	require.Equal(t, "false", central.Annotations[PauseReconcileAnnotation])
 }
 
 func TestReconcileDeleteWithManagedDB(t *testing.T) {

--- a/fleetshard/pkg/fleetshardmetrics/metrics.go
+++ b/fleetshard/pkg/fleetshardmetrics/metrics.go
@@ -30,6 +30,7 @@ type Metrics struct {
 	centralDBInstancesMax       prometheus.Gauge
 	centralDBSnapshotsUsed      prometheus.Gauge
 	centralDBSnapshotsMax       prometheus.Gauge
+	pauseReconcileInstances     *prometheus.GaugeVec
 }
 
 // Register registers the metrics with the given prometheus.Registerer
@@ -46,6 +47,7 @@ func (m *Metrics) Register(r prometheus.Registerer) {
 	r.MustRegister(m.centralDBInstancesMax)
 	r.MustRegister(m.centralDBSnapshotsUsed)
 	r.MustRegister(m.centralDBSnapshotsMax)
+	r.MustRegister(m.pauseReconcileInstances)
 }
 
 // IncFleetManagerRequests increments the metric counter for fleet-manager requests
@@ -97,6 +99,16 @@ func (m *Metrics) SetDatabaseAccountQuotas(quotas cloudprovider.AccountQuotas) {
 		m.centralDBSnapshotsUsed.Set(float64(quota.Used))
 		m.centralDBSnapshotsMax.Set(float64(quota.Max))
 	}
+}
+
+// SetPauseReconcileStatus sets the pause reconcile metric for a particular instance
+func (m *Metrics) SetPauseReconcileStatus(instance string, pauseReconcileEnabled bool) {
+	var pauseReconcileValue float64
+	if pauseReconcileEnabled {
+		pauseReconcileValue = 1.0
+	}
+
+	m.pauseReconcileInstances.With(prometheus.Labels{"instance": instance}).Set(pauseReconcileValue)
 }
 
 // MetricsInstance return the global Singleton instance for Metrics
@@ -159,5 +171,12 @@ func newMetrics() *Metrics {
 			Name: metricsPrefix + "central_db_snapshots_max",
 			Help: "The maximum number of Central DB snapshots in the cloud region of fleetshard-sync",
 		}),
+		pauseReconcileInstances: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: metricsPrefix + "pause_reconcile_instances",
+				Help: "The pause-reconcile annotation status of all the instances managed by fleetshard-sync",
+			},
+			[]string{"instance"},
+		),
 	}
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This PR adds a Prometheus metric that exposes the pause-reconcile instances managed by fleetshard-sync.

The metric is implemented as a Gauge, where value 1 means an instance is pause-reconcile'd, and 0 means it's not. Values are labeled by the instance name.

See also https://github.com/stackrox/rhacs-observability-resources/pull/102

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] ~~Added test description under `Test manual`~~
- [ ] ~~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- [ ] ~~Add secret to app-interface Vault or Secrets Manager if necessary~~
- [ ] ~~RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
- [ ] ~~Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual

Manual testing:
```
make deploy/dev
kubectl -n acsms port-forward fleetshard-sync-5479d64d89-v4mph 8080:8080
```

Then opened `http://localhost:8080/metrics` in a browser and checked that the new metrics are there and have correct values, before and after adding the pause-reconcile annotation, e.g.:
```
./scripts/create-central.sh
# edit the central and add annotation: "stackrox.io/pause-reconcile: "true"
kubectl -n rhacs-chs64i3dabr0026a6fag edit centrals.platform.stackrox.io test-central-1
```

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
