### PR TITLE
Add pre-commit target for faster runs locally

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ run:
     - internal/dinosaur/pkg/api/admin/private
     - pkg/client/redhatsso/api
   skip-files:
-    - "*_moq.go"
+    - ".*_moq.go"
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 10m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,8 @@ run:
     - internal/dinosaur/pkg/api/private
     - internal/dinosaur/pkg/api/admin/private
     - pkg/client/redhatsso/api
+  skip-files:
+    - "*_moq.go"
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 10m
 

--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,10 @@ lint: specinstall
 	spectral lint templates/*.yml templates/*.yaml --ignore-unknown-format --ruleset .validate-templates.yaml
 .PHONY: lint
 
+pre-commit:
+	pre-commit run --files $(git --no-pager diff --name-only main)
+.PHONY: pre-commit
+
 # Build binaries
 # NOTE it may be necessary to use CGO_ENABLED=0 for backwards compatibility with centos7 if not using centos7
 


### PR DESCRIPTION
## Description

My pre-commit runs sometimes take a lot of time. It seems that on my machine they are often executed against all files.
I didn't figured out how to fix this, instead added a workaround as a Makefile target.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

 - Run `make pre-commit`