### PR TITLE
fix(probe): init probe metric gauges with zero value

### DIFF
--- a/probe/cmd/probe/main.go
+++ b/probe/cmd/probe/main.go
@@ -27,7 +27,7 @@ func main() {
 		glog.Fatal(err)
 	}
 
-	if metricsServer := metrics.NewMetricsServer(config.MetricsAddress); metricsServer != nil {
+	if metricsServer := metrics.NewMetricsServer(config.MetricsAddress, config.DataPlaneRegion); metricsServer != nil {
 		defer metrics.CloseMetricsServer(metricsServer)
 		go metrics.ListenAndServe(metricsServer)
 	} else {

--- a/probe/pkg/metrics/metrics.go
+++ b/probe/pkg/metrics/metrics.go
@@ -42,6 +42,13 @@ func (m *Metrics) Register(r prometheus.Registerer) {
 	r.MustRegister(m.lastFailureTimestamp)
 }
 
+// Init sets initial values for the gauge metrics.
+func (m *Metrics) Init(region string) {
+	m.lastFailureTimestamp.With(prometheus.Labels{regionLabelName: region}).Set(0)
+	m.lastStartedTimestamp.With(prometheus.Labels{regionLabelName: region}).Set(0)
+	m.lastSuccessTimestamp.With(prometheus.Labels{regionLabelName: region}).Set(0)
+}
+
 // IncStartedRuns increments the metric counter for started probe runs.
 func (m *Metrics) IncStartedRuns(region string) {
 	m.startedRuns.With(prometheus.Labels{regionLabelName: region}).Inc()


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Initialize gauage metrics to avoid complications due to undefined gauge values. See https://github.com/stackrox/rhacs-observability-resources/pull/115. The timestamps default to 0, which translates to `1970-01-01`. It is defined such that any actual timestamp will be larger than this value.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
