### PR TITLE
fix(fleetshard): use FQDN for k8s svc

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -269,7 +269,7 @@ func (r *CentralReconciler) getInstanceConfig(remoteCentral *private.ManagedCent
 		Host: r.auditLogging.Endpoint(false),
 	}
 	kubernetesURL := url.URL{
-		Host: "https://kubernetes.default.svc:443",
+		Host: "kubernetes.default.svc.cluster.local.:443",
 	}
 	envVars := getProxyEnvVars(remoteCentralNamespace, auditLoggingURL, kubernetesURL)
 


### PR DESCRIPTION
## Description
Use the FQDN to prevent unnecessary DNS lookups and to make sure that the no_proxy env var is set correctly with protocol prefix.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

Tested on OpenShift cluster.
