### PR TITLE
Make helm.sh build dependencies in the chart directory instead of the working directory

### DIFF
--- a/scripts/lib/helm.sh
+++ b/scripts/lib/helm.sh
@@ -9,7 +9,7 @@ function invoke_helm() {
     helm repo add vector "https://helm.vector.dev"
 
     # Build the external dependencies like the vector helm chart bundle.
-    helm dependencies build
+    helm dependencies build "${dir}"
 
     if [[ "${ENVIRONMENT}" == "dev" ]]; then
         # Dev env is special, as there is no real dev cluster. Instead


### PR DESCRIPTION
## Description
Make `helm.sh` build dependencies in the chart directory instead of the working directory

When I run the terraforming script from the project root, I get the following error:
```
Error: Chart.yaml file is missing
```

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
