### PR TITLE
chore: fix probe log when response if empty

### DIFF
--- a/probe/pkg/probe/probe.go
+++ b/probe/pkg/probe/probe.go
@@ -144,7 +144,11 @@ func (p *ProbeImpl) createCentral(ctx context.Context) (*public.CentralRequest, 
 	}
 	central, resp, err := p.fleetManagerPublicAPI.CreateCentral(ctx, true, request)
 	defer utils.IgnoreError(closeBodyIfNonEmpty(resp))
-	glog.Infof("creation of central instance (%s) requested", central.Id)
+	if central.Id == "" {
+		glog.Infof("creation of central instance requested - got empty response", central.Id)
+	} else {
+		glog.Infof("creation of central instance (%s) requested", central.Id)
+	}
 	if err != nil {
 		err = errors.WithMessage(err, extractCentralError(resp))
 		return nil, errors.Wrap(err, "creation of central instance failed")

--- a/probe/pkg/runtime/runtime.go
+++ b/probe/pkg/runtime/runtime.go
@@ -74,6 +74,7 @@ func (r *Runtime) RunSingle(ctx context.Context) (errReturn error) {
 	if err := r.probe.Execute(probeRunCtx); err != nil {
 		metrics.MetricsInstance().IncFailedRuns(r.Config.DataPlaneRegion)
 		metrics.MetricsInstance().SetLastFailureTimestamp(r.Config.DataPlaneRegion)
+		glog.Error("probe run failed", err)
 		return errors.Wrap(err, "probe run failed")
 	}
 	metrics.MetricsInstance().IncSucceededRuns(r.Config.DataPlaneRegion)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Prevent the `()` in log when the Central response is empty.

```
E0904 10:29:57.650706 1 probe.go:103] could not list centrals: : Get "https://api.integration.openshift.com/api/rhacs/v1/centrals": context deadline exceeded
W0904 10:29:57.650759 1 runtime.go:44] cleanup failed: cleanup centrals failed: retry failed: context deadline exceeded: probe run failed: creation of central instance failed: parsing HTTP response: undefined response type
I0904 10:29:57.650781 1 probe.go:69] probe run has been started: fleetManagerEndpoint="https://api.integration.openshift.com/", provider="aws", region="us-east-1"
I0904 10:29:57.661891 1 probe.go:147] creation of central instance () requested
I0904 10:29:57.661931 1 probe.go:54] elapsed time: 11.143458ms
I0904 10:29:57.661946 1 probe.go:79] probe run has ended
```
Compared to healthy one:
```
I0904 09:49:37.082595 1 probe.go:127] finished clean up attempt of probe resources
I0904 09:49:37.082638 1 probe.go:69] probe run has been started: fleetManagerEndpoint="https://api.stage.openshift.com/", provider="aws", region="us-east-1"
I0904 09:49:37.331281 1 probe.go:147] creation of central instance (cjqqgcdib723trpqgtag) requested
I0904 10:01:07.349105 1 probe.go:212] central instance cjqqgcdib723trpqgtag is in "ready" state
I0904 10:01:12.430202 1 probe.go:176] deletion of central instance cjqqgcdib723trpqgtag requested
I0904 10:02:02.438883 1 probe.go:235] central instance cjqqgcdib723trpqgtag has been deleted
I0904 10:02:02.438911 1 probe.go:54] elapsed time: 12m25.356266322s
I0904 10:02:02.438923 1 probe.go:86] probe run has ended
```

Also added a dedicated log statement when the probe fails, so we don't have to wait until the cleanup is done (which may also fail and retry).
