### PR TITLE
Do not fail on empty operator images

### DIFF
--- a/fleetshard/pkg/central/operator/upgrade.go
+++ b/fleetshard/pkg/central/operator/upgrade.go
@@ -24,8 +24,9 @@ const (
 
 func parseOperatorImages(images []ACSOperatorImage) ([]chartutil.Values, string, error) {
 	if len(images) == 0 {
-		return nil, "", fmt.Errorf("the list of images is empty")
+		return nil, "", nil
 	}
+
 	var operatorImages []chartutil.Values
 	var crdTag string
 	uniqueImages := make(map[string]bool)

--- a/fleetshard/pkg/central/operator/upgrade_test.go
+++ b/fleetshard/pkg/central/operator/upgrade_test.go
@@ -232,9 +232,9 @@ func TestParseOperatorImages(t *testing.T) {
 				{"repository": operatorRepository, "tag": "3.74.1"},
 			},
 		},
-		"fail if images list is empty": {
+		"do not fail if images list is empty": {
 			images:     []ACSOperatorImage{},
-			shouldFail: true,
+			shouldFail: false,
 		},
 		"should accept images from multiple repositories with the same tag": {
 			images: []ACSOperatorImage{{

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -127,7 +127,6 @@ func (r *Runtime) Start() error {
 		if err != nil {
 			err = errors.Wrapf(err, "Upgrading operator")
 			glog.Error(err)
-			return err
 		}
 	}
 


### PR DESCRIPTION
## Description

Do not fail on empty operator images. This lead fleetshard-sync to CrashLoop if no Centrals are available.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

 - /