### PR TITLE
ROX-18728: Add operator deployment cache

### DIFF
--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -134,7 +134,6 @@ func (r *Runtime) Start() error {
 		}
 
 		if features.TargetedOperatorUpgrades.Enabled() {
-			glog.Info("Starting operator upgrades")
 			err := r.upgradeOperator(list)
 			if err != nil {
 				err = errors.Wrapf(err, "Upgrading operator")
@@ -262,8 +261,10 @@ func (r *Runtime) upgradeOperator(list private.ManagedCentralList) error {
 	}
 
 	if reflect.DeepEqual(cachedOperatorConfigs, desiredOperatorConfigs) {
+		glog.Infof("Operators are up-to-date")
 		return nil
 	}
+	cachedOperatorConfigs = desiredOperatorConfigs
 
 	ctx := context.Background()
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Skip ACS Operator installation attempt if it's already attempted
Delete duplicate operator images

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
- [x] Added test description under `Test manual`
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
~~- [ ] CI and all relevant tests are passing~~
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
~~- [ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
~~- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
~~- [ ] Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual

```
1. Prepare cluster for canary upgrade feature
scripts/install_operator_canary.sh

2. Create a new central instance
curl -XPOST --header "Authorization: Bearer $(ocm token)" 'http://localhost:7000/api/rhacs/v1/centrals?async=true' --data '{"region": "standalone", "cloud_provider": "standalone", "multi_az": true, "name": "testcache"}' | jq

3. Check Fleetshard-sync logs
k logs -f fleetshard-sync-57db87795f-pblbw -n acsms
....
I0804 15:06:16.408486       1 main.go:33] Starting application
I0804 15:06:16.408777       1 main.go:34] FleetManagerEndpoint: http://fleet-manager:8000
I0804 15:06:16.408881       1 main.go:35] ClusterID: 1234567890abcdef1234567890abcdef
I0804 15:06:16.408943       1 main.go:36] RuntimePollPeriod: 10s
I0804 15:06:16.409117       1 main.go:37] AuthType: RHSSO
I0804 15:06:16.409186       1 main.go:39] ManagedDB.Enabled: false
I0804 15:06:16.409269       1 main.go:40] ManagedDB.SecurityGroup: sg-09084991144b8d1fc
I0804 15:06:16.409418       1 main.go:41] ManagedDB.SubnetGroup: acs-dev-dp-01-database-vpc-private-subnet-group
I0804 15:06:17.204713       1 client.go:42] Connected to k8s cluster: https://10.43.0.1:443
I0804 15:06:18.065581       1 runtime.go:113] fleetshard runtime started
I0804 15:06:18.065861       1 runtime.go:114] Auth provider initialisation enabled: false
I0804 15:06:18.065914       1 runtime.go:299] OpenShift Routes available: true
E0804 15:06:18.275740       1 runtime.go:132] retrieving list of managed centrals: 401 Unauthorized
I0804 15:06:19.297058       1 runtime.go:276] Installing Operator version: 4.0.1
I0804 15:06:20.418246       1 logger.go:208] Received central count changed: received 1 centrals
I0804 15:06:20.420207       1 reconciler.go:127] Start reconcile central rhacs-cj6h12hsnsig01svr7i0/testcache
I0804 15:06:20.759968       1 reconciler.go:444] Central rhacs-cj6h12hsnsig01svr7i0/testcache is already up to date
I0804 15:06:30.609595       1 reconciler.go:127] Start reconcile central rhacs-cj6h12hsnsig01svr7i0/testcache
I0804 15:06:30.935064       1 reconciler.go:444] Central rhacs-cj6h12hsnsig01svr7i0/testcache is already up to date
....
```
