### PR TITLE
ROX-18427: read central DB ID override from optional ConfigMap

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -76,8 +76,9 @@ const (
 	dbUserTypeCentral    = "central"
 	dbCentralUserName    = "rhacs_central"
 
-	centralDbSecretName       = "central-db-password" // pragma: allowlist secret
-	centralDeletePollInterval = 5 * time.Second
+	centralDbSecretName        = "central-db-password" // pragma: allowlist secret
+	centralDbOverrideConfigMap = "central-db-override"
+	centralDeletePollInterval  = 5 * time.Second
 
 	sensibleDeclarativeConfigSecretName = "cloud-service-sensible-declarative-configs" // pragma: allowlist secret
 	manualDeclarativeConfigSecretName   = "cloud-service-manual-declarative-configs"   // pragma: allowlist secret
@@ -1031,7 +1032,7 @@ func (r *CentralReconciler) ensureCentralDeleted(ctx context.Context, remoteCent
 // By default the database ID is equal to the centralID. It can be overridden by a ConfigMap.
 func (r *CentralReconciler) getDatabaseID(ctx context.Context, remoteCentralNamespace, centralID string) (string, error) {
 	configMap := &corev1.ConfigMap{}
-	err := r.client.Get(ctx, ctrlClient.ObjectKey{Namespace: remoteCentralNamespace, Name: "central-db-override"}, configMap)
+	err := r.client.Get(ctx, ctrlClient.ObjectKey{Namespace: remoteCentralNamespace, Name: centralDbOverrideConfigMap}, configMap)
 	if err != nil {
 		if apiErrors.IsNotFound(err) {
 			return centralID, nil
@@ -1046,7 +1047,7 @@ func (r *CentralReconciler) getDatabaseID(ctx context.Context, remoteCentralName
 		return overrideValue, nil
 	}
 
-	glog.Infof("The central-db-override ConfigMap exists but contains no databaseID field, using default: %s", centralID)
+	glog.Infof("The %s ConfigMap exists but contains no databaseID field, using default: %s", centralDbOverrideConfigMap, centralID)
 	return centralID, nil
 }
 

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -1027,9 +1027,9 @@ func (r *CentralReconciler) ensureCentralDeleted(ctx context.Context, remoteCent
 	return globalDeleted, nil
 }
 
+// getDatabaseID returns the cloud database ID for a central tenant.
+// By default the database ID is equal to the centralID. It can be overridden by a ConfigMap.
 func (r *CentralReconciler) getDatabaseID(ctx context.Context, remoteCentralNamespace, centralID string) (string, error) {
-	// By default the database ID (which is used to name the cloud DB resources) is the same as the central ID,
-	// but this value can be overriden
 	configMap := &corev1.ConfigMap{}
 	err := r.client.Get(ctx, ctrlClient.ObjectKey{Namespace: remoteCentralNamespace, Name: "central-db-override"}, configMap)
 	if err != nil {

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -672,7 +672,7 @@ func TestReconcileDeleteWithManagedDBOverride(t *testing.T) {
 		UseRoutes:        true,
 		ManagedDBEnabled: true,
 	}
-	fakeClient, _, r := getClientTrackerAndReconciler(
+	_, _, r := getClientTrackerAndReconciler(
 		t,
 		defaultCentralConfig,
 		managedDBProvisioningClient,


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Currently the name of a Central DB is fixed and based on the Central's ID. E.g. for the ID `cjmugfm9rusboqitae5g` the DB cluster must be called `rhacs-cjmugfm9rusboqitae5g-db-cluster`.

This PR gives the possibility to override the default naming scheme. For example, if the above DB is restored from backup into `rhacs-examplebackup-db-cluster`, then fleetshard-sync can be instructed to use the alternate name in the following way:
`kubectl create configmap central-db-override --namespace=rhacs-cjmugfm9rusboqitae5g --from-literal=databaseID=examplebackup`

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] ~~Added test description under `Test manual`~~
- [ ] ~~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- [ ] ~~Add secret to app-interface Vault or Secrets Manager if necessary~~
- [x] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] ~~Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual

Tested E2E locally by creating a ConfigMap as described above and confirming that Central can connect to an overridden DB.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
