### PR TITLE
ROX-19494: Increase timeout and improve debugability of e2e test.

### DIFF
--- a/dev/env/scripts/up.sh
+++ b/dev/env/scripts/up.sh
@@ -81,7 +81,7 @@ if [[ "$SPAWN_LOGGER" == "true" && -n "${LOG_DIR:-}" ]]; then
 fi
 
 # Sanity check.
-wait_for_container_to_become_ready "$ACSMS_NAMESPACE" "application=fleetshard-sync" "fleetshard-sync"
+wait_for_container_to_become_ready "$ACSMS_NAMESPACE" "application=fleetshard-sync" "fleetshard-sync" 500
 # Prerequisite for port-forwarding are pods in ready state.
 wait_for_container_to_become_ready "$ACSMS_NAMESPACE" "application=fleet-manager" "fleet-manager"
 

--- a/scripts/lib/log.sh
+++ b/scripts/lib/log.sh
@@ -3,7 +3,7 @@
 die() {
     {
         # shellcheck disable=SC2059
-        printf "$*"
+        printf "$(date --iso-8601=ns) $*"
         echo
     } >&2
     exit 1
@@ -11,6 +11,6 @@ die() {
 
 log() {
     # shellcheck disable=SC2059
-    printf "$*"
+    printf "$(date --iso-8601=ns) $*"
     echo
 }

--- a/scripts/lib/log.sh
+++ b/scripts/lib/log.sh
@@ -1,16 +1,12 @@
 #!/usr/bin/env bash
 
 die() {
-    {
-        # shellcheck disable=SC2059
-        printf "$(date --iso-8601=ns) $*"
-        echo
-    } >&2
+    log "$@" >&2
     exit 1
 }
 
 log() {
     # shellcheck disable=SC2059
-    printf "$(date --iso-8601=ns) $*"
+    printf "$(date "+%Y-%m-%dT%H:%M:%S,%N%:z") $*"
     echo
 }


### PR DESCRIPTION
## Description

See ticket for timeouts we're seeing from time to time. This bumps the timeout a little and provides better/more log messages to be able to debug this better in the future should the bump prove insufficient.

FTR, this is the "safe" part of #1229 that does not include the context propagation changes, which proved problematic.

@vladbologa please kindly verify that the date command works as expected on a mac.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~Unit and integration tests added~
- [x] Added test description under `Test manual`
- [x] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~
- [x] ~Add secret to app-interface Vault or Secrets Manager if necessary~
- [x] ~RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~
- [x] ~Check AWS limits are reasonable for changes provisioning new resources~

## Test manual

CI should be sufficient.