### PR TITLE
ROX-18427: tag RDS DBs with their corresponding ACS instance ID

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -340,7 +340,7 @@
         "filename": "fleetshard/pkg/central/cloudprovider/dbclient_moq.go",
         "hashed_secret": "80519927d0f3ce1efe933f46ca9e05e68e491adc",
         "is_verified": false,
-        "line_number": 139
+        "line_number": 143
       }
     ],
     "internal/dinosaur/pkg/api/public/api/openapi.yaml": [
@@ -564,5 +564,5 @@
       }
     ]
   },
-  "generated_at": "2023-06-21T12:15:21Z"
+  "generated_at": "2023-07-19T10:20:12Z"
 }

--- a/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
+++ b/fleetshard/pkg/central/cloudprovider/awsclient/rds_test.go
@@ -129,7 +129,7 @@ func TestRDSProvisioning(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, failoverExists)
 
-	err = rdsClient.EnsureDBProvisioned(ctx, dbID, dbMasterPassword, false)
+	err = rdsClient.EnsureDBProvisioned(ctx, dbID, dbID, dbMasterPassword, false)
 	defer func() {
 		// clean-up AWS resources in case the test fails
 		deleteErr := rdsClient.EnsureDBDeprovisioned(dbID, false)

--- a/fleetshard/pkg/central/cloudprovider/dbclient.go
+++ b/fleetshard/pkg/central/cloudprovider/dbclient.go
@@ -13,7 +13,7 @@ import (
 type DBClient interface {
 	// EnsureDBProvisioned is a blocking function that makes sure that a database with the given databaseID was provisioned,
 	// using the master password given as parameter
-	EnsureDBProvisioned(ctx context.Context, databaseID, passwordSecretName string, isTestInstance bool) error
+	EnsureDBProvisioned(ctx context.Context, databaseID, acsInstanceID, passwordSecretName string, isTestInstance bool) error
 	// EnsureDBDeprovisioned is a non-blocking function that makes sure that a managed DB is deprovisioned (more
 	// specifically, that its deletion was initiated)
 	EnsureDBDeprovisioned(databaseID string, skipFinalSnapshot bool) error

--- a/fleetshard/pkg/central/cloudprovider/dbclient_moq.go
+++ b/fleetshard/pkg/central/cloudprovider/dbclient_moq.go
@@ -22,7 +22,7 @@ var _ DBClient = &DBClientMock{}
 //			EnsureDBDeprovisionedFunc: func(databaseID string, skipFinalSnapshot bool) error {
 //				panic("mock out the EnsureDBDeprovisioned method")
 //			},
-//			EnsureDBProvisionedFunc: func(ctx context.Context, databaseID string, passwordSecretName string, isTestInstance bool) error {
+//			EnsureDBProvisionedFunc: func(ctx context.Context, databaseID string, acsInstanceID string, passwordSecretName string, isTestInstance bool) error {
 //				panic("mock out the EnsureDBProvisioned method")
 //			},
 //			GetAccountQuotasFunc: func(ctx context.Context) (AccountQuotas, error) {
@@ -42,7 +42,7 @@ type DBClientMock struct {
 	EnsureDBDeprovisionedFunc func(databaseID string, skipFinalSnapshot bool) error
 
 	// EnsureDBProvisionedFunc mocks the EnsureDBProvisioned method.
-	EnsureDBProvisionedFunc func(ctx context.Context, databaseID string, passwordSecretName string, isTestInstance bool) error
+	EnsureDBProvisionedFunc func(ctx context.Context, databaseID string, acsInstanceID string, passwordSecretName string, isTestInstance bool) error
 
 	// GetAccountQuotasFunc mocks the GetAccountQuotas method.
 	GetAccountQuotasFunc func(ctx context.Context) (AccountQuotas, error)
@@ -65,6 +65,8 @@ type DBClientMock struct {
 			Ctx context.Context
 			// DatabaseID is the databaseID argument value.
 			DatabaseID string
+			// AcsInstanceID is the acsInstanceID argument value.
+			AcsInstanceID string
 			// PasswordSecretName is the passwordSecretName argument value.
 			PasswordSecretName string
 			// IsTestInstance is the isTestInstance argument value.
@@ -124,25 +126,27 @@ func (mock *DBClientMock) EnsureDBDeprovisionedCalls() []struct {
 }
 
 // EnsureDBProvisioned calls EnsureDBProvisionedFunc.
-func (mock *DBClientMock) EnsureDBProvisioned(ctx context.Context, databaseID string, passwordSecretName string, isTestInstance bool) error {
+func (mock *DBClientMock) EnsureDBProvisioned(ctx context.Context, databaseID string, acsInstanceID string, passwordSecretName string, isTestInstance bool) error {
 	if mock.EnsureDBProvisionedFunc == nil {
 		panic("DBClientMock.EnsureDBProvisionedFunc: method is nil but DBClient.EnsureDBProvisioned was just called")
 	}
 	callInfo := struct {
 		Ctx                context.Context
 		DatabaseID         string
+		AcsInstanceID      string
 		PasswordSecretName string
 		IsTestInstance     bool
 	}{
 		Ctx:                ctx,
 		DatabaseID:         databaseID,
+		AcsInstanceID:      acsInstanceID,
 		PasswordSecretName: passwordSecretName,
 		IsTestInstance:     isTestInstance,
 	}
 	mock.lockEnsureDBProvisioned.Lock()
 	mock.calls.EnsureDBProvisioned = append(mock.calls.EnsureDBProvisioned, callInfo)
 	mock.lockEnsureDBProvisioned.Unlock()
-	return mock.EnsureDBProvisionedFunc(ctx, databaseID, passwordSecretName, isTestInstance)
+	return mock.EnsureDBProvisionedFunc(ctx, databaseID, acsInstanceID, passwordSecretName, isTestInstance)
 }
 
 // EnsureDBProvisionedCalls gets all the calls that were made to EnsureDBProvisioned.
@@ -152,12 +156,14 @@ func (mock *DBClientMock) EnsureDBProvisioned(ctx context.Context, databaseID st
 func (mock *DBClientMock) EnsureDBProvisionedCalls() []struct {
 	Ctx                context.Context
 	DatabaseID         string
+	AcsInstanceID      string
 	PasswordSecretName string
 	IsTestInstance     bool
 } {
 	var calls []struct {
 		Ctx                context.Context
 		DatabaseID         string
+		AcsInstanceID      string
 		PasswordSecretName string
 		IsTestInstance     bool
 	}

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -775,7 +775,7 @@ func (r *CentralReconciler) ensureManagedCentralDBInitialized(ctx context.Contex
 		return fmt.Errorf("getting DB password from secret: %w", err)
 	}
 
-	err = r.managedDBProvisioningClient.EnsureDBProvisioned(ctx, remoteCentral.Id, dbMasterPassword, remoteCentral.Metadata.Internal)
+	err = r.managedDBProvisioningClient.EnsureDBProvisioned(ctx, remoteCentral.Id, remoteCentral.Id, dbMasterPassword, remoteCentral.Metadata.Internal)
 	if err != nil {
 		return fmt.Errorf("provisioning RDS DB: %w", err)
 	}

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -134,7 +134,7 @@ func TestReconcileCreateWithManagedDB(t *testing.T) {
 	fakeClient := testutils.NewFakeClientBuilder(t).Build()
 
 	managedDBProvisioningClient := &cloudprovider.DBClientMock{}
-	managedDBProvisioningClient.EnsureDBProvisionedFunc = func(_ context.Context, _ string, _ string, _ bool) error {
+	managedDBProvisioningClient.EnsureDBProvisionedFunc = func(_ context.Context, _string, _ string, _ string, _ bool) error {
 		return nil
 	}
 	managedDBProvisioningClient.GetDBConnectionFunc = func(_ string) (postgres.DBConnection, error) {
@@ -413,7 +413,7 @@ func TestReconcileDeleteWithManagedDB(t *testing.T) {
 	fakeClient := testutils.NewFakeClientBuilder(t).Build()
 
 	managedDBProvisioningClient := &cloudprovider.DBClientMock{}
-	managedDBProvisioningClient.EnsureDBProvisionedFunc = func(_ context.Context, _ string, _ string, _ bool) error {
+	managedDBProvisioningClient.EnsureDBProvisionedFunc = func(_ context.Context, _string, _ string, _ string, _ bool) error {
 		return nil
 	}
 	managedDBProvisioningClient.EnsureDBDeprovisionedFunc = func(_ string, _ bool) error {
@@ -441,7 +441,7 @@ func TestReconcileDeleteWithManagedDB(t *testing.T) {
 	deletedCentral.Metadata.DeletionTimestamp = "2006-01-02T15:04:05Z07:00"
 
 	// trigger deletion
-	managedDBProvisioningClient.EnsureDBProvisionedFunc = func(_ context.Context, _ string, _ string, _ bool) error {
+	managedDBProvisioningClient.EnsureDBProvisionedFunc = func(_ context.Context, _ string, _ string, _ string, _ bool) error {
 		return nil
 	}
 	statusTrigger, err := r.Reconcile(context.TODO(), deletedCentral)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

In preparation for dynamic DB URLs, this PR adds the following changes:
* the DB client interface now supports different names for the databaseID and the acsInstanceID
* the DB clusters and instances are tagged with the acsInstanceID (this is needed because if the names DB name is changed and there is data loss, we can use the tag to determine to which ACS instance the DB belonged to)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

Manually verified that the DB cluster and instances created by the AWS integration tests are properly tagged.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
