### PR TITLE
Improve AMS error experience

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -768,7 +768,7 @@ func OrganisationNameInvalid(externalID string, name string) *ServiceError {
 func FailedClusterAuthorization(err error) *ServiceError {
 	svcErr := ToServiceError(err)
 	reason := "failed to use ACSCS subscription"
-	if svcErr.Is404() || svcErr.IsForbidden() {
+	if svcErr.IsForbidden() {
 		reason += " - you might not have RedhatManagedCluster permission. Please contact your administrator."
 	}
 	return NewWithCause(svcErr.Code, svcErr, reason)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -770,8 +770,8 @@ func FailedClusterAuthorization(err error) *ServiceError {
 	reason := "failed to reserve quota"
 	// Visiting the OpenShift page in console registers the user and their organisation with OCM.
 	// See https://issues.redhat.com/browse/SDB-3194 for more context.
-	if svcErr.Is404() {
-		reason += " - visit https://console.redhat.com/openshift and try again"
+	if svcErr.Is404() || svcErr.IsForbidden() {
+		reason += " - visit https://console.redhat.com/openshift and try again. If that does not help and you are new customer of ACSCS, wait for 30 minutes and try again."
 	}
 	return NewWithCause(svcErr.Code, svcErr, reason)
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -767,11 +767,9 @@ func OrganisationNameInvalid(externalID string, name string) *ServiceError {
 // FailedClusterAuthorization converts the error to a ServiceError and returns a reason and hint for the user.
 func FailedClusterAuthorization(err error) *ServiceError {
 	svcErr := ToServiceError(err)
-	reason := "failed to reserve quota"
-	// Visiting the OpenShift page in console registers the user and their organisation with OCM.
-	// See https://issues.redhat.com/browse/SDB-3194 for more context.
+	reason := "failed to use ACSCS subscription"
 	if svcErr.Is404() || svcErr.IsForbidden() {
-		reason += " - visit https://console.redhat.com/openshift and try again. If that does not help and you are new customer of ACSCS, wait for 30 minutes and try again."
+		reason += " - you might not have RedhatManagedCluster permission. Please contact your administrator."
 	}
 	return NewWithCause(svcErr.Code, svcErr, reason)
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -769,7 +769,7 @@ func FailedClusterAuthorization(err error) *ServiceError {
 	svcErr := ToServiceError(err)
 	reason := "failed to use ACSCS subscription"
 	if svcErr.IsForbidden() {
-		reason += " - you might not have RedhatManagedCluster permission. Please contact your administrator."
+		reason += " - please contact your administrator to ensure that your Red Hat account has the RedhatManagedCluster permission."
 	}
 	return NewWithCause(svcErr.Code, svcErr, reason)
 }


### PR DESCRIPTION
## Description
Broaden amount of error codes that return an extended error message + give customer alternative if going to `/openshift` URL does not work

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
