### PR TITLE
ROX-19478: Parameterize manager RDS secret name.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -462,70 +462,70 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "13032f402fed753c2248419ea4f69f99931f6dbc",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 557
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "30025f80f6e22cdafb85db387d50f90ea884576a",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 557
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "355f24fd038bcaf85617abdcaa64af51ed19bbcf",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 557
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "3d8a1dcd2c3c765ce35c9a9552d23273cc4ddace",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 557
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "4ac7b0522761eba972467942cd5cd7499dd2c361",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 557
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "7639ab2a6bcf2ea30a055a99468c9cd844d4c22a",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 557
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "b56360daf4793d2a74991a972b34d95bc00fb2da",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 557
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "c9a73ef9ee8ce9f38437227801c70bcc6740d1a1",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 557
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "14736999d9940728c5294277831a702f7882dece",
         "is_verified": false,
-        "line_number": 589
+        "line_number": 594
       },
       {
         "type": "Secret Keyword",
         "filename": "templates/service-template.yml",
         "hashed_secret": "4e199b4a1c40b497a95fcd1cd896351733849949",
         "is_verified": false,
-        "line_number": 676,
+        "line_number": 681,
         "is_secret": false
       },
       {
@@ -533,7 +533,7 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "9d51dabe59aa776bef2909d3689374ebb93ab2be",
         "is_verified": false,
-        "line_number": 720
+        "line_number": 725
       }
     ],
     "test/support/certs.json": [
@@ -564,5 +564,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-19T10:20:12Z"
+  "generated_at": "2023-08-30T10:02:58Z"
 }

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -104,6 +104,11 @@ parameters:
   description: Health check server bind adddress
   value: :8083
 
+- name: DATABASE_SECRET_NAME
+  displayName: Database secret name
+  description: Name of k8s secret that contains credentials for the fleet manager RDS database
+  value: "acs-fleet-manager-rds"
+
 - name: DB_MAX_OPEN_CONNS
   displayName: Maximum Open Database Connections
   description: Maximum number of open database connections per pod
@@ -1013,7 +1018,7 @@ objects:
               secretName: fleet-manager-dataplane-certificate # pragma: allowlist secret
           - name: rds
             secret:
-              secretName: acs-fleet-manager-rds # pragma: allowlist secret
+              secretName: ${DATABASE_SECRET_NAME}
           - name: fleet-manager-providers-config
             configMap:
               name: fleet-manager-providers-config


### PR DESCRIPTION
## Description

For integration env we need to use a slightly different name to avoid clashes with the stage RDS which resides in the same appsre stage account.

Also updated the secrets baseline since presubmit asked me to :shrug:
However I did not include all the changes applied by local pre-submit because they would fail in the CI presubmit check.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~Unit and integration tests added~
- [x] ~Added test description under `Test manual`~
- [x] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~
- [x] Add secret to app-interface Vault or Secrets Manager if necessary
- [x] ~RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~
- [x] ~Check AWS limits are reasonable for changes provisioning new resources~

## Test manual

CI is enough.