### PR TITLE
ROX-18428: report secret data to fleet-manager

### DIFF
--- a/dev/config/dataplane-cluster-configuration-infractl-osd.yaml
+++ b/dev/config/dataplane-cluster-configuration-infractl-osd.yaml
@@ -5,13 +5,14 @@
 #  'deprovisioning' and will later be deleted.
 #- This list is ordered, any new cluster should be appended at the end.
 clusters:
- - name: default/api-evan-acsms-fm-d-0a51-s2-devshift-org:6443/admin
+ - name: default/api-jmalsam-test-g57s-p1-openshiftapps-com:6443/jmalsam
    cluster_id: 1sdu4lati28ifrnk73d3o4qa720rb5ek
-   cloud_provider: gcp
-   region: us-east1
+   cloud_provider: standalone
+   region: standalone
    schedulable: true
    status: ready
    central_instance_limit: 10
    provider_type: standalone
    supported_instance_type: "eval,standard"
-   cluster_dns: evan-acsms-fm-d.0a51.s2.devshift.org
+   cluster_dns: jmalsam-test.g57s.p1.openshiftapps.com
+   multi_az: true

--- a/dev/config/dataplane-cluster-configuration-infractl-osd.yaml
+++ b/dev/config/dataplane-cluster-configuration-infractl-osd.yaml
@@ -5,14 +5,13 @@
 #  'deprovisioning' and will later be deleted.
 #- This list is ordered, any new cluster should be appended at the end.
 clusters:
- - name: default/api-jmalsam-test-g57s-p1-openshiftapps-com:6443/jmalsam
+ - name: default/api-evan-acsms-fm-d-0a51-s2-devshift-org:6443/admin
    cluster_id: 1sdu4lati28ifrnk73d3o4qa720rb5ek
-   cloud_provider: standalone
-   region: standalone
+   cloud_provider: gcp
+   region: us-east1
    schedulable: true
    status: ready
    central_instance_limit: 10
    provider_type: standalone
    supported_instance_type: "eval,standard"
-   cluster_dns: jmalsam-test.g57s.p1.openshiftapps.com
-   multi_az: true
+   cluster_dns: evan-acsms-fm-d.0a51.s2.devshift.org

--- a/dev/env/scripts/up.sh
+++ b/dev/env/scripts/up.sh
@@ -72,7 +72,7 @@ if [[ "$SPAWN_LOGGER" == "true" && -n "${LOG_DIR:-}" ]]; then
 fi
 
 log "Deploying fleetshard-sync"
-shard_sync.sh apply "${MANIFESTS_DIR}/fleetshard-sync"
+exec_fleetshard_sync.sh apply "${MANIFESTS_DIR}/fleetshard-sync"
 inject_exported_env_vars "$ACSMS_NAMESPACE" "fleetshard-sync"
 
 wait_for_container_to_appear "$ACSMS_NAMESPACE" "application=fleetshard-sync" "fleetshard-sync"

--- a/dev/env/scripts/up.sh
+++ b/dev/env/scripts/up.sh
@@ -72,7 +72,7 @@ if [[ "$SPAWN_LOGGER" == "true" && -n "${LOG_DIR:-}" ]]; then
 fi
 
 log "Deploying fleetshard-sync"
-exec_fleetshard_sync.sh apply "${MANIFESTS_DIR}/fleetshard-sync"
+shard_sync.sh apply "${MANIFESTS_DIR}/fleetshard-sync"
 inject_exported_env_vars "$ACSMS_NAMESPACE" "fleetshard-sync"
 
 wait_for_container_to_appear "$ACSMS_NAMESPACE" "application=fleetshard-sync" "fleetshard-sync"

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -75,6 +75,10 @@ spec:
           value: {{ required "fleetshardSync.managedDB.securityGroup is required when fleetshardSync.managedDB.enabled = true" .Values.fleetshardSync.managedDB.securityGroup }}
         - name: MANAGED_DB_PERFORMANCE_INSIGHTS
           value: {{ .Values.fleetshardSync.managedDB.performanceInsights | quote }}
+        - name: SECRET_ENCRYPTION_TYPE
+          value: {{ .Values.fleetshardSync.secretEncryption.type | quote }}
+        - name: SECRET_ENCRYPTION_KEY_ID
+          value: {{ .Values.fleetshardSync.secretEncryption.keyID | quote }}
         {{- end }}
         - name: AWS_REGION
           value: {{ .Values.fleetshardSync.aws.region }}

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -168,6 +168,8 @@ invoke_helm "${SCRIPT_DIR}" rhacs-terraform \
   --set fleetshardSync.imageCredentials.registry="quay.io" \
   --set fleetshardSync.imageCredentials.username="${QUAY_READ_ONLY_USERNAME}" \
   --set fleetshardSync.imageCredentials.password="${QUAY_READ_ONLY_PASSWORD}" \
+  --set fleetshardSync.secretEncryption.type="kms" \
+  --set fleetshardSync.secretEncryption.keyID="${CLUSTER_SECRET_ENCRYPTION_KEY_ID}" \
   --set cloudwatch.aws.accessKeyId="${CLOUDWATCH_EXPORTER_AWS_ACCESS_KEY_ID:-}" \
   --set cloudwatch.aws.secretAccessKey="${CLOUDWATCH_EXPORTER_AWS_SECRET_ACCESS_KEY:-}" \
   --set cloudwatch.clusterName="${CLUSTER_NAME}" \

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -35,6 +35,9 @@ fleetshardSync:
     subnetGroup: ""
     securityGroup: ""
     performanceInsights: true
