### PR TITLE
ROX-14547: Update audit logs aggregator config

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -93,6 +93,7 @@ else
     "${SCRIPT_DIR}/../../../scripts/check_image_exists.sh" "${FLEETSHARD_SYNC_ORG}" "${FLEETSHARD_SYNC_IMAGE}" "${FLEETSHARD_SYNC_TAG}"
 fi
 
+load_external_config "audit-logs/${CLUSTER_NAME}" VECTOR_
 load_external_config "cluster-${CLUSTER_NAME}" CLUSTER_
 if [[ "${ENVIRONMENT}" != "dev" ]]; then
     oc login --token="${CLUSTER_ROBOT_OC_TOKEN}" --server="$CLUSTER_URL"
@@ -111,9 +112,6 @@ if [[ "${OPERATOR_USE_UPSTREAM}" == "true" ]]; then
 
     OPERATOR_SOURCE="rhacs-operators"
 fi
-
-# TODO(ROX-14547): Use parameter store value for bucket name.
-# load_external_config "audit-logs--${CLUSTER_NAME}" VECTOR_
 
 # TODO(ROX-16771): Move this to env-specific values.yaml files
 # TODO(ROX-16645): set acsOperator.enabled to false
@@ -167,8 +165,7 @@ invoke_helm "${SCRIPT_DIR}" rhacs-terraform \
   --set vector.service.annotations.rhacs\\.redhat\\.com/environment="${ENVIRONMENT}" \
   --set vector.customConfig.sinks.aws_s3.region="${CLUSTER_REGION}" \
   --set vector.customConfig.sinks.aws_s3.bucket="${VECTOR_BUCKET:-}" \
-  --set vector.secrets.generic.aws_access_key_id="${VECTOR_ACCESSKEY:-}" \
-  --set vector.secrets.generic.aws_secret_access_key="${VECTOR_SECRETACCESSKEY:-}"
+  --set vector.secrets.generic.aws_role_arn="${VECTOR_ROLE_ARN:-}"
 
 # To uninstall an existing release:
 # helm uninstall rhacs-terraform --namespace rhacs

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -96,7 +96,9 @@ logging:
     accessKeyId: ""
     secretAccessKey: ""
 
+# See available parameters in https://github.com/vectordotdev/helm-charts/blob/develop/charts/vector/README.md
 vector:
+  enabled: false
   role: "Aggregator"
   service:
     annotations:
@@ -105,6 +107,8 @@ vector:
       service.beta.openshift.io/serving-cert-secret-name: rhacs-vector-tls-secret
   podLabels:
     app: rhacs-vector
+  serviceAccount:
+    name: audit-logs-aggregator
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -117,7 +121,7 @@ vector:
           topologyKey: "topology.kubernetes.io/zone"
   persistence:
     enabled: true
-    size: 300Mi
+    size: 1Gi
   replicas: 3
   extraVolumes:
     - name: service-tls-secret
@@ -125,11 +129,21 @@ vector:
         sources:
           - secret:
               name: rhacs-vector-tls-secret
+    - name: aws-token
+      projected:
+        sources:
+          - serviceAccountToken:
+              path: aws-token
+              audience: sts.amazonaws.com
   extraVolumeMounts:
     - name: service-tls-secret
       mountPath: /etc/vector/tls
       readOnly: true
+    - name: aws-token
+      mountPath: /var/run/secrets/aws-token
   customConfig:
+    # We have to set it because default "data_dir" is different from mount path defined by enabled "persistence".
+    data_dir: /vector-data-dir
     sources:
       http_server:
         type: "http_server"
@@ -154,26 +168,24 @@ vector:
           enabled: false
         batch:
           timeout_secs: 60
-          max_size: 2621440
+          # 4.5M Bytes
+          max_size: 4718592
         buffer:
           type: disk
-          max_size: 283115520
+          # 900M Bytes (disk is 1Gi)
+          max_size: 943718400
           when_full: block
         encoding:
           codec: "json"
   fullnameOverride: rhacs-vector
   secrets:
     generic:
-      aws_access_key_id: ""
-      aws_secret_access_key: ""
+      aws_role_arn: ""
   env:
-    - name: AWS_ACCESS_KEY_ID
+    - name: AWS_WEB_IDENTITY_TOKEN_FILE
+      value: /var/run/secrets/aws-token/aws-token
+    - name: AWS_ROLE_ARN
       valueFrom:
         secretKeyRef:
           name: rhacs-vector
-          key: aws_access_key_id
-    - name: AWS_SECRET_ACCESS_KEY
-      valueFrom:
-        secretKeyRef:
-          name: rhacs-vector
-          key: aws_secret_access_key
+          key: aws_role_arn


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This PR updates required audit logs aggregator configuration to use the correct AWS resources.

Related tickets:
Epic - https://issues.redhat.com/browse/ROX-14547
AWS terraform: https://issues.redhat.com/browse/ROX-16736
Audit logs aggregator: https://issues.redhat.com/browse/ROX-16735

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~[ ] Unit and integration tests added~
- ~[ ] Added test description under `Test manual`~
- ~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- ~[ ] Add secret to app-interface Vault or Secrets Manager if necessary~
- ~[ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~
- ~[ ] Check AWS limits are reasonable for changes provisioning new resources~

## Test manual

I tested provided configuration on a dev OSD cluster, and resources terraformed on the dev AWS account. It wasn't tested as a complete set with the usage of `dp-terraform/helm/rhacs-terraform/terraform_cluster.sh` script.

To test it manually:
1. Setup dev OSD cluster
2. Setup AWS IDP on the dev AWS account to work with your OSD cluster. https://github.com/stackrox/acs-fleet-manager/blob/main/docs/development/setup-aws-idp-on-osd.md
3. Use the configuration provided in `dp-terraform/helm/rhacs-terraform/values.yaml` - everything under `vector` property and create new YAML file (`example-vector-values.yaml`) with that config (it's Vector Helm chart config)
4. Update all values in YAML file that are changed by `dp-terraform/helm/rhacs-terraform/terraform_cluster.sh` script (search for: `set vector.`)
5. After that install vector on dev OSD cluster by using the newly created values file.
```
helm install rhacs-audit-vector --namespace rhacs --values example-vector-values.yaml vector/vector
```
7. After that, you can deploy a single ACS instance. The easiest way is by using the existing ACS operator on ODS cluster.
8. Create a generic notifier that will use deployed aggregator:
   - Endpoint: `https://rhacs-vector.rhacs:8888`
   - Enable audit logging
   - Additional field: `tenant_id`
10. After what if click `Test` - audit log should be sent to aggregator and persisted in AWS S3 bucket. You can look for tenant defined under `tenant_id` in extra arguments for your generic notifier
