### PR TITLE
fix(reconciler): make default group not declarative

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -487,7 +487,6 @@ func (r *CentralReconciler) configureAuditLogNotifier(secret *corev1.Secret, nam
 func getAuthProviderConfig(remoteCentral private.ManagedCentral) *declarativeconfig.AuthProvider {
 	return &declarativeconfig.AuthProvider{
 		Name:             authProviderName(remoteCentral),
-		MinimumRoleName:  "None",
 		UIEndpoint:       remoteCentral.Spec.UiEndpoint.Host,
 		ExtraUIEndpoints: []string{"localhost:8443"},
 		Groups: []declarativeconfig.Group{


### PR DESCRIPTION
## Description

With the introduction of declarative config, the default group, also referred to as the "minimum role", has been made declarative. That means that currently it is not possible to change it going forward, or use a different value than `None`.

While only a limited amount of users do use the feature (currently only two instances across all instances use this), we still don't want to break the behavior for them.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

- see CI.
