### PR TITLE
Add rds ca certs to unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN useradd -u 1001 unprivilegeduser
 # Switch to non-root user
 USER unprivilegeduser
 
-COPY --from=build-standard /src/fleet-manager /src/fleetshard-sync /usr/local/bin/
-COPY --from=build /rds_ca /usr/local/share/ca-certificates
+COPY --chown=unprivilegeduser --from=build-standard /src/fleet-manager /src/fleetshard-sync /usr/local/bin/
+COPY --chown=unprivilegeduser --from=build /rds_ca /usr/local/share/ca-certificates
 EXPOSE 8000
 WORKDIR /
 ENTRYPOINT ["/usr/local/bin/fleet-manager", "serve"]


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual
```
MANAGED_DB_ENABLED=TRUE make deploy/dev
.....
create an isntance
....
Check logs
...
I0717 11:50:34.612442       1 logger.go:208] Received central count changed: received 0 centrals
I0717 12:41:31.713546       1 logger.go:208] Received central count changed: received 1 centrals
I0717 12:41:31.714822       1 reconciler.go:125] Start reconcile central rhacs-ciqjdadn69cg01rgplq0/test
I0717 12:41:31.857270       1 charts.go:145] Creating object rhacs-ciqjdadn69cg01rgplq0/egress-proxy-config
I0717 12:41:31.908291       1 charts.go:145] Creating object rhacs-ciqjdadn69cg01rgplq0/egress-proxy
I0717 12:41:32.010662       1 charts.go:145] Creating object rhacs-ciqjdadn69cg01rgplq0/egress-proxy
I0717 12:41:32.163467       1 charts.go:145] Creating object rhacs-ciqjdadn69cg01rgplq0/egress-proxy
I0717 12:41:32.642808       1 rds.go:156] Initiating provisioning of RDS database cluster rhacs-ciqjdadn69cg01rgplq0-db-cluster.
I0717 12:41:34.194032       1 rds.go:175] Initiating provisioning of RDS database instance rhacs-ciqjdadn69cg01rgplq0-db-instance.
I0717 12:41:35.287205       1 rds.go:175] Initiating provisioning of RDS database instance rhacs-ciqjdadn69cg01rgplq0-db-failover.
I0717 12:41:36.418691       1 rds.go:314] RDS instance status: creating (instance ID: rhacs-ciqjdadn69cg01rgplq0-db-instance)
I0717 12:42:06.704645       1 rds.go:314] RDS instance status: creating (instance ID: rhacs-ciqjdadn69cg01rgplq0-db-instance)
```
