### PR TITLE
ROX-17723: Add image pull secret for quay to Fleetshard-sync

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/_helpers.tpl
+++ b/dp-terraform/helm/rhacs-terraform/templates/_helpers.tpl
@@ -1,0 +1,5 @@
+{{- define "imagePullSecret" }}
+{{- with .Values.imageCredentials }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
+{{- end }}
+{{- end }}

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-secret.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-secret.yaml
@@ -8,6 +8,7 @@ metadata:
 stringData:
   rhsso-service-account-client-id: {{ .Values.fleetshardSync.redHatSSO.clientId | quote }}
   rhsso-service-account-client-secret: {{ .Values.fleetshardSync.redHatSSO.clientSecret | quote }}
+  image-pull.dockerconfigjson: {{ template "imagePullSecret" . }}
   {{- if eq .Values.fleetshardSync.aws.enableTokenAuth false }}
   aws-access-key-id: {{ required "fleetshardSync.aws.accessKeyId is required when fleetshardSync.aws.enableTokenAuth = false" .Values.fleetshardSync.aws.accessKeyId | quote }}
   aws-secret-access-key: {{ required "fleetshardSync.aws.secretAccessKey is required when fleetshardSync.aws.enableTokenAuth = false" .Values.fleetshardSync.aws.secretAccessKey | quote }}

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -27,6 +27,7 @@ load_external_config cloudwatch-exporter CLOUDWATCH_EXPORTER_
 load_external_config logging LOGGING_
 load_external_config observability OBSERVABILITY_
 load_external_config secured-cluster SECURED_CLUSTER_
+load_external_config quay/rhacs-eng QUAY_
 
 case $ENVIRONMENT in
   dev)
@@ -105,7 +106,6 @@ fi
 OPERATOR_SOURCE="redhat-operators"
 OPERATOR_USE_UPSTREAM="${OPERATOR_USE_UPSTREAM:-false}"
 if [[ "${OPERATOR_USE_UPSTREAM}" == "true" ]]; then
-    load_external_config quay/rhacs-eng QUAY_
     quay_basic_auth="${QUAY_READ_ONLY_USERNAME}:${QUAY_READ_ONLY_PASSWORD}"
     pull_secret_json="$(mktemp)"
     trap 'rm -f "${pull_secret_json}"' EXIT
@@ -149,6 +149,9 @@ invoke_helm "${SCRIPT_DIR}" rhacs-terraform \
   --set fleetshardSync.resources.requests.memory="${FLEETSHARD_SYNC_MEMORY_REQUEST}" \
   --set fleetshardSync.resources.limits.cpu="${FLEETSHARD_SYNC_CPU_LIMIT}" \
   --set fleetshardSync.resources.limits.memory="${FLEETSHARD_SYNC_MEMORY_LIMIT}" \
+  --set fleetshardSync.imageCredentials.registry="quay.io" \
+  --set fleetshardSync.imageCredentials.username="${QUAY_READ_ONLY_USERNAME}" \
+  --set fleetshardSync.imageCredentials.password="${QUAY_READ_ONLY_PASSWORD}" \
   --set cloudwatch.aws.accessKeyId="${CLOUDWATCH_EXPORTER_AWS_ACCESS_KEY_ID:-}" \
   --set cloudwatch.aws.secretAccessKey="${CLOUDWATCH_EXPORTER_AWS_SECRET_ACCESS_KEY:-}" \
   --set cloudwatch.clusterName="${CLUSTER_NAME}" \

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -50,6 +50,11 @@ fleetshardSync:
     limits:
       cpu: "500m"
       memory: "512Mi"
+  imageCredentials:
+    registry: quay.io
+    username: ""
+    password: ""
+    email: "quayuser@example.com"
 
 acsOperator:
   enabled: false


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Insert image pull `dockerconfigjson` for quay to Fleetshard-sync secret. Credentials comes from Secrets Manager.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
- [x] Added test description under `Test manual`
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
~~- [ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
~~- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
~~- [ ] Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual

```
# switch to stage cluster
helm upgrade --install --debug --dry-run rhacs-terraform \
  --namespace rhacs \
  --values ./values-acs-dp-02.yaml
```
