### PR TITLE
ROX-11640: RHSSO dynamic clients rotation API

### DIFF
--- a/internal/dinosaur/pkg/api/admin/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/admin/private/api/openapi.yaml
@@ -376,6 +376,44 @@ paths:
       security:
       - Bearer: []
       summary: Update a Central instance by ID
+  /api/rhacs/v1/admin/centrals/{id}/rotate-secrets:
+    post:
+      parameters:
+      - description: The ID of record
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: RHSSO client successfully rotated
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Auth token is invalid
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: User is not authorised to access the service
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: No Central found with the specified ID or dynamic clients are
+            not configured
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unexpected error occurred
+      summary: Rotate RHSSO client of a central tenant
   /api/rhacs/v1/admin/centrals/{id}/restore:
     post:
       parameters:

--- a/internal/dinosaur/pkg/api/admin/private/api_default.go
+++ b/internal/dinosaur/pkg/api/admin/private/api_default.go
@@ -143,6 +143,111 @@ func (a *DefaultApiService) ApiRhacsV1AdminCentralsIdRestorePost(ctx _context.Co
 }
 
 /*
+ApiRhacsV1AdminCentralsIdRotateSecretsPost Rotate RHSSO client of a central tenant
+  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+  - @param id The ID of record
+*/
+func (a *DefaultApiService) ApiRhacsV1AdminCentralsIdRotateSecretsPost(ctx _context.Context, id string) (*_nethttp.Response, error) {
+	var (
+		localVarHTTPMethod   = _nethttp.MethodPost
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/api/rhacs/v1/admin/centrals/{id}/rotate-secrets"
+	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", _neturl.QueryEscape(parameterToString(id, "")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 401 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 403 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 404 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 500 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
+
+/*
 CreateCentral Creates a Central request
 Creates a new Central that is owned by the user and organisation authenticated for the request. Each Central has a single owner organisation and a single owner user. This API allows providing custom resource settings for the new Central instance.
   - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().

--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -44,6 +44,8 @@ type AdminCentralHandler interface {
 	GetCentralDefaultVersion(w http.ResponseWriter, r *http.Request)
 	// Restore restores a tenant that was already marked as deleted
 	Restore(w http.ResponseWriter, r *http.Request)
+	// RotateSecrets rotates secrets within central
+	RotateSecrets(writer http.ResponseWriter, request *http.Request)
 }
 
 type adminCentralHandler struct {
@@ -427,6 +429,22 @@ func (h adminCentralHandler) GetCentralDefaultVersion(w http.ResponseWriter, r *
 	handlers.Handle(w, r, cfg, http.StatusOK)
 }
 
+func (h adminCentralHandler) RotateSecrets(w http.ResponseWriter, r *http.Request) {
+	cfg := &handlers.HandlerConfig{
+		Action: func() (i interface{}, serviceError *errors.ServiceError) {
+			id := mux.Vars(r)["id"]
+			ctx := r.Context()
+			centralRequest, err := h.service.Get(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+			svcErr := h.service.RotateCentralRHSSOClient(ctx, centralRequest)
+			return nil, svcErr
+		},
+	}
+	handlers.Handle(w, r, cfg, http.StatusOK)
+}
+
 type gitOpsAdminHandler struct{}
 
 var _ AdminCentralHandler = (*gitOpsAdminHandler)(nil)
@@ -464,5 +482,9 @@ func (g gitOpsAdminHandler) GetCentralDefaultVersion(w http.ResponseWriter, r *h
 }
 
 func (g gitOpsAdminHandler) Restore(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "not implemented", http.StatusNotImplemented)
+}
+
+func (g gitOpsAdminHandler) RotateSecrets(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "not implemented", http.StatusNotImplemented)
 }

--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -45,7 +45,7 @@ type AdminCentralHandler interface {
 	// Restore restores a tenant that was already marked as deleted
 	Restore(w http.ResponseWriter, r *http.Request)
 	// RotateSecrets rotates secrets within central
-	RotateSecrets(writer http.ResponseWriter, request *http.Request)
+	RotateSecrets(w http.ResponseWriter, r *http.Request)
 }
 
 type adminCentralHandler struct {
@@ -434,12 +434,12 @@ func (h adminCentralHandler) RotateSecrets(w http.ResponseWriter, r *http.Reques
 		Action: func() (i interface{}, serviceError *errors.ServiceError) {
 			id := mux.Vars(r)["id"]
 			ctx := r.Context()
-			centralRequest, svcErr := h.service.Get(ctx, id)
-			if svcErr != nil {
-				return nil, svcErr
+			centralRequest, err := h.service.Get(ctx, id)
+			if err != nil {
+				return nil, err
 			}
-			svcErr = h.service.RotateCentralRHSSOClient(ctx, centralRequest)
-			return nil, svcErr
+			err = h.service.RotateCentralRHSSOClient(ctx, centralRequest)
+			return nil, err
 		},
 	}
 	handlers.Handle(w, r, cfg, http.StatusOK)

--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -434,11 +434,11 @@ func (h adminCentralHandler) RotateSecrets(w http.ResponseWriter, r *http.Reques
 		Action: func() (i interface{}, serviceError *errors.ServiceError) {
 			id := mux.Vars(r)["id"]
 			ctx := r.Context()
-			centralRequest, err := h.service.Get(ctx, id)
-			if err != nil {
-				return nil, err
+			centralRequest, svcErr := h.service.Get(ctx, id)
+			if svcErr != nil {
+				return nil, svcErr
 			}
-			svcErr := h.service.RotateCentralRHSSOClient(ctx, centralRequest)
+			svcErr = h.service.RotateCentralRHSSOClient(ctx, centralRequest)
 			return nil, svcErr
 		},
 	}

--- a/internal/dinosaur/pkg/rhsso/augment.go
+++ b/internal/dinosaur/pkg/rhsso/augment.go
@@ -1,0 +1,38 @@
+package rhsso
+
+import (
+	"context"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
+	"github.com/stackrox/acs-fleet-manager/pkg/client/iam"
+	"github.com/stackrox/acs-fleet-manager/pkg/client/redhatsso/api"
+	"github.com/stackrox/rox/pkg/stringutils"
+)
+
+const (
+	oidcProviderCallbackPath    = "/sso/providers/oidc/callback"
+	dynamicClientsNameMaxLength = 50
+)
+
+func AugmentWithDynamicAuthConfig(ctx context.Context, r *dbapi.CentralRequest, realmConfig *iam.IAMRealmConfig, apiClient *api.AcsTenantsApiService) error {
+	// There is a limit on name length of the dynamic client. To avoid unnecessary errors,
+	// we truncate name here.
+	name := stringutils.Truncate(fmt.Sprintf("acsms-%s", r.Name), dynamicClientsNameMaxLength)
+	orgID := r.OrganisationID
+	redirectURIs := []string{fmt.Sprintf("https://%s%s", r.GetUIHost(), oidcProviderCallbackPath)}
+
+	dynamicClientData, _, err := apiClient.CreateAcsClient(ctx, api.AcsClientRequestData{
+		Name:         name,
+		OrgId:        orgID,
+		RedirectUris: redirectURIs,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to create RHSSO dynamic client for %s", r.ID)
+	}
+
+	r.AuthConfig.ClientID = dynamicClientData.ClientId
+	r.AuthConfig.ClientSecret = dynamicClientData.Secret // pragma: allowlist secret
+	r.AuthConfig.Issuer = realmConfig.ValidIssuerURI
+	return nil
+}

--- a/internal/dinosaur/pkg/rhsso/augment.go
+++ b/internal/dinosaur/pkg/rhsso/augment.go
@@ -18,7 +18,7 @@ const (
 func AugmentWithDynamicAuthConfig(ctx context.Context, r *dbapi.CentralRequest, realmConfig *iam.IAMRealmConfig, apiClient *api.AcsTenantsApiService) error {
 	// There is a limit on name length of the dynamic client. To avoid unnecessary errors,
 	// we truncate name here.
-	name := stringutils.Truncate(fmt.Sprintf("acsms-%s", r.Name), dynamicClientsNameMaxLength)
+	name := stringutils.Truncate(fmt.Sprintf("acscs-%s", r.Name), dynamicClientsNameMaxLength)
 	orgID := r.OrganisationID
 	redirectURIs := []string{fmt.Sprintf("https://%s%s", r.GetUIHost(), oidcProviderCallbackPath)}
 

--- a/internal/dinosaur/pkg/routes/route_loader.go
+++ b/internal/dinosaur/pkg/routes/route_loader.go
@@ -266,6 +266,9 @@ func (s *options) buildAPIBaseRouter(mainRouter *mux.Router, basePath string, op
 	adminCentralsRouter.HandleFunc("/{id}/restore", adminCentralHandler.Restore).
 		Name(logger.NewLogEvent("admin-restore-central", "[admin] restore central by id").ToString()).
 		Methods(http.MethodPost)
+	adminCentralsRouter.HandleFunc("/{id}/rotate-secrets", adminCentralHandler.RotateSecrets).
+		Name(logger.NewLogEvent("admin-rotate-central-secrets", "[admin] rotate central secrets by id").ToString()).
+		Methods(http.MethodPatch)
 
 	adminCreateRouter := adminCentralsRouter.NewRoute().Subrouter()
 	adminCreateRouter.HandleFunc("", adminCentralHandler.Create).Methods(http.MethodPost)

--- a/internal/dinosaur/pkg/routes/route_loader.go
+++ b/internal/dinosaur/pkg/routes/route_loader.go
@@ -268,7 +268,7 @@ func (s *options) buildAPIBaseRouter(mainRouter *mux.Router, basePath string, op
 		Methods(http.MethodPost)
 	adminCentralsRouter.HandleFunc("/{id}/rotate-secrets", adminCentralHandler.RotateSecrets).
 		Name(logger.NewLogEvent("admin-rotate-central-secrets", "[admin] rotate central secrets by id").ToString()).
-		Methods(http.MethodPatch)
+		Methods(http.MethodPost)
 
 	adminCreateRouter := adminCentralsRouter.NewRoute().Subrouter()
 	adminCreateRouter.HandleFunc("", adminCentralHandler.Create).Methods(http.MethodPost)

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -159,10 +159,10 @@ func NewDinosaurService(connectionFactory *db.ConnectionFactory, clusterService 
 func (k *dinosaurService) RotateCentralRHSSOClient(ctx context.Context, centralRequest *dbapi.CentralRequest) *errors.ServiceError {
 	realmConfig := k.iamConfig.RedhatSSORealm
 	if k.dinosaurConfig.HasStaticAuth() {
-		return errors.New(errors.ErrorClientRotationNotConfigured, "RHSSO is configured via static configuration")
+		return errors.New(errors.ErrorDynamicClientsNotUsed, "RHSSO is configured via static configuration")
 	}
 	if !realmConfig.IsConfigured() {
-		return errors.New(errors.ErrorClientRotationNotConfigured, "RHSSO dynamic configuration is not present")
+		return errors.New(errors.ErrorDynamicClientsNotUsed, "RHSSO dynamic configuration is not present")
 	}
 
 	previousAuthConfig := centralRequest.AuthConfig

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -162,7 +162,7 @@ func (k *dinosaurService) RotateCentralRHSSOClient(ctx context.Context, centralR
 		return errors.New(errors.ErrorDynamicClientsNotUsed, "RHSSO is configured via static configuration")
 	}
 	if !realmConfig.IsConfigured() {
-		return errors.New(errors.ErrorDynamicClientsNotUsed, "RHSSO dynamic configuration is not present")
+		return errors.New(errors.ErrorDynamicClientsNotUsed, "RHSSO dynamic client configuration is not present")
 	}
 
 	previousAuthConfig := centralRequest.AuthConfig

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -171,12 +171,12 @@ func (k *dinosaurService) RotateCentralRHSSOClient(ctx context.Context, centralR
 
 	}
 	if err := k.Update(centralRequest); err != nil {
-		glog.Errorf("Created new RHSSO dynamic client, but failed to update central record, client ID is %s", centralRequest.AuthConfig.ClientID)
+		glog.Errorf("Rotating RHSSO client failed: created new RHSSO dynamic client, but failed to update central record, client ID is %s", centralRequest.AuthConfig.ClientID)
 		return errors.NewWithCause(errors.ErrorClientRotationFailed, err, "failed to update database record")
 	}
 	if _, err := k.rhSSODynamicClientsAPI.DeleteAcsClient(ctx, previousAuthConfig.ClientID); err != nil {
-		glog.Errorf("Failed to delete RHSSO dynamic client, client ID is %s", centralRequest.AuthConfig.ClientID)
-		return errors.NewWithCause(errors.ErrorClientRotationFailed, err, "failed to delete previous OIDC client")
+		glog.Errorf("Rotating RHSSO client failed: failed to delete RHSSO dynamic client, client ID is %s", centralRequest.AuthConfig.ClientID)
+		return errors.NewWithCause(errors.ErrorClientRotationFailed, err, "failed to delete previous RHSSO dynamic client")
 	}
 	return nil
 }

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -171,11 +171,11 @@ func (k *dinosaurService) RotateCentralRHSSOClient(ctx context.Context, centralR
 
 	}
 	if err := k.Update(centralRequest); err != nil {
-		glog.Errorf("Created new RHSSO dynamic client, but failed to update central record: %s", centralRequest.AuthConfig.ClientID)
+		glog.Errorf("Created new RHSSO dynamic client, but failed to update central record, client ID is %s", centralRequest.AuthConfig.ClientID)
 		return errors.NewWithCause(errors.ErrorClientRotationFailed, err, "failed to update database record")
 	}
 	if _, err := k.rhSSODynamicClientsAPI.DeleteAcsClient(ctx, previousAuthConfig.ClientID); err != nil {
-		glog.Errorf("Failed to delete RHSSO dynamic client: %s", centralRequest.AuthConfig.ClientID)
+		glog.Errorf("Failed to delete RHSSO dynamic client, client ID is %s", centralRequest.AuthConfig.ClientID)
 		return errors.NewWithCause(errors.ErrorClientRotationFailed, err, "failed to delete previous OIDC client")
 	}
 	return nil

--- a/internal/dinosaur/pkg/services/dinosaurservice_moq.go
+++ b/internal/dinosaur/pkg/services/dinosaurservice_moq.go
@@ -88,6 +88,9 @@ var _ DinosaurService = &DinosaurServiceMock{}
 //			RestoreFunc: func(ctx context.Context, id string) *serviceError.ServiceError {
 //				panic("mock out the Restore method")
 //			},
+//			RotateCentralRHSSOClientFunc: func(ctx context.Context, centralRequest *dbapi.CentralRequest) *serviceError.ServiceError {
+//				panic("mock out the RotateCentralRHSSOClient method")
+//			},
 //			UpdateFunc: func(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError {
 //				panic("mock out the Update method")
 //			},
@@ -169,6 +172,9 @@ type DinosaurServiceMock struct {
 
 	// RestoreFunc mocks the Restore method.
 	RestoreFunc func(ctx context.Context, id string) *serviceError.ServiceError
+
+	// RotateCentralRHSSOClientFunc mocks the RotateCentralRHSSOClient method.
+	RotateCentralRHSSOClientFunc func(ctx context.Context, centralRequest *dbapi.CentralRequest) *serviceError.ServiceError
 
 	// UpdateFunc mocks the Update method.
 	UpdateFunc func(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError
@@ -295,6 +301,13 @@ type DinosaurServiceMock struct {
 			// ID is the id argument value.
 			ID string
 		}
+		// RotateCentralRHSSOClient holds details about calls to the RotateCentralRHSSOClient method.
+		RotateCentralRHSSOClient []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// CentralRequest is the centralRequest argument value.
+			CentralRequest *dbapi.CentralRequest
+		}
 		// Update holds details about calls to the Update method.
 		Update []struct {
 			// DinosaurRequest is the dinosaurRequest argument value.
@@ -343,6 +356,7 @@ type DinosaurServiceMock struct {
 	lockRegisterDinosaurDeprovisionJob    sync.RWMutex
 	lockRegisterDinosaurJob               sync.RWMutex
 	lockRestore                           sync.RWMutex
+	lockRotateCentralRHSSOClient          sync.RWMutex
 	lockUpdate                            sync.RWMutex
 	lockUpdateStatus                      sync.RWMutex
 	lockUpdates                           sync.RWMutex
@@ -1027,6 +1041,42 @@ func (mock *DinosaurServiceMock) RestoreCalls() []struct {
 	mock.lockRestore.RLock()
 	calls = mock.calls.Restore
 	mock.lockRestore.RUnlock()
+	return calls
+}
+
+// RotateCentralRHSSOClient calls RotateCentralRHSSOClientFunc.
+func (mock *DinosaurServiceMock) RotateCentralRHSSOClient(ctx context.Context, centralRequest *dbapi.CentralRequest) *serviceError.ServiceError {
+	if mock.RotateCentralRHSSOClientFunc == nil {
+		panic("DinosaurServiceMock.RotateCentralRHSSOClientFunc: method is nil but DinosaurService.RotateCentralRHSSOClient was just called")
+	}
+	callInfo := struct {
+		Ctx            context.Context
+		CentralRequest *dbapi.CentralRequest
+	}{
+		Ctx:            ctx,
+		CentralRequest: centralRequest,
+	}
+	mock.lockRotateCentralRHSSOClient.Lock()
+	mock.calls.RotateCentralRHSSOClient = append(mock.calls.RotateCentralRHSSOClient, callInfo)
+	mock.lockRotateCentralRHSSOClient.Unlock()
+	return mock.RotateCentralRHSSOClientFunc(ctx, centralRequest)
+}
+
+// RotateCentralRHSSOClientCalls gets all the calls that were made to RotateCentralRHSSOClient.
+// Check the length with:
+//
+//	len(mockedDinosaurService.RotateCentralRHSSOClientCalls())
+func (mock *DinosaurServiceMock) RotateCentralRHSSOClientCalls() []struct {
+	Ctx            context.Context
+	CentralRequest *dbapi.CentralRequest
+} {
+	var calls []struct {
+		Ctx            context.Context
+		CentralRequest *dbapi.CentralRequest
+	}
+	mock.lockRotateCentralRHSSOClient.RLock()
+	calls = mock.calls.RotateCentralRHSSOClient
+	mock.lockRotateCentralRHSSOClient.RUnlock()
 	return calls
 }
 

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config_mgr.go
@@ -2,9 +2,6 @@ package dinosaurmgrs
 
 import (
 	"context"
-	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/rhsso"
-
-	"github.com/stackrox/acs-fleet-manager/pkg/metrics"
 
 	"github.com/golang/glog"
 	"github.com/google/uuid"
@@ -12,10 +9,12 @@ import (
 
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/config"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/rhsso"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/services"
 	"github.com/stackrox/acs-fleet-manager/pkg/client/iam"
 	"github.com/stackrox/acs-fleet-manager/pkg/client/redhatsso/api"
 	"github.com/stackrox/acs-fleet-manager/pkg/client/redhatsso/dynamicclients"
+	"github.com/stackrox/acs-fleet-manager/pkg/metrics"
 	"github.com/stackrox/acs-fleet-manager/pkg/workers"
 	"github.com/stackrox/rox/pkg/ternary"
 )

--- a/openapi/fleet-manager-private-admin.yaml
+++ b/openapi/fleet-manager-private-admin.yaml
@@ -259,6 +259,38 @@ paths:
             application/json:
               schema:
                 $ref: 'fleet-manager.yaml#/components/schemas/Error'
+  '/api/rhacs/v1/admin/centrals/{id}/rotate-secrets':
+    post:
+      summary: Rotate RHSSO client of a central tenant
+      parameters:
+        - $ref: "fleet-manager.yaml#/components/parameters/id"
+      responses:
+        "200":
+          description: RHSSO client successfully rotated
+        "401":
+          description: Auth token is invalid
+          content:
+            application/json:
+              schema:
+                $ref: 'fleet-manager.yaml#/components/schemas/Error'
+        "403":
+          description: User is not authorised to access the service
+          content:
+            application/json:
+              schema:
+                $ref: 'fleet-manager.yaml#/components/schemas/Error'
+        "404":
+          description: No Central found with the specified ID or dynamic clients are not configured
+          content:
+            application/json:
+              schema:
+                $ref: 'fleet-manager.yaml#/components/schemas/Error'
+        "500":
+          description: Unexpected error occurred
+          content:
+            application/json:
+              schema:
+                $ref: 'fleet-manager.yaml#/components/schemas/Error'
   '/api/rhacs/v1/admin/centrals/{id}/restore':
     post:
       summary: Restore a central tenant that was already deleted

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -128,6 +128,12 @@ const (
 	ErrorMaxLimitForServiceAccountsReached       ServiceErrorCode = 115
 	ErrorMaxLimitForServiceAccountsReachedReason string           = "Max limit for the service account creation has reached"
 
+	ErrorClientRotationNotConfigured       ServiceErrorCode = 116
+	ErrorClientRotationNotConfiguredReason string           = "RHSSO client rotation is not configured"
+
+	ErrorClientRotationFailed       ServiceErrorCode = 117
+	ErrorClientRotationFailedReason string           = "RHSSO client rotation failed"
+
 	// Insufficient quota
 	ErrorInsufficientQuota       ServiceErrorCode = 120
 	ErrorInsufficientQuotaReason string           = "Insufficient quota"
@@ -274,6 +280,8 @@ func Errors() ServiceErrors {
 		ServiceError{ErrorMaxLimitForServiceAccountsReached, ErrorMaxLimitForServiceAccountsReachedReason, http.StatusForbidden, nil},
 		ServiceError{ErrorInstancePlanNotSupported, ErrorInstancePlanNotSupportedReason, http.StatusBadRequest, nil},
 		ServiceError{ErrorInvalidCloudAccountID, ErrorInvalidCloudAccountIDReason, http.StatusBadRequest, nil},
+		ServiceError{ErrorClientRotationNotConfigured, ErrorClientRotationNotConfiguredReason, http.StatusBadRequest, nil},
+		ServiceError{ErrorClientRotationFailed, ErrorClientRotationFailedReason, http.StatusBadRequest, nil},
 	}
 }
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -282,7 +282,7 @@ func Errors() ServiceErrors {
 		ServiceError{ErrorMaxLimitForServiceAccountsReached, ErrorMaxLimitForServiceAccountsReachedReason, http.StatusForbidden, nil},
 		ServiceError{ErrorInstancePlanNotSupported, ErrorInstancePlanNotSupportedReason, http.StatusBadRequest, nil},
 		ServiceError{ErrorInvalidCloudAccountID, ErrorInvalidCloudAccountIDReason, http.StatusBadRequest, nil},
-		ServiceError{ErrorClientRotationNotConfigured, ErrorClientRotationNotConfiguredReason, http.StatusMethodNotAllowed, nil},
+		ServiceError{ErrorClientRotationNotConfigured, ErrorClientRotationNotConfiguredReason, http.StatusNotFound, nil},
 		ServiceError{ErrorClientRotationFailed, ErrorClientRotationFailedReason, http.StatusInternalServerError, nil},
 	}
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -128,9 +128,11 @@ const (
 	ErrorMaxLimitForServiceAccountsReached       ServiceErrorCode = 115
 	ErrorMaxLimitForServiceAccountsReachedReason string           = "Max limit for the service account creation has reached"
 
+	// RHSSO client rotation is not configured for this particular fleet-manager instance
 	ErrorClientRotationNotConfigured       ServiceErrorCode = 116
 	ErrorClientRotationNotConfiguredReason string           = "RHSSO client rotation is not configured"
 
+	// RHSSO client rotation attempted and failed
 	ErrorClientRotationFailed       ServiceErrorCode = 117
 	ErrorClientRotationFailedReason string           = "RHSSO client rotation failed"
 
@@ -280,8 +282,8 @@ func Errors() ServiceErrors {
 		ServiceError{ErrorMaxLimitForServiceAccountsReached, ErrorMaxLimitForServiceAccountsReachedReason, http.StatusForbidden, nil},
 		ServiceError{ErrorInstancePlanNotSupported, ErrorInstancePlanNotSupportedReason, http.StatusBadRequest, nil},
 		ServiceError{ErrorInvalidCloudAccountID, ErrorInvalidCloudAccountIDReason, http.StatusBadRequest, nil},
-		ServiceError{ErrorClientRotationNotConfigured, ErrorClientRotationNotConfiguredReason, http.StatusBadRequest, nil},
-		ServiceError{ErrorClientRotationFailed, ErrorClientRotationFailedReason, http.StatusBadRequest, nil},
+		ServiceError{ErrorClientRotationNotConfigured, ErrorClientRotationNotConfiguredReason, http.StatusMethodNotAllowed, nil},
+		ServiceError{ErrorClientRotationFailed, ErrorClientRotationFailedReason, http.StatusInternalServerError, nil},
 	}
 }
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -128,9 +128,9 @@ const (
 	ErrorMaxLimitForServiceAccountsReached       ServiceErrorCode = 115
 	ErrorMaxLimitForServiceAccountsReachedReason string           = "Max limit for the service account creation has reached"
 
-	// RHSSO client rotation is not configured for this particular fleet-manager instance
-	ErrorClientRotationNotConfigured       ServiceErrorCode = 116
-	ErrorClientRotationNotConfiguredReason string           = "RHSSO client rotation is not configured"
+	// RHSSO dynamic clients are not configured for this particular fleet-manager instance
+	ErrorDynamicClientsNotUsed       ServiceErrorCode = 116
+	ErrorDynamicClientsNotUsedReason string           = "RHSSO dynamic clients are not used"
 
 	// RHSSO client rotation attempted and failed
 	ErrorClientRotationFailed       ServiceErrorCode = 117
@@ -282,7 +282,7 @@ func Errors() ServiceErrors {
 		ServiceError{ErrorMaxLimitForServiceAccountsReached, ErrorMaxLimitForServiceAccountsReachedReason, http.StatusForbidden, nil},
 		ServiceError{ErrorInstancePlanNotSupported, ErrorInstancePlanNotSupportedReason, http.StatusBadRequest, nil},
 		ServiceError{ErrorInvalidCloudAccountID, ErrorInvalidCloudAccountIDReason, http.StatusBadRequest, nil},
-		ServiceError{ErrorClientRotationNotConfigured, ErrorClientRotationNotConfiguredReason, http.StatusNotFound, nil},
+		ServiceError{ErrorDynamicClientsNotUsed, ErrorDynamicClientsNotUsedReason, http.StatusNotFound, nil},
 		ServiceError{ErrorClientRotationFailed, ErrorClientRotationFailedReason, http.StatusInternalServerError, nil},
 	}
 }


### PR DESCRIPTION
## Description
This PR creates an admin API that:
* creates a new client/secret pair via the dynamic client sso.r.c API.
* delete the previous dynamic client.
* updates the client/secret pair in fleet manager DB.

In case of failure to either use new client or delete the previous one, client ID is logged that allows for ACSCS engineer to manually delete stale client.
In case dynamic clients are not configured, `404` status code is returned.

The dynamic clients API client is initialized once, however, it might not be initialized properly if dynamic clients are not configured. Whether dynamic clients are configured is checked on every request.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

(You need to set up `SSO_CLIENT_ID_DEFAULT` and `SSO_CLIENT_SECRET_DEFAULT`, as well as specify `--central-idp-client-id` as empty string)

1. `make deploy/bootstrap`
2. `make deploy/dev`
3. Create central
4. Look into `cloud-service-sensible-declarative-configs` secret and see client ID and secret values
5. Call `/rotate-secrets` endpoint
6. See that client ID and secret have changed within `cloud-service-sensible-declarative-configs` 
