### PR TITLE
ROX-19588: Log HTTP error response

### DIFF
--- a/internal/dinosaur/pkg/rhsso/augment.go
+++ b/internal/dinosaur/pkg/rhsso/augment.go
@@ -3,6 +3,7 @@ package rhsso
 import (
 	"context"
 	"fmt"
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
 	"github.com/stackrox/acs-fleet-manager/pkg/client/iam"
@@ -28,6 +29,9 @@ func AugmentWithDynamicAuthConfig(ctx context.Context, r *dbapi.CentralRequest, 
 		RedirectUris: redirectURIs,
 	})
 	if err != nil {
+		if apiError, ok := err.(*api.GenericOpenAPIError); ok {
+			glog.Errorf("Error response when creating RHSSO dynamic client: %s", string(apiError.Body()))
+		}
 		return errors.Wrapf(err, "failed to create RHSSO dynamic client for %s", r.ID)
 	}
 


### PR DESCRIPTION
## Description

Within a recent incident, we received failures when creating dynamic clients for sso.r.c.

The error message was lackluster, as it only included: `403 Forbidden`.

The API itself _should_ return a proper error message, however we currently do not log it.

This PR changes this by ensuring we log the API response contained within the custom error type.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
