### PR TITLE
ROX-19330: Add second declarative config mount point to central CR

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -76,6 +76,7 @@ const (
 	centralDeletePollInterval = 5 * time.Second
 
 	sensibleDeclarativeConfigSecretName = "cloud-service-sensible-declarative-configs" // pragma: allowlist secret
+	manualDeclarativeConfigSecretName   = "cloud-service-manual-declarative-configs"   // pragma: allowlist secret
 
 	authProviderDeclarativeConfigKey = "default-sso-auth-provider"
 )
@@ -316,6 +317,9 @@ func (r *CentralReconciler) getInstanceConfig(remoteCentral *private.ManagedCent
 					Secrets: []v1alpha1.LocalSecretReference{
 						{
 							Name: sensibleDeclarativeConfigSecretName,
+						},
+						{
+							Name: manualDeclarativeConfigSecretName,
 						},
 					},
 				},

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -1473,10 +1473,14 @@ func TestGetInstanceConfigSetsDeclarativeConfigSecretInCentralCR(t *testing.T) {
 	require.NotNil(t, centralConfig.Spec.Central.DeclarativeConfiguration)
 	centralCRDeclarativeConfig := centralConfig.Spec.Central.DeclarativeConfiguration
 	assert.NotZero(t, len(centralCRDeclarativeConfig.Secrets))
-	expectedSecretReference := v1alpha1.LocalSecretReference{ // pragma: allowlist secret
+	expectedReconciledSecretReference := v1alpha1.LocalSecretReference{ // pragma: allowlist secret
 		Name: sensibleDeclarativeConfigSecretName,
 	}
-	assert.Contains(t, centralCRDeclarativeConfig.Secrets, expectedSecretReference)
+	expectedManualSecretReference := v1alpha1.LocalSecretReference{ // pragma: allowlist secret
+		Name: manualDeclarativeConfigSecretName,
+	}
+	assert.Contains(t, centralCRDeclarativeConfig.Secrets, expectedReconciledSecretReference)
+	assert.Contains(t, centralCRDeclarativeConfig.Secrets, expectedManualSecretReference)
 }
 
 func TestGetAuditLogNotifierConfig(t *testing.T) {


### PR DESCRIPTION
## Description

This PR adds a second declarative config mount point to ACSCS centrals. 

The secret referenced here will not be created by reconciler, but rather manually and only when customer requests multiple orgs support. In that case `cloud-service-manual-declarative-configs` secret will be created and populated with the corresponding auth provider configuration.

The reasons to introduce separate secret here:
* Want to separate ownership - `cloud-service-sensible-declarative-configs` contents are  controlled only by `fleetshard-sync`, let's keep it that way
* It's easier to identify if declarative configuration was manually changed if secret is separate

Ideally, I would like to name secrets `cloud-service-reconciled-declarative-configs` and `cloud-service-manual-declarative-configs`, however, migrating existing secret names looks like a non-trivial task not worth pursuing.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

1. CI is sufficient
