### PR TITLE
Suppress chamber errors for secretsmanager backend

### DIFF
--- a/scripts/lib/external_config.sh
+++ b/scripts/lib/external_config.sh
@@ -67,8 +67,10 @@ load_external_config() {
     local prefix="${2:-}"
     local parameter_store_output
     local secrets_manager_output
-    parameter_store_output=$(chamber env "$service")
-    secrets_manager_output=$(chamber env "$service" -b secretsmanager)
+    parameter_store_output=$(chamber env "$service" --backend ssm)
+    # chamber fails for secretsmanager backend, but not for ssm (parameter store).
+    # We suppress pipefail error for secretsmanager backend to get similar behaviour.
+    secrets_manager_output=$(chamber env "$service" --backend secretsmanager) || true
     [[ -z "$parameter_store_output" && -z "$secrets_manager_output" ]] && echo "WARNING: no parameters found under '/$service' of this environment"
     eval "$(printf '%s\n%s' "$parameter_store_output" "$secrets_manager_output" | sed -E "s/(^export +)(.*)/readonly ${prefix}\2/")"
 }


### PR DESCRIPTION
## Description

Chamber has inconsistent error handling for different backends:
- if the requested "service" does not exist in Parameter Store it will not return an error code
- if the requested "service" does not exist in Secret Manager it will return an error code

This is a problem for us because not all results of the AWS Terraform process store "output" in Secret Manager. Some values are stored in Parameter Store (i.e. ARNs, generated names, etc.)

This PR is adding a small tweak to ignore errors from chamber when "service" does not exist in Secret Manager.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~[ ] Unit and integration tests added~
- ~[ ] Added test description under `Test manual`~
- ~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- ~[ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- ~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~
- ~[ ] Add secret to app-interface Vault or Secrets Manager if necessary~
- ~[ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~
- ~[ ] Check AWS limits are reasonable for changes provisioning new resources~

## Test manual

Chamber behavior is easy to test:
```
chamber env 'test-fail-why' --backend secretsmanager

echo $?
```
We output an error message and fail. So, echo will output `1`.

But for Parameter Store command will not return an error code.
```
chamber env 'test-fail-why' --backend ssm

echo $?
```
We output an error message and fail. Echo will output `0`.
