### PR TITLE
Use the access key for the fleetshard-sync AWS auth on the local dev environment

### DIFF
--- a/dev/env/manifests/fleetshard-sync/01-fleetshard-sync-secrets.yaml
+++ b/dev/env/manifests/fleetshard-sync/01-fleetshard-sync-secrets.yaml
@@ -9,4 +9,5 @@ stringData:
   rhsso-service-account-client-id: "${RHSSO_SERVICE_ACCOUNT_CLIENT_ID}"
   rhsso-service-account-client-secret: "${RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET}"
   aws-role-arn: "${AWS_ROLE_ARN}"
-  aws-token: "${AWS_STATIC_TOKEN}"
+  aws-access-key-id: "${AWS_ACCESS_KEY_ID}"
+  aws-secret-access-key: "${AWS_SECRET_ACCESS_KEY}"

--- a/dev/env/manifests/fleetshard-sync/02-fleetshard-sync-deployment.yaml
+++ b/dev/env/manifests/fleetshard-sync/02-fleetshard-sync-deployment.yaml
@@ -51,11 +51,16 @@ spec:
               value: "$MANAGED_DB_SUBNET_GROUP"
             - name: MANAGED_DB_PERFORMANCE_INSIGHTS
               value: "$MANAGED_DB_PERFORMANCE_INSIGHTS"
-            - name: AWS_ROLE_ARN
+            - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
                   name: fleetshard-sync
-                  key: "aws-role-arn"
+                  key: "aws-access-key-id"
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: fleetshard-sync
+                  key: "aws-secret-access-key"
           image: "${FLEET_MANAGER_IMAGE}"
           imagePullPolicy: IfNotPresent
           name: fleetshard-sync
@@ -65,8 +70,6 @@ spec:
               name: secrets
             - mountPath: /config
               name: config
-            - mountPath: /var/run/secrets/tokens
-              name: aws-token
       restartPolicy: Always
       volumes:
         - name: secrets
@@ -76,9 +79,3 @@ spec:
         - name: config
           configMap:
             name: config
-        - name: aws-token
-          secret:
-            secretName: fleetshard-sync # pragma: allowlist secret
-            items:
-              - key: aws-token
-                path: aws-token

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-secret.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-secret.yaml
@@ -8,3 +8,7 @@ metadata:
 stringData:
   rhsso-service-account-client-id: {{ .Values.fleetshardSync.redHatSSO.clientId | quote }}
   rhsso-service-account-client-secret: {{ .Values.fleetshardSync.redHatSSO.clientSecret | quote }}
+  {{- if eq .Values.fleetshardSync.aws.enableTokenAuth false }}
+  aws-access-key-id: {{ required "fleetshardSync.aws.accessKeyId is required when fleetshardSync.aws.enableTokenAuth = false" .Values.fleetshardSync.aws.accessKeyId | quote }}
+  aws-secret-access-key: {{ required "fleetshardSync.aws.secretAccessKey is required when fleetshardSync.aws.enableTokenAuth = false" .Values.fleetshardSync.aws.secretAccessKey | quote }}
+  {{- end }}

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -80,6 +80,21 @@ spec:
           value: {{ .Values.fleetshardSync.telemetry.storage.endpoint | quote }}
         - name: TELEMETRY_STORAGE_KEY
           value: {{ .Values.fleetshardSync.telemetry.storage.key | quote }}
+        {{- if .Values.fleetshardSync.aws.enableTokenAuth }}
+        - name: AWS_WEB_IDENTITY_TOKEN_FILE
+          value: "/var/run/secrets/tokens/aws-token"
+        {{- else }}
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: fleetshard-sync
+              key: "aws-access-key-id"
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: fleetshard-sync
+              key: "aws-secret-access-key"
+        {{- end }}
         volumeMounts:
           - mountPath: /var/run/secrets/tokens
             name: aws-token

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -35,6 +35,9 @@ fleetshardSync:
   aws:
     region: "us-east-1"  # TODO(2023-05-01): Remove the default value here as we now set it explicitly
     roleARN: ""
+    enableTokenAuth: true
+    accessKeyId: ""
+    secretAccessKey: ""
   telemetry:
     storage:
       endpoint: ""

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -30,16 +30,8 @@ type Config struct {
 	FeatureFlagUpgradeOperatorEnabled bool          `env:"FEATURE_FLAG_UPGRADE_OPERATOR_ENABLED" envDefault:"false"`
 	BaseCrdURL                        string        `env:"BASE_CRD_URL" envDefault:"https://raw.githubusercontent.com/stackrox/stackrox/%s/operator/bundle/manifests/"`
 
-	AWS       AWS
 	ManagedDB ManagedDB
 	Telemetry Telemetry
-}
-
-// AWS for configuring AWS specific parameters
-type AWS struct {
-	Region    string `env:"AWS_REGION" envDefault:"us-east-1"`
-	RoleARN   string `env:"AWS_ROLE_ARN"`
-	TokenFile string `env:"AWS_STS_TOKEN_FILE" envDefault:"/var/run/secrets/tokens/aws-token"`
 }
 
 // ManagedDB for configuring managed DB specific parameters
