### PR TITLE
Remove available_central_operator_versions database field

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -257,63 +257,63 @@
         "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
         "hashed_secret": "13032f402fed753c2248419ea4f69f99931f6dbc",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 38
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
         "hashed_secret": "30025f80f6e22cdafb85db387d50f90ea884576a",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 38
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
         "hashed_secret": "355f24fd038bcaf85617abdcaa64af51ed19bbcf",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 38
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
         "hashed_secret": "3d8a1dcd2c3c765ce35c9a9552d23273cc4ddace",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 38
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
         "hashed_secret": "4ac7b0522761eba972467942cd5cd7499dd2c361",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 38
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
         "hashed_secret": "7639ab2a6bcf2ea30a055a99468c9cd844d4c22a",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 38
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
         "hashed_secret": "b56360daf4793d2a74991a972b34d95bc00fb2da",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 38
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
         "hashed_secret": "c9a73ef9ee8ce9f38437227801c70bcc6740d1a1",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 38
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "dev/env/manifests/shared/03-configmap-config.yaml",
         "hashed_secret": "14736999d9940728c5294277831a702f7882dece",
         "is_verified": false,
-        "line_number": 80
+        "line_number": 75
       }
     ],
     "dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml": [
@@ -555,5 +555,5 @@
       }
     ]
   },
-  "generated_at": "2023-06-16T13:33:57Z"
+  "generated_at": "2023-06-21T12:15:21Z"
 }

--- a/config/dataplane-cluster-configuration-staging.yaml
+++ b/config/dataplane-cluster-configuration-staging.yaml
@@ -16,8 +16,3 @@ clusters:
    provider_type: standalone
    supported_instance_type: "eval,standard"
    cluster_dns: acs-dp-01.ce55.p1.openshiftapps.com
-   available_central_operator_versions:
-    - version: "3.70.0"
-      ready: true
-      central_versions:
-       - version: "3.70.0"

--- a/dev/config/dataplane-cluster-configuration-crc.yaml
+++ b/dev/config/dataplane-cluster-configuration-crc.yaml
@@ -16,8 +16,3 @@ clusters:
    supported_instance_type: "eval,standard"
    cluster_dns: apps-crc.testing
    multi_az: true
-   available_central_operator_versions:
-    - version: "0.1.0"
-      ready: true
-      central_versions:
-       - version: "0.1.0"

--- a/dev/config/dataplane-cluster-configuration-dockerdesktop.yaml
+++ b/dev/config/dataplane-cluster-configuration-dockerdesktop.yaml
@@ -15,8 +15,3 @@ clusters:
    supported_instance_type: "eval,standard"
    cluster_dns: kubernetes.docker.internal
    central_instance_limit: 5
-   available_central_operator_versions:
-    - version: "0.1.0"
-      ready: true
-      central_versions:
-       - version: "0.1.0"

--- a/dev/config/dataplane-cluster-configuration-minikube.yaml
+++ b/dev/config/dataplane-cluster-configuration-minikube.yaml
@@ -28,8 +28,3 @@ clusters:
    provider_type: standalone
    supported_instance_type: "eval,standard"
    cluster_dns: cluster.local
-   available_central_operator_versions:
-    - version: "0.1.0"
-      ready: true
-      central_versions:
-       - version: "0.1.0"

--- a/dev/config/dataplane-cluster-configuration-rancherdesktop.yaml
+++ b/dev/config/dataplane-cluster-configuration-rancherdesktop.yaml
@@ -28,8 +28,3 @@ clusters:
    provider_type: standalone
    supported_instance_type: "eval,standard"
    cluster_dns: cluster.local
-   available_central_operator_versions:
-    - version: "0.1.0"
-      ready: true
-      central_versions:
-       - version: "0.1.0"

--- a/dev/env/manifests/shared/03-configmap-config.yaml
+++ b/dev/env/manifests/shared/03-configmap-config.yaml
@@ -14,11 +14,6 @@ data:
         supported_instance_type: "eval,standard"
         cluster_dns: "$CLUSTER_DNS"
         central_instance_limit: 5
-        available_central_operator_versions:
-          - version: "0.1.0"
-            ready: true
-            central_versions:
-              - version: "0.1.0"
   fleetshard-authz-org-ids-development.yaml: |-
     # RH ACS Organization (returned for personal tokens obtained by ocm token).
     - "11009103"

--- a/docs/development/setup-developer-osd-cluster.md
+++ b/docs/development/setup-developer-osd-cluster.md
@@ -242,11 +242,6 @@ clusters:
    provider_type: standalone
    supported_instance_type: "eval,standard"
    cluster_dns: '${OSD_CLUSTER_NAME}.${OSD_CLUSTER_DOMAIN}'
-   available_central_operator_versions:
-     - version: "${RHACS_OPERATOR_CATALOG_VERSION}"
-       ready: true
-       central_versions:
-         - version: "${RHACS_OPERATOR_CATALOG_VERSION}"
 EOF
 ```
 

--- a/internal/dinosaur/pkg/migrations/20230621000000_remove_available_operators_field_cluster.go
+++ b/internal/dinosaur/pkg/migrations/20230621000000_remove_available_operators_field_cluster.go
@@ -1,0 +1,32 @@
+package migrations
+
+// Migrations should NEVER use types from other packages. Types can change
+// and then migrations run on a _new_ database will fail or behave unexpectedly.
+// Instead of importing types, always re-create the type in the migration, as
+// is done here, even though the same type is defined in pkg/api
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/stackrox/acs-fleet-manager/pkg/api"
+	"github.com/stackrox/acs-fleet-manager/pkg/db"
+	"gorm.io/gorm"
+)
+
+func removeAvailableOperatorField() *gormigrate.Migration {
+	type Cluster struct {
+		db.Model
+		AvailableCentralOperatorVersions api.JSON `json:"available_central_operator_versions"`
+	}
+
+	migrationID := "20230621000000"
+
+	return &gormigrate.Migration{
+		ID: migrationID,
+		Migrate: func(tx *gorm.DB) error {
+			return dropIfColumnExists(tx, &Cluster{}, "available_central_operator_versions")
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return nil
+		},
+	}
+}

--- a/internal/dinosaur/pkg/migrations/migrations.go
+++ b/internal/dinosaur/pkg/migrations/migrations.go
@@ -45,6 +45,7 @@ func getMigrations() []*gormigrate.Migration {
 		addSchedulableToClusters(),
 		addForceReconcileToCentralRequest(),
 		addOperatorImageFields(),
+		removeAvailableOperatorField(),
 	}
 }
 


### PR DESCRIPTION
## Description

Remove available_central_operator_versions database field

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

 - CI
 - Install Fleet-Manager and see if database migration works
 - Check that Data-Plane clusters are not broken
