### PR TITLE
ROX-17260: Add annotation to trigger yearly certificate rotation

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/audit-logs/templates/06-statefulset.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/audit-logs/templates/06-statefulset.yaml
@@ -23,6 +23,7 @@ spec:
   template:
     metadata:
       annotations:
+        trigger-tls-rotation: {{ now | date "2006" | quote }}
         checksum/config: {{ include (print .Template.BasePath "/02-configmap.yaml") . | sha256sum }}
       {{- with .Values.annotations }}
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Description

This PR adds a trigger to roll out aggregator pods once a year in order to use a rotated certificate.

## Checklist (Definition of Done)
- ~~[ ] Unit and integration tests added~~
- [x] Added test description under `Test manual`
- ~~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- ~~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- ~~[ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
- ~~[ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
- ~~[ ] Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual

Manual testing is possible on a local cluster (i.e. colima), but it requires some modifications to go around OpenShift generated secrets.

Steps:
1. Go to `audit-logs` chart directory:
```
cd dp-terraform/helm/rhacs-terraform/charts/audit-logs
```

2. Change in `06-statefulset.yaml` - to set `tls-secret` as optional
```
               - secret:
                  name: {{ include "aggregator.fullname" . }}-tls-secret
                  optional: true
```

3. Create `test-values.yaml` file with the following content:
```
replicas: 1
customConfig:
  sources:
    http_server:
      tls:
        enabled: false
  sinks:
    aws_cloudwatch_logs:
      healthcheck:
        enabled: false
```
We are disabling TLS, because it's not relevant to test if pods will be rolled out, and also access to AWS healthcheck is not relevant.

4. Prepare namespace and deploy helm:
```
# Create namespace:
kubectl create namespace rhacs

# Deploy HELM
helm install rhacs-audit-vector . --namespace rhacs --values ./test-values.yaml
```

5. Check pod "AGE"
```
kubectl get pods -n rhacs-audit-logs
```

6. Apply helm update:
```
helm upgrade rhacs-audit-vector . --namespace rhacs --values ./test-values.yaml
```

7. Check pod "AGE":
```
kubectl get pods -n rhacs-audit-logs
```
Pods should **not** be **restarted**.


8. Change template `06-statefulset.yaml` to simulate next year:
```
trigger-tls-rotation: {{ toDate "2006-01-02" "2024-01-01" | date "2006" | quote }}
```

9. Apply helm update:
```
helm upgrade rhacs-audit-vector . --namespace rhacs --values ./test-values.yaml
```

10. Check pod "AGE":
```
kubectl get pods -n rhacs-audit-logs
```
This time pods should be **restarted**.