+  secretEncryption:
+    type: "" # local or kms
+    keyID: ""
   aws:
     region: "us-east-1" # TODO(2023-05-01): Remove the default value here as we now set it explicitly
     roleARN: ""

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -11,6 +11,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	// EnvProd is the expected value of the environment variable "ENVIRONMENT" for prod deployments of fleetshard-sync
+	EnvProd = "prod"
+	// EnvStage is the expected value of the environment variable "ENVIRONMENT" for stage deployments of fleetshard-sync
+	EnvStage = "stage"
+)
+
 // Config contains this application's runtime configuration.
 type Config struct {
 	FleetManagerEndpoint string        `env:"FLEET_MANAGER_ENDPOINT" envDefault:"http://127.0.0.1:8000"`
@@ -30,9 +37,10 @@ type Config struct {
 	EgressProxyImage     string        `env:"EGRESS_PROXY_IMAGE"`
 	DefaultBaseCRDURL    string        `env:"DEFAULT_BASE_CRD_URL" envDefault:"https://raw.githubusercontent.com/stackrox/stackrox/%s/operator/bundle/manifests/"`
 
-	ManagedDB    ManagedDB
-	Telemetry    Telemetry
-	AuditLogging AuditLogging
+	ManagedDB        ManagedDB
+	Telemetry        Telemetry
+	AuditLogging     AuditLogging
+	SecretEncryption SecretEncryption
 }
 
 // ManagedDB for configuring managed DB specific parameters
@@ -58,6 +66,12 @@ type Telemetry struct {
 	StorageKey      string `env:"TELEMETRY_STORAGE_KEY"`
 }
 
+// SecretEncryption defines paramaters to configure encryption of tenant secrest
+type SecretEncryption struct {
+	Type  string `env:"SECRET_ENCRYPTION_TYPE" envDefault:"local"`
+	KeyID string `env:"SECRET_ENCRYPTION_KEY_ID"`
+}
+
 // GetConfig retrieves the current runtime configuration from the environment and returns it.
 func GetConfig() (*Config, error) {
 	c := Config{}
@@ -76,6 +90,7 @@ func GetConfig() (*Config, error) {
 		configErrors.AddError(errors.New("AUTH_TYPE unset in the environment"))
 	}
 	validateManagedDBConfig(c, &configErrors)
+	validateSecretEncryptionConfig(c, &configErrors)
 
 	cfgErr := configErrors.ToError()
 	if cfgErr != nil {
@@ -98,4 +113,18 @@ func (a *AuditLogging) Endpoint(withScheme bool) string {
 		return fmt.Sprintf("%s://%s:%d", a.URLScheme, a.AuditLogTargetHost, a.AuditLogTargetPort)
 	}
 	return fmt.Sprintf("%s:%d", a.AuditLogTargetHost, a.AuditLogTargetPort)
+}
+
+func validateSecretEncryptionConfig(c Config, configErrors *errorhelpers.ErrorList) {
+	if !isDevEnvironment(c) && c.SecretEncryption.Type == "local" {
+		configErrors.AddError(errors.New("SECRET_ENCRYPTION_TYPE == local not allowed for non dev environments")) // pragma: allowlist secret
+	}
+
+	if c.SecretEncryption.Type == "kms" && c.SecretEncryption.KeyID == "" {
+		configErrors.AddError(errors.New("SECRET_ENCRYPTION_TYPE == kms and SECRET_ENCRYPTION_KEY_ID unset in the environment")) // pragma: allowlist secret
+	}
+}
+
+func isDevEnvironment(c Config) bool {
+	return c.Environment != EnvProd && c.Environment != EnvStage
 }

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -12,10 +12,8 @@ import (
 )
 
 const (
-	// EnvProd is the expected value of the environment variable "ENVIRONMENT" for prod deployments of fleetshard-sync
-	EnvProd = "prod"
-	// EnvStage is the expected value of the environment variable "ENVIRONMENT" for stage deployments of fleetshard-sync
-	EnvStage = "stage"
+	// EnvDev is the expected value of the environment variable "ENVIRONMENT" for dev deployments of fleetshard-sync
+	EnvDev = "dev"
 )
 
 // Config contains this application's runtime configuration.
@@ -126,5 +124,5 @@ func validateSecretEncryptionConfig(c Config, configErrors *errorhelpers.ErrorLi
 }
 
 func isDevEnvironment(c Config) bool {
-	return c.Environment != EnvProd && c.Environment != EnvStage
+	return c.Environment == EnvDev || c.Environment == ""
 }

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -750,7 +750,8 @@ func (r *CentralReconciler) collectReconciliationStatus(ctx context.Context, rem
 	}
 
 	// Only report secrets if central is ready to ensure we're not trying to get secrets before they are created
-	// also only report secrets once to don't store corrupted secrets
+	// also only report secrets once to don't overwrite initial secrets with possibly corrupted secrets
+	// from the cluster state.
 	if isRemoteCentralReady(remoteCentral) && !remoteCentral.Metadata.SecretsStored {
 		secrets, err := r.collectSecretsEncrypted(ctx, remoteCentral)
 		if err != nil {

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -4,6 +4,7 @@ package reconciler
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -819,7 +820,7 @@ func (r *CentralReconciler) encryptSecrets(secrets map[string]*corev1.Secret) (m
 			return nil, errors.Wrapf(err, "encrypting secret: %s", key)
 		}
 
-		encryptedSecrets[key] = string(encryptedBytes)
+		encryptedSecrets[key] = base64.StdEncoding.EncodeToString(encryptedBytes)
 	}
 
 	return encryptedSecrets, nil

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -750,7 +750,8 @@ func (r *CentralReconciler) collectReconciliationStatus(ctx context.Context, rem
 	}
 
 	// Only report secrets if central is ready to ensure we're not trying to get secrets before they are created
-	if isRemoteCentralReady(remoteCentral) {
+	// also only report secrets once to don't store corrupted secrets
+	if isRemoteCentralReady(remoteCentral) && !remoteCentral.Metadata.SecretsStored {
 		secrets, err := r.collectSecretsEncrypted(ctx, remoteCentral)
 		if err != nil {
 			return nil, err

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -789,6 +789,14 @@ func (r *CentralReconciler) collectSecrets(ctx context.Context, remoteCentral *p
 		return secrets, errors.Wrapf(err, "collecting secrets for namespace %s", namespace)
 	}
 
+	// remove ResourceVersion and owner reference as this is only intended to recreate non-existent
+	// resources instead of updating existing ones, the owner reference might get invalid in case of
+	// central namespace recreation
+	for _, secret := range secrets { // pragma: allowlist secret
+		secret.ObjectMeta.ResourceVersion = ""
+		secret.ObjectMeta.OwnerReferences = []metav1.OwnerReference{}
+	}
+
 	return secrets, nil
 }
 

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -109,7 +109,7 @@ type CentralReconciler struct {
 	useRoutes        bool
 	Resources        bool
 	routeService     *k8s.RouteService
-	secretService    *k8s.SecretBackup
+	secretBackup     *k8s.SecretBackup
 	secretCipher     cipher.Cipher
 	egressProxyImage string
 	telemetry        config.Telemetry
@@ -784,7 +784,7 @@ func (r *CentralReconciler) areSecretsStored(secretsStored []string) bool {
 
 func (r *CentralReconciler) collectSecrets(ctx context.Context, remoteCentral *private.ManagedCentral) (map[string]*corev1.Secret, error) {
 	namespace := remoteCentral.Metadata.Namespace
-	secrets, err := r.secretService.CollectSecrets(ctx, namespace)
+	secrets, err := r.secretBackup.CollectSecrets(ctx, namespace)
 	if err != nil {
 		return secrets, fmt.Errorf("collecting secrets for namespace %s: %w", namespace, err)
 	}
@@ -1491,7 +1491,7 @@ func NewCentralReconciler(k8sClient ctrlClient.Client, central private.ManagedCe
 		useRoutes:         opts.UseRoutes,
 		wantsAuthProvider: opts.WantsAuthProvider,
 		routeService:      k8s.NewRouteService(k8sClient),
-		secretService:     k8s.NewSecretBackup(k8sClient),
+		secretBackup:      k8s.NewSecretBackup(k8sClient),
 		secretCipher:      secretCipher, // pragma: allowlist secret
 		egressProxyImage:  opts.EgressProxyImage,
 		telemetry:         opts.Telemetry,

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -100,28 +100,29 @@ type CentralReconcilerOptions struct {
 // CentralReconciler is a reconciler tied to a one Central instance. It installs, updates and deletes Central instances
 // in its Reconcile function.
 type CentralReconciler struct {
-	client            ctrlClient.Client
-	central           private.ManagedCentral
-	status            *int32
-	lastCentralHash   [16]byte
-	useRoutes         bool
-	wantsAuthProvider bool
-	hasAuthProvider   bool
-	Resources         bool
-	routeService      *k8s.RouteService
-	secretService     *k8s.SecretService
-	secretCipher      cipher.Cipher
-	egressProxyImage  string
-	telemetry         config.Telemetry
-	clusterName       string
-	environment       string
-	auditLogging      config.AuditLogging
+	client           ctrlClient.Client
+	central          private.ManagedCentral
+	status           *int32
+	lastCentralHash  [16]byte
+	useRoutes        bool
+	Resources        bool
+	routeService     *k8s.RouteService
+	secretService    *k8s.SecretService
+	secretCipher     cipher.Cipher
+	egressProxyImage string
+	telemetry        config.Telemetry
+	clusterName      string
+	environment      string
+	auditLogging     config.AuditLogging
 
 	managedDBEnabled            bool
 	managedDBProvisioningClient cloudprovider.DBClient
 	managedDBInitFunc           postgres.CentralDBInitFunc
 
-	resourcesChart         *chart.Chart
+	resourcesChart *chart.Chart
+
+	wantsAuthProvider      bool
+	hasAuthProvider        bool
 	verifyAuthProviderFunc verifyAuthProviderExistsFunc
 }
 

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -121,10 +121,7 @@ type CentralReconciler struct {
 	managedDBProvisioningClient cloudprovider.DBClient
 	managedDBInitFunc           postgres.CentralDBInitFunc
 
-	resourcesChart *chart.Chart
-
-	wantsAuthProvider      bool
-	hasAuthProvider        bool
+	resourcesChart         *chart.Chart
 	verifyAuthProviderFunc verifyAuthProviderExistsFunc
 }
 

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -5,6 +5,10 @@ import (
 	"context"
 	"embed"
 	"fmt"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"github.com/stackrox/rox/pkg/utils"
 	"gopkg.in/yaml.v2"
@@ -12,9 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"strings"
-	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/cloudprovider"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/cloudprovider/awsclient"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/postgres"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/cipher"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/testutils"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/util"
@@ -120,6 +122,12 @@ var simpleManagedCentral = private.ManagedCentral{
 //go:embed testdata
 var testdata embed.FS
 
+func createBase64Cipher(t *testing.T) cipher.Cipher {
+	b64Cipher, err := cipher.NewLocalBase64Cipher()
+	require.NoError(t, err, "creating base64 cipher for test")
+	return b64Cipher
+}
+
 func getClientTrackerAndReconciler(
 	t *testing.T,
 	centralConfig private.ManagedCentral,
@@ -133,6 +141,7 @@ func getClientTrackerAndReconciler(
 		centralConfig,
 		managedDBClient,
 		centralDBInitFunc,
+		createBase64Cipher(t),
 		reconcilerOptions,
 	)
 	return fakeClient, tracker, reconciler
@@ -140,6 +149,24 @@ func getClientTrackerAndReconciler(
 
 func centralDBInitFunc(_ context.Context, _ postgres.DBConnection, _, _ string) error {
 	return nil
+}
+
+func centralTLSSecretObject() *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "central-tls",
+			Namespace: centralNamespace,
+		},
+	}
+}
+
+func centralDBPasswordSecretObject() *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "central-db-password",
+			Namespace: centralNamespace,
+		},
+	}
 }
 
 func conditionForType(conditions []private.DataPlaneClusterUpdateStatusRequestConditions, conditionType string) (*private.DataPlaneClusterUpdateStatusRequestConditions, bool) {
@@ -364,6 +391,8 @@ func TestReconcileLastHashSetOnSuccess(t *testing.T) {
 			},
 		},
 		centralDeploymentObject(),
+		centralTLSSecretObject(),
+		centralDBPasswordSecretObject(),
 	)
 
 	managedCentral := simpleManagedCentral
@@ -431,6 +460,8 @@ func TestIgnoreCacheForCentralForceReconcileAlways(t *testing.T) {
 			},
 		},
 		centralDeploymentObject(),
+		centralTLSSecretObject(),
+		centralDBPasswordSecretObject(),
 	)
 
 	managedCentral := simpleManagedCentral

--- a/fleetshard/pkg/cipher/cipher.go
+++ b/fleetshard/pkg/cipher/cipher.go
@@ -1,10 +1,31 @@
 // Package cipher defines encryption and decryption methods used by fleetshard-sync
 package cipher
 
+import (
+	"fmt"
+
+	"github.com/stackrox/acs-fleet-manager/fleetshard/config"
+)
+
 //go:generate moq -out cipher_moq.go . Cipher
 
 // Cipher is the interface used to encrypt and decrypt content
 type Cipher interface {
 	Encrypt(plaintext []byte) ([]byte, error)
 	Decrypt(ciphertext []byte) ([]byte, error)
+}
+
+// NewCipher returns a new object implementing cipher, based on the Type defined in config
+func NewCipher(config *config.Config) (Cipher, error) {
+	encryptionType := config.SecretEncryption.Type
+
+	if encryptionType == "local" {
+		return NewLocalBase64Cipher()
+	}
+
+	if encryptionType == "kms" {
+		return NewKMSCipher(config.SecretEncryption.KeyID)
+	}
+
+	return nil, fmt.Errorf("no Cipher implementation for SecretEncryption.Type: %s", encryptionType)
 }

--- a/fleetshard/pkg/cipher/local_base64_cipher.go
+++ b/fleetshard/pkg/cipher/local_base64_cipher.go
@@ -27,7 +27,7 @@ func (a LocalBase64Cipher) Encrypt(plaintext []byte) ([]byte, error) {
 func (a LocalBase64Cipher) Decrypt(ciphertext []byte) ([]byte, error) {
 	plaintext, err := base64.StdEncoding.DecodeString(string(ciphertext))
 	if err != nil {
-		return nil, fmt.Errorf("decoding base64 string %v", err)
+		return nil, fmt.Errorf("decoding base64 string %w", err)
 	}
 	return plaintext, nil
 }

--- a/fleetshard/pkg/cipher/local_base64_cipher.go
+++ b/fleetshard/pkg/cipher/local_base64_cipher.go
@@ -1,0 +1,33 @@
+package cipher
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+// LocalBase64Cipher simulates encryption by using base64 encoding and decoding
+// Warning: Only use this for development it does not encrypt data
+type LocalBase64Cipher struct {
+}
+
+// NewLocalBase64Cipher returns a new Cipher using the given key
+func NewLocalBase64Cipher() (Cipher, error) {
+	return LocalBase64Cipher{}, nil
+}
+
+var _ Cipher = LocalBase64Cipher{}
+
+// Encrypt implementes the logic to encode plaintext with base64
+func (a LocalBase64Cipher) Encrypt(plaintext []byte) ([]byte, error) {
+	enc := base64.StdEncoding.EncodeToString(plaintext)
+	return []byte(enc), nil
+}
+
+// Decrypt implements the logic to decode base64 text to plaintext
+func (a LocalBase64Cipher) Decrypt(ciphertext []byte) ([]byte, error) {
+	plaintext, err := base64.StdEncoding.DecodeString(string(ciphertext))
+	if err != nil {
+		return nil, fmt.Errorf("decoding base64 string %v", err)
+	}
+	return plaintext, nil
+}

--- a/fleetshard/pkg/cipher/local_base64_cipher_test.go
+++ b/fleetshard/pkg/cipher/local_base64_cipher_test.go
@@ -1,0 +1,22 @@
+package cipher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBase64EncryptDecryptMatch(t *testing.T) {
+	plaintext := []byte("test plaintext")
+
+	b64Cipher, err := NewLocalBase64Cipher()
+	require.NoError(t, err, "creating cipher")
+
+	cipher, err := b64Cipher.Encrypt(plaintext)
+	require.NoError(t, err, "encyrpting plaintext")
+
+	decrypted, err := b64Cipher.Decrypt(cipher)
+	require.NoError(t, err, "decrypting ciphertext")
+
+	require.Equal(t, string(plaintext), string(decrypted), "decrypted string does not match plaintext")
+}

--- a/fleetshard/pkg/k8s/route.go
+++ b/fleetshard/pkg/k8s/route.go
@@ -8,8 +8,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
-	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -18,13 +16,12 @@ import (
 const (
 	centralReencryptRouteName   = "managed-central-reencrypt"
 	centralPassthroughRouteName = "managed-central-passthrough"
-	centralTLSSecretName        = "central-tls" // pragma: allowlist secret
 
 	centralReencryptTimeoutAnnotationKey   = "haproxy.router.openshift.io/timeout"
 	centralReencryptTimeoutAnnotationValue = "10m"
 )
 
-// ErrCentralTLSSecretNotFound returned when central-tls secret is not found during creation of the reencrypt route
+// ErrCentralTLSSecretNotFound returned when central-tls secret is not found
 var ErrCentralTLSSecretNotFound = errors.New("central-tls secret not found")
 
 // RouteService is responsible for performing read and write operations on the OpenShift Route objects in the cluster.
@@ -83,14 +80,10 @@ func isAdmitted(ingress openshiftRouteV1.RouteIngress) bool {
 
 // CreateReencryptRoute creates a new managed central reencrypt route.
 func (s *RouteService) CreateReencryptRoute(ctx context.Context, remoteCentral private.ManagedCentral) error {
-	centralTLSSecret := &v1.Secret{}
 	namespace := remoteCentral.Metadata.Namespace
-	err := s.client.Get(ctx, ctrlClient.ObjectKey{Namespace: namespace, Name: centralTLSSecretName}, centralTLSSecret)
+	centralTLSSecret, err := getSecret(ctx, s.client, centralTLSSecretName, namespace)
 	if err != nil {
-		if apiErrors.IsNotFound(err) {
-			return ErrCentralTLSSecretNotFound
-		}
-		return errors.Wrapf(err, "get central TLS secret %s/%s", namespace, remoteCentral.Metadata.Name)
+		return errors.Wrapf(err, "getting central-tls secret for tenant %s", remoteCentral.Metadata.Name)
 	}
 	centralCA, ok := centralTLSSecret.Data["ca.pem"]
 	if !ok {

--- a/fleetshard/pkg/k8s/route.go
+++ b/fleetshard/pkg/k8s/route.go
@@ -83,11 +83,11 @@ func (s *RouteService) CreateReencryptRoute(ctx context.Context, remoteCentral p
 	namespace := remoteCentral.Metadata.Namespace
 	centralTLSSecret, err := getSecret(ctx, s.client, centralTLSSecretName, namespace)
 	if err != nil {
-		return errors.Wrapf(err, "getting central-tls secret for tenant %s", remoteCentral.Metadata.Name)
+		return fmt.Errorf("getting central-tls secret for tenant %s: %w", remoteCentral.Metadata.Name, err)
 	}
 	centralCA, ok := centralTLSSecret.Data["ca.pem"]
 	if !ok {
-		return errors.Errorf("could not find centrals ca certificate 'ca.pem' in secret/%s", centralTLSSecretName)
+		return fmt.Errorf("could not find centrals ca certificate 'ca.pem' in secret/%s", centralTLSSecretName)
 	}
 
 	annotations := map[string]string{

--- a/fleetshard/pkg/k8s/secret.go
+++ b/fleetshard/pkg/k8s/secret.go
@@ -1,0 +1,60 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	centralTLSSecretName        = "central-tls"         // pragma: allowlist secret
+	centralDBPasswordSecretName = "central-db-password" // pragma: allowlist secret
+)
+
+var secretsToWatch = []string{
+	centralTLSSecretName,
+	centralDBPasswordSecretName,
+}
+
+// SecretService is responsible for reading and writing secrets
+// This servise is specific to ACS Managed Services and provides methods work on specific secrets
+type SecretService struct {
+	client ctrlClient.Client
+}
+
+// NewSecretService creates a new instance of SecretService.
+func NewSecretService(client ctrlClient.Client) *SecretService {
+	return &SecretService{client: client}
+}
+
+// CollectSecrets return a map of secret name to secret object for all secrets
+// watched by SecretServices
+func (s *SecretService) CollectSecrets(ctx context.Context, namespace string) (map[string]*corev1.Secret, error) {
+	secrets := map[string]*corev1.Secret{}
+	for _, secretname := range secretsToWatch { // pragma: allowlist secret
+		secret, err := getSecret(ctx, s.client, secretname, namespace)
+		if err != nil {
+			return nil, err
+		}
+		secrets[secretname] = secret // pragma: allowlist secret
+	}
+
+	return secrets, nil
+}
+
+func getSecret(ctx context.Context, client ctrlClient.Client, secretname, namespace string) (*corev1.Secret, error) {
+	centralSecret := &corev1.Secret{}
+	err := client.Get(ctx, ctrlClient.ObjectKey{Namespace: namespace, Name: secretname}, centralSecret)
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			return centralSecret, fmt.Errorf("%s secret not found", secretname)
+		}
+		return centralSecret, errors.Wrapf(err, "getting secret %s/%s", namespace, secretname)
+	}
+
+	return centralSecret, nil
+}

--- a/fleetshard/pkg/k8s/secret.go
+++ b/fleetshard/pkg/k8s/secret.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +30,14 @@ type SecretService struct {
 // NewSecretService creates a new instance of SecretService.
 func NewSecretService(client ctrlClient.Client) *SecretService {
 	return &SecretService{client: client}
+}
+
+// GetWatchedSecrets return a sorted list of secrets watched by this package
+func GetWatchedSecrets() []string {
+	secrets := make([]string, len(secretsToWatch))
+	copy(secrets, secretsToWatch)
+	sort.Strings(secrets)
+	return secrets
 }
 
 // CollectSecrets return a map of secret name to secret object for all secrets

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -96,7 +96,7 @@ func NewRuntime(config *config.Config, k8sClient ctrlClient.Client) (*Runtime, e
 	operatorManager := operator.NewACSOperatorManager(k8sClient)
 	secretCipher, err := cipher.NewCipher(config)
 	if err != nil {
-		return nil, fmt.Errorf("creating secretCipher: %v", err)
+		return nil, fmt.Errorf("creating secretCipher: %w", err)
 	}
 
 	return &Runtime{

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/operator"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/postgres"
 	centralReconciler "github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/reconciler"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/cipher"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/fleetshardmetrics"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
@@ -55,6 +56,7 @@ type Runtime struct {
 	dbProvisionClient cloudprovider.DBClient
 	statusResponseCh  chan private.DataPlaneCentralStatus
 	operatorManager   *operator.ACSOperatorManager
+	secretCipher      cipher.Cipher
 }
 
 // NewRuntime creates a new runtime
@@ -92,6 +94,10 @@ func NewRuntime(config *config.Config, k8sClient ctrlClient.Client) (*Runtime, e
 	}
 
 	operatorManager := operator.NewACSOperatorManager(k8sClient)
+	secretCipher, err := cipher.NewCipher(config)
+	if err != nil {
+		return nil, fmt.Errorf("creating secretCipher: %v", err)
+	}
 
 	return &Runtime{
 		config:            config,
@@ -101,6 +107,7 @@ func NewRuntime(config *config.Config, k8sClient ctrlClient.Client) (*Runtime, e
 		dbProvisionClient: dbProvisionClient,
 		reconcilers:       make(reconcilerRegistry),
 		operatorManager:   operatorManager,
+		secretCipher:      secretCipher, // pragma: allowlist secret
 	}, nil
 }
 
@@ -149,7 +156,7 @@ func (r *Runtime) Start() error {
 		for _, central := range list.Items {
 			if _, ok := r.reconcilers[central.Id]; !ok {
 				r.reconcilers[central.Id] = centralReconciler.NewCentralReconciler(r.k8sClient, central,
-					r.dbProvisionClient, postgres.InitializeDatabase, reconcilerOpts)
+					r.dbProvisionClient, postgres.InitializeDatabase, r.secretCipher, reconcilerOpts)
 			}
 
 			reconciler := r.reconcilers[central.Id]

--- a/internal/dinosaur/pkg/api/dbapi/central_request_types.go
+++ b/internal/dinosaur/pkg/api/dbapi/central_request_types.go
@@ -165,7 +165,7 @@ func (k *CentralRequest) SetRoutes(routes []DataPlaneCentralRoute) error {
 func (k *CentralRequest) SetSecrets(secrets map[string]string) error {
 	r, err := json.Marshal(secrets)
 	if err != nil {
-		return fmt.Errorf("marshalling routes into JSON: %w", err)
+		return fmt.Errorf("marshalling secrets into JSON: %w", err)
 	}
 	k.Secrets = r
 	return nil

--- a/internal/dinosaur/pkg/api/dbapi/central_request_types.go
+++ b/internal/dinosaur/pkg/api/dbapi/central_request_types.go
@@ -75,8 +75,11 @@ type CentralRequest struct {
 	RoutesCreated bool `json:"routes_created"`
 	// Namespace is the namespace of the provisioned central instance.
 	// We store this in the database to ensure that old centrals whose namespace contained "owner-<central-id>" information will continue to work.
-	Namespace        string `json:"namespace"`
-	RoutesCreationID string `json:"routes_creation_id"`
+
+	// Secrets stores the encrypted secrets reported for a central tenant
+	Secrets          api.JSON `json:"secrets"`
+	Namespace        string   `json:"namespace"`
+	RoutesCreationID string   `json:"routes_creation_id"`
 	// DeletionTimestamp stores the timestamp of the DELETE api call for the resource.
 	DeletionTimestamp *time.Time `json:"deletionTimestamp"`
 
@@ -155,6 +158,16 @@ func (k *CentralRequest) SetRoutes(routes []DataPlaneCentralRoute) error {
 		return fmt.Errorf("marshalling routes into JSON: %w", err)
 	}
 	k.Routes = r
+	return nil
+}
+
+// SetSecrets sets CentralRequest.Secret field by converting secrets to api.JSON
+func (k *CentralRequest) SetSecrets(secrets map[string]string) error {
+	r, err := json.Marshal(secrets)
+	if err != nil {
+		return fmt.Errorf("marshalling routes into JSON: %w", err)
+	}
+	k.Secrets = r
 	return nil
 }
 

--- a/internal/dinosaur/pkg/api/dbapi/data_plane_central_status.go
+++ b/internal/dinosaur/pkg/api/dbapi/data_plane_central_status.go
@@ -10,6 +10,7 @@ type DataPlaneCentralStatus struct {
 	Conditions       []DataPlaneCentralStatusCondition
 	// Going to ignore the rest of fields (like capacity and versions) for now, until when they are needed
 	Routes                 []DataPlaneCentralRoute
+	Secrets                map[string]string
 	CentralVersion         string
 	CentralOperatorVersion string
 }

--- a/internal/dinosaur/pkg/api/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/private/api/openapi.yaml
@@ -418,7 +418,9 @@ components:
         deletionTimestamp:
           type: string
         secretsStored:
-          type: boolean
+          items:
+            type: string
+          type: array
     ManagedCentral_allOf_spec_auth:
       properties:
         clientSecret:

--- a/internal/dinosaur/pkg/api/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/private/api/openapi.yaml
@@ -417,6 +417,8 @@ components:
           $ref: '#/components/schemas/ManagedCentral_allOf_metadata_annotations'
         deletionTimestamp:
           type: string
+        secretsStored:
+          type: boolean
     ManagedCentral_allOf_spec_auth:
       properties:
         clientSecret:

--- a/internal/dinosaur/pkg/api/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/private/api/openapi.yaml
@@ -358,6 +358,11 @@ components:
           items:
             $ref: '#/components/schemas/DataPlaneCentralStatus_routes'
           type: array
+        secrets:
+          additionalProperties:
+            type: string
+          description: Map of Secrets created for a Central
+          type: object
       type: object
     DataPlaneCentralStatusUpdateRequest:
       additionalProperties:

--- a/internal/dinosaur/pkg/api/private/model_data_plane_central_status.go
+++ b/internal/dinosaur/pkg/api/private/model_data_plane_central_status.go
@@ -16,4 +16,6 @@ type DataPlaneCentralStatus struct {
 	Conditions []DataPlaneClusterUpdateStatusRequestConditions `json:"conditions,omitempty"`
 	// Routes created for a Central
 	Routes []DataPlaneCentralStatusRoutes `json:"routes,omitempty"`
+	// Map of Secrets created for a Central
+	Secrets map[string]string `json:"secrets,omitempty"`
 }

--- a/internal/dinosaur/pkg/api/private/model_managed_central_all_of_metadata.go
+++ b/internal/dinosaur/pkg/api/private/model_managed_central_all_of_metadata.go
@@ -17,4 +17,5 @@ type ManagedCentralAllOfMetadata struct {
 	Internal          bool                                   `json:"internal,omitempty"`
 	Annotations       ManagedCentralAllOfMetadataAnnotations `json:"annotations,omitempty"`
 	DeletionTimestamp string                                 `json:"deletionTimestamp,omitempty"`
+	SecretsStored     bool                                   `json:"secretsStored,omitempty"`
 }

--- a/internal/dinosaur/pkg/api/private/model_managed_central_all_of_metadata.go
+++ b/internal/dinosaur/pkg/api/private/model_managed_central_all_of_metadata.go
@@ -17,5 +17,5 @@ type ManagedCentralAllOfMetadata struct {
 	Internal          bool                                   `json:"internal,omitempty"`
 	Annotations       ManagedCentralAllOfMetadataAnnotations `json:"annotations,omitempty"`
 	DeletionTimestamp string                                 `json:"deletionTimestamp,omitempty"`
-	SecretsStored     bool                                   `json:"secretsStored,omitempty"`
+	SecretsStored     []string                               `json:"secretsStored,omitempty"`
 }

--- a/internal/dinosaur/pkg/migrations/20230802000000_add_secrets_field_to_central_request.go
+++ b/internal/dinosaur/pkg/migrations/20230802000000_add_secrets_field_to_central_request.go
@@ -1,0 +1,63 @@
+package migrations
+
+// Migrations should NEVER use types from other packages. Types can change
+// and then migrations run on a _new_ database will fail or behave unexpectedly.
+// Instead of importing types, always re-create the type in the migration, as
+// is done here, even though the same type is defined in pkg/api
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/stackrox/acs-fleet-manager/pkg/api"
+	"github.com/stackrox/acs-fleet-manager/pkg/db"
+	"gorm.io/gorm"
+
+	"time"
+)
+
+func addSecretFieldToCentralRequests() *gormigrate.Migration {
+	type CentralRequest struct {
+		db.Model
+		Region                        string     `json:"region"`
+		ClusterID                     string     `json:"cluster_id" gorm:"index"`
+		CloudProvider                 string     `json:"cloud_provider"`
+		MultiAZ                       bool       `json:"multi_az"`
+		Name                          string     `json:"name" gorm:"index"`
+		Status                        string     `json:"status" gorm:"index"`
+		SubscriptionID                string     `json:"subscription_id"`
+		Owner                         string     `json:"owner" gorm:"index"`
+		OwnerAccountID                string     `json:"owner_account_id"`
+		OwnerUserID                   string     `json:"owner_user_id"`
+		Host                          string     `json:"host"`
+		OrganisationID                string     `json:"organisation_id" gorm:"index"`
+		FailedReason                  string     `json:"failed_reason"`
+		PlacementID                   string     `json:"placement_id"`
+		DesiredCentralVersion         string     `json:"desired_central_version"`
+		ActualCentralVersion          string     `json:"actual_central_version"`
+		DesiredCentralOperatorVersion string     `json:"desired_central_operator_version"`
+		ActualCentralOperatorVersion  string     `json:"actual_central_operator_version"`
+		CentralUpgrading              bool       `json:"central_upgrading"`
+		CentralOperatorUpgrading      bool       `json:"central_operator_upgrading"`
+		InstanceType                  string     `json:"instance_type"`
+		QuotaType                     string     `json:"quota_type"`
+		Routes                        api.JSON   `json:"routes"`
+		Secrets                       api.JSON   `json:"secrets"`
+		RoutesCreated                 bool       `json:"routes_created"`
+		Namespace                     string     `json:"namespace"`
+		RoutesCreationID              string     `json:"routes_creation_id"`
+		DeletionTimestamp             *time.Time `json:"deletionTimestamp"`
+		Central                       api.JSON   `json:"central"`
+		Scanner                       api.JSON   `json:"scanner"`
+		OperatorImage                 string     `json:"operator_image"`
+	}
+	migrationID := "20230802000000"
+
+	return &gormigrate.Migration{
+		ID: migrationID,
+		Migrate: func(tx *gorm.DB) error {
+			return addColumnIfNotExists(tx, &CentralRequest{}, "secrets")
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return nil
+		},
+	}
+}

--- a/internal/dinosaur/pkg/migrations/20230802000000_add_secrets_field_to_central_request.go
+++ b/internal/dinosaur/pkg/migrations/20230802000000_add_secrets_field_to_central_request.go
@@ -10,44 +10,12 @@ import (
 	"github.com/stackrox/acs-fleet-manager/pkg/api"
 	"github.com/stackrox/acs-fleet-manager/pkg/db"
 	"gorm.io/gorm"
-
-	"time"
 )
 
 func addSecretFieldToCentralRequests() *gormigrate.Migration {
 	type CentralRequest struct {
 		db.Model
-		Region                        string     `json:"region"`
-		ClusterID                     string     `json:"cluster_id" gorm:"index"`
-		CloudProvider                 string     `json:"cloud_provider"`
-		MultiAZ                       bool       `json:"multi_az"`
-		Name                          string     `json:"name" gorm:"index"`
-		Status                        string     `json:"status" gorm:"index"`
-		SubscriptionID                string     `json:"subscription_id"`
-		Owner                         string     `json:"owner" gorm:"index"`
-		OwnerAccountID                string     `json:"owner_account_id"`
-		OwnerUserID                   string     `json:"owner_user_id"`
-		Host                          string     `json:"host"`
-		OrganisationID                string     `json:"organisation_id" gorm:"index"`
-		FailedReason                  string     `json:"failed_reason"`
-		PlacementID                   string     `json:"placement_id"`
-		DesiredCentralVersion         string     `json:"desired_central_version"`
-		ActualCentralVersion          string     `json:"actual_central_version"`
-		DesiredCentralOperatorVersion string     `json:"desired_central_operator_version"`
-		ActualCentralOperatorVersion  string     `json:"actual_central_operator_version"`
-		CentralUpgrading              bool       `json:"central_upgrading"`
-		CentralOperatorUpgrading      bool       `json:"central_operator_upgrading"`
-		InstanceType                  string     `json:"instance_type"`
-		QuotaType                     string     `json:"quota_type"`
-		Routes                        api.JSON   `json:"routes"`
-		Secrets                       api.JSON   `json:"secrets"`
-		RoutesCreated                 bool       `json:"routes_created"`
-		Namespace                     string     `json:"namespace"`
-		RoutesCreationID              string     `json:"routes_creation_id"`
-		DeletionTimestamp             *time.Time `json:"deletionTimestamp"`
-		Central                       api.JSON   `json:"central"`
-		Scanner                       api.JSON   `json:"scanner"`
-		OperatorImage                 string     `json:"operator_image"`
+		Secrets api.JSON `json:"secrets"`
 	}
 	migrationID := "20230802000000"
 

--- a/internal/dinosaur/pkg/migrations/migrations.go
+++ b/internal/dinosaur/pkg/migrations/migrations.go
@@ -2,6 +2,7 @@ package migrations
 
 import (
 	"fmt"
+
 	"github.com/go-gormigrate/gormigrate/v2"
 	"github.com/stackrox/acs-fleet-manager/pkg/db"
 	"gorm.io/gorm"
@@ -46,6 +47,7 @@ func getMigrations() []*gormigrate.Migration {
 		addForceReconcileToCentralRequest(),
 		addOperatorImageFields(),
 		removeAvailableOperatorField(),
+		addSecretFieldToCentralRequests(),
 	}
 }
 

--- a/internal/dinosaur/pkg/presenters/data_plane_dinosaur_status.go
+++ b/internal/dinosaur/pkg/presenters/data_plane_dinosaur_status.go
@@ -29,10 +29,12 @@ func ConvertDataPlaneDinosaurStatus(status map[string]private.DataPlaneCentralSt
 				})
 			}
 		}
+
 		res = append(res, &dbapi.DataPlaneCentralStatus{
 			CentralClusterID: k,
 			Conditions:       c,
 			Routes:           routes,
+			Secrets:          v.Secrets, // pragma: allowlist secret
 		})
 	}
 

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -59,7 +59,8 @@ func (c *ManagedCentralPresenter) PresentManagedCentral(from *dbapi.CentralReque
 				MasId:          from.ID,
 				MasPlacementId: from.PlacementID,
 			},
-			Internal: from.Internal,
+			Internal:      from.Internal,
+			SecretsStored: from.Secrets != nil, // pragma: allowlist secret
 		},
 		Spec: private.ManagedCentralAllOfSpec{
 			Owners: []string{

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -60,7 +60,7 @@ func (c *ManagedCentralPresenter) PresentManagedCentral(from *dbapi.CentralReque
 				MasPlacementId: from.PlacementID,
 			},
 			Internal:      from.Internal,
-			SecretsStored: from.Secrets != nil, // pragma: allowlist secret
+			SecretsStored: getSecretNames(from), // pragma: allowlist secret
 		},
 		Spec: private.ManagedCentralAllOfSpec{
 			Owners: []string{
@@ -163,4 +163,21 @@ func orDefaultInt32(i int32, def int32) int32 {
 		return i
 	}
 	return def
+}
+
+func getSecretNames(from *dbapi.CentralRequest) []string {
+	secrets, err := from.Secrets.Object()
+	if err != nil {
+		glog.Errorf("Failed to get Secrets as JSON object for Central request %q/%s: %v", from.Name, from.ClusterID, err)
+		return []string{}
+	}
+
+	secretNames := make([]string, len(secrets))
+	i := 0
+	for k := range secrets {
+		secretNames[i] = k
+		i++
+	}
+
+	return secretNames
 }

--- a/internal/dinosaur/pkg/services/data_plane_dinosaur.go
+++ b/internal/dinosaur/pkg/services/data_plane_dinosaur.go
@@ -75,7 +75,7 @@ func (d *dataPlaneCentralService) UpdateDataPlaneCentralService(ctx context.Cont
 		case statusReady:
 			// Only store the routes (and create them) when the Dinosaurs are ready, as by the time they are ready,
 			// the routes should definitely be there.
-			e = d.persistCentralRoutes(dinosaur, ks, cluster)
+			e = d.persistCentralValues(dinosaur, ks, cluster)
 			if e == nil {
 				e = d.setCentralClusterReady(dinosaur)
 			}
@@ -217,7 +217,23 @@ func (d *dataPlaneCentralService) checkCentralRequestCurrentStatus(centralReques
 	return matchStatus, nil
 }
 
-func (d *dataPlaneCentralService) persistCentralRoutes(centralRequest *dbapi.CentralRequest, centralStatus *dbapi.DataPlaneCentralStatus, cluster *api.Cluster) *serviceError.ServiceError {
+func (d *dataPlaneCentralService) persistCentralValues(centralRequest *dbapi.CentralRequest, centralStatus *dbapi.DataPlaneCentralStatus, cluster *api.Cluster) *serviceError.ServiceError {
+	if err := d.addRoutesToRequest(centralRequest, centralStatus, cluster); err != nil {
+		return err
+	}
+
+	if err := d.addSecretsToRequest(centralRequest, centralStatus, cluster); err != nil {
+		return err
+	}
+
+	if err := d.dinosaurService.Update(centralRequest); err != nil {
+		return serviceError.NewWithCause(err.Code, err, "failed to update routes for central cluster %s", centralRequest.ID)
+	}
+
+	return nil
+}
+
+func (d *dataPlaneCentralService) addRoutesToRequest(centralRequest *dbapi.CentralRequest, centralStatus *dbapi.DataPlaneCentralStatus, cluster *api.Cluster) *serviceError.ServiceError {
 	if centralRequest.Routes != nil {
 		logger.Logger.V(10).Infof("skip persisting routes for Central %s as they are already stored", centralRequest.ID)
 		return nil
@@ -238,9 +254,20 @@ func (d *dataPlaneCentralService) persistCentralRoutes(centralRequest *dbapi.Cen
 		return serviceError.NewWithCause(serviceError.ErrorGeneral, err, "failed to set routes for central %s", centralRequest.ID)
 	}
 
-	if err := d.dinosaurService.Update(centralRequest); err != nil {
-		return serviceError.NewWithCause(err.Code, err, "failed to update routes for central cluster %s", centralRequest.ID)
+	return nil
+}
+
+func (d *dataPlaneCentralService) addSecretsToRequest(centralRequest *dbapi.CentralRequest, centralStatus *dbapi.DataPlaneCentralStatus, cluster *api.Cluster) *serviceError.ServiceError {
+	if centralRequest.Secrets != nil { // pragma: allowlist secret
+		logger.Logger.V(10).Infof("skip persisting secrets for Central %s as they are already stored", centralRequest.ID)
+		return nil
 	}
+	logger.Logger.Infof("store secret information for central %s", centralRequest.ID)
+
+	if err := centralRequest.SetSecrets(centralStatus.Secrets); err != nil {
+		return serviceError.NewWithCause(serviceError.ErrorGeneral, err, "failed to set secrets for central %s", centralRequest.ID)
+	}
+
 	return nil
 }
 

--- a/internal/dinosaur/pkg/services/data_plane_dinosaur.go
+++ b/internal/dinosaur/pkg/services/data_plane_dinosaur.go
@@ -73,8 +73,7 @@ func (d *dataPlaneCentralService) UpdateDataPlaneCentralService(ctx context.Cont
 		var e *serviceError.ServiceError
 		switch s := getStatus(ks); s {
 		case statusReady:
-			// Only store the routes (and create them) when the Dinosaurs are ready, as by the time they are ready,
-			// the routes should definitely be there.
+			// Persist values only known once central is in statusReady e.g. routes, secrets
 			e = d.persistCentralValues(dinosaur, ks, cluster)
 			if e == nil {
 				e = d.setCentralClusterReady(dinosaur)

--- a/openapi/fleet-manager-private.yaml
+++ b/openapi/fleet-manager-private.yaml
@@ -416,6 +416,12 @@ components:
                 type: string
               router:
                 type: string
+        secrets:
+          description: "Map of Secrets created for a Central"
+          type: object
+          additionalProperties:
+            type: string
+
       example:
         $ref: "#/components/examples/DataPlaneCentralStatusRequestExample"
 

--- a/openapi/fleet-manager-private.yaml
+++ b/openapi/fleet-manager-private.yaml
@@ -235,7 +235,9 @@ components:
                 deletionTimestamp:
                   type: string
                 secretsStored:
-                  type: boolean
+                  type: array
+                  items:
+                    type: string
             spec:
               type: object
               properties:

--- a/openapi/fleet-manager-private.yaml
+++ b/openapi/fleet-manager-private.yaml
@@ -234,6 +234,8 @@ components:
                       type: string
                 deletionTimestamp:
                   type: string
+                secretsStored:
+                  type: boolean
             spec:
               type: object
               properties:


### PR DESCRIPTION
## Description

This PR adds the logic to report K8s secrets created by FS sync or the RHACS operator back to store them in fleet-manager (namely `central-tls` and `central-db-password`). The secrets are encrypted using AWS KMS to ensure they are stored securely in FMs database and in transit. We need to create the KMS keys before merging this into main and deploying it to the stage environment. Because of that the PR: https://github.com/stackrox/acs-fleet-manager-aws-config/pull/117 has to be merged first.

This is part of the Epic https://issues.redhat.com/browse/ROX-17060, the implementation to restore secrets if they are missing in the cluster will be done in another PR.

In this PR we implement following parts of the overall solution:
- Getting the secret from cluster
- Encrypting them
- Report from fleetshard-sync to fleet-manager
- Store them in fleet-manager DB
- Report if secrets are stored or not

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- ~~[ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
- ~~[ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
- [x] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

```
# Create an OSD cluster using the rhacs-managed-service-dev account
# Provision enough resources for an internal PostgreSQL DB at this point at least 1 node with 8 CPUs

make binary
make db/teardown db/setup db/migrate

# Login to OSD cluster and install RHACS Operator
# Configure AWS CLIE to point to dev
# Create a fleet-manager cluster-config for the OSD cluster by editing /dev/config/dataplane-cluster-configuration-infractl-osd.yaml

# Start fleet-manager and fleetshard-sync in different shells
# Configure fleetshard-sync
export AWS_REGION=us-east-1
export SECRET_ENCYRPTION_TYPE=kms
export OCM_TOKEN=$(ocm token --refresh)
export AUTH_TYPE="ocm"
export SECRET_ENCRYPTION_KEY_ID=<dev secret encryption key>
export CLUSTER_ID=<your-cluster-id>
./fleetshard-sync

# Run fleet-manager
./fleet-manager serve --dataplane-cluster-config-file "./dev/config/dataplane-cluster-configuration-infractl-osd.yaml"

# Create a central and make sure it get's to ready state without errors
./scripts/create-central.sh

# Make sure secrets are populated in the database
make db/psql
select id, status, secrets from central_requests;



```

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
