### PR TITLE
ROX-15940 default version cli

### DIFF
--- a/internal/dinosaur/pkg/cmd/admin/centrals/cmd.go
+++ b/internal/dinosaur/pkg/cmd/admin/centrals/cmd.go
@@ -27,6 +27,7 @@ func NewAdminCentralsCommand() *cobra.Command {
 	cmd.AddCommand(
 		NewAdminCentralsListCommand(),
 		NewAdminCentralsGetDefaultVersionCommand(fleetmanagerclient.AuthenticatedClientWithRHOASToken()),
+		NewAdminCentralsSetDefaultVersionCommand(fleetmanagerclient.AuthenticatedClientWithRHOASToken()),
 	)
 
 	return cmd

--- a/internal/dinosaur/pkg/cmd/admin/centrals/cmd.go
+++ b/internal/dinosaur/pkg/cmd/admin/centrals/cmd.go
@@ -1,7 +1,15 @@
 // Package centrals contains the admin central CLI interface.
 package centrals
 
-import "github.com/spf13/cobra"
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/cmd/fleetmanagerclient"
+)
 
 const (
 	apiErrorMsg = "%s admin Central failed: To fix this ensure you are authenticated, fleet-manager endpoint is configured and reachable. Status Code: %s."
@@ -18,7 +26,18 @@ func NewAdminCentralsCommand() *cobra.Command {
 	}
 	cmd.AddCommand(
 		NewAdminCentralsListCommand(),
+		NewAdminCentralsGetDefaultVersionCommand(fleetmanagerclient.AuthenticatedClientWithRHOASToken()),
 	)
 
 	return cmd
+}
+
+func printJSON(out io.Writer, data interface{}) {
+	output, err := json.Marshal(data)
+	if err != nil {
+		glog.Errorf("Failed to marshal %T: %s", &data, err)
+		return
+	}
+
+	fmt.Fprint(out, string(output))
 }

--- a/internal/dinosaur/pkg/cmd/admin/centrals/get_default_version.go
+++ b/internal/dinosaur/pkg/cmd/admin/centrals/get_default_version.go
@@ -1,0 +1,31 @@
+package centrals
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
+)
+
+// NewAdminCentralsGetDefaultVersionCommand returns a new command to get the default version for centrals.
+func NewAdminCentralsGetDefaultVersionCommand(client *fleetmanager.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get-default-version",
+		Short: "Get the default version for centrals",
+		Long:  "Get the default version for centrals",
+		Run: func(cmd *cobra.Command, args []string) {
+			runGetDefaultVersion(client, cmd, args)
+		},
+	}
+	return cmd
+}
+
+func runGetDefaultVersion(client *fleetmanager.Client, cmd *cobra.Command, _ []string) {
+	defaultVersion, _, err := client.AdminAPI().GetCentralDefaultVersion(cmd.Context())
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "error calling fleet-manager API: %v\n", err)
+		return
+	}
+
+	printJSON(cmd.OutOrStdout(), &defaultVersion)
+}

