### PR TITLE
ROX-17987: Remove unused Operator deployments

### DIFF
--- a/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-deployment.yaml
+++ b/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     control-plane: controller-manager
   ## Name field must contain up to 63 characters
   ## https://www.rfc-editor.org/rfc/rfc1123
-  name: {{ $.Values.operator.deploymentPrefix | lower }}{{ .tag | lower }}
+  name: {{ .deploymentName | lower }}
   namespace: stackrox-operator
 spec:
   replicas: 1

--- a/fleetshard/pkg/central/charts/data/rhacs-operator/values.yaml
+++ b/fleetshard/pkg/central/charts/data/rhacs-operator/values.yaml
@@ -3,15 +3,15 @@
 # Declare variables to be passed into your templates.
 
 operator:
-  deploymentPrefix: rhacs-operator-manager-
-
   # Each item in images should contain `repository` and `tag` key
   # example:
   #   images:
-  #   - repository: quay.io/rhacs-eng/stackrox-operator
-  #     tag: 3.74.0
-  #   - repository: quay.io/rhacs-eng/stackrox-operator
-  #     tag: 3.74.1
+  #   - deploymentName: rhacs-operator-manager-4.0.0
+  #     repository: quay.io/rhacs-eng/stackrox-operator
+  #     tag: 4.0.0
+  #   - deploymentName: rhacs-operator-manager-4.0.1
+  #     repository: quay.io/rhacs-eng/stackrox-operator
+  #     tag: 4.0.1
   images: []
   # TODO: add values for resource limits and requests for both proxy and manager container
   # TODO: add value for kube-rbac-proxy image

--- a/fleetshard/pkg/central/operator/upgrade.go
+++ b/fleetshard/pkg/central/operator/upgrade.go
@@ -129,7 +129,7 @@ func (u *ACSOperatorManager) Delete(ctx context.Context, images []string) error 
 		return fmt.Errorf("failed list operator deployments: %w", err)
 	}
 
