### PR TITLE
ROX-17532: add update logic for central routes on Host and TLS changes

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -5,9 +5,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/stackrox/acs-fleet-manager/pkg/features"
 	"sync/atomic"
 	"time"
+
+	"github.com/stackrox/acs-fleet-manager/pkg/features"
 
 	"github.com/golang/glog"
 	openshiftRouteV1 "github.com/openshift/api/route/v1"
@@ -873,7 +874,7 @@ func (r *CentralReconciler) ensureRoutesExist(ctx context.Context, remoteCentral
 // TODO(ROX-9310): Move re-encrypt route reconciliation to the StackRox operator
 func (r *CentralReconciler) ensureReencryptRouteExists(ctx context.Context, remoteCentral private.ManagedCentral) error {
 	namespace := remoteCentral.Metadata.Namespace
-	_, err := r.routeService.FindReencryptRoute(ctx, namespace)
+	route, err := r.routeService.FindReencryptRoute(ctx, namespace)
 	if err != nil && !apiErrors.IsNotFound(err) {
 		return fmt.Errorf("retrieving reencrypt route for namespace %q: %w", namespace, err)
 	}
@@ -883,6 +884,13 @@ func (r *CentralReconciler) ensureReencryptRouteExists(ctx context.Context, remo
 		if err != nil {
 			return fmt.Errorf("creating reencrypt route for central %s: %w", remoteCentral.Id, err)
 		}
+
+		return nil
+	}
+
+	err = r.routeService.UpdateReencryptRoute(ctx, route, remoteCentral)
+	if err != nil {
+		return fmt.Errorf("updating reencrypt route for central %s: %w", remoteCentral.Id, err)
 	}
 
 	return nil
@@ -901,7 +909,7 @@ func (r *CentralReconciler) ensureReencryptRouteDeleted(ctx context.Context, nam
 // TODO(ROX-11918): Make hostname configurable on the StackRox operator
 func (r *CentralReconciler) ensurePassthroughRouteExists(ctx context.Context, remoteCentral private.ManagedCentral) error {
 	namespace := remoteCentral.Metadata.Namespace
-	_, err := r.routeService.FindPassthroughRoute(ctx, namespace)
+	route, err := r.routeService.FindPassthroughRoute(ctx, namespace)
 	if err != nil && !apiErrors.IsNotFound(err) {
 		return fmt.Errorf("retrieving passthrough route for namespace %q: %w", namespace, err)
 	}
@@ -911,6 +919,13 @@ func (r *CentralReconciler) ensurePassthroughRouteExists(ctx context.Context, re
 		if err != nil {
 			return fmt.Errorf("creating passthrough route for central %s: %w", remoteCentral.Id, err)
 		}
+
+		return nil
+	}
+
+	err = r.routeService.UpdatePassthroughRoute(ctx, route, remoteCentral)
+	if err != nil {
+		return fmt.Errorf("updating passthrough route for central %s: %w", remoteCentral.Id, err)
 	}
 
 	return nil


### PR DESCRIPTION
## Description
Fleetshard-sync does not react to changes in host names or the TLS certificates for central tenant routes. This result in the problem that rotating the certificates for central tenants is currently not possible without manual interaction with the routes.

This PR changes fleetshard-sync, so that it recognizes changes in the private.ManagedCentral Endpoints configuration. If it detects changes the routes are updated accordingly.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Added test description under `Test manual`
- ~~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- ~~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- ~~[ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
- ~~[ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
- ~~[ ] Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual

```
make binary
make db/teardown db/setup db/migrate

# Start a local crc cluster
# Install RHACS operator on CRC cluster
# Start with empty ./secrets/central-tls.crt and ./secrets/central-tls.key

# Each in seperate terminal session
./fleet-manager serve --dataplane-cluster-config-file "./dev/config/dataplane-cluster-configuration-crc.yaml"
AUTH_TYPE=OCM OCM_TOKEN=$(ocm token --refresh) CLUSTER_ID=1234567890abcdef1234567890abcdef ./fleetshard-sync

# Create a central instance
export OCM_TOKEN=$(ocm token --refresh)
./acsfleetctl centrals create --name "test-central-1" --region "standalone" --provider "standalone"

# Wait for all pods and routes to be created
# call your reencrypt hostname, verify it's using crcs wildcard cert
# Terminate fleet-manager and populate ./secrets/central-tls.crt and ./secrets/central-tls.key with the Dev certificates for ACSCS and restart
# Verify that certs used by route change

# Next verify hostname changes are propaged

make db/psql
UPDATE central_requests set host = 'test.test';
k get routes -n <central-namespace>
# See that host is now acs-<id>.test.test


```


```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
