### PR TITLE
Tweak probe log to show central ID on create

### DIFF
--- a/probe/pkg/probe/probe.go
+++ b/probe/pkg/probe/probe.go
@@ -137,7 +137,7 @@ func (p *ProbeImpl) createCentral(ctx context.Context) (*public.CentralRequest, 
 	}
 	central, resp, err := p.fleetManagerPublicAPI.CreateCentral(ctx, true, request)
 	defer utils.IgnoreError(closeBodyIfNonEmpty(resp))
-	glog.Infof("creation of central instance requested")
+	glog.Infof("creation of central instance (%s) requested", central.Id)
 	if err != nil {
 		err = errors.WithMessage(err, extractCentralError(resp))
 		return nil, errors.Wrap(err, "creation of central instance failed")


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

During the release process, it would be helpful to see which central is created by probe.

This can be helpful for a few reasons:
1. when we update ACS operator and all ACS instances are paused for reconciliation. A new instance would still be created with a new version of the operator and it would be helpful to see the ID of the instance created by probe, so that we can make a closer look at used images in generated resources and see if it is really using a new version
2. sometimes, during release, when we are rolling out updates for ACS instances and there are several restarts we can see a lot of alerts in a pending state, but we are not sure if that is a probe instance or not. By looking at the log what was created by probe we could easy ignore related namespace and identify if there are really problems with existing instances

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~[ ] Unit and integration tests added~
- ~[ ] Added test description under `Test manual`~
- ~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- ~[ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- ~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~
- ~[ ] Add secret to app-interface Vault or Secrets Manager if necessary~
- ~[ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~
- ~[ ] Check AWS limits are reasonable for changes provisioning new resources~