-	var deleteDeps []string
+	var deleteDeployments []string
 	for _, deployment := range deployments.Items {
 		for _, container := range deployment.Spec.Template.Spec.Containers {
 			if container.Name == "manager" && slices.Contains(images, container.Image) {

--- a/fleetshard/pkg/central/operator/upgrade.go
+++ b/fleetshard/pkg/central/operator/upgrade.go
@@ -117,7 +117,7 @@ func (u *ACSOperatorManager) ListVersionsWithReplicas(ctx context.Context) (map[
 	return versionWithReplicas, nil
 }
 
-// RemoveUnusedOperators removes unused operator deployments from the cluster
+// RemoveUnusedOperators removes unused operator deployments from the cluster. It receives a list of operator images which should be present in the cluster and removes all deployments which do not deploy any of the desired images.
 func (u *ACSOperatorManager) RemoveUnusedOperators(ctx context.Context, desiredImages []string) error {
 	deployments := &appsv1.DeploymentList{}
 	labels := map[string]string{"app": "rhacs-operator"}

--- a/fleetshard/pkg/central/operator/upgrade.go
+++ b/fleetshard/pkg/central/operator/upgrade.go
@@ -133,12 +133,12 @@ func (u *ACSOperatorManager) Delete(ctx context.Context, images []string) error 
 	for _, deployment := range deployments.Items {
 		for _, container := range deployment.Spec.Template.Spec.Containers {
 			if container.Name == "manager" && slices.Contains(images, container.Image) {
-				deleteDeps = append(deleteDeps, deployment.Name)
+				deleteDeployments = append(deleteDeployments, deployment.Name)
 			}
 		}
 	}
 
-	for _, deploymentName := range deleteDeps {
+	for _, deploymentName := range deleteDeployments {
 		deployment := &appsv1.Deployment{}
 		err := u.client.Get(ctx, ctrlClient.ObjectKey{Namespace: operatorNamespace, Name: deploymentName}, deployment)
 		if err != nil && !errors.IsNotFound(err) {

--- a/fleetshard/pkg/central/operator/upgrade_test.go
+++ b/fleetshard/pkg/central/operator/upgrade_test.go
@@ -172,16 +172,16 @@ func TestOperatorUpgradeDoNotInstallLongTagVersion(t *testing.T) {
 	assert.Len(t, deployments.Items, 0)
 }
 
-func TestDeleteOperatorNotExist(t *testing.T) {
+func TestRemoveUnusedEmpty(t *testing.T) {
 	fakeClient := testutils.NewFakeClientBuilder(t).Build()
 	u := NewACSOperatorManager(fakeClient, crdURL)
 	ctx := context.Background()
 
-	err := u.Delete(ctx, []string{operatorImage1})
+	err := u.RemoveUnusedOperators(ctx, []string{})
 	require.NoError(t, err)
 }
 
-func TestDeleteOneOperator(t *testing.T) {
+func TestRemoveOneUnusedOperator(t *testing.T) {
 	fakeClient := testutils.NewFakeClientBuilder(t, operatorDeployment1, serviceAccount).Build()
 	u := NewACSOperatorManager(fakeClient, crdURL)
 	ctx := context.Background()
@@ -191,7 +191,7 @@ func TestDeleteOneOperator(t *testing.T) {
 	err = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: operatorNamespace, Name: serviceAccount.GetName()}, serviceAccount)
 	require.NoError(t, err)
 
-	err = u.Delete(ctx, []string{operatorImage1})
+	err = u.RemoveUnusedOperators(ctx, []string{operatorImage2})
 	require.NoError(t, err)
 	// deployment is deleted but service account still persist
 	err = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: operatorNamespace, Name: operatorDeployment1.Name}, operatorDeployment1)
@@ -200,12 +200,12 @@ func TestDeleteOneOperator(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestDeleteOneOperatorFromMany(t *testing.T) {
+func TestRemoveOneUnusedOperatorFromMany(t *testing.T) {
 	fakeClient := testutils.NewFakeClientBuilder(t, operatorDeployment1, operatorDeployment2, serviceAccount).Build()
 	u := NewACSOperatorManager(fakeClient, crdURL)
 	ctx := context.Background()
 
-	err := u.Delete(ctx, []string{operatorImage1})
+	err := u.RemoveUnusedOperators(ctx, []string{operatorImage2})
 	require.NoError(t, err)
 	err = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: operatorNamespace, Name: operatorDeployment1.Name}, operatorDeployment1)
 	require.True(t, errors.IsNotFound(err))
@@ -214,8 +214,8 @@ func TestDeleteOneOperatorFromMany(t *testing.T) {
 	err = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: operatorNamespace, Name: serviceAccount.GetName()}, serviceAccount)
 	require.NoError(t, err)
 
-	// delete another one
-	err = u.Delete(ctx, []string{operatorImage2})
+	// remove remaining
+	err = u.RemoveUnusedOperators(ctx, []string{})
 	require.NoError(t, err)
 	err = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: operatorNamespace, Name: operatorDeployment1.Name}, operatorDeployment1)
 	require.True(t, errors.IsNotFound(err))
@@ -225,12 +225,12 @@ func TestDeleteOneOperatorFromMany(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestDeleteMultipleOperators(t *testing.T) {
+func TestRemoveMultipleUnusedOperators(t *testing.T) {
 	fakeClient := testutils.NewFakeClientBuilder(t, operatorDeployment1, operatorDeployment2, serviceAccount).Build()
 	u := NewACSOperatorManager(fakeClient, crdURL)
 	ctx := context.Background()
 
-	err := u.Delete(ctx, []string{operatorImage1, operatorImage2})
+	err := u.RemoveUnusedOperators(ctx, []string{})
 	require.NoError(t, err)
 	deployments := &appsv1.DeploymentList{}
 	err = fakeClient.List(context.Background(), deployments)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Add method for removing unused operator deployments based on desired slice of operator images. So any deployed image which **is not** presented in the desired slice should be removed.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
~~- [ ] Added test description under `Test manual`~~
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
~~- [ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
~~- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
~~- [ ] Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual

```
# To run tests locally run:
make deploy/dev-fast
```