--- a/internal/dinosaur/pkg/cmd/admin/centrals/get_default_version_test.go
+++ b/internal/dinosaur/pkg/cmd/admin/centrals/get_default_version_test.go
@@ -1,0 +1,89 @@
+package centrals
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/admin/private"
+	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDefaultVersionCommand(t *testing.T) {
+
+	defaultVersionResponse := private.CentralDefaultVersion{
+		Version: "testversion",
+	}
+
+	tt := []struct {
+		name            string
+		buildMockClient func() *fleetmanager.Client
+		expectedOut     func() (string, error)
+		expectedErr     func() (string, error)
+	}{
+		{
+			name: "should output CentralDefaultVersion as json",
+			buildMockClient: func() *fleetmanager.Client {
+				fmMock := fleetmanager.NewClientMock()
+				fmMock.AdminAPIMock.GetCentralDefaultVersionFunc = func(ctx context.Context) (private.CentralDefaultVersion, *http.Response, error) {
+					return defaultVersionResponse, nil, nil
+				}
+
+				return fmMock.Client()
+			},
+			expectedOut: func() (string, error) {
+				out, err := json.Marshal(&defaultVersionResponse)
+				return string(out), err
+			},
+			expectedErr: func() (string, error) {
+				return "", nil
+			},
+		},
+		{
+			name: "should output api error message",
+			buildMockClient: func() *fleetmanager.Client {
+				fmMock := fleetmanager.NewClientMock()
+				fmMock.AdminAPIMock.GetCentralDefaultVersionFunc = func(ctx context.Context) (private.CentralDefaultVersion, *http.Response, error) {
+					return private.CentralDefaultVersion{}, nil, errors.New("test error")
+				}
+				return fmMock.Client()
+			},
+			expectedOut: func() (string, error) {
+				return "", nil
+			},
+			expectedErr: func() (string, error) {
+				return "error calling fleet-manager API: test error\n", nil
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := NewAdminCentralsGetDefaultVersionCommand(tc.buildMockClient())
+			outBuf := bytes.Buffer{}
+			errBuf := bytes.Buffer{}
+
+			cmd.SetOut(&outBuf)
+			cmd.SetErr(&errBuf)
+
+			cmd.Execute()
+			outB, err := io.ReadAll(&outBuf)
+			require.NoError(t, err, "error reading out buffer")
+			errB, err := io.ReadAll(&errBuf)
+			require.NoError(t, err, "error reading err buffer")
+
+			expectedOut, err := tc.expectedOut()
+			require.NoError(t, err, "error generating expected stdout output")
+			require.Equal(t, expectedOut, string(outB))
+
+			expectedErr, err := tc.expectedErr()
+			require.NoError(t, err, "error generating expected stderr output")
+			require.Equal(t, expectedErr, string(errB))
+		})
+	}
+}

--- a/internal/dinosaur/pkg/cmd/admin/centrals/list.go
+++ b/internal/dinosaur/pkg/cmd/admin/centrals/list.go
@@ -1,9 +1,6 @@
 package centrals
 
 import (
-	"encoding/json"
-	"fmt"
-
 	admin "github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/admin/private"
 
 	"github.com/golang/glog"
@@ -32,11 +29,5 @@ func runList(client *fleetmanager.Client, cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	centralJSON, err := json.Marshal(centrals)
-	if err != nil {
-		glog.Errorf("Failed to marshal CentralRequests: %s", err)
-		return
-	}
-
-	fmt.Println(string(centralJSON))
+	printJSON(cmd.OutOrStdout(), centrals)
 }

--- a/internal/dinosaur/pkg/cmd/admin/centrals/set_default_version.go
+++ b/internal/dinosaur/pkg/cmd/admin/centrals/set_default_version.go
@@ -1,0 +1,33 @@
+package centrals
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
+)
+
+// NewAdminCentralsSetDefaultVersionCommand returns a new command to set the default version for centrals.
+func NewAdminCentralsSetDefaultVersionCommand(client *fleetmanager.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set-default-version version",
+		Short: "Set the default version for centrals",
+		Long:  "Set the default version for centrals",
+		Run: func(cmd *cobra.Command, args []string) {
+			runSetDefaultVersion(client, cmd, args)
+		},
+		Args: cobra.ExactArgs(1),
+	}
+	return cmd
+}
+
+func runSetDefaultVersion(client *fleetmanager.Client, cmd *cobra.Command, _ []string) {
+	fmt.Println("das ist der test")
+	// defaultVersion, _, err := client.AdminAPI().SetCentralDefaultVersion(cmd.Context(), private.CentralDefaultVersion{})
+	// if err != nil {
+	// 	fmt.Fprintf(cmd.ErrOrStderr(), "error calling fleet-manager API: %v\n", err)
+	// 	return
+	// }
+
+	// printJSON(cmd.OutOrStdout(), &defaultVersion)
+}

--- a/internal/dinosaur/pkg/cmd/admin/centrals/set_default_version.go
+++ b/internal/dinosaur/pkg/cmd/admin/centrals/set_default_version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/admin/private"
 	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
 )
 
@@ -21,13 +22,14 @@ func NewAdminCentralsSetDefaultVersionCommand(client *fleetmanager.Client) *cobr
 	return cmd
 }
 
