### PR TITLE
feat(terraform): add acsOperator repository value

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/acs-operator.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/acs-operator.yaml
@@ -37,7 +37,7 @@ spec:
   displayName: 'RHACS Development'
   publisher: 'Red Hat ACS'
   sourceType: grpc
-  image: quay.io/rhacs-eng/stackrox-operator-index:{{ .Values.acsOperator.version }}
+  image: "{{ .Values.acsOperator.repository }}/stackrox-operator-index:{{ .Values.acsOperator.version }}"
 ---
 {{- end }}
 {{- end }}

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -62,6 +62,7 @@ fleetshardSync:
 acsOperator:
   enabled: false
   channel: latest
+  repository: quay.io/rhacs-eng
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   version: v3.70.0


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Expose the ACS operator repository in the terraform Helm chart as a value. This comes in handy when deploying a data plane cluster with an upstream operator version, because it allows to inject your own images.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