@@ -85,9 +77,6 @@ func GetConfig() (*Config, error) {
 func validateManagedDBConfig(c Config, configErrors *errorhelpers.ErrorList) {
 	if !c.ManagedDB.Enabled {
 		return
-	}
-	if c.AWS.RoleARN == "" {
-		configErrors.AddError(errors.New("MANAGED_DB_ENABLED == true and AWS_ROLE_ARN unset in the environment"))
 	}
 	if c.ManagedDB.SecurityGroup == "" {
 		configErrors.AddError(errors.New("MANAGED_DB_ENABLED == true and MANAGED_DB_SECURITY_GROUP unset in the environment"))

--- a/fleetshard/config/config_test.go
+++ b/fleetshard/config/config_test.go
@@ -30,30 +30,17 @@ func TestSingleton_Failure(t *testing.T) {
 
 func TestSingleton_Success_WhenManagedDBEnabled(t *testing.T) {
 	t.Setenv("CLUSTER_ID", "some-value")
-	t.Setenv("AWS_ROLE_ARN", "arn:aws:iam::012456789:role/fake_role")
 	t.Setenv("MANAGED_DB_ENABLED", "true")
 	t.Setenv("MANAGED_DB_SECURITY_GROUP", "some-group")
 	cfg, err := GetConfig()
 	require.NoError(t, err)
-	assert.Equal(t, cfg.AWS.RoleARN, "arn:aws:iam::012456789:role/fake_role")
-	assert.Equal(t, cfg.AWS.Region, "us-east-1")
 	assert.Equal(t, cfg.ManagedDB.Enabled, true)
 	assert.Equal(t, cfg.ManagedDB.SecurityGroup, "some-group")
-}
-
-func TestSingleton_Failure_WhenManagedDBEnabledAndAWSRoleArnNotSet(t *testing.T) {
-	t.Setenv("CLUSTER_ID", "some-value")
-	t.Setenv("MANAGED_DB_ENABLED", "true")
-	t.Setenv("MANAGED_DB_SECURITY_GROUP", "some-group")
-	cfg, err := GetConfig()
-	assert.Error(t, err, "MANAGED_DB_ENABLED == true and AWS_ROLE_ARN unset in the environment")
-	assert.Nil(t, cfg)
 }
 
 func TestSingleton_Failure_WhenManagedDBEnabledAndManagedDbSecurityGroupNotSet(t *testing.T) {
 	t.Setenv("CLUSTER_ID", "some-value")
 	t.Setenv("MANAGED_DB_ENABLED", "true")
-	t.Setenv("AWS_ROLE_ARN", "arn:aws:iam::012456789:role/fake_role")
 	cfg, err := GetConfig()
 	assert.Error(t, err, "MANAGED_DB_ENABLED == true and MANAGED_DB_SECURITY_GROUP unset in the environment")
 	assert.Nil(t, cfg)

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -190,14 +190,16 @@ func TestReconcileCreateWithLabelOperatorVersion(t *testing.T) {
 }
 
 func TestReconcileCreateWithManagedDBNoCredentials(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_ROLE_ARN", "arn:aws:iam::012456789:role/fake_role")
+	t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "/var/run/secrets/tokens/aws-token")
+
 	fakeClient := testutils.NewFakeClientBuilder(t).Build()
 
 	managedDBProvisioningClient, err := awsclient.NewRDSClient(
 		&config.Config{
-			AWS: config.AWS{
-				Region:  "us-east-1",
-				RoleARN: "arn:aws:iam::012456789:role/fake_role",
-			},
 			ManagedDB: config.ManagedDB{
 				SecurityGroup: "security-group",
 				SubnetGroup:   "db-group",


### PR DESCRIPTION
## Description
It turned out that the static key or jwt loaded from the OAuth identity provider is not suitable for the local development, because:

1. AWS rejects tokens with the long validity period even if they are not expired. It means that we need to refresh the "static" token periodically, which requires some effort.
2. It's hard to setup the token in a case when fleetshard-sync runs locally out of the cluster.

**As a result, fleetshard-sync can't start locally with `MANAGED_DB_ENABLED=true`**

We are forced to use the access key for this special case, as it is most convenient. It will also help in addressing the concerns raised in #1078.

The change in `rds.go` will make the configuration loadable from environment variables, allowing the auth type to be switched. In the case of dev environments, the access key will be used. In other cases the token will remain.

I also added the support of the access key to the helm chart to use it on the dev environment in the future.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual
1. `helm template`
2. `./dev/env/scripts/up.sh`
3. `./dev/env/scripts/exec_fleetshard_sync.sh`
4. RDS E2E tests