-func runSetDefaultVersion(client *fleetmanager.Client, cmd *cobra.Command, _ []string) {
-	fmt.Println("das ist der test")
-	// defaultVersion, _, err := client.AdminAPI().SetCentralDefaultVersion(cmd.Context(), private.CentralDefaultVersion{})
-	// if err != nil {
-	// 	fmt.Fprintf(cmd.ErrOrStderr(), "error calling fleet-manager API: %v\n", err)
-	// 	return
-	// }
+func runSetDefaultVersion(client *fleetmanager.Client, cmd *cobra.Command, args []string) {
+	version := args[0]
 
-	// printJSON(cmd.OutOrStdout(), &defaultVersion)
+	_, err := client.AdminAPI().SetCentralDefaultVersion(cmd.Context(), private.CentralDefaultVersion{})
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "error calling fleet-manager API: %v\n", err)
+		return
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Central Default Version set to: %s\n", version)
 }

--- a/internal/dinosaur/pkg/cmd/admin/centrals/set_default_version_test.go
+++ b/internal/dinosaur/pkg/cmd/admin/centrals/set_default_version_test.go
@@ -1,0 +1,90 @@
+package centrals
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/admin/private"
+	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetDefaultVersionCommand(t *testing.T) {
+
+	defaultTestVersion := "testregistry.com/testversion:123"
+	defaultExpectedOutput := fmt.Sprintf("Central Default Version set to: %s\n", defaultTestVersion)
+
+	tt := []struct {
+		name            string
+		args            []string
+		buildMockClient func() *fleetmanager.Client
+		expectedOut     func() (string, error)
+		expectedErr     func() (string, error)
+	}{
+		{
+			name: "should output succesfull response",
+			args: []string{defaultTestVersion},
+			buildMockClient: func() *fleetmanager.Client {
+				fmMock := fleetmanager.NewClientMock()
+				fmMock.AdminAPIMock.SetCentralDefaultVersionFunc = func(ctx context.Context, centralDefaultVersionPayload private.CentralDefaultVersion) (*http.Response, error) {
+					return nil, nil
+				}
+
+				return fmMock.Client()
+			},
+			expectedOut: func() (string, error) {
+				return defaultExpectedOutput, nil
+			},
+			expectedErr: func() (string, error) {
+				return "", nil
+			},
+		},
+		{
+			name: "should output api error message",
+			args: []string{defaultTestVersion},
+			buildMockClient: func() *fleetmanager.Client {
+				fmMock := fleetmanager.NewClientMock()
+				fmMock.AdminAPIMock.SetCentralDefaultVersionFunc = func(ctx context.Context, centralDefaultVersionPayload private.CentralDefaultVersion) (*http.Response, error) {
+					return nil, errors.New("test error")
+				}
+				return fmMock.Client()
+			},
+			expectedOut: func() (string, error) {
+				return "", nil
+			},
+			expectedErr: func() (string, error) {
+				return "error calling fleet-manager API: test error\n", nil
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := NewAdminCentralsSetDefaultVersionCommand(tc.buildMockClient())
+			outBuf := bytes.Buffer{}
+			errBuf := bytes.Buffer{}
+
+			cmd.SetOut(&outBuf)
+			cmd.SetErr(&errBuf)
+			cmd.SetArgs(tc.args)
+			cmd.Execute()
+			outB, err := io.ReadAll(&outBuf)
+			require.NoError(t, err, "error reading out buffer")
+			errB, err := io.ReadAll(&errBuf)
+			require.NoError(t, err, "error reading err buffer")
+
+			expectedOut, err := tc.expectedOut()
+			require.NoError(t, err, "error generating expected stdout output")
+			require.Equal(t, expectedOut, string(outB))
+
+			expectedErr, err := tc.expectedErr()
+			require.NoError(t, err, "error generating expected stderr output")
+			require.Equal(t, expectedErr, string(errB))
+		})
+	}
+}

--- a/internal/dinosaur/pkg/cmd/admin/cmd.go
+++ b/internal/dinosaur/pkg/cmd/admin/cmd.go
@@ -4,11 +4,10 @@ package admin
 import (
 	"github.com/spf13/cobra"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/cmd/admin/centrals"
-	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
 )
 
 // NewAdminCommand creates a new admin command.
-func NewAdminCommand(client *fleetmanager.Client) *cobra.Command {
+func NewAdminCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:              "admin",
 		Short:            "Perform admin API calls.",

--- a/internal/dinosaur/pkg/cmd/admin/cmd.go
+++ b/internal/dinosaur/pkg/cmd/admin/cmd.go
@@ -4,10 +4,11 @@ package admin
 import (
 	"github.com/spf13/cobra"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/cmd/admin/centrals"
+	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
 )
 
 // NewAdminCommand creates a new admin command.
-func NewAdminCommand() *cobra.Command {
+func NewAdminCommand(client *fleetmanager.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:              "admin",
 		Short:            "Perform admin API calls.",

--- a/pkg/client/fleetmanager/api_moq.go
+++ b/pkg/client/fleetmanager/api_moq.go
@@ -446,6 +446,9 @@ var _ AdminAPI = &AdminAPIMock{}
 //			GetCentralsFunc: func(ctx context.Context, localVarOptionals *admin.GetCentralsOpts) (admin.CentralList, *http.Response, error) {
 //				panic("mock out the GetCentrals method")
 //			},
+//			SetCentralDefaultVersionFunc: func(ctx context.Context, centralDefaultVersionPayload admin.CentralDefaultVersion) (*http.Response, error) {
+//				panic("mock out the SetCentralDefaultVersion method")
+//			},
 //			UpdateCentralByIdFunc: func(ctx context.Context, id string, centralUpdateRequest admin.CentralUpdateRequest) (admin.Central, *http.Response, error) {
 //				panic("mock out the UpdateCentralById method")
 //			},
@@ -467,6 +470,9 @@ type AdminAPIMock struct {
 
 	// GetCentralsFunc mocks the GetCentrals method.
 	GetCentralsFunc func(ctx context.Context, localVarOptionals *admin.GetCentralsOpts) (admin.CentralList, *http.Response, error)
+
+	// SetCentralDefaultVersionFunc mocks the SetCentralDefaultVersion method.
+	SetCentralDefaultVersionFunc func(ctx context.Context, centralDefaultVersionPayload admin.CentralDefaultVersion) (*http.Response, error)
 
 	// UpdateCentralByIdFunc mocks the UpdateCentralById method.
 	UpdateCentralByIdFunc func(ctx context.Context, id string, centralUpdateRequest admin.CentralUpdateRequest) (admin.Central, *http.Response, error)
@@ -501,6 +507,13 @@ type AdminAPIMock struct {
 			// LocalVarOptionals is the localVarOptionals argument value.
 			LocalVarOptionals *admin.GetCentralsOpts
 		}
+		// SetCentralDefaultVersion holds details about calls to the SetCentralDefaultVersion method.
+		SetCentralDefaultVersion []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// CentralDefaultVersionPayload is the centralDefaultVersionPayload argument value.
+			CentralDefaultVersionPayload admin.CentralDefaultVersion
+		}
 		// UpdateCentralById holds details about calls to the UpdateCentralById method.
 		UpdateCentralById []struct {
 			// Ctx is the ctx argument value.
@@ -515,6 +528,7 @@ type AdminAPIMock struct {
 	lockDeleteDbCentralById      sync.RWMutex
 	lockGetCentralDefaultVersion sync.RWMutex
 	lockGetCentrals              sync.RWMutex
+	lockSetCentralDefaultVersion sync.RWMutex
 	lockUpdateCentralById        sync.RWMutex
 }
 
@@ -659,6 +673,42 @@ func (mock *AdminAPIMock) GetCentralsCalls() []struct {
 	mock.lockGetCentrals.RLock()
 	calls = mock.calls.GetCentrals
 	mock.lockGetCentrals.RUnlock()
+	return calls
+}
+
+// SetCentralDefaultVersion calls SetCentralDefaultVersionFunc.
+func (mock *AdminAPIMock) SetCentralDefaultVersion(ctx context.Context, centralDefaultVersionPayload admin.CentralDefaultVersion) (*http.Response, error) {
+	if mock.SetCentralDefaultVersionFunc == nil {
+		panic("AdminAPIMock.SetCentralDefaultVersionFunc: method is nil but AdminAPI.SetCentralDefaultVersion was just called")
+	}
+	callInfo := struct {
+		Ctx                          context.Context
+		CentralDefaultVersionPayload admin.CentralDefaultVersion
+	}{
+		Ctx:                          ctx,
+		CentralDefaultVersionPayload: centralDefaultVersionPayload,
+	}
+	mock.lockSetCentralDefaultVersion.Lock()
+	mock.calls.SetCentralDefaultVersion = append(mock.calls.SetCentralDefaultVersion, callInfo)
+	mock.lockSetCentralDefaultVersion.Unlock()
+	return mock.SetCentralDefaultVersionFunc(ctx, centralDefaultVersionPayload)
+}
+
+// SetCentralDefaultVersionCalls gets all the calls that were made to SetCentralDefaultVersion.
+// Check the length with:
+//
+//	len(mockedAdminAPI.SetCentralDefaultVersionCalls())
+func (mock *AdminAPIMock) SetCentralDefaultVersionCalls() []struct {
+	Ctx                          context.Context
+	CentralDefaultVersionPayload admin.CentralDefaultVersion
+} {
+	var calls []struct {
+		Ctx                          context.Context
+		CentralDefaultVersionPayload admin.CentralDefaultVersion
+	}
+	mock.lockSetCentralDefaultVersion.RLock()
+	calls = mock.calls.SetCentralDefaultVersion
+	mock.lockSetCentralDefaultVersion.RUnlock()
 	return calls
 }
 

--- a/pkg/client/fleetmanager/api_moq.go
+++ b/pkg/client/fleetmanager/api_moq.go
@@ -440,6 +440,9 @@ var _ AdminAPI = &AdminAPIMock{}
 //			DeleteDbCentralByIdFunc: func(ctx context.Context, id string) (*http.Response, error) {
 //				panic("mock out the DeleteDbCentralById method")
 //			},
+//			GetCentralDefaultVersionFunc: func(ctx context.Context) (admin.CentralDefaultVersion, *http.Response, error) {
+//				panic("mock out the GetCentralDefaultVersion method")
+//			},
 //			GetCentralsFunc: func(ctx context.Context, localVarOptionals *admin.GetCentralsOpts) (admin.CentralList, *http.Response, error) {
 //				panic("mock out the GetCentrals method")
 //			},
@@ -458,6 +461,9 @@ type AdminAPIMock struct {
 
 	// DeleteDbCentralByIdFunc mocks the DeleteDbCentralById method.
 	DeleteDbCentralByIdFunc func(ctx context.Context, id string) (*http.Response, error)
+
+	// GetCentralDefaultVersionFunc mocks the GetCentralDefaultVersion method.
+	GetCentralDefaultVersionFunc func(ctx context.Context) (admin.CentralDefaultVersion, *http.Response, error)
 
 	// GetCentralsFunc mocks the GetCentrals method.
 	GetCentralsFunc func(ctx context.Context, localVarOptionals *admin.GetCentralsOpts) (admin.CentralList, *http.Response, error)
@@ -483,6 +489,11 @@ type AdminAPIMock struct {
 			// ID is the id argument value.
 			ID string
 		}
+		// GetCentralDefaultVersion holds details about calls to the GetCentralDefaultVersion method.
+		GetCentralDefaultVersion []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+		}
 		// GetCentrals holds details about calls to the GetCentrals method.
 		GetCentrals []struct {
 			// Ctx is the ctx argument value.
@@ -500,10 +511,11 @@ type AdminAPIMock struct {
 			CentralUpdateRequest admin.CentralUpdateRequest
 		}
 	}
-	lockCreateCentral       sync.RWMutex
-	lockDeleteDbCentralById sync.RWMutex
-	lockGetCentrals         sync.RWMutex
-	lockUpdateCentralById   sync.RWMutex
+	lockCreateCentral            sync.RWMutex
+	lockDeleteDbCentralById      sync.RWMutex
+	lockGetCentralDefaultVersion sync.RWMutex
+	lockGetCentrals              sync.RWMutex
+	lockUpdateCentralById        sync.RWMutex
 }
 
 // CreateCentral calls CreateCentralFunc.
@@ -579,6 +591,38 @@ func (mock *AdminAPIMock) DeleteDbCentralByIdCalls() []struct {
 	mock.lockDeleteDbCentralById.RLock()
 	calls = mock.calls.DeleteDbCentralById
 	mock.lockDeleteDbCentralById.RUnlock()
+	return calls
+}
+
+// GetCentralDefaultVersion calls GetCentralDefaultVersionFunc.
+func (mock *AdminAPIMock) GetCentralDefaultVersion(ctx context.Context) (admin.CentralDefaultVersion, *http.Response, error) {
+	if mock.GetCentralDefaultVersionFunc == nil {
+		panic("AdminAPIMock.GetCentralDefaultVersionFunc: method is nil but AdminAPI.GetCentralDefaultVersion was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+	}{
+		Ctx: ctx,
+	}
+	mock.lockGetCentralDefaultVersion.Lock()
+	mock.calls.GetCentralDefaultVersion = append(mock.calls.GetCentralDefaultVersion, callInfo)
+	mock.lockGetCentralDefaultVersion.Unlock()
+	return mock.GetCentralDefaultVersionFunc(ctx)
+}
+
+// GetCentralDefaultVersionCalls gets all the calls that were made to GetCentralDefaultVersion.
+// Check the length with:
+//
+//	len(mockedAdminAPI.GetCentralDefaultVersionCalls())
+func (mock *AdminAPIMock) GetCentralDefaultVersionCalls() []struct {
+	Ctx context.Context
+} {
+	var calls []struct {
+		Ctx context.Context
+	}
+	mock.lockGetCentralDefaultVersion.RLock()
+	calls = mock.calls.GetCentralDefaultVersion
+	mock.lockGetCentralDefaultVersion.RUnlock()
 	return calls
 }
 

--- a/pkg/client/fleetmanager/client.go
+++ b/pkg/client/fleetmanager/client.go
@@ -34,6 +34,7 @@ type AdminAPI interface {
 	CreateCentral(ctx context.Context, async bool, centralRequestPayload admin.CentralRequestPayload) (admin.CentralRequest, *http.Response, error)
 	UpdateCentralById(ctx context.Context, id string, centralUpdateRequest admin.CentralUpdateRequest) (admin.Central, *http.Response, error)
 	DeleteDbCentralById(ctx context.Context, id string) (*http.Response, error)
+	GetCentralDefaultVersion(ctx context.Context) (admin.CentralDefaultVersion, *http.Response, error)
 }
 
 var (

--- a/pkg/client/fleetmanager/client.go
+++ b/pkg/client/fleetmanager/client.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/public"
 )
 
-//go:generate moq -out api_moq.go . PublicAPI PrivateAPI AdminAPI
+//go:generate moq -rm -out api_moq.go . PublicAPI PrivateAPI AdminAPI
 
 // PublicAPI is a wrapper interface for the fleetmanager client public API.
 type PublicAPI interface {
@@ -35,6 +35,7 @@ type AdminAPI interface {
 	UpdateCentralById(ctx context.Context, id string, centralUpdateRequest admin.CentralUpdateRequest) (admin.Central, *http.Response, error)
 	DeleteDbCentralById(ctx context.Context, id string) (*http.Response, error)
 	GetCentralDefaultVersion(ctx context.Context) (admin.CentralDefaultVersion, *http.Response, error)
+	SetCentralDefaultVersion(ctx context.Context, centralDefaultVersionPayload admin.CentralDefaultVersion) (*http.Response, error)
 }
 
 var (

--- a/pkg/client/fleetmanager/client.go
+++ b/pkg/client/fleetmanager/client.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/public"
 )
 
-//go:generate moq -rm -out api_moq.go . PublicAPI PrivateAPI AdminAPI
+//go:generate moq -out api_moq.go . PublicAPI PrivateAPI AdminAPI
 
 // PublicAPI is a wrapper interface for the fleetmanager client public API.
 type PublicAPI interface {


### PR DESCRIPTION
## Description
Implemente acsfleetctl commands to set and get the central default version through fleet-manager's API.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
