### PR TITLE
remove orphaned probe instances

### DIFF
--- a/probe/pkg/probe/probe_test.go
+++ b/probe/pkg/probe/probe_test.go
@@ -430,7 +430,7 @@ func TestCleanUp(t *testing.T) {
 							Id:        "id-42",
 							Name:      "not-probe-42",
 							Owner:     "service-account-client",
-							CreatedAt: time.Date(2000, 0, 0, 0o0, 0, 0, 0, time.UTC),
+							CreatedAt: time.Date(2000, 0, 0, 0, 0, 0, 0, time.UTC),
 						},
 						{
 							Id:        "id-43",


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Currently the probe does not delete instances that have been created by other probe instances to prevent interfering with other concurrently running probes. This can lead to orphaned instances, if the probe pod has an ungraceful shutdown. To clean up in such cases, also delete Centrals from other probe instances if they are older than 24 hours.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

CI