### PR TITLE
ROX-14547: Configure audit logs to use proper region

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/audit-logs/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/audit-logs/values.yaml
@@ -35,7 +35,7 @@ customConfig:
   sinks:
     aws_cloudwatch_logs:
       type: "aws_cloudwatch_logs"
-      region: ""
+      region: "us-east-1"
       group_name: ""
       create_missing_group: false
       create_missing_stream: true
@@ -58,5 +58,5 @@ customConfig:
 
 # Secrets used to set environment variables for Vector pod.
 secrets:
-  aws_region: ""
+  aws_region: "us-east-1"
   aws_role_arn: ""

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -173,9 +173,7 @@ invoke_helm "${SCRIPT_DIR}" rhacs-terraform \
   --set audit-logs.enabled=true \
   --set audit-logs.annotations.rhacs\\.redhat\\.com/cluster-name="${CLUSTER_NAME}" \
   --set audit-logs.annotations.rhacs\\.redhat\\.com/environment="${ENVIRONMENT}" \
-  --set audit-logs.customConfig.sinks.aws_cloudwatch_logs.region="${CLUSTER_REGION}" \
   --set audit-logs.customConfig.sinks.aws_cloudwatch_logs.group_name="${AUDIT_LOGS_LOG_GROUP_NAME}" \
-  --set audit-logs.secrets.aws_region="${CLUSTER_REGION:-}" \
   --set audit-logs.secrets.aws_role_arn="${AUDIT_LOGS_ROLE_ARN:-}" \
   --set secured-cluster.enabled="${SECURED_CLUSTER_ENABLED}" \
   --set secured-cluster.clusterName="${CLUSTER_NAME}" \

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -131,7 +131,6 @@ audit-logs:
     sinks:
       aws_cloudwatch_logs:
         type: "aws_cloudwatch_logs"
-        region: ""
         group_name: "acs_audit_logs"
         create_missing_group: false
         create_missing_stream: true
@@ -152,7 +151,6 @@ audit-logs:
         encoding:
           codec: "json"
   secrets:
-    aws_region: ""
     aws_role_arn: ""
 
 secured-cluster:


### PR DESCRIPTION
## Description

This PR fixes the configuration for audit logs to use the `us-east-1` region because CloudWatch log groups will be created there.

Logging has the same setup. Log Groups are created in the `us-east-1` region.

PR to move Log Groups and SSM params is provided here: https://github.com/stackrox/acs-fleet-manager-aws-config/pull/111
Changes are already applied, and AWS resources are provisioned on staging.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~~[ ] Unit and integration tests added~~
- ~~[ ] Added test description under `Test manual`~~
- ~~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- ~~[ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~~
- ~~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- ~~[ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
- ~~[ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
- ~~[ ] Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual

The audit logs setup is already tested, but CloudWatch Logs groups have been created in the `eu-west-1` region.

IAM roles can access Log Groups between regions.
