### PR TITLE
fix(fleet-manager): add nil check to deleting mgr

### DIFF
--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/deleting_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/deleting_dinosaurs_mgr.go
@@ -129,7 +129,7 @@ func (k *DeletingDinosaurManager) reconcileDeletingDinosaurs(dinosaur *dbapi.Cen
 			dinosaur.ID)
 	case dbapi.AuthConfigDynamicClientOrigin:
 		if resp, err := k.dynamicAPI.DeleteAcsClient(context.Background(), dinosaur.ClientID); err != nil {
-			if resp.StatusCode == http.StatusNotFound {
+			if resp != nil && resp.StatusCode == http.StatusNotFound {
 				glog.V(7).Infof("dynamic client %s could not be found; will continue as if the client "+
 					"has been deleted", dinosaur.ClientID)
 			} else {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Add a nil check because when `err != nil`, it is not guaranteed that `resp` is not nil. See https://issues.redhat.com/browse/ROX-19332 for an example of where we ran into a nil pointer dereference because of the missing check.

PS: Sadly the golang standard library does not provide a nil-safe getter for the status code :(