### PR TITLE
Reduce worker interval to 3 seconds

### DIFF
--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/accepted_centrals_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/accepted_centrals_mgr.go
@@ -17,7 +17,9 @@ import (
 	"github.com/golang/glog"
 )
 
-const acceptedCentralWorkerType = "accepted_dinosaur"
+const (
+	acceptedCentralWorkerType = "accepted_dinosaur"
+)
 
 // AcceptedCentralManager represents a manager that periodically reconciles central requests
 type AcceptedCentralManager struct {
@@ -34,9 +36,10 @@ func NewAcceptedCentralManager(centralService services.DinosaurService, quotaSer
 	metrics.InitReconcilerMetricsForType(acceptedCentralWorkerType)
 	return &AcceptedCentralManager{
 		BaseWorker: workers.BaseWorker{
-			ID:         uuid.New().String(),
-			WorkerType: acceptedCentralWorkerType,
-			Reconciler: workers.Reconciler{},
+			ID:              uuid.New().String(),
+			WorkerType:      acceptedCentralWorkerType,
+			Reconciler:      workers.Reconciler{},
+			ReconcilePeriod: workers.FastReconcilePeriod,
 		},
 		centralService:         centralService,
 		quotaServiceFactory:    quotaServiceFactory,

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/preparing_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/preparing_dinosaurs_mgr.go
@@ -19,7 +19,9 @@ import (
 	serviceErr "github.com/stackrox/acs-fleet-manager/pkg/errors"
 )
 
-const preparingCentralWorkerType = "preparing_dinosaur"
+const (
+	preparingCentralWorkerType = "preparing_dinosaur"
+)
 
 // PreparingDinosaurManager represents a dinosaur manager that periodically reconciles dinosaur requests
 type PreparingDinosaurManager struct {
@@ -33,9 +35,10 @@ func NewPreparingDinosaurManager(dinosaurService services.DinosaurService, centr
 	metrics.InitReconcilerMetricsForType(preparingCentralWorkerType)
 	return &PreparingDinosaurManager{
 		BaseWorker: workers.BaseWorker{
-			ID:         uuid.New().String(),
-			WorkerType: preparingCentralWorkerType,
-			Reconciler: workers.Reconciler{},
+			ID:              uuid.New().String(),
+			WorkerType:      preparingCentralWorkerType,
+			Reconciler:      workers.Reconciler{},
+			ReconcilePeriod: workers.FastReconcilePeriod,
 		},
 		dinosaurService:       dinosaurService,
 		centralRequestTimeout: centralRequestConfig.ExpirationTimeout,

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/provisioning_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/provisioning_dinosaurs_mgr.go
@@ -31,9 +31,10 @@ func NewProvisioningDinosaurManager(dinosaurService services.DinosaurService, ob
 	metrics.InitReconcilerMetricsForType(provisioningCentralWorkerType)
 	return &ProvisioningDinosaurManager{
 		BaseWorker: workers.BaseWorker{
-			ID:         uuid.New().String(),
-			WorkerType: provisioningCentralWorkerType,
-			Reconciler: workers.Reconciler{},
+			ID:              uuid.New().String(),
+			WorkerType:      provisioningCentralWorkerType,
+			Reconciler:      workers.Reconciler{},
+			ReconcilePeriod: workers.FastReconcilePeriod,
 		},
 		dinosaurService:       dinosaurService,
 		observatoriumService:  observatoriumService,

--- a/pkg/workers/reconciler.go
+++ b/pkg/workers/reconciler.go
@@ -13,7 +13,7 @@ import (
 )
 
 // RepeatInterval ...
-var RepeatInterval = 30 * time.Second
+var RepeatInterval = 10 * time.Second
 
 // Reconciler ...
 type Reconciler struct {

--- a/pkg/workers/reconciler.go
+++ b/pkg/workers/reconciler.go
@@ -12,15 +12,6 @@ import (
 	"github.com/golang/glog"
 )
 
-// GetRepeatIntervalInterface sets a custom repeat interval. A worker can implement this interface
-// to configure its repeat interval.
-type GetRepeatIntervalInterface interface {
-	GetRepeatInterval() time.Duration
-}
-
-// RepeatInterval ...
-var RepeatInterval = 30 * time.Second
-
 // Reconciler ...
 type Reconciler struct {
 	di.Inject
@@ -32,12 +23,7 @@ func (r *Reconciler) Start(worker Worker) {
 	worker.GetSyncGroup().Add(1)
 	worker.SetIsRunning(true)
 
-	reconcilePeriod := RepeatInterval
-	if worker.GetReconcilePeriod() == 0 {
-		reconcilePeriod = RepeatInterval
-	}
-
-	ticker := time.NewTicker(reconcilePeriod)
+	ticker := time.NewTicker(worker.GetReconcilePeriod())
 	go func() {
 		// starts reconcile immediately and then on every repeat interval
 		glog.V(1).Infoln(fmt.Sprintf("Initial reconciliation loop for %T [%s]", worker, worker.GetID()))

--- a/pkg/workers/worker_interface.go
+++ b/pkg/workers/worker_interface.go
@@ -9,7 +9,10 @@ import (
 )
 
 const (
-	FastReconcilePeriod    = 3 * time.Second
+	// FastReconcilePeriod is used for workers which are blocking provisioning time.
+	FastReconcilePeriod = 3 * time.Second
+	// DefaultReconcilePeriod is used for workers which do not transition states actively or perform
+	// time critical tasks.
 	DefaultReconcilePeriod = 30 * time.Second
 )
 

--- a/test/helper.go
+++ b/test/helper.go
@@ -36,7 +36,6 @@ import (
 	"github.com/stackrox/acs-fleet-manager/pkg/auth"
 	"github.com/stackrox/acs-fleet-manager/pkg/db"
 	"github.com/stackrox/acs-fleet-manager/pkg/environments"
-	"github.com/stackrox/acs-fleet-manager/pkg/workers"
 	"github.com/stackrox/acs-fleet-manager/test/mocks"
 )
 
@@ -127,7 +126,6 @@ func NewHelperWithHooks(t *testing.T, httpServer *httptest.Server, configuration
 
 	// Set server if provided
 	if httpServer != nil && ocmConfig.MockMode == ocm.MockModeEmulateServer {
-		workers.RepeatInterval = 1 * time.Second
 		fmt.Printf("Setting OCM base URL to %s\n", httpServer.URL)
 		ocmConfig.BaseURL = httpServer.URL
 		ocmConfig.AmsURL = httpServer.URL


### PR DESCRIPTION
## Description
Reduce worker interval to 3 seconds for `accepted`, `preparing` and `provisioning` states.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

 - CI