### PR TITLE
Update alertmanager grouping confiugration

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-03-secret-alertmanager.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-03-secret-alertmanager.yaml
@@ -10,12 +10,20 @@ stringData:
     route:
       receiver: managed-rhacs-pagerduty
       repeat_interval: 12h
+      group_by:
+      - cluster_id
       routes:
       - receiver: managed-rhacs-deadmanssnitch
         repeat_interval: 5m
+        continue: false
         match:
           alertname: DeadMansSwitch
           observability: managed-rhacs
+      - receiver: managed-rhacs-pagerduty
+        group_by:
+        - rhacs_instance_id
+        matchers:
+        - "rhacs_instance_id =~ \".*\""
     receivers:
     - name: managed-rhacs-pagerduty
       pagerduty_configs:


### PR DESCRIPTION
Alerts in PagerDuty are currently all grouped together, even when it doesn't make any sense.

So instead, group PD alerts by rhacs_instance_id if rhacs_instance_id is on the alert; otherwise group by cluster_id.

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
