### PR TITLE
Add feature flags package

### DIFF
--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -290,7 +290,7 @@ inject_feature_flags_from_env() {
     local deployment="$2"
 
     flags=$(printenv | grep -e "RHACS_*")
-    for flag in "$flags"
+    for flag in $flags
     do
         $KUBECTL -n "$namespace" set env "deployment/$deployment" --all "$flag"
     done

--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -292,7 +292,7 @@ inject_exported_env_vars() {
     flags=$(printenv | grep -e "RHACS_*")
     for flag in $flags
     do
-        $KUBECTL -n "$namespace" set env "deployment/$deployment" --all "$flag"
+        $KUBECTL -n "$namespace" set env "deployment/$deployment" "$flag"
     done
 }
 

--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -285,6 +285,17 @@ inject_ips() {
     $KUBECTL -n "$namespace" patch sa "$service_account" -p "\"imagePullSecrets\": [{\"name\": \"${secret_name}\" }]"
 }
 
+inject_feature_flags_from_env() {
+    local namespace="$1"
+    local deployment="$2"
+
+    flags=$(printenv | grep -e "RHACS_*")
+    for flag in "$flags"
+    do
+        $KUBECTL -n "$namespace" set env "deployment/$deployment" --all "$flag"
+    done
+}
+
 is_local_cluster() {
     local cluster_type=${1:-}
     if [[ "$cluster_type" == "minikube" || "$cluster_type" == "colima" || "$cluster_type" == "rancher-desktop" ]]; then

--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -285,7 +285,7 @@ inject_ips() {
     $KUBECTL -n "$namespace" patch sa "$service_account" -p "\"imagePullSecrets\": [{\"name\": \"${secret_name}\" }]"
 }
 
-inject_feature_flags_from_env() {
+inject_exported_env_vars() {
     local namespace="$1"
     local deployment="$2"
 

--- a/dev/env/scripts/up.sh
+++ b/dev/env/scripts/up.sh
@@ -64,7 +64,7 @@ log "Database is ready."
 # Deploy MS components.
 log "Deploying fleet-manager"
 chamber exec "fleet-manager" -- apply "${MANIFESTS_DIR}/fleet-manager"
-inject_feature_flags_from_env "$ACSMS_NAMESPACE" "fleet-manager"
+inject_exported_env_vars "$ACSMS_NAMESPACE" "fleet-manager"
 
 wait_for_container_to_appear "$ACSMS_NAMESPACE" "application=fleet-manager" "fleet-manager"
 if [[ "$SPAWN_LOGGER" == "true" && -n "${LOG_DIR:-}" ]]; then
@@ -73,7 +73,7 @@ fi
 
 log "Deploying fleetshard-sync"
 exec_fleetshard_sync.sh apply "${MANIFESTS_DIR}/fleetshard-sync"
-inject_feature_flags_from_env "$ACSMS_NAMESPACE" "fleetshard-sync"
+inject_exported_env_vars "$ACSMS_NAMESPACE" "fleetshard-sync"
 
 wait_for_container_to_appear "$ACSMS_NAMESPACE" "application=fleetshard-sync" "fleetshard-sync"
 if [[ "$SPAWN_LOGGER" == "true" && -n "${LOG_DIR:-}" ]]; then

--- a/dev/env/scripts/up.sh
+++ b/dev/env/scripts/up.sh
@@ -64,6 +64,8 @@ log "Database is ready."
 # Deploy MS components.
 log "Deploying fleet-manager"
 chamber exec "fleet-manager" -- apply "${MANIFESTS_DIR}/fleet-manager"
+inject_feature_flags_from_env "$ACSMS_NAMESPACE" "fleet-manager"
+
 wait_for_container_to_appear "$ACSMS_NAMESPACE" "application=fleet-manager" "fleet-manager"
 if [[ "$SPAWN_LOGGER" == "true" && -n "${LOG_DIR:-}" ]]; then
     $KUBECTL -n "$ACSMS_NAMESPACE" logs -l application=fleet-manager --all-containers --pod-running-timeout=1m --since=1m --tail=100 -f >"${LOG_DIR}/pod-logs_fleet-manager.txt" 2>&1 &
@@ -71,6 +73,8 @@ fi
 
 log "Deploying fleetshard-sync"
 exec_fleetshard_sync.sh apply "${MANIFESTS_DIR}/fleetshard-sync"
+inject_feature_flags_from_env "$ACSMS_NAMESPACE" "fleetshard-sync"
+
 wait_for_container_to_appear "$ACSMS_NAMESPACE" "application=fleetshard-sync" "fleetshard-sync"
 if [[ "$SPAWN_LOGGER" == "true" && -n "${LOG_DIR:-}" ]]; then
     $KUBECTL -n "$ACSMS_NAMESPACE" logs -l application=fleetshard-sync --all-containers --pod-running-timeout=1m --since=1m --tail=100 -f >"${LOG_DIR}/pod-logs_fleetshard-sync_fleetshard-sync.txt" 2>&1 &

--- a/docs/development/feature-flags.md
+++ b/docs/development/feature-flags.md
@@ -1,0 +1,19 @@
+# Feature Flags
+
+Feature Flags can be added to the `pkg/features/list.go` file.
+All feature flags must be prefixed with `RHACS_`.
+
+Example in `list.go`: 
+```
+TargetedOperatorUpgrades = registerFeature("Upgrade Central instances targetedly via fleet-manager API", "RHACS_TARGETED_OPERATOR_UPGRADES", false)
+```
+
+The feature flag can be referenced in code globally:
+
+```
+if features.TargetedOperator.Upgrades.Enabled() {
+  // do something...
+}
+```
+
+`make deploy/dev` will automatically inject exported feature flags into your local deployments.

--- a/docs/development/feature-flags.md
+++ b/docs/development/feature-flags.md
@@ -3,7 +3,7 @@
 Feature Flags can be added to the `pkg/features/list.go` file.
 All feature flags must be prefixed with `RHACS_`.
 
-Example in `list.go`: 
+Example in `list.go`:
 ```
 TargetedOperatorUpgrades = registerFeature("Upgrade Central instances targetedly via fleet-manager API", "RHACS_TARGETED_OPERATOR_UPGRADES", false)
 ```

--- a/docs/legacy/feature-flags.md
+++ b/docs/legacy/feature-flags.md
@@ -1,4 +1,9 @@
+# [Deprecated] Note
+
+To introduce new feature flags please use package `pkg/features/` and add your flag to `list.go`.
+
 # Feature Flags
+
 This lists the feature flags and their sub-configurations to enable/disable and configure features of the Fleet Manager. This set of features can be seen below.
 
   - [Feature Flags](#feature-flags)

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -12,23 +12,22 @@ import (
 
 // Config contains this application's runtime configuration.
 type Config struct {
-	FleetManagerEndpoint              string        `env:"FLEET_MANAGER_ENDPOINT" envDefault:"http://127.0.0.1:8000"`
-	ClusterID                         string        `env:"CLUSTER_ID"`
-	ClusterName                       string        `env:"CLUSTER_NAME"`
-	Environment                       string        `env:"ENVIRONMENT"`
-	RuntimePollPeriod                 time.Duration `env:"RUNTIME_POLL_PERIOD" envDefault:"5s"`
-	AuthType                          string        `env:"AUTH_TYPE" envDefault:"RHSSO"`
-	RHSSOClientID                     string        `env:"RHSSO_SERVICE_ACCOUNT_CLIENT_ID"`
-	RHSSOClientSecret                 string        `env:"RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET"`
-	RHSSORealm                        string        `env:"RHSSO_REALM" envDefault:"redhat-external"`
-	RHSSOEndpoint                     string        `env:"RHSSO_ENDPOINT" envDefault:"https://sso.redhat.com"`
-	OCMRefreshToken                   string        `env:"OCM_TOKEN"`
-	StaticToken                       string        `env:"STATIC_TOKEN"`
-	CreateAuthProvider                bool          `env:"CREATE_AUTH_PROVIDER" envDefault:"false"`
-	MetricsAddress                    string        `env:"FLEETSHARD_METRICS_ADDRESS" envDefault:":8080"`
-	EgressProxyImage                  string        `env:"EGRESS_PROXY_IMAGE"`
-	FeatureFlagUpgradeOperatorEnabled bool          `env:"FEATURE_FLAG_UPGRADE_OPERATOR_ENABLED" envDefault:"false"`
-	BaseCrdURL                        string        `env:"BASE_CRD_URL" envDefault:"https://raw.githubusercontent.com/stackrox/stackrox/%s/operator/bundle/manifests/"`
+	FleetManagerEndpoint string        `env:"FLEET_MANAGER_ENDPOINT" envDefault:"http://127.0.0.1:8000"`
+	ClusterID            string        `env:"CLUSTER_ID"`
+	ClusterName          string        `env:"CLUSTER_NAME"`
+	Environment          string        `env:"ENVIRONMENT"`
+	RuntimePollPeriod    time.Duration `env:"RUNTIME_POLL_PERIOD" envDefault:"5s"`
+	AuthType             string        `env:"AUTH_TYPE" envDefault:"RHSSO"`
+	RHSSOClientID        string        `env:"RHSSO_SERVICE_ACCOUNT_CLIENT_ID"`
+	RHSSOClientSecret    string        `env:"RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET"`
+	RHSSORealm           string        `env:"RHSSO_REALM" envDefault:"redhat-external"`
+	RHSSOEndpoint        string        `env:"RHSSO_ENDPOINT" envDefault:"https://sso.redhat.com"`
+	OCMRefreshToken      string        `env:"OCM_TOKEN"`
+	StaticToken          string        `env:"STATIC_TOKEN"`
+	CreateAuthProvider   bool          `env:"CREATE_AUTH_PROVIDER" envDefault:"false"`
+	MetricsAddress       string        `env:"FLEETSHARD_METRICS_ADDRESS" envDefault:":8080"`
+	EgressProxyImage     string        `env:"EGRESS_PROXY_IMAGE"`
+	BaseCrdURL           string        `env:"BASE_CRD_URL" envDefault:"https://raw.githubusercontent.com/stackrox/stackrox/%s/operator/bundle/manifests/"`
 
 	AWS       AWS
 	ManagedDB ManagedDB

--- a/fleetshard/config/config_test.go
+++ b/fleetshard/config/config_test.go
@@ -19,7 +19,6 @@ func TestSingleton_Success(t *testing.T) {
 	assert.Equal(t, cfg.RHSSORealm, "redhat-external")
 	assert.Equal(t, cfg.RHSSOEndpoint, "https://sso.redhat.com")
 	assert.Empty(t, cfg.OCMRefreshToken)
-	assert.False(t, cfg.FeatureFlagUpgradeOperatorEnabled)
 }
 
 func TestSingleton_Failure(t *testing.T) {

--- a/fleetshard/main.go
+++ b/fleetshard/main.go
@@ -35,7 +35,6 @@ func main() {
 	glog.Infof("ClusterID: %s", config.ClusterID)
 	glog.Infof("RuntimePollPeriod: %s", config.RuntimePollPeriod.String())
 	glog.Infof("AuthType: %s", config.AuthType)
-	glog.Infof("FeatureFlagUpgradeOperatorEnabled: %t", config.FeatureFlagUpgradeOperatorEnabled)
 
 	glog.Infof("ManagedDB.Enabled: %t", config.ManagedDB.Enabled)
 	glog.Infof("ManagedDB.SecurityGroup: %s", config.ManagedDB.SecurityGroup)

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"embed"
 	"fmt"
-	"github.com/stackrox/acs-fleet-manager/pkg/features"
 	"testing"
 	"time"
 
@@ -23,6 +22,7 @@ import (
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/util"
 	centralConstants "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
+	"github.com/stackrox/acs-fleet-manager/pkg/features"
 	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"embed"
 	"fmt"
+	"github.com/stackrox/acs-fleet-manager/pkg/features"
 	"testing"
 	"time"
 
@@ -170,11 +171,11 @@ func TestReconcileCreateWithManagedDB(t *testing.T) {
 
 func TestReconcileCreateWithLabelOperatorVersion(t *testing.T) {
 	fakeClient := testutils.NewFakeClientBuilder(t).Build()
+	t.Setenv(features.TargetedOperatorUpgrades.EnvVar(), "true")
 
 	r := NewCentralReconciler(fakeClient, private.ManagedCentral{}, nil, centralDBInitFunc,
 		CentralReconcilerOptions{
-			UseRoutes:                         true,
-			FeatureFlagUpgradeOperatorEnabled: true,
+			UseRoutes: true,
 		})
 
 	status, err := r.Reconcile(context.TODO(), simpleManagedCentral)

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -4,6 +4,7 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"github.com/stackrox/acs-fleet-manager/pkg/features"
 	"time"
 
 	"github.com/golang/glog"
@@ -112,17 +113,16 @@ func (r *Runtime) Start() error {
 	routesAvailable := r.routesAvailable()
 
 	reconcilerOpts := centralReconciler.CentralReconcilerOptions{
-		UseRoutes:                         routesAvailable,
-		WantsAuthProvider:                 r.config.CreateAuthProvider,
-		EgressProxyImage:                  r.config.EgressProxyImage,
-		ManagedDBEnabled:                  r.config.ManagedDB.Enabled,
-		Telemetry:                         r.config.Telemetry,
-		ClusterName:                       r.config.ClusterName,
-		Environment:                       r.config.Environment,
-		FeatureFlagUpgradeOperatorEnabled: r.config.FeatureFlagUpgradeOperatorEnabled,
+		UseRoutes:         routesAvailable,
+		WantsAuthProvider: r.config.CreateAuthProvider,
+		EgressProxyImage:  r.config.EgressProxyImage,
+		ManagedDBEnabled:  r.config.ManagedDB.Enabled,
+		Telemetry:         r.config.Telemetry,
+		ClusterName:       r.config.ClusterName,
+		Environment:       r.config.Environment,
 	}
 
-	if r.config.FeatureFlagUpgradeOperatorEnabled {
+	if features.TargetedOperatorUpgrades.Enabled() {
 		err := r.upgradeOperator()
 		if err != nil {
 			err = errors.Wrapf(err, "Upgrading operator")

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -4,7 +4,6 @@ package runtime
 import (
 	"context"
 	"fmt"
-	"github.com/stackrox/acs-fleet-manager/pkg/features"
 	"time"
 
 	"github.com/golang/glog"
@@ -19,6 +18,7 @@ import (
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
 	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
+	"github.com/stackrox/acs-fleet-manager/pkg/features"
 	"github.com/stackrox/acs-fleet-manager/pkg/logger"
 	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
 	"github.com/stackrox/rox/pkg/concurrency"

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -1,0 +1,35 @@
+package features
+
+import (
+	"os"
+	"strings"
+)
+
+type feature struct {
+	envVar       string
+	name         string
+	defaultValue bool
+}
+
+func (f *feature) EnvVar() string {
+	return f.envVar
+}
+
+func (f *feature) Name() string {
+	return f.name
+}
+
+func (f *feature) Default() bool {
+	return f.defaultValue
+}
+
+func (f *feature) Enabled() bool {
+	switch strings.ToLower(os.Getenv(f.envVar)) {
+	case "false":
+		return false
+	case "true":
+		return true
+	default:
+		return f.defaultValue
+	}
+}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -1,0 +1,33 @@
+// Package features helps enable or disable features.
+package features
+
+import (
+	"fmt"
+	"strings"
+)
+
+// A FeatureFlag is a product behavior that can be enabled or disabled using an environment variable.
+type FeatureFlag interface {
+	Name() string
+	EnvVar() string
+	Enabled() bool
+	Default() bool
+}
+
+var (
+	// Flags contains all defined FeatureFlags by name.
+	Flags = make(map[string]FeatureFlag)
+)
+
+func registerFeature(name, envVar string, defaultValue bool) FeatureFlag {
+	if !strings.HasPrefix(envVar, "RHACS_") {
+		panic(fmt.Sprintf("invalid env var: %s, must start with ROX_", envVar))
+	}
+	f := &feature{
+		name:         name,
+		envVar:       envVar,
+		defaultValue: defaultValue,
+	}
+	Flags[f.Name()] = f
+	return f
+}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -21,7 +21,7 @@ var (
 
 func registerFeature(name, envVar string, defaultValue bool) FeatureFlag {
 	if !strings.HasPrefix(envVar, "RHACS_") {
-		panic(fmt.Sprintf("invalid env var: %s, must start with ROX_", envVar))
+		panic(fmt.Sprintf("invalid env var: %s, must start with RHACS_", envVar))
 	}
 	f := &feature{
 		name:         name,

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -69,11 +69,11 @@ func TestFlags(t *testing.T) {
 	assert.Panics(t, func() {
 		registerFeature("blah", "NOT_ROX_WHATEVER", false)
 	})
-	defaultTrueFeature := registerFeature("default_true", "ROX_DEFAULT_TRUE", true)
+	defaultTrueFeature := registerFeature("default_true", "RHACS_DEFAULT_TRUE", true)
 	for _, test := range defaultTrueCases {
 		testFlagEnabled(t, defaultTrueFeature, test, true)
 	}
-	defaultFalseFeature := registerFeature("default_false", "ROX_DEFAULT_FALSE", false)
+	defaultFalseFeature := registerFeature("default_false", "RHACS_DEFAULT_FALSE", false)
 	for _, test := range defaultFalseCases {
 		testFlagEnabled(t, defaultFalseFeature, test, false)
 	}

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -1,0 +1,80 @@
+package features
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stackrox/rox/pkg/buildinfo"
+	"github.com/stretchr/testify/assert"
+)
+
+type envTest struct {
+	env      string
+	expected bool
+}
+
+var (
+	defaultTrueCases = []envTest{
+		{"true", true},
+		{"TRUE", true},
+		{"True", true},
+		{"false", false},
+		{"FALSE", false},
+		{"False", false},
+		{"", true},
+		{"blargle!", true},
+	}
+
+	defaultFalseCases = []envTest{
+		{"true", true},
+		{"TRUE", true},
+		{"True", true},
+		{"false", false},
+		{"FALSE", false},
+		{"False", false},
+		{"", false},
+		{"blargle!", false},
+	}
+)
+
+func testFlagEnabled(t *testing.T, feature FeatureFlag, test envTest, defaultValue bool) {
+	t.Run(fmt.Sprintf("%s/%s", feature.Name(), test.env), func(t *testing.T) {
+		oldValue, exists := os.LookupEnv(feature.EnvVar())
+
+		err := os.Setenv(feature.EnvVar(), test.env)
+		if err != nil {
+			t.Fatalf("Setting env failed for %s", feature.EnvVar())
+		}
+		if !exists {
+			defer func() {
+				assert.NoError(t, os.Unsetenv(feature.EnvVar()))
+			}()
+		} else {
+			defer func() {
+				assert.NoError(t, os.Setenv(feature.EnvVar(), oldValue))
+			}()
+		}
+
+		got := feature.Enabled()
+		if buildinfo.ReleaseBuild {
+			assert.Equal(t, got, defaultValue)
+		} else {
+			assert.Equal(t, got, test.expected)
+		}
+	})
+}
+
+func TestFlags(t *testing.T) {
+	assert.Panics(t, func() {
+		registerFeature("blah", "NOT_ROX_WHATEVER", false)
+	})
+	defaultTrueFeature := registerFeature("default_true", "ROX_DEFAULT_TRUE", true)
+	for _, test := range defaultTrueCases {
+		testFlagEnabled(t, defaultTrueFeature, test, true)
+	}
+	defaultFalseFeature := registerFeature("default_false", "ROX_DEFAULT_FALSE", false)
+	for _, test := range defaultFalseCases {
+		testFlagEnabled(t, defaultFalseFeature, test, false)
+	}
+}

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -1,0 +1,6 @@
+package features
+
+var (
+	// TargetedOperatorUpgrades enables the targeted operator upgrades
+	TargetedOperatorUpgrades = registerFeature("Upgrade Central instances targetedly via fleet-manager API", "RHACS_TARGETED_OPERATOR_UPGRADES", false)
+)


### PR DESCRIPTION
## Description

Adds feature flags package from StackRox repository.
It removes the buildinfo protection for release build. This flag is not supported in fleet-manager and not necessary as fleet-manager is not shipped to customers.

Added documentation with more details.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

 - unit tests
 - deploy acs-fleet-manager locally with dev scripts