### PR TITLE
ROX-17712 prevent unnecessary central updates

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -476,7 +476,6 @@ func centralNeedsUpdating(ctx context.Context, client ctrlClient.Client, existin
 		shouldUpdate = true
 	}
 
-	// TODO: should labels and annotations be included?
 	if !shouldUpdate && stringMapNeedsUpdating(desired.Annotations, existing.Annotations) {
 		glog.Infof("Detected that Central %v annotations are out of date and needs to be updated", centralKey)
 		shouldUpdate = true

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -32,6 +32,7 @@ import (
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/pointer"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -445,14 +446,17 @@ func (r *CentralReconciler) reconcileCentral(ctx context.Context, remoteCentral 
 func printCentralDiff(desired, actual *v1alpha1.Central) {
 	desiredBytes, err := json.Marshal(desired.Spec)
 	if err != nil {
+		glog.Warningf("Failed to marshal desired Central %s/%s spec: %v", desired.Namespace, desired.Name, err)
 		return
 	}
 	actualBytes, err := json.Marshal(actual.Spec)
 	if err != nil {
+		glog.Warningf("Failed to marshal actual Central %s/%s spec: %v", desired.Namespace, desired.Name, err)
 		return
 	}
 	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(desiredBytes, actualBytes, &v1alpha1.CentralSpec{})
 	if err != nil {
+		glog.Warningf("Failed to create Central %s/%s patch: %v", desired.Namespace, desired.Name, err)
 		return
 	}
 	glog.Infof("Central %s/%s diff: %s", desired.Namespace, desired.Name, string(patchBytes))

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -851,3 +851,62 @@ func TestReconcileUpdatesRoutes(t *testing.T) {
 		})
 	}
 }
+
+func Test_stringMapNeedsUpdating(t *testing.T) {
+	type tc struct {
+		name    string
+		actual  map[string]string
+		desired map[string]string
+		want    bool
+	}
+	tests := []tc{
+		{
+			name:    "both nil",
+			desired: nil,
+			actual:  nil,
+			want:    false,
+		}, {
+			name:    "both empty",
+			desired: map[string]string{},
+			actual:  map[string]string{},
+			want:    false,
+		}, {
+			name:    "desired nil",
+			desired: nil,
+			actual:  map[string]string{"foo": "bar"},
+			want:    false,
+		}, {
+			name:    "actual nil",
+			desired: map[string]string{"foo": "bar"},
+			actual:  nil,
+			want:    true,
+		}, {
+			name:    "desired empty",
+			desired: map[string]string{},
+			actual:  map[string]string{"foo": "bar"},
+			want:    false,
+		}, {
+			name:    "actual empty",
+			desired: map[string]string{"foo": "bar"},
+			actual:  map[string]string{},
+			want:    true,
+		}, {
+			name:    "desired has more keys",
+			desired: map[string]string{"foo": "bar", "bar": "baz"},
+			actual:  map[string]string{"foo": "bar"},
+			want:    true,
+		}, {
+			name:    "actual has more keys",
+			desired: map[string]string{"foo": "bar"},
+			actual:  map[string]string{"foo": "bar", "bar": "baz"},
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stringMapNeedsUpdating(tt.desired, tt.actual)
+			assert.Equal(t, tt.want, got, tt.name)
+		})
+	}
+}

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -3,4 +3,7 @@ package features
 var (
 	// TargetedOperatorUpgrades enables the targeted operator upgrades
 	TargetedOperatorUpgrades = registerFeature("Upgrade Central instances targetedly via fleet-manager API", "RHACS_TARGETED_OPERATOR_UPGRADES", false)
+
+	// PrintCentralUpdateDiff enables printing the diff of the central update
+	PrintCentralUpdateDiff = registerFeature("Print the diff of the central update", "RHACS_PRINT_CENTRAL_UPDATE_DIFF", false)
 )


### PR DESCRIPTION
This PR adds some logic to prevent fleetshard from updating Centrals if there are no changes, which prevent unnecessary opreator reconciliation loops. 