### PR TITLE
ROX-19013: Add gitops to fleetshard

### DIFF
--- a/dev/env/manifests/fleetshard-sync/02-fleetshard-sync-deployment.yaml
+++ b/dev/env/manifests/fleetshard-sync/02-fleetshard-sync-deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: "$MANAGED_DB_PERFORMANCE_INSIGHTS"
             - name: AWS_REGION
               value: "$AWS_REGION"
+            - name: RHACS_GITOPS_ENABLED
+              value: "$RHACS_GITOPS_ENABLED"
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -255,14 +255,12 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 func (r *CentralReconciler) getInstanceConfig(remoteCentral *private.ManagedCentral) (*v1alpha1.Central, error) {
 	var central *v1alpha1.Central
 	var err error
-	if features.GitOpsCentrals.Enabled() {
-		central, err = r.getInstanceConfigWithGitops(remoteCentral)
-		if err != nil {
+	if r.shouldUseGitopsConfig(remoteCentral) {
+		if central, err = r.getInstanceConfigWithGitops(remoteCentral); err != nil {
 			return nil, err
 		}
 	} else {
-		central, err = r.getLegacyInstanceConfig(remoteCentral)
-		if err != nil {
+		if central, err = r.getLegacyInstanceConfig(remoteCentral); err != nil {
 			return nil, err
 		}
 	}
@@ -270,6 +268,10 @@ func (r *CentralReconciler) getInstanceConfig(remoteCentral *private.ManagedCent
 		return nil, err
 	}
 	return central, nil
+}
+
+func (r *CentralReconciler) shouldUseGitopsConfig(remoteCentral *private.ManagedCentral) bool {
+	return features.GitOpsCentrals.Enabled() && len(remoteCentral.Spec.CentralCRYAML) > 0
 }
 
 func (r *CentralReconciler) getInstanceConfigWithGitops(remoteCentral *private.ManagedCentral) (*v1alpha1.Central, error) {

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -263,7 +263,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 func (r *CentralReconciler) getInstanceConfigWithGitops(remoteCentral *private.ManagedCentral) (*v1alpha1.Central, error) {
 	var central = new(v1alpha1.Central)
 
-	if err := yaml2.Unmarshal([]byte(remoteCentral.Spec.CentralYAML), central); err != nil {
+	if err := yaml2.Unmarshal([]byte(remoteCentral.Spec.CentralCRYAML), central); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal central yaml")
 	}
 	if err := r.applyCentralConfig(remoteCentral, central); err != nil {

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/pointer"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+	yaml2 "sigs.k8s.io/yaml"
 )
 
 // FreeStatus ...
@@ -155,9 +156,17 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 
 	remoteCentralNamespace := remoteCentral.Metadata.Namespace
 
-	central, err := r.getInstanceConfig(&remoteCentral)
-	if err != nil {
-		return nil, err
+	var central *v1alpha1.Central
+	if features.GitOpsCentrals.Enabled() {
+		central, err = r.getInstanceConfigWithGitops(&remoteCentral)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		central, err = r.getInstanceConfig(&remoteCentral)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if remoteCentral.Metadata.DeletionTimestamp != "" {
@@ -251,6 +260,18 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	return status, nil
 }
 
+func (r *CentralReconciler) getInstanceConfigWithGitops(remoteCentral *private.ManagedCentral) (*v1alpha1.Central, error) {
+	var central = new(v1alpha1.Central)
+
+	if err := yaml2.Unmarshal([]byte(remoteCentral.Spec.CentralYAML), central); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal central yaml")
+	}
+	if err := r.applyCentralConfig(remoteCentral, central); err != nil {
+		return nil, err
+	}
+	return central, nil
+}
+
 func (r *CentralReconciler) getInstanceConfig(remoteCentral *private.ManagedCentral) (*v1alpha1.Central, error) {
 	if remoteCentral == nil {
 		return nil, errInvalidArguments
@@ -260,10 +281,6 @@ func (r *CentralReconciler) getInstanceConfig(remoteCentral *private.ManagedCent
 	remoteCentralNamespace := remoteCentral.Metadata.Namespace
 
 	monitoringExposeEndpointEnabled := v1alpha1.ExposeEndpointEnabled
-	// Telemetry will only be enabled if the storage key is set _and_ the central is not an "internal" central created
-	// from internal clients such as probe service or others.
-	telemetryEnabled := r.telemetry.StorageKey != "" && !remoteCentral.Metadata.Internal
-
 	centralResources, err := converters.ConvertPrivateResourceRequirementsToCoreV1(&remoteCentral.Spec.Central.Resources)
 	if err != nil {
 		return nil, errors.Wrap(err, "converting Central resources")
@@ -277,15 +294,6 @@ func (r *CentralReconciler) getInstanceConfig(remoteCentral *private.ManagedCent
 	if err != nil {
 		return nil, errors.Wrap(err, "converting Scanner DB resources")
 	}
-
-	// Set proxy configuration
-	auditLoggingURL := url.URL{
-		Host: r.auditLogging.Endpoint(false),
-	}
-	kubernetesURL := url.URL{
-		Host: "kubernetes.default.svc.cluster.local.:443",
-	}
-	envVars := getProxyEnvVars(remoteCentralNamespace, auditLoggingURL, kubernetesURL)
 
 	scannerComponentEnabled := v1alpha1.ScannerComponentEnabled
 
@@ -307,33 +315,11 @@ func (r *CentralReconciler) getInstanceConfig(remoteCentral *private.ManagedCent
 		},
 		Spec: v1alpha1.CentralSpec{
 			Central: &v1alpha1.CentralComponentSpec{
-				Exposure: &v1alpha1.Exposure{
-					Route: &v1alpha1.ExposureRoute{
-						Enabled: pointer.Bool(r.useRoutes),
-					},
-				},
 				Monitoring: &v1alpha1.Monitoring{
 					ExposeEndpoint: &monitoringExposeEndpointEnabled,
 				},
 				DeploymentSpec: v1alpha1.DeploymentSpec{
 					Resources: &centralResources,
-				},
-				Telemetry: &v1alpha1.Telemetry{
-					Enabled: pointer.Bool(telemetryEnabled),
-					Storage: &v1alpha1.TelemetryStorage{
-						Endpoint: &r.telemetry.StorageEndpoint,
-						Key:      &r.telemetry.StorageKey,
-					},
-				},
-				DeclarativeConfiguration: &v1alpha1.DeclarativeConfiguration{
-					Secrets: []v1alpha1.LocalSecretReference{
-						{
-							Name: sensibleDeclarativeConfigSecretName,
-						},
-						{
-							Name: manualDeclarativeConfigSecretName,
-						},
-					},
 				},
 			},
 			Scanner: &v1alpha1.ScannerComponentSpec{
@@ -352,11 +338,8 @@ func (r *CentralReconciler) getInstanceConfig(remoteCentral *private.ManagedCent
 				ScannerComponent: &scannerComponentEnabled,
 			},
 			Customize: &v1alpha1.CustomizeSpec{
-				EnvVars: envVars,
 				Annotations: map[string]string{
-					envAnnotationKey:         r.environment,
-					clusterNameAnnotationKey: r.clusterName,
-					orgNameAnnotationKey:     remoteCentral.Spec.Auth.OwnerOrgName,
+					orgNameAnnotationKey: remoteCentral.Spec.Auth.OwnerOrgName,
 				},
 				Labels: map[string]string{
 					orgIDLabelKey:        remoteCentral.Spec.Auth.OwnerOrgId,
@@ -367,11 +350,29 @@ func (r *CentralReconciler) getInstanceConfig(remoteCentral *private.ManagedCent
 		},
 	}
 
+	if err := r.applyCentralConfig(remoteCentral, central); err != nil {
+		return nil, err
+	}
+
+	return central, nil
+}
+
+func (r *CentralReconciler) applyCentralConfig(remoteCentral *private.ManagedCentral, central *v1alpha1.Central) error {
+	r.applyTelemetry(remoteCentral, central)
+	r.applyRoutes(central)
+	r.applyProxyConfig(central)
+	r.applyDeclarativeConfig(central)
+	r.applyAnnotations(central)
+	return r.applyLabelSelector(remoteCentral, central)
+}
+
+func (r *CentralReconciler) applyLabelSelector(remoteCentral *private.ManagedCentral, central *v1alpha1.Central) error {
+	// apply label selector
 	if features.TargetedOperatorUpgrades.Enabled() {
 		// TODO: use GitRef as a LabelSelector
 		image, err := containerImage.Parse(remoteCentral.Spec.OperatorImage)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed parse labelSelector")
+			return errors.Wrapf(err, "failed parse labelSelector")
 		}
 		var labelSelector string
 		if tagged, ok := image.(containerImage.Tagged); ok {
@@ -379,13 +380,86 @@ func (r *CentralReconciler) getInstanceConfig(remoteCentral *private.ManagedCent
 		}
 		errs := validation.IsValidLabelValue(labelSelector)
 		if errs != nil {
-			return nil, errors.Wrapf(err, "invalid labelSelector %s: %v", labelSelector, errs)
+			return errors.Wrapf(err, "invalid labelSelector %s: %v", labelSelector, errs)
+		}
+		if central.Labels == nil {
+			central.Labels = map[string]string{}
 		}
 		central.Labels[ReconcileOperatorSelector] = labelSelector
+	}
+	return nil
+}
 
+func (r *CentralReconciler) applyAnnotations(central *v1alpha1.Central) {
+	if central.Spec.Customize == nil {
+		central.Spec.Customize = &v1alpha1.CustomizeSpec{}
+	}
+	if central.Spec.Customize.Annotations == nil {
+		central.Spec.Customize.Annotations = map[string]string{}
+	}
+	central.Spec.Customize.Annotations[envAnnotationKey] = r.environment
+	central.Spec.Customize.Annotations[clusterNameAnnotationKey] = r.clusterName
+}
+
+func (r *CentralReconciler) applyDeclarativeConfig(central *v1alpha1.Central) {
+	if central.Spec.Central == nil {
+		central.Spec.Central = &v1alpha1.CentralComponentSpec{}
+	}
+	declarativeConfig := &v1alpha1.DeclarativeConfiguration{
+		Secrets: []v1alpha1.LocalSecretReference{
+			{
+				Name: sensibleDeclarativeConfigSecretName,
+			},
+			{
+				Name: manualDeclarativeConfigSecretName,
+			},
+		},
 	}
 
-	return central, nil
+	central.Spec.Central.DeclarativeConfiguration = declarativeConfig
+}
+
+func (r *CentralReconciler) applyProxyConfig(central *v1alpha1.Central) {
+	if central.Spec.Customize == nil {
+		central.Spec.Customize = &v1alpha1.CustomizeSpec{}
+	}
+	auditLoggingURL := url.URL{
+		Host: r.auditLogging.Endpoint(false),
+	}
+	kubernetesURL := url.URL{
+		Host: "kubernetes.default.svc.cluster.local.:443",
+	}
+	envVars := getProxyEnvVars(central.Namespace, auditLoggingURL, kubernetesURL)
+	central.Spec.Customize.EnvVars = append(central.Spec.Customize.EnvVars, envVars...)
+}
+
+func (r *CentralReconciler) applyRoutes(central *v1alpha1.Central) {
+	if central.Spec.Central == nil {
+		central.Spec.Central = &v1alpha1.CentralComponentSpec{}
+	}
+	exposure := &v1alpha1.Exposure{
+		Route: &v1alpha1.ExposureRoute{
+			Enabled: pointer.Bool(r.useRoutes),
+		},
+	}
+	central.Spec.Central.Exposure = exposure
+}
+
+func (r *CentralReconciler) applyTelemetry(remoteCentral *private.ManagedCentral, central *v1alpha1.Central) {
+	if central.Spec.Central == nil {
+		central.Spec.Central = &v1alpha1.CentralComponentSpec{}
+	}
+	// Telemetry will only be enabled if the storage key is set _and_ the central is not an "internal" central created
+	// from internal clients such as probe service or others.
+	telemetryEnabled := r.telemetry.StorageKey != "" && !remoteCentral.Metadata.Internal
+	telemetry := &v1alpha1.Telemetry{
+		Enabled: pointer.Bool(telemetryEnabled),
+		Storage: &v1alpha1.TelemetryStorage{
+			Endpoint: &r.telemetry.StorageEndpoint,
+			Key:      &r.telemetry.StorageKey,
+		},
+	}
+	central.Spec.Central.Telemetry = telemetry
 }
 
 func (r *CentralReconciler) restoreCentralSecrets(ctx context.Context, remoteCentral private.ManagedCentral) error {

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -1470,7 +1470,7 @@ func TestGetInstanceConfigSetsNoProxyEnvVarsForAuditLog(t *testing.T) {
 			nil,
 			reconcilerOptions,
 		)
-		centralConfig, err := r.getInstanceConfig(&simpleManagedCentral)
+		centralConfig, err := r.getLegacyInstanceConfig(&simpleManagedCentral)
 		assert.NoError(t, err)
 		require.NotNil(t, centralConfig)
 		require.NotNil(t, centralConfig.Spec.Customize)
@@ -1501,7 +1501,7 @@ func TestGetInstanceConfigSetsDeclarativeConfigSecretInCentralCR(t *testing.T) {
 		nil,
 		reconcilerOptions,
 	)
-	centralConfig, err := r.getInstanceConfig(&simpleManagedCentral)
+	centralConfig, err := r.getLegacyInstanceConfig(&simpleManagedCentral)
 	assert.NoError(t, err)
 	require.NotNil(t, centralConfig)
 	require.NotNil(t, centralConfig.Spec.Central)

--- a/fleetshard/pkg/runtime/runtime_test.go
+++ b/fleetshard/pkg/runtime/runtime_test.go
@@ -1,1 +1,0 @@
-package runtime

--- a/internal/dinosaur/pkg/api/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/private/api/openapi.yaml
@@ -139,7 +139,7 @@ paths:
           description: Auth token is not valid.
       security:
       - Bearer: []
-      summary: Get the list of ManagedaCentrals for the specified agent cluster
+      summary: Get the list of ManagedCentrals for the specified agent cluster
       tags:
       - Agent Clusters
   /api/rhacs/v1/agent-clusters/centrals/{id}:
@@ -545,6 +545,8 @@ components:
           $ref: '#/components/schemas/ManagedCentral_allOf_spec_scanner_db'
     ManagedCentral_allOf_spec:
       properties:
+        centralCRYAML:
+          type: string
         owners:
           items:
             type: string

--- a/internal/dinosaur/pkg/api/private/api_agent_clusters.go
+++ b/internal/dinosaur/pkg/api/private/api_agent_clusters.go
@@ -124,7 +124,7 @@ func (a *AgentClustersApiService) GetCentral(ctx _context.Context, id string) (M
 }
 
 /*
-GetCentrals Get the list of ManagedaCentrals for the specified agent cluster
+GetCentrals Get the list of ManagedCentrals for the specified agent cluster
   - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
   - @param id The ID of record
 

--- a/internal/dinosaur/pkg/api/private/model_managed_central_all_of_spec.go
+++ b/internal/dinosaur/pkg/api/private/model_managed_central_all_of_spec.go
@@ -12,6 +12,7 @@ package private
 
 // ManagedCentralAllOfSpec struct for ManagedCentralAllOfSpec
 type ManagedCentralAllOfSpec struct {
+	CentralCRYAML string                              `json:"centralCRYAML,omitempty"`
 	Owners        []string                            `json:"owners,omitempty"`
 	Auth          ManagedCentralAllOfSpecAuth         `json:"auth,omitempty"`
 	UiEndpoint    ManagedCentralAllOfSpecUiEndpoint   `json:"uiEndpoint,omitempty"`

--- a/openapi/fleet-manager-private.yaml
+++ b/openapi/fleet-manager-private.yaml
@@ -137,7 +137,7 @@ paths:
       security:
         - Bearer: []
       operationId: getCentrals
-      summary: Get the list of ManagedaCentrals for the specified agent cluster
+      summary: Get the list of ManagedCentrals for the specified agent cluster
 
   "/api/rhacs/v1/agent-clusters/centrals/{id}":
     get:
@@ -285,6 +285,8 @@ components:
             spec:
               type: object
               properties:
+                centralCRYAML:
+                  type: string
                 owners:
                   type: array
                   items:

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -4,6 +4,9 @@ var (
 	// TargetedOperatorUpgrades enables the targeted operator upgrades
 	TargetedOperatorUpgrades = registerFeature("Upgrade Central instances targetedly via fleet-manager API", "RHACS_TARGETED_OPERATOR_UPGRADES", false)
 
+	// GitOpsCentrals enables the GitOps for Central instances
+	GitOpsCentrals = registerFeature("GitOps for Central instances", "RHACS_GITOPS_ENABLED", false)
+
 	// PrintCentralUpdateDiff enables printing the diff of the central update
 	PrintCentralUpdateDiff = registerFeature("Print the diff of the central update", "RHACS_PRINT_CENTRAL_UPDATE_DIFF", false)
 )


### PR DESCRIPTION
## Description
Uses the `centralYAML` from the gitops config to reconcile the centrals. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] ~~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- [ ] ~~Add secret to app-interface Vault or Secrets Manager if necessary~~
- [ ] ~~RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
- [ ] ~~Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual

- Use a hardcoded gitops config
- Add an override patch to modify the central instance
- Verify that the patch is applied to Centraly lint binary test test/integration
