### PR TITLE
ROX-17485: Reconcile ACS Operator versions

### DIFF
--- a/fleetshard/pkg/central/charts/charts.go
+++ b/fleetshard/pkg/central/charts/charts.go
@@ -161,6 +161,9 @@ func DeleteChart(ctx context.Context, client ctrlClient.Client, releaseName stri
 	deleteInProgress := false
 	for _, obj := range objs {
 		key := ctrlClient.ObjectKey{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+		if key.Namespace == "" && obj.GetKind() == "Service" {
+			key.Namespace = namespace
+		}
 		var out unstructured.Unstructured
 		out.SetGroupVersionKind(obj.GroupVersionKind())
 		err := client.Get(ctx, key, &out)

--- a/fleetshard/pkg/central/operator/reconciler.go
+++ b/fleetshard/pkg/central/operator/reconciler.go
@@ -53,16 +53,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, targetImages []string, crdTa
 		}
 	}
 
-	if len(installImages) == 0 && len(deleteImages) == 0 {
-		return currentImages, nil
-	}
-
-	updatedImages, err := r.operatorManager.ListVersions(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list operator versions: %w", err)
-	}
-
-	return updatedImages, nil
+	return targetImages, nil
 }
 
 // NewOperatorReconciler creates a new Operator Reconciler instance

--- a/fleetshard/pkg/central/operator/reconciler.go
+++ b/fleetshard/pkg/central/operator/reconciler.go
@@ -1,0 +1,71 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+	"golang.org/x/exp/slices"
+)
+
+// Reconciler keeps necessary dependencies for the operator Reconciler
+type Reconciler struct {
+	operatorManager *ACSOperatorManager
+}
+
+// Reconcile takes a list of desired operator versions and makes sure that current cluster state has those operator versions
+func (r *Reconciler) Reconcile(ctx context.Context, targetImages []string, crdTag string) ([]string, error) {
+	currentImages, err := r.operatorManager.ListVersions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list operator versions: %w", err)
+	}
+
+	// collect operator images for installation
+	var installImages []string
+	for _, img := range targetImages {
+		if !slices.Contains(currentImages, img) {
+			installImages = append(installImages, img)
+		}
+	}
+	if len(installImages) > 0 {
+		glog.Infof("Installing operator versions: %s", strings.Join(installImages, ","))
+		installOperatorImages := toOperatorImage(installImages, crdTag)
+		err = r.operatorManager.InstallOrUpgrade(ctx, installOperatorImages)
+		if err != nil {
+			glog.Warningf("Failed installing operator versions: %v", err)
+		}
+	}
+
+	// collect operator images for deletion
+	var deleteImages []string
+	for _, img := range currentImages {
+		if !slices.Contains(targetImages, img) {
+			deleteImages = append(deleteImages, img)
+		}
+	}
+	if len(deleteImages) > 0 {
+		glog.Infof("Deleting operator versions: %s", strings.Join(installImages, ","))
+		deleteOperatorImages := toOperatorImage(deleteImages, crdTag)
+		err = r.operatorManager.Delete(ctx, deleteOperatorImages)
+		if err != nil {
+			glog.Warningf("Failed deleting operator versions: %v", err)
+		}
+	}
+
+	if len(installImages) == 0 && len(deleteImages) == 0 {
+		return currentImages, nil
+	}
+
+	updatedImages, err := r.operatorManager.ListVersions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list operator versions: %w", err)
+	}
+
+	return updatedImages, nil
+}
+
+// NewOperatorReconciler creates a new Operator Reconciler instance
+func NewOperatorReconciler(operatorManager *ACSOperatorManager) *Reconciler {
+	return &Reconciler{operatorManager}
+}

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/pointer"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -830,36 +829,12 @@ func (r *CentralReconciler) ensureChartResourcesDeleted(ctx context.Context, rem
 		return false, fmt.Errorf("obtaining values for resources chart: %w", err)
 	}
 
-	objs, err := charts.RenderToObjects(helmReleaseName, remoteCentral.Metadata.Namespace, r.resourcesChart, vals)
+	deleted, err := charts.DeleteChart(ctx, r.client, helmReleaseName, remoteCentral.Metadata.Namespace, r.resourcesChart, vals)
 	if err != nil {
-		return false, fmt.Errorf("rendering resources chart: %w", err)
+		return false, fmt.Errorf("failed deleting chart: %w", err)
 	}
 
-	waitForDelete := false
-	for _, obj := range objs {
-		key := ctrlClient.ObjectKey{Namespace: obj.GetNamespace(), Name: obj.GetName()}
-		if key.Namespace == "" {
-			key.Namespace = remoteCentral.Metadata.Namespace
-		}
-		var out unstructured.Unstructured
-		out.SetGroupVersionKind(obj.GroupVersionKind())
-		err := r.client.Get(ctx, key, &out)
-		if err != nil {
-			if apiErrors.IsNotFound(err) {
-				continue
-			}
-			return false, fmt.Errorf("retrieving object %s/%s of type %v: %w", key.Namespace, key.Name, obj.GroupVersionKind(), err)
-		}
-		if out.GetDeletionTimestamp() != nil {
-			waitForDelete = true
-			continue
-		}
-		err = r.client.Delete(ctx, &out)
-		if err != nil && !apiErrors.IsNotFound(err) {
-			return false, fmt.Errorf("retrieving object %s/%s of type %v: %w", key.Namespace, key.Name, obj.GroupVersionKind(), err)
-		}
-	}
-	return !waitForDelete, nil
+	return deleted, nil
 }
 
 func (r *CentralReconciler) ensureRoutesExist(ctx context.Context, remoteCentral private.ManagedCentral) error {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
- Add ACS Operator reconciler. It takes desired operator versions and makes cluster to run exactly those versions
- Add DeleteChart function to charts package

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [x] Add secret to app-interface Vault or Secrets Manager if necessary
- [x] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [x] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

```
# To run tests locally run:
make deploy/dev-fast
```
