### PR TITLE
Fix local bootstrap for RHACS_TARGETED_OPERATOR_UPGRADES mode

### DIFF
--- a/dev/env/scripts/create-imagepullsecrets
+++ b/dev/env/scripts/create-imagepullsecrets
@@ -70,7 +70,7 @@ function print_auth() {
 
 registry_auth="$(print_auth "$(mkauth "${username}" "${password}")")"
 
-if [[ "$INSTALL_OPERATOR" == "true" ]]; then
+if [[ "$INSTALL_OPERATOR" == "true" || "$RHACS_TARGETED_OPERATOR_UPGRADES" == "true" ]]; then
     res=$(
         cat <<EOF
 apiVersion: v1

--- a/dev/env/scripts/docker.sh
+++ b/dev/env/scripts/docker.sh
@@ -110,11 +110,12 @@ preload_dependency_images() {
     fi
     log "Preloading images into ${CLUSTER_TYPE} cluster..."
     docker_pull "postgres:13"
-    if [[ "$INSTALL_OPERATOR" == "true" ]]; then
+    if [[ "$INSTALL_OPERATOR" == "true" || "$RHACS_TARGETED_OPERATOR_UPGRADES" == "true" ]]; then
         # Preload images required by Central installation.
         docker_pull "${IMAGE_REGISTRY}/scanner:${SCANNER_VERSION}"
         docker_pull "${IMAGE_REGISTRY}/scanner-db:${SCANNER_VERSION}"
         docker_pull "${IMAGE_REGISTRY}/main:${CENTRAL_VERSION}"
+        docker_pull "${IMAGE_REGISTRY}/central-db:${CENTRAL_VERSION}"
     fi
     log "Images preloaded"
 }

--- a/scripts/install_operator_canary.sh
+++ b/scripts/install_operator_canary.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-export RHACS_TARGETED_OPERATOR_UPGRADES=true
+export RHACS_TARGETED_OPERATOR_UPGRADES="true"
 export INSTALL_OLM="false"
 export INSTALL_OPERATOR="false"
 make deploy/bootstrap


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
- Install necessary pull secrets for operator namespace
- download necessary images

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
- [x] Added test description under `Test manual`
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [ ] CI and all relevant tests are passing
~~- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~~
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
~~- [ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
~~- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
~~- [ ] Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual

```
# Reset the cluster
colima k reset

# bootstrap and deploy using the script
scripts/install_operator_canary.sh
```
