### PR TITLE
ROX-18445: Move secured-cluster to dedicated namespace

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/_helpers.tpl
+++ b/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "secured-cluster.namespace" }}
+{{- printf "%s-%s" .Release.Namespace "secured-cluster" }}
+{{- end }}

--- a/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-cr.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-cr.yaml
@@ -2,6 +2,7 @@ apiVersion: platform.stackrox.io/v1alpha1
 kind: SecuredCluster
 metadata:
   name: stackrox-secured-cluster-services
+  namespace: {{ include "secured-cluster.namespace" . }}
 spec:
   {{- if .Values.pullSecret }}
   imagePullSecrets:

--- a/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-secrets.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-secrets.yaml
@@ -6,6 +6,7 @@ metadata:
     init-bundle.stackrox.io/name: {{ .Values.clusterName }}
   creationTimestamp: null
   name: admission-control-tls
+  namespace: {{ include "secured-cluster.namespace" . }}
 stringData:
   ca.pem: |
 {{ .Values.ca.cert | indent 4 }}
@@ -21,6 +22,7 @@ metadata:
     init-bundle.stackrox.io/name: {{ .Values.clusterName }}
   creationTimestamp: null
   name: collector-tls
+  namespace: {{ include "secured-cluster.namespace" . }}
 stringData:
   ca.pem: |
 {{ .Values.ca.cert | indent 4 }}
@@ -36,6 +38,7 @@ metadata:
     init-bundle.stackrox.io/name: {{ .Values.clusterName }}
   creationTimestamp: null
   name: sensor-tls
+  namespace: {{ include "secured-cluster.namespace" . }}
 stringData:
   ca.pem: |
 {{ .Values.ca.cert | indent 4 }}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Move dogfooding instance from `rhacs` to `rhacs-secured-cluster` namespace

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
- [x] Added test description under `Test manual`
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
~~- [ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
~~- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
~~- [ ] Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual


```
HELM_DRY_RUN=true HELM_DEBUG=true AWS_SAML_ROLE=<stage user>  ./terraform_cluster.sh stage stage_cluster
```
