### PR TITLE
Fix service account name in unit test

### DIFF
--- a/fleetshard/pkg/central/operator/upgrade_test.go
+++ b/fleetshard/pkg/central/operator/upgrade_test.go
@@ -51,7 +51,7 @@ var serviceAccount = &unstructured.Unstructured{
 		"kind":       "ServiceAccount",
 		"apiVersion": "v1",
 		"metadata": map[string]interface{}{
-			"name":      "rhacs-operator-manager",
+			"name":      "rhacs-operator-controller-manager",
 			"namespace": operatorNamespace,
 		},
 	},


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Fix the CI by correcting the name of a service account that was changed in a previous PR (https://github.com/stackrox/acs-fleet-manager/pull/1084) but not in the test

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
