### PR TITLE
Add k8s API to NO_PROXY configuration

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -265,13 +265,13 @@ func (r *CentralReconciler) getInstanceConfig(remoteCentral *private.ManagedCent
 	}
 
 	// Set proxy configuration
-	additionalNoProxyURL := url.URL{
+	auditLoggingURL := url.URL{
 		Host: r.auditLogging.Endpoint(false),
 	}
 	kubernetesURL := url.URL{
 		Host: "https://kubernetes.default.svc:443",
 	}
-	envVars := getProxyEnvVars(remoteCentralNamespace, additionalNoProxyURL, kubernetesURL)
+	envVars := getProxyEnvVars(remoteCentralNamespace, auditLoggingURL, kubernetesURL)
 
 	scannerComponentEnabled := v1alpha1.ScannerComponentEnabled
 

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -268,7 +268,10 @@ func (r *CentralReconciler) getInstanceConfig(remoteCentral *private.ManagedCent
 	additionalNoProxyURL := url.URL{
 		Host: r.auditLogging.Endpoint(false),
 	}
-	envVars := getProxyEnvVars(remoteCentralNamespace, additionalNoProxyURL)
+	kubernetesURL := url.URL{
+		Host: "https://kubernetes.default.svc:443",
+	}
+	envVars := getProxyEnvVars(remoteCentralNamespace, additionalNoProxyURL, kubernetesURL)
 
 	scannerComponentEnabled := v1alpha1.ScannerComponentEnabled
 


### PR DESCRIPTION
## Description
Diagnostic bundle functionality within central requires access to k8s API to obtain diagnostic data about central cluster.
This PR aims to provide such access via `NO_PROXY` variable.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

TBD
