### PR TITLE
ROX-17336: Migrate authn/z declarative config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@
 cmd/fleet-manager/fleet-manager
 /fleetshard-sync
 /acsfleetctl
+/dataplane-migrator
+cmd/dataplane-migrator/dataplane-migrator
 # Ignore generated templates
 /templates/*-template.json
 

--- a/Makefile
+++ b/Makefile
@@ -303,7 +303,11 @@ acsfleetctl:
 	GOOS="$(GOOS)" GOARCH="$(GOARCH)" $(GO) build $(GOARGS) -o acsfleetctl ./cmd/acsfleetctl
 .PHONY: acsfleetctl
 
-binary: fleet-manager fleetshard-sync probe acsfleetctl
+dataplane-migrator:
+	GOOS="$(GOOS)" GOARCH="$(GOARCH)" $(GO) build $(GOARGS) -o dataplane-migrator ./cmd/dataplane-migrator
+.PHONY: dataplane-migrator
+
+binary: fleet-manager fleetshard-sync probe acsfleetctl dataplane-migrator
 .PHONY: binary
 
 # Install

--- a/cmd/dataplane-migrator/main.go
+++ b/cmd/dataplane-migrator/main.go
@@ -1,0 +1,33 @@
+// Package main provides a command line utility for running dataplane migrations.
+package main
+
+import (
+	"flag"
+	"os"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	dp_migrator "github.com/stackrox/acs-fleet-manager/dp-migrator"
+)
+
+func main() {
+	// This is needed to make `glog` believe that the flags have already been parsed, otherwise
+	// every log messages is prefixed by an error message stating that the flags haven't been
+	// parsed.
+	_ = flag.CommandLine.Parse([]string{})
+	// Always log to stderr by default
+	if err := flag.Set("logtostderr", "true"); err != nil {
+		glog.Infof("Unable to set logtostderr to true")
+	}
+
+	rootCmd := &cobra.Command{
+		Use:  "dataplane-migrator",
+		Long: "Helper utility for running migrations on dataplane clusters.",
+	}
+
+	rootCmd.AddCommand(dp_migrator.Command())
+
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/dp-migrator/auth/migrate.go
+++ b/dp-migrator/auth/migrate.go
@@ -194,8 +194,9 @@ func (m *migrator) retrieveAuthProviderAndGroups() (string, []*storage.Group, er
 	glog.Info("Filtering out groups that are non-default")
 	var filteredGroups []*storage.Group
 	for _, group := range groups {
-		// ALLOW_MUTATE_FORCE will only be set for groups created imperatively.
-		if group.GetProps().GetTraits().GetMutabilityMode() == storage.Traits_ALLOW_MUTATE_FORCED {
+		// ALLOW_MUTATE_FORCE will only be set for groups created imperatively. We can skip those, since they
+		// will be replaced by the ones created in declarative config.
+		if group.GetProps().GetTraits().GetMutabilityMode() != storage.Traits_ALLOW_MUTATE_FORCED {
 			filteredGroups = append(filteredGroups, group)
 		}
 	}

--- a/dp-migrator/auth/migrate.go
+++ b/dp-migrator/auth/migrate.go
@@ -196,13 +196,8 @@ func (m *migrator) retrieveAuthProviderAndGroups() (string, []*storage.Group, er
 	for _, group := range groups {
 		// ALLOW_MUTATE_FORCE will only be set for groups created imperatively.
 		if group.GetProps().GetTraits().GetMutabilityMode() == storage.Traits_ALLOW_MUTATE_FORCED {
-			continue
+			filteredGroups = append(filteredGroups, group)
 		}
-		// We will also skip the default group since it will already be created by the declarative config.
-		if group.GetProps().GetValue() == "" && group.GetProps().GetKey() == "" {
-			continue
-		}
-		filteredGroups = append(filteredGroups, group)
 	}
 	glog.Infof("Groups after filtering out non-default ones: \n%s", prettyPrintGroups(filteredGroups))
 

--- a/dp-migrator/auth/migrate.go
+++ b/dp-migrator/auth/migrate.go
@@ -1,0 +1,301 @@
+// Package auth handles auth migrations for data plane clusters.
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/client"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/reconciler"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
+	"github.com/stackrox/acs-fleet-manager/pkg/shared"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+// MigrateCommand provides the command to run the migration of authn/z resources on the dataplane clusters to support
+// declarative configuration.
+func MigrateCommand() *cobra.Command {
+	m := migrator{}
+
+	cmd := &cobra.Command{
+		Use:   "authn-z",
+		Short: "Run the migration of authn/z resources to declarative configuration",
+		Long: `Run the migration of authn/z resources to declarative configuration.
+For existing instances, the default authn/z resources (auth provider and groups) have been created imperatively via
+API calls. This makes migrating things hard (that's why we have to write migrations like these).
+
+While the secret has been created already containing the declarative configuration, they are currently not applied
+since the auth provider cannot be created due to name clashes with the existing one.
+
+The goal of this migration is to do the following:
+* Retrieve potential custom groups added by users within the default auth provider.
+* Remove the default auth provider that's created imperatively.
+* Re-apply any custom groups that have been created previously.
+
+The time until the auth provider is added after removal should be no more than 20 seconds, as this is the interval
+Central will read and reconcile declarative configurations. The expectation is that the downtime should be less than 1
+minute. It's worthwhile to note that users will have to re-login, as the auth provider ID changes, thus tokens issued
+by the specific auth provider ID will be seen as invalid.
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := m.Construct(); err != nil {
+				return errors.Wrap(err, "constructing command's dependencies")
+			}
+			if err := m.DoMigration(); err != nil {
+				return errors.Wrapf(err, "migrating instance %q", m.centralName)
+			}
+			return nil
+		},
+		SilenceUsage: true,
+	}
+
+	cmd.Flags().StringVarP(&m.centralURL, "url", "u", "",
+		`URL of the central instance which should be migrated. The format should be https://<hostname>:<port> and
+should be the UI URL, not the data URL.`)
+	cmd.Flags().StringVar(&m.centralName, "name", "", "name of the central instance")
+	cmd.Flags().StringVar(&m.centralID, "id", "", "id of the central instance")
+	cmd.Flags().StringVar(&m.centralIssuer, "issuer", "", "issuer for the auth provider of the central instance")
+
+	utils.Must(cmd.MarkFlagRequired("url"))
+	utils.Must(cmd.MarkFlagRequired("id"))
+	utils.Must(cmd.MarkFlagRequired("name"))
+
+	return cmd
+}
+
+type migrator struct {
+	centralID     string
+	centralName   string
+	centralURL    string
+	centralIssuer string
+
+	adminPassword    string
+	parsedCentralURL *url.URL
+	apiClient        *client.Client
+}
+
+func (m *migrator) Construct() error {
+	parsedCentralURL, err := url.Parse(m.centralURL)
+	if err != nil {
+		return errors.Wrapf(err, "parsing central URL %q", m.centralURL)
+	}
+	m.parsedCentralURL = parsedCentralURL
+
+	// Always enable the admin password for the specific central instance.
+	adminPassword, err := shared.EnableAdminPassword(context.Background(), m.centralID, m.centralName, m.centralURL)
+	if err != nil {
+		return errors.Wrapf(err, "enabling admin password and basic auth provider for central %q", m.centralName)
+	}
+
+	m.adminPassword = adminPassword // pragma: allowlist secret
+
+	// This is currently required due to the Central client requiring this to be injected. It will only be used for
+	// logging purposes in case of errors. Ideally this shouldn't really be a dependency when creating the client.
+	remoteCentral := private.ManagedCentral{Metadata: private.ManagedCentralAllOfMetadata{
+		Name:      m.centralURL,
+		Namespace: "default",
+	}}
+	m.apiClient = client.NewCentralClient(remoteCentral, m.centralURL, m.adminPassword)
+
+	return nil
+}
+
+func (m *migrator) DoMigration() error {
+	defer func() {
+		utils.Must(shared.DisableAdminPassword(context.Background(), m.centralID, m.centralName))
+	}()
+
+	// 1. Retrieve all existing information from Central.
+	// This includes:
+	//	- the existing groups associated with the auth provider. Note that we will skip groups which are immutable,
+	//	  since they are the "default" groups and are already covered by the declarative configuration created.
+	defaultAuthProviderID, customGroups, err := m.retrieveAuthProviderAndGroups()
+	if err != nil {
+		return errors.Wrapf(err, "retrieving auth provider and groups for central %q", m.centralName)
+	}
+
+	// Short-circuit here: if the auth provider ID is the declarative auth provider ID, then we can assume
+	// we have already migrated this instance.
+	if defaultAuthProviderID == declarativeconfig.NewDeclarativeAuthProviderUUID(m.defaultAuthProviderName()).String() {
+		glog.Infof("Central %s already uses declarative configuration for the authN/Z configuration, skipping..",
+			m.centralName)
+		return nil
+	}
+
+	// 2. Delete the existing auth provider that has been created imperatively.
+	waitForConfirmation("deleting the existing auth provider")
+	if err := m.removeDefaultAuthProvider(defaultAuthProviderID); err != nil {
+		return errors.Wrapf(err, "removing auth provider %q for central %q", defaultAuthProviderID, m.centralName)
+	}
+
+	// 3. Verify that the new auth provider will be created eventually.
+	//    Note that we can query this via API since the UUID of the auth provider will be deterministic.
+	waitForConfirmation("verifying the declarative auth provider exists")
+	if err := m.verifyAuthProviderExists(); err != nil {
+		return errors.Wrapf(err, "verifying auth provider exists for central %q", m.centralName)
+	}
+
+	// 4. Re-create the previously existing groups with references to the newly declarative created auth provider.
+	waitForConfirmation("migrating custom groups to the new auth provider")
+	if err := m.migrateCustomGroups(customGroups); err != nil {
+		return errors.Wrapf(err, "migrating groups to new auth provider for central %q", m.centralName)
+	}
+	// That's it, we are done.
+	return nil
+}
+
+func (m *migrator) retrieveAuthProviderAndGroups() (string, []*storage.Group, error) {
+	glog.Infof("Retrieving login auth providers for central %q", m.centralName)
+	authProviders, err := m.apiClient.GetLoginAuthProviders(context.Background())
+	if err != nil {
+		return "", nil, errors.Wrapf(err, "retrieving login auth providers for central %q", m.centralName)
+	}
+
+	glog.Infof("Received login auth providers from Central %q:\n%+v", m.centralName, authProviders)
+
+	authProviderID, exists := m.getDefaultAuthProviderID(authProviders)
+	if !exists {
+		return "", nil, errors.Errorf("could not find default sso.r.c. auth provider for central %q", m.centralName)
+	}
+
+	groups, err := m.getGroupsForAuthProvider(authProviderID)
+	if err != nil {
+		return "", nil, errors.Wrapf(err, "retrieving groups for auth provider %q for central %q",
+			authProviderID, m.centralName)
+	}
+
+	glog.Info("Filtering out groups that are non-default")
+	var filteredGroups []*storage.Group
+	for _, group := range groups {
+		// ALLOW_MUTATE_FORCE will only be set for groups created imperatively.
+		if group.GetProps().GetTraits().GetMutabilityMode() == storage.Traits_ALLOW_MUTATE_FORCED {
+			continue
+		}
+		// We will also skip the default group since it will already be created by the declarative config.
+		if group.GetProps().GetValue() == "" && group.GetProps().GetKey() == "" {
+			continue
+		}
+		filteredGroups = append(filteredGroups, group)
+	}
+	glog.Infof("Groups after filtering out non-default ones: \n%+v", filteredGroups)
+
+	return authProviderID, filteredGroups, nil
+}
+
+func (m *migrator) removeDefaultAuthProvider(id string) error {
+	glog.Infof("Removing auth provider %q for central %q", id, m.centralName)
+	if err := m.apiClient.SendRequestToCentral(context.Background(), nil, http.MethodDelete,
+		fmt.Sprintf("/v1/authProviders/%s?force=true", id), nil); err != nil {
+		return errors.Wrapf(err, "attempting to delete auth provider %q for central %q", id, m.centralName)
+	}
+
+	glog.Infof("Successfully deleted auth provider %q for central %q", id, m.centralName)
+	return nil
+}
+
+func (m *migrator) verifyAuthProviderExists() error {
+	verified := concurrency.PollWithTimeout(func() bool {
+		authProviders, err := m.apiClient.GetLoginAuthProviders(context.Background())
+		if err != nil {
+			glog.Errorf("Received an error when attempting to retrieve login auth providers for central %q",
+				m.centralName)
+			return false
+		}
+		glog.Infof("Received login auth providers for central %q:\n%+v", m.centralName, authProviders)
+		authProviderID, exists := m.getDefaultAuthProviderID(authProviders)
+
+		glog.Infof("Received auth provider exists (%t) and ID (%s)", exists, authProviderID)
+
+		if exists && authProviderID == declarativeconfig.
+			NewDeclarativeAuthProviderUUID(m.defaultAuthProviderName()).String() {
+			glog.Infof("Found the auth provider ID we expect from the declarative provider")
+			return true
+		}
+		return false
+	}, 5*time.Second, 5*time.Minute)
+
+	if verified {
+		glog.Infof("Successfully verified that the declarative auth provider exists for central %q", m.centralName)
+		return nil
+	}
+
+	glog.Infof("Failed to verify the declarative auth provider exists for central %q", m.centralName)
+	return errors.Errorf("failed to verify that the declarative auth provider exists")
+}
+
+func (m *migrator) migrateCustomGroups(groups []*storage.Group) error {
+	glog.Infof("Custom groups before adjusting the auth provider ID for central %q:\n%+v", m.centralName, groups)
+	declarativeAuthProviderUUID := declarativeconfig.NewDeclarativeAuthProviderUUID(m.defaultAuthProviderName()).String()
+	glog.Infof("New auth provider ID: %q", declarativeAuthProviderUUID)
+
+	for _, group := range groups {
+		group.Props.AuthProviderId = declarativeAuthProviderUUID
+		group.Props.Id = ""
+		if err := m.apiClient.SendRequestToCentral(context.Background(), group, http.MethodPost, "/v1/groups",
+			nil); err != nil {
+			return errors.Wrapf(err, "creating group %+v for auth provider %q for central %q",
+				group, declarativeAuthProviderUUID, m.centralName)
+		}
+	}
+
+	glog.Infof("Verifying that groups are as expected")
+	groups, err := m.getGroupsForAuthProvider(declarativeAuthProviderUUID)
+	if err != nil {
+		return errors.Wrapf(err, "retrieving groups for auth provider %q for central %q",
+			declarativeAuthProviderUUID, m.centralName)
+	}
+	glog.Infof("Groups after migration:\n%+v", groups)
+	return nil
+}
+
+func (m *migrator) defaultAuthProviderName() string {
+	return reconciler.AuthProviderName(
+		private.ManagedCentral{
+			Spec: private.ManagedCentralAllOfSpec{
+				Auth: private.ManagedCentralAllOfSpecAuth{
+					Issuer: m.centralIssuer,
+				},
+			},
+		},
+	)
+}
+
+func (m *migrator) getGroupsForAuthProvider(id string) ([]*storage.Group, error) {
+	glog.Infof("Retrieving groups for auth provider %q", id)
+	var groups v1.GetGroupsResponse
+	if err := m.apiClient.SendRequestToCentral(context.Background(),
+		nil,
+		http.MethodGet, fmt.Sprintf("/v1/groups?authProviderId=%s", id), &groups); err != nil {
+		return nil, errors.Wrapf(err, "retrieving groups associated with auth provider %q for central %q",
+			id, m.centralName)
+	}
+
+	glog.Infof("Received groups associated with auth provider %q for Central %q:\n%+v",
+		id, m.centralName, groups)
+	return groups.GetGroups(), nil
+}
+
+func (m *migrator) getDefaultAuthProviderID(authProviders *v1.GetLoginAuthProvidersResponse) (string, bool) {
+	for _, provider := range authProviders.GetAuthProviders() {
+		if provider.GetType() == "oidc" && provider.GetName() == m.defaultAuthProviderName() {
+			glog.Infof("Found default sso.r.c auth provider for Central %q:\n%+v", m.centralName, provider)
+			return provider.GetId(), true
+		}
+	}
+	return "", false
+}
+
+func waitForConfirmation(step string) {
+	fmt.Printf("Press Enter to continue with %q\n", step)
+	_, _ = fmt.Scanln()
+}

--- a/dp-migrator/auth/migrate.go
+++ b/dp-migrator/auth/migrate.go
@@ -2,13 +2,16 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
 	"net/url"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/golang/glog"
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/client"
@@ -49,6 +52,11 @@ by the specific auth provider ID will be seen as invalid.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := m.Construct(); err != nil {
+				if errors.Is(err, shared.ErrPausedReconciliation) {
+					glog.Warningf("Central %s has reconciliation paused. It currently "+
+						"CAN NOT be migrated and will be SKIPPED!", m.centralName)
+					return nil
+				}
 				return errors.Wrap(err, "constructing command's dependencies")
 			}
 			if err := m.DoMigration(); err != nil {
@@ -65,6 +73,8 @@ should be the UI URL, not the data URL.`)
 	cmd.Flags().StringVar(&m.centralName, "name", "", "name of the central instance")
 	cmd.Flags().StringVar(&m.centralID, "id", "", "id of the central instance")
 	cmd.Flags().StringVar(&m.centralIssuer, "issuer", "", "issuer for the auth provider of the central instance")
+	cmd.Flags().BoolVar(&m.skipConfirmation, "skip-confirmation", false, "skip user confirmation before executing each step")
+	cmd.Flags().BoolVar(&m.readOnly, "read-only", false, "read only auth provider and groups without making changes")
 
 	utils.Must(cmd.MarkFlagRequired("url"))
 	utils.Must(cmd.MarkFlagRequired("id"))
@@ -74,10 +84,12 @@ should be the UI URL, not the data URL.`)
 }
 
 type migrator struct {
-	centralID     string
-	centralName   string
-	centralURL    string
-	centralIssuer string
+	centralID        string
+	centralName      string
+	centralURL       string
+	centralIssuer    string
+	skipConfirmation bool
+	readOnly         bool
 
 	adminPassword    string
 	parsedCentralURL *url.URL
@@ -132,21 +144,26 @@ func (m *migrator) DoMigration() error {
 		return nil
 	}
 
+	if m.readOnly {
+		glog.Infof("Read only mode selected, returning after retrieving all groups and auth provider")
+		return nil
+	}
+
 	// 2. Delete the existing auth provider that has been created imperatively.
-	waitForConfirmation("deleting the existing auth provider")
+	waitForConfirmation("deleting the existing auth provider", m.skipConfirmation)
 	if err := m.removeDefaultAuthProvider(defaultAuthProviderID); err != nil {
 		return errors.Wrapf(err, "removing auth provider %q for central %q", defaultAuthProviderID, m.centralName)
 	}
 
 	// 3. Verify that the new auth provider will be created eventually.
 	//    Note that we can query this via API since the UUID of the auth provider will be deterministic.
-	waitForConfirmation("verifying the declarative auth provider exists")
+	waitForConfirmation("verifying the declarative auth provider exists", m.skipConfirmation)
 	if err := m.verifyAuthProviderExists(); err != nil {
 		return errors.Wrapf(err, "verifying auth provider exists for central %q", m.centralName)
 	}
 
 	// 4. Re-create the previously existing groups with references to the newly declarative created auth provider.
-	waitForConfirmation("migrating custom groups to the new auth provider")
+	waitForConfirmation("migrating custom groups to the new auth provider", m.skipConfirmation)
 	if err := m.migrateCustomGroups(customGroups); err != nil {
 		return errors.Wrapf(err, "migrating groups to new auth provider for central %q", m.centralName)
 	}
@@ -161,7 +178,7 @@ func (m *migrator) retrieveAuthProviderAndGroups() (string, []*storage.Group, er
 		return "", nil, errors.Wrapf(err, "retrieving login auth providers for central %q", m.centralName)
 	}
 
-	glog.Infof("Received login auth providers from Central %q:\n%+v", m.centralName, authProviders)
+	glog.Infof("Received login auth providers from Central %q:\n%s", m.centralName, prettyPrintProto(authProviders))
 
 	authProviderID, exists := m.getDefaultAuthProviderID(authProviders)
 	if !exists {
@@ -187,7 +204,7 @@ func (m *migrator) retrieveAuthProviderAndGroups() (string, []*storage.Group, er
 		}
 		filteredGroups = append(filteredGroups, group)
 	}
-	glog.Infof("Groups after filtering out non-default ones: \n%+v", filteredGroups)
+	glog.Infof("Groups after filtering out non-default ones: \n%s", prettyPrintGroups(filteredGroups))
 
 	return authProviderID, filteredGroups, nil
 }
@@ -211,7 +228,7 @@ func (m *migrator) verifyAuthProviderExists() error {
 				m.centralName)
 			return false
 		}
-		glog.Infof("Received login auth providers for central %q:\n%+v", m.centralName, authProviders)
+		glog.Infof("Received login auth providers for central %q:\n%s", m.centralName, prettyPrintProto(authProviders))
 		authProviderID, exists := m.getDefaultAuthProviderID(authProviders)
 
 		glog.Infof("Received auth provider exists (%t) and ID (%s)", exists, authProviderID)
@@ -234,7 +251,8 @@ func (m *migrator) verifyAuthProviderExists() error {
 }
 
 func (m *migrator) migrateCustomGroups(groups []*storage.Group) error {
-	glog.Infof("Custom groups before adjusting the auth provider ID for central %q:\n%+v", m.centralName, groups)
+	glog.Infof("Custom groups before adjusting the auth provider ID for central %q:\n%s", m.centralName,
+		prettyPrintGroups(groups))
 	declarativeAuthProviderUUID := declarativeconfig.NewDeclarativeAuthProviderUUID(m.defaultAuthProviderName()).String()
 	glog.Infof("New auth provider ID: %q", declarativeAuthProviderUUID)
 
@@ -243,8 +261,8 @@ func (m *migrator) migrateCustomGroups(groups []*storage.Group) error {
 		group.Props.Id = ""
 		if err := m.apiClient.SendRequestToCentral(context.Background(), group, http.MethodPost, "/v1/groups",
 			nil); err != nil {
-			return errors.Wrapf(err, "creating group %+v for auth provider %q for central %q",
-				group, declarativeAuthProviderUUID, m.centralName)
+			return errors.Wrapf(err, "creating group %s for auth provider %q for central %q",
+				prettyPrintProto(group), declarativeAuthProviderUUID, m.centralName)
 		}
 	}
 
@@ -254,7 +272,7 @@ func (m *migrator) migrateCustomGroups(groups []*storage.Group) error {
 		return errors.Wrapf(err, "retrieving groups for auth provider %q for central %q",
 			declarativeAuthProviderUUID, m.centralName)
 	}
-	glog.Infof("Groups after migration:\n%+v", groups)
+	glog.Infof("Groups after migration:\n%s", prettyPrintGroups(groups))
 	return nil
 }
 
@@ -280,22 +298,44 @@ func (m *migrator) getGroupsForAuthProvider(id string) ([]*storage.Group, error)
 			id, m.centralName)
 	}
 
-	glog.Infof("Received groups associated with auth provider %q for Central %q:\n%+v",
-		id, m.centralName, groups)
+	glog.Infof("Received groups associated with auth provider %q for Central %q:\n%s",
+		id, m.centralName, prettyPrintProto(&groups))
 	return groups.GetGroups(), nil
 }
 
 func (m *migrator) getDefaultAuthProviderID(authProviders *v1.GetLoginAuthProvidersResponse) (string, bool) {
 	for _, provider := range authProviders.GetAuthProviders() {
 		if provider.GetType() == "oidc" && provider.GetName() == m.defaultAuthProviderName() {
-			glog.Infof("Found default sso.r.c auth provider for Central %q:\n%+v", m.centralName, provider)
+			glog.Infof("Found default sso.r.c auth provider for Central %q:\n%s", m.centralName, prettyPrintProto(provider))
 			return provider.GetId(), true
 		}
 	}
 	return "", false
 }
 
-func waitForConfirmation(step string) {
+func waitForConfirmation(step string, skip bool) {
+	if skip {
+		return
+	}
 	fmt.Printf("Press Enter to continue with %q\n", step)
 	_, _ = fmt.Scanln()
+}
+
+func prettyPrintProto(msgs ...proto.Message) string {
+	buf := &bytes.Buffer{}
+	marshaller := jsonpb.Marshaler{
+		Indent: "  ",
+	}
+	for _, msg := range msgs {
+		utils.Must(marshaller.Marshal(buf, msg))
+	}
+	return buf.String()
+}
+
+func prettyPrintGroups(groups []*storage.Group) string {
+	var res string
+	for _, g := range groups {
+		res += prettyPrintProto(g)
+	}
+	return res
 }

--- a/dp-migrator/cmd.go
+++ b/dp-migrator/cmd.go
@@ -1,0 +1,19 @@
+// Package dpmigrator handles data plane migrations.
+package dpmigrator
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/stackrox/acs-fleet-manager/dp-migrator/auth"
+)
+
+// Command provides the command to migrate things on the dataplane cluster.
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "migrate",
+		Short: "All migrations for data plane clusters",
+	}
+
+	cmd.AddCommand(auth.MigrateCommand())
+
+	return cmd
+}

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -486,7 +486,7 @@ func (r *CentralReconciler) configureAuditLogNotifier(secret *corev1.Secret, nam
 
 func getAuthProviderConfig(remoteCentral private.ManagedCentral) *declarativeconfig.AuthProvider {
 	return &declarativeconfig.AuthProvider{
-		Name:             authProviderName(remoteCentral),
+		Name:             AuthProviderName(remoteCentral),
 		UIEndpoint:       remoteCentral.Spec.UiEndpoint.Host,
 		ExtraUIEndpoints: []string{"localhost:8443"},
 		Groups: []declarativeconfig.Group{

--- a/fleetshard/pkg/central/reconciler/util.go
+++ b/fleetshard/pkg/central/reconciler/util.go
@@ -62,8 +62,8 @@ func getHTTPSServicePort(service *core.Service) (int32, error) {
 	return 0, errors.Errorf("no `https` port is present in %s/%s service", service.Namespace, service.Name)
 }
 
-// authProviderName deduces auth provider name from issuer URL.
-func authProviderName(central private.ManagedCentral) (name string) {
+// AuthProviderName deduces auth provider name from issuer URL.
+func AuthProviderName(central private.ManagedCentral) (name string) {
 	switch {
 	case strings.Contains(central.Spec.Auth.Issuer, "sso.stage.redhat"):
 		name = "Red Hat SSO (stage)"
@@ -100,7 +100,7 @@ func hasAuthProvider(ctx context.Context, central private.ManagedCentral, client
 	}
 
 	for _, provider := range authProvidersResp.AuthProviders {
-		if provider.Type == oidcType && provider.GetName() == authProviderName(central) {
+		if provider.Type == oidcType && provider.GetName() == AuthProviderName(central) {
 			return true, nil
 		}
 	}

--- a/scripts/hack/migrate-authn-z.sh
+++ b/scripts/hack/migrate-authn-z.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+function log() {
+    echo "${1:-}" >&2
+}
+
+function log_exit() {
+    log "${1:-}"
+
+    exit 1
+}
+
+function usage() {
+    log "
+Usage:
+    migrate-authn-z.sh MANDATORY [OPTION]
+MANDATORY:
+    --central-list-path     The path to the with list of central instances that should be migrated.
+OPTION:
+    --help                  Prints help information.
+Example:
+    migrate-authn-z.sh --central-list gabi-list.json
+"
+}
+
+function usage_exit() {
+    usage
+
+    exit 1
+}
+
+function check_command() {
+    local cmd="${1:-}"
+
+    echo "- Looking for '${cmd}'"
+    command -v "${cmd}" || log_exit "-- Command '${cmd}' required."
+    echo "- Found '${cmd}'!"
+}
+
+function check_dependencies() {
+    check_command jq
+    check_command realpath
+}
+
+function migrate_all_centrals() {
+    echo "-- Processing all ACS instance from the list"
+
+    local central_list_path="${1:-}"
+    [[ "${central_list_path}" = "" ]] && log "Error: Parameter 'central_list_path' is empty." && usage_exit
+
+    local script_dir
+    script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+    local binary_file_path
+    binary_file_path=$(realpath "${script_dir}/../../dataplane-migrators")
+
+    # 1. read CSV file and process central one by one. So that we can log results nicely.
+    # Used query:
+    # ./stage-action.sh gabi "SELECT id,name,CONCAT('https://acs-',id,'.',host),issuer FROM central_requests WHERE deleted_at IS NULL ORDER BY created_at DESC;" | jq '.result[1:][] | @csv ' --raw-output > stage.csv
+    while read -r csv_line; do
+        # id,name,CONCAT('https://acs-',id,'.',host)
+        IFS="," read -r csv_id csv_name csv_host csv_issuer <<<"${csv_line}"
+
+        # trim quotes
+        csv_id=$(echo "${csv_id}" | xargs)
+        csv_name=$(echo "${csv_name}" | xargs)
+        csv_host=$(echo "${csv_host}" | xargs)
+        csv_issuer=$(echo "${csv_issuer}" | xargs)
+        echo ">>> Migrate central ID: ${csv_id} - with name: ${csv_name}"
+
+        echo ">>> Calling command:"
+        echo ">>> " "${binary_file_path}" migrate authn-z \
+            --id "${csv_id}" \
+            --name "${csv_name}" \
+            --url "${csv_host}" \
+            --issuer "${csv_issuer}"
+
+        # execute migration
+        ${binary_file_path} migrate authn-z \
+            --id "${csv_id}" \
+            --name "${csv_name}" \
+            --url "${csv_host}" \
+            --issuer "${csv_issuer}"
+
+        echo ">>> Done"
+    done <"${central_list_path}"
+
+    echo "-- Done"
+}
+
+function main() {
+    local central_list_path=""
+
+    while [[ -n "${1:-}" ]]; do
+        case "${1}" in
+        "--central-list-path")
+            central_list_path="${2:-}"
+            shift
+            ;;
+        "--help")
+            usage_exit
+            ;;
+        *)
+            log "Error: Unknown parameter: ${1:-}"
+            usage_exit
+            ;;
+        esac
+
+        if ! shift; then
+            log "Error: Missing parameter argument."
+            usage_exit
+        fi
+    done
+
+    check_dependencies
+
+    [[ "${central_list_path}" = "" ]] && log "Error: Command option '--central-list-path' is mandatory." && usage_exit
+
+    central_list_path=$(realpath "${central_list_path}")
+    [[ ! -f "${central_list_path}" ]] && log "Error: File provided in option '--central-list-path' does not exist." && usage_exit
+
+    migrate_all_centrals "${central_list_path}" "{stage}"
+}
+
+main "$@"


### PR DESCRIPTION
## Description

```
./dataplane-migrator migrate authn-z --help                                                                                                                                                                                                                                                                          
Run the migration of authn/z resources to declarative configuration.
For existing instances, the default authn/z resources (auth provider and groups) have been created imperatively via
API calls. This makes migrating things hard (that's why we have to write migrations like these).

While the secret has been created already containing the declarative configuration, they are currently not applied
since the auth provider cannot be created due to name clashes with the existing one.

The goal of this migration is to do the following:
* Retrieve potential custom groups added by users within the default auth provider.
* Remove the default auth provider that's created imperatively.
* Re-apply any custom groups that have been created previously.

The time until the auth provider is added after removal should be no more than 20 seconds, as this is the interval
Central will read and reconcile declarative configurations. The expectation is that the downtime should be less than 1
minute. It's worthwhile to note that users will have to re-login, as the auth provider ID changes, thus tokens issued
by the specific auth provider ID will be seen as invalid.

Usage:
  dataplane-migrator migrate authn-z [flags]

Flags:
  -h, --help          help for authn-z
      --id string     id of the central instance
      --name string   name of the central instance
      --stage         specify whether running against stage
  -u, --url string    URL of the central instance which should be migrated. The format should be https://<hostname>:<port> and
                      should be the UI URL, not the data URL.
```

As a reference, [a authn/z migration was done previously in a similar fashion](https://github.com/stackrox/acs-fleet-manager/pull/750).

**Note: this is not expected to be merged.**

### How to run a migration

1. Get all Centrals from GABI:
```bash
./stage-action.sh gabi "SELECT id,name,CONCAT('https://acs-',id,'.',host),issuer FROM central_requests WHERE deleted_at IS NULL AND region = 'us-east-1' AND name NOT LIKE '%probe%' ORDER BY created_at DESC;" | jq '.result[1:][] | @csv ' --raw-output > input.csv
```

2. Run the script that will use that file as input:
```bash
./scripts/hack/migrate-authn-z.sh --central-list-path ./input.csv
```

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

