### PR TITLE
Fix local dev env when using ACS 4.2 without OLM

### DIFF
--- a/dev/env/manifests/monitoring/01-namespace.yaml
+++ b/dev/env/manifests/monitoring/01-namespace.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: openshift-monitoring

--- a/dev/env/manifests/monitoring/02-monitoring.coreos.com_prometheusrules.yaml
+++ b/dev/env/manifests/monitoring/02-monitoring.coreos.com_prometheusrules.yaml
@@ -1,0 +1,129 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: prometheusrules.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    categories:
+      - prometheus-operator
+    kind: PrometheusRule
+    listKind: PrometheusRuleList
+    plural: prometheusrules
+    shortNames:
+      - promrule
+    singular: prometheusrule
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: PrometheusRule defines recording and alerting rules for a Prometheus
+            instance
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Specification of desired alerting rule definitions for Prometheus.
+              properties:
+                groups:
+                  description: Content of Prometheus rule file
+                  items:
+                    description: RuleGroup is a list of sequentially evaluated recording
+                      and alerting rules.
+                    properties:
+                      interval:
+                        description: Interval determines how often rules in the group
+                          are evaluated.
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
+                      limit:
+                        description: Limit the number of alerts an alerting rule and
+                          series a recording rule can produce. Limit is supported starting
+                          with Prometheus >= 2.31 and Thanos Ruler >= 0.24.
+                        type: integer
+                      name:
+                        description: Name of the rule group.
+                        minLength: 1
+                        type: string
+                      partial_response_strategy:
+                        description: 'PartialResponseStrategy is only used by ThanosRuler
+                        and will be ignored by Prometheus instances. More info: https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md#partial-response'
+                        pattern: ^(?i)(abort|warn)?$
+                        type: string
+                      rules:
+                        description: List of alerting and recording rules.
+                        items:
+                          description: 'Rule describes an alerting or recording rule
+                          See Prometheus documentation: [alerting](https://www.prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)
+                          or [recording](https://www.prometheus.io/docs/prometheus/latest/configuration/recording_rules/#recording-rules)
+                          rule'
+                          properties:
+                            alert:
+                              description: Name of the alert. Must be a valid label
+                                value. Only one of `record` and `alert` must be set.
+                              type: string
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations to add to each alert. Only valid
+                                for alerting rules.
+                              type: object
+                            expr:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: PromQL expression to evaluate.
+                              x-kubernetes-int-or-string: true
+                            for:
+                              description: Alerts are considered firing once they have
+                                been returned for this long.
+                              pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                              type: string
+                            keep_firing_for:
+                              description: KeepFiringFor defines how long an alert will
+                                continue firing after the condition that triggered it
+                                has cleared.
+                              minLength: 1
+                              pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                              type: string
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: Labels to add or overwrite.
+                              type: object
+                            record:
+                              description: Name of the time series to output to. Must
+                                be a valid metric name. Only one of `record` and `alert`
+                                must be set.
+                              type: string
+                          required:
+                            - expr
+                          type: object
+                        type: array
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true

--- a/dev/env/manifests/monitoring/03-monitoring.coreos.com_servicemonitors.yaml
+++ b/dev/env/manifests/monitoring/03-monitoring.coreos.com_servicemonitors.yaml
@@ -1,0 +1,713 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: servicemonitors.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    categories:
+      - prometheus-operator
+    kind: ServiceMonitor
+    listKind: ServiceMonitorList
+    plural: servicemonitors
+    shortNames:
+      - smon
+    singular: servicemonitor
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ServiceMonitor defines monitoring for a set of services.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Specification of desired Service selection for target discovery
+                by Prometheus.
+              properties:
+                attachMetadata:
+                  description: Attaches node metadata to discovered targets. Requires
+                    Prometheus v2.37.0 and above.
+                  properties:
+                    node:
+                      description: When set to true, Prometheus must have permissions
+                        to get Nodes.
+                      type: boolean
+                  type: object
+                endpoints:
+                  description: A list of endpoints allowed as part of this ServiceMonitor.
+                  items:
+                    description: Endpoint defines a scrapeable endpoint serving Prometheus
+                      metrics.
+                    properties:
+                      authorization:
+                        description: Authorization section for this endpoint
+                        properties:
+                          credentials:
+                            description: Selects a key of a Secret in the namespace
+                              that contains the credentials for authentication.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must
+                                  be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type:
+                            description: "Defines the authentication type. The value
+                            is case-insensitive. \n \"Basic\" is not a supported value.
+                            \n Default: \"Bearer\""
+                            type: string
+                        type: object
+                      basicAuth:
+                        description: 'BasicAuth allow an endpoint to authenticate over
+                        basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                        properties:
+                          password:
+                            description: The secret in the service monitor namespace
+                              that contains the password for authentication.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must
+                                  be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          username:
+                            description: The secret in the service monitor namespace
+                              that contains the username for authentication.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must
+                                  be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      bearerTokenFile:
+                        description: File to read bearer token for scraping targets.
+                        type: string
+                      bearerTokenSecret:
+                        description: Secret to mount to read bearer token for scraping
+                          targets. The secret needs to be in the same namespace as the
+                          service monitor and accessible by the Prometheus Operator.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                          - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      enableHttp2:
+                        description: Whether to enable HTTP2.
+                        type: boolean
+                      filterRunning:
+                        description: 'Drop pods that are not running. (Failed, Succeeded).
+                        Enabled by default. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase'
+                        type: boolean
+                      followRedirects:
+                        description: FollowRedirects configures whether scrape requests
+                          follow HTTP 3xx redirects.
+                        type: boolean
+                      honorLabels:
+                        description: HonorLabels chooses the metric's labels on collisions
+                          with target labels.
+                        type: boolean
+                      honorTimestamps:
+                        description: HonorTimestamps controls whether Prometheus respects
+                          the timestamps present in scraped data.
+                        type: boolean
+                      interval:
+                        description: Interval at which metrics should be scraped If
+                          not specified Prometheus' global scrape interval is used.
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
+                      metricRelabelings:
+                        description: MetricRelabelConfigs to apply to samples before
+                          ingestion.
+                        items:
+                          description: "RelabelConfig allows dynamic rewriting of the
+                          label set for targets, alerts, scraped samples and remote
+                          write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
+                          properties:
+                            action:
+                              default: replace
+                              description: "Action to perform based on the regex matching.
+                              \n `Uppercase` and `Lowercase` actions require Prometheus
+                              >= v2.36.0. `DropEqual` and `KeepEqual` actions require
+                              Prometheus >= v2.41.0. \n Default: \"Replace\""
+                              enum:
+                                - replace
+                                - Replace
+                                - keep
+                                - Keep
+                                - drop
+                                - Drop
+                                - hashmod
+                                - HashMod
+                                - labelmap
+                                - LabelMap
+                                - labeldrop
+                                - LabelDrop
+                                - labelkeep
+                                - LabelKeep
+                                - lowercase
+                                - Lowercase
+                                - uppercase
+                                - Uppercase
+                                - keepequal
+                                - KeepEqual
+                                - dropequal
+                                - DropEqual
+                              type: string
+                            modulus:
+                              description: "Modulus to take of the hash of the source
+                              label values. \n Only applicable when the action is
+                              `HashMod`."
+                              format: int64
+                              type: integer
+                            regex:
+                              description: Regular expression against which the extracted
+                                value is matched.
+                              type: string
+                            replacement:
+                              description: "Replacement value against which a Replace
+                              action is performed if the regular expression matches.
+                              \n Regex capture groups are available."
+                              type: string
+                            separator:
+                              description: Separator is the string between concatenated
+                                SourceLabels.
+                              type: string
+                            sourceLabels:
+                              description: The source labels select values from existing
+                                labels. Their content is concatenated using the configured
+                                Separator and matched against the configured regular
+                                expression.
+                              items:
+                                description: LabelName is a valid Prometheus label name
+                                  which may only contain ASCII letters, numbers, as
+                                  well as underscores.
+                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                type: string
+                              type: array
+                            targetLabel:
+                              description: "Label to which the resulting string is written
+                              in a replacement. \n It is mandatory for `Replace`,
+                              `HashMod`, `Lowercase`, `Uppercase`, `KeepEqual` and
+                              `DropEqual` actions. \n Regex capture groups are available."
+                              type: string
+                          type: object
+                        type: array
+                      oauth2:
+                        description: OAuth2 for the URL. Only valid in Prometheus versions
+                          2.27.0 and newer.
+                        properties:
+                          clientId:
+                            description: The secret or configmap containing the OAuth2
+                              client id
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secret:
+                                description: Secret containing data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          clientSecret:
+                            description: The secret containing the OAuth2 client secret
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must
+                                  be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          endpointParams:
+                            additionalProperties:
+                              type: string
+                            description: Parameters to append to the token URL
+                            type: object
+                          scopes:
+                            description: OAuth2 scopes used for the token request
+                            items:
+                              type: string
+                            type: array
+                          tokenUrl:
+                            description: The URL to fetch the token from
+                            minLength: 1
+                            type: string
+                        required:
+                          - clientId
+                          - clientSecret
+                          - tokenUrl
+                        type: object
+                      params:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Optional HTTP URL parameters
+                        type: object
+                      path:
+                        description: HTTP path to scrape for metrics. If empty, Prometheus
+                          uses the default value (e.g. `/metrics`).
+                        type: string
+                      port:
+                        description: Name of the service port this endpoint refers to.
+                          Mutually exclusive with targetPort.
+                        type: string
+                      proxyUrl:
+                        description: ProxyURL eg http://proxyserver:2195 Directs scrapes
+                          to proxy through this endpoint.
+                        type: string
+                      relabelings:
+                        description: 'RelabelConfigs to apply to samples before scraping.
+                        Prometheus Operator automatically adds relabelings for a few
+                        standard Kubernetes fields. The original scrape job''s name
+                        is available via the `__tmp_prometheus_job_name` label. More
+                        info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                        items:
+                          description: "RelabelConfig allows dynamic rewriting of the
+                          label set for targets, alerts, scraped samples and remote
+                          write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
+                          properties:
+                            action:
+                              default: replace
+                              description: "Action to perform based on the regex matching.
+                              \n `Uppercase` and `Lowercase` actions require Prometheus
+                              >= v2.36.0. `DropEqual` and `KeepEqual` actions require
+                              Prometheus >= v2.41.0. \n Default: \"Replace\""
+                              enum:
+                                - replace
+                                - Replace
+                                - keep
+                                - Keep
+                                - drop
+                                - Drop
+                                - hashmod
+                                - HashMod
+                                - labelmap
+                                - LabelMap
+                                - labeldrop
+                                - LabelDrop
+                                - labelkeep
+                                - LabelKeep
+                                - lowercase
+                                - Lowercase
+                                - uppercase
+                                - Uppercase
+                                - keepequal
+                                - KeepEqual
+                                - dropequal
+                                - DropEqual
+                              type: string
+                            modulus:
+                              description: "Modulus to take of the hash of the source
+                              label values. \n Only applicable when the action is
+                              `HashMod`."
+                              format: int64
+                              type: integer
+                            regex:
+                              description: Regular expression against which the extracted
+                                value is matched.
+                              type: string
+                            replacement:
+                              description: "Replacement value against which a Replace
+                              action is performed if the regular expression matches.
+                              \n Regex capture groups are available."
+                              type: string
+                            separator:
+                              description: Separator is the string between concatenated
+                                SourceLabels.
+                              type: string
+                            sourceLabels:
+                              description: The source labels select values from existing
+                                labels. Their content is concatenated using the configured
+                                Separator and matched against the configured regular
+                                expression.
+                              items:
+                                description: LabelName is a valid Prometheus label name
+                                  which may only contain ASCII letters, numbers, as
+                                  well as underscores.
+                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                type: string
+                              type: array
+                            targetLabel:
+                              description: "Label to which the resulting string is written
+                              in a replacement. \n It is mandatory for `Replace`,
+                              `HashMod`, `Lowercase`, `Uppercase`, `KeepEqual` and
+                              `DropEqual` actions. \n Regex capture groups are available."
+                              type: string
+                          type: object
+                        type: array
+                      scheme:
+                        description: HTTP scheme to use for scraping. `http` and `https`
+                          are the expected values unless you rewrite the `__scheme__`
+                          label via relabeling. If empty, Prometheus uses the default
+                          value `http`.
+                        enum:
+                          - http
+                          - https
+                        type: string
+                      scrapeTimeout:
+                        description: Timeout after which the scrape is ended If not
+                          specified, the Prometheus global scrape timeout is used unless
+                          it is less than `Interval` in which the latter is used.
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
+                      targetPort:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: Name or number of the target port of the Pod behind
+                          the Service, the port must be specified with container port
+                          property. Mutually exclusive with port.
+                        x-kubernetes-int-or-string: true
+                      tlsConfig:
+                        description: TLS configuration to use when scraping the endpoint
+                        properties:
+                          ca:
+                            description: Certificate authority used when verifying server
+                              certificates.
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secret:
+                                description: Secret containing data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          caFile:
+                            description: Path to the CA cert in the Prometheus container
+                              to use for the targets.
+                            type: string
+                          cert:
+                            description: Client certificate to present when doing client-authentication.
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secret:
+                                description: Secret containing data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          certFile:
+                            description: Path to the client cert file in the Prometheus
+                              container for the targets.
+                            type: string
+                          insecureSkipVerify:
+                            description: Disable target certificate validation.
+                            type: boolean
+                          keyFile:
+                            description: Path to the client key file in the Prometheus
+                              container for the targets.
+                            type: string
+                          keySecret:
+                            description: Secret containing the client key file for the
+                              targets.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must
+                                  be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          serverName:
+                            description: Used to verify the hostname for the targets.
+                            type: string
+                        type: object
+                    type: object
+                  type: array
+                jobLabel:
+                  description: "JobLabel selects the label from the associated Kubernetes
+                  service which will be used as the `job` label for all metrics. \n
+                  For example: If in `ServiceMonitor.spec.jobLabel: foo` and in `Service.metadata.labels.foo:
+                  bar`, then the `job=\"bar\"` label is added to all metrics. \n If
+                  the value of this field is empty or if the label doesn't exist for
+                  the given Service, the `job` label of the metrics defaults to the
+                  name of the Kubernetes Service."
+                  type: string
+                labelLimit:
+                  description: Per-scrape limit on number of labels that will be accepted
+                    for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+                  format: int64
+                  type: integer
+                labelNameLengthLimit:
+                  description: Per-scrape limit on length of labels name that will be
+                    accepted for a sample. Only valid in Prometheus versions 2.27.0
+                    and newer.
+                  format: int64
+                  type: integer
+                labelValueLengthLimit:
+                  description: Per-scrape limit on length of labels value that will
+                    be accepted for a sample. Only valid in Prometheus versions 2.27.0
+                    and newer.
+                  format: int64
+                  type: integer
+                namespaceSelector:
+                  description: Selector to select which namespaces the Kubernetes Endpoints
+                    objects are discovered from.
+                  properties:
+                    any:
+                      description: Boolean describing whether all namespaces are selected
+                        in contrast to a list restricting them.
+                      type: boolean
+                    matchNames:
+                      description: List of namespace names to select from.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                podTargetLabels:
+                  description: PodTargetLabels transfers labels on the Kubernetes `Pod`
+                    onto the created metrics.
+                  items:
+                    type: string
+                  type: array
+                sampleLimit:
+                  description: SampleLimit defines per-scrape limit on number of scraped
+                    samples that will be accepted.
+                  format: int64
+                  type: integer
+                selector:
+                  description: Selector to select Endpoints objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the key
+                          and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to
+                              a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                targetLabels:
+                  description: TargetLabels transfers labels from the Kubernetes `Service`
+                    onto the created metrics.
+                  items:
+                    type: string
+                  type: array
+                targetLimit:
+                  description: TargetLimit defines a limit on the number of scraped
+                    targets that will be accepted.
+                  format: int64
+                  type: integer
+              required:
+                - endpoints
+                - selector
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true

--- a/dev/env/scripts/bootstrap.sh
+++ b/dev/env/scripts/bootstrap.sh
@@ -54,6 +54,7 @@ if [[ "$INSTALL_OPERATOR" == "true" ]]; then
 else
     # We will be running without RHACS operator, but at least install our CRDs.
     apply "${MANIFESTS_DIR}/crds"
+    apply "${MANIFESTS_DIR}/monitoring"
 fi
 
 if [[ "$RHACS_STANDALONE_MODE" == "true" ]]; then


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This PR fixes the ACS CS dev env (specifically the ability to reconcile a Central) for the following use-case:
* ACS version is 4.2.0
* the dev environment is set up with `make deploy/bootstrap` && `make deploy/dev`, and
* `INSTALL_OPERATOR=false`

In the scenario above, a locally run operator is failing to reconcile Centrals, with errors like
```
 namespace: \"openshift-monitoring\" from \"\": no matches for kind \"ServiceMonitor\" in version \"monitoring.coreos.com/v1\"\nensure CRDs are installed first]"
 ```
 
 This PR fixes this by installing the missing CRDs.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

```
# Prepare local dev env (in the acs-fleet-manager dir)
INSTALL_OPERATOR=false make deploy/bootstrap
INSTALL_OPERATOR=false make deploy/dev

# Start a local operator (in the stackrox src dir)
make -C operator install run

# Create test central
./scripts/create-central.sh
```

The operator should be able to reconcile the Central, and the Central pod should start.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
