### PR TITLE
Fix operator RBAC rules

### DIFF
--- a/fleetshard/pkg/central/charts/data/rhacs-operator/templates/leader-election-role.yaml
+++ b/fleetshard/pkg/central/charts/data/rhacs-operator/templates/leader-election-role.yaml
@@ -1,0 +1,51 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rhacs-operator-controller-manager-role
+  namespace: stackrox-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rhacs-operator-controller-manager-role-binding
+  namespace: stackrox-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rhacs-operator-controller-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: rhacs-operator-controller-manager
+    namespace: stackrox-operator

--- a/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-role.yaml
+++ b/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-role.yaml
@@ -1,0 +1,89 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhacs-operator
+  namespace: stackrox-operator
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - platform.stackrox.io
+    resources:
+      - centrals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - platform.stackrox.io
+    resources:
+      - centrals/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - platform.stackrox.io
+    resources:
+      - centrals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - platform.stackrox.io
+    resources:
+      - securedclusters
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - platform.stackrox.io
+    resources:
+      - securedclusters/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - platform.stackrox.io
+    resources:
+      - securedclusters/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhacs-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhacs-operator
+subjects:
+  - kind: ServiceAccount
+    name: rhacs-operator-controller-manager
+    namespace: stackrox-operator

--- a/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-role.yaml
+++ b/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-role.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: rhacs-operator
-  namespace: stackrox-operator
 rules:
   - apiGroups:
       - '*'

--- a/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-service-account.yaml
+++ b/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-service-account.yaml
@@ -3,5 +3,5 @@ imagePullSecrets:
   - name: quay-ips
 kind: ServiceAccount
 metadata:
-  name: rhacs-operator-manager
+  name: rhacs-operator-controller-manager
   namespace: stackrox-operator


### PR DESCRIPTION
## Description

Fix RBAC operator rules in fleetshard deployment.
These were missing when the fleetshard-based installation was introducded.
Currently this operator installation is protected by a feature flag and not used in production.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

 - needs to be added later