### PR TITLE
ROX-19228: ACS CS connection string updates for 4.2

### DIFF
--- a/fleetshard/pkg/central/postgres/dbconnection.go
+++ b/fleetshard/pkg/central/postgres/dbconnection.go
@@ -21,7 +21,11 @@ var (
 	rdsCertificateData []byte
 )
 
-const sslMode = "verify-full"
+const (
+	sslMode          = "verify-full"
+	statementTimeout = 1200000
+	clientEncoding   = "UTF8"
+)
 
 // NewDBConnection constructs a new DBConnection struct
 func NewDBConnection(host string, port int, user, database string) (DBConnection, error) {
@@ -61,8 +65,8 @@ func (c DBConnection) WithSSLRootCert(sslrootcert string) DBConnection {
 
 // AsConnectionString returns a string that can be used to connect to a PostgreSQL server. The password is omitted.
 func (c DBConnection) AsConnectionString() string {
-	connectionString := fmt.Sprintf("host=%s port=%d user=%s dbname=%s sslmode=%s",
-		c.host, c.port, c.user, c.database, sslMode)
+	connectionString := fmt.Sprintf("host=%s port=%d user=%s dbname=%s statement_timeout=%d client_encoding=%s sslmode=%s",
+		c.host, c.port, c.user, c.database, statementTimeout, clientEncoding, sslMode)
 	if c.sslrootcert != "" {
 		connectionString = fmt.Sprintf("%s sslrootcert=%s", connectionString, c.sslrootcert)
 	}
@@ -76,9 +80,10 @@ func (c DBConnection) asConnectionStringWithPassword() string {
 }
 
 // GetConnectionForUser returns a DBConnection struct for the user given as parameter
-func (c DBConnection) GetConnectionForUser(userName string) DBConnection {
-	nonPrivilegedConnection := c
-	nonPrivilegedConnection.user = userName
+func (c DBConnection) GetConnectionForUserAndDB(userName, dbName string) DBConnection {
+	newConnection := c
+	newConnection.user = userName
+	newConnection.database = dbName
 
-	return nonPrivilegedConnection
+	return newConnection
 }

--- a/fleetshard/pkg/central/postgres/dbconnection_test.go
+++ b/fleetshard/pkg/central/postgres/dbconnection_test.go
@@ -11,19 +11,23 @@ func TestPostgresConnectionString(t *testing.T) {
 	dbConnection, err := NewDBConnection("localhost", 14543, "test-user", "postgresdb")
 	require.NoError(t, err)
 
-	require.Equal(t, "host=localhost port=14543 user=test-user dbname=postgresdb sslmode=verify-full", dbConnection.AsConnectionString())
+	require.Equal(t, "host=localhost port=14543 user=test-user dbname=postgresdb statement_timeout=1200000 client_encoding=UTF8 sslmode=verify-full", dbConnection.AsConnectionString())
 
 	dbConnectionWithPassword := dbConnection.WithPassword("test_pass")
-	require.Equal(t, "host=localhost port=14543 user=test-user dbname=postgresdb sslmode=verify-full",
+	require.Equal(t, "host=localhost port=14543 user=test-user dbname=postgresdb statement_timeout=1200000 client_encoding=UTF8 sslmode=verify-full",
 		dbConnectionWithPassword.AsConnectionString())
-	require.Equal(t, "host=localhost port=14543 user=test-user dbname=postgresdb sslmode=verify-full password=test_pass", // pragma: allowlist secret
+	require.Equal(t, "host=localhost port=14543 user=test-user dbname=postgresdb statement_timeout=1200000 client_encoding=UTF8 sslmode=verify-full password=test_pass", // pragma: allowlist secret
 		dbConnectionWithPassword.asConnectionStringWithPassword())
 
 	dbConnectionWithSSLRootCert := dbConnectionWithPassword.WithSSLRootCert("/tmp/ssl-root-cert.pem")
-	require.Equal(t, "host=localhost port=14543 user=test-user dbname=postgresdb sslmode=verify-full sslrootcert=/tmp/ssl-root-cert.pem",
+	require.Equal(t, "host=localhost port=14543 user=test-user dbname=postgresdb statement_timeout=1200000 client_encoding=UTF8 sslmode=verify-full sslrootcert=/tmp/ssl-root-cert.pem",
 		dbConnectionWithSSLRootCert.AsConnectionString())
-	require.Equal(t, "host=localhost port=14543 user=test-user dbname=postgresdb sslmode=verify-full sslrootcert=/tmp/ssl-root-cert.pem password=test_pass", // pragma: allowlist secret
+	require.Equal(t, "host=localhost port=14543 user=test-user dbname=postgresdb statement_timeout=1200000 client_encoding=UTF8 sslmode=verify-full sslrootcert=/tmp/ssl-root-cert.pem password=test_pass", // pragma: allowlist secret
 		dbConnectionWithSSLRootCert.asConnectionStringWithPassword())
+
+	dbConnectionWithChangedUserAndDB := dbConnection.GetConnectionForUserAndDB("new_user", "central_active")
+	require.Equal(t, "host=localhost port=14543 user=new_user dbname=central_active statement_timeout=1200000 client_encoding=UTF8 sslmode=verify-full",
+		dbConnectionWithChangedUserAndDB.AsConnectionString())
 }
 
 func TestNewDBConnection(t *testing.T) {

--- a/fleetshard/pkg/central/postgres/dbinit.go
+++ b/fleetshard/pkg/central/postgres/dbinit.go
@@ -8,10 +8,11 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/lib/pq"
-	stackroxDBClones "github.com/stackrox/rox/migrator/clone/postgres"
 )
 
-const centralDBName = stackroxDBClones.CurrentClone
+// CentralDBName is the name of database that Central uses. Any name would be acceptable, and the value is
+// "central_active" because existing Centrals use it (the name was required to be this one before ACS v4.2.0)
+const CentralDBName = "central_active"
 
 // CentralDBInitFunc is a type for functions that perform initialization on a fresh Central DB.
 // It requires a valid DBConnection of a user with administrative privileges, and the user name and password
@@ -40,12 +41,12 @@ func InitializeDatabase(ctx context.Context, con DBConnection, userName, userPas
 
 	// We have to create the central_active database here, in order to install extensions.
 	// Central won't be able to do it, due to having a limited privileges user.
-	err = createCentralDB(ctx, db, centralDBName, userName, con.user)
+	err = createCentralDB(ctx, db, CentralDBName, userName, con.user)
 	if err != nil {
 		return err
 	}
 
-	con.database = centralDBName // extensions are installed in the newly created DB
+	con.database = CentralDBName // extensions are installed in the newly created DB
 	err = installExtensions(ctx, con)
 	if err != nil {
 		return err

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -1105,7 +1105,7 @@ func (r *CentralReconciler) getCentralDBConnectionString(ctx context.Context, re
 	if err != nil {
 		return "", fmt.Errorf("getting RDS DB connection data: %w", err)
 	}
-	return dbConnection.GetConnectionForUser(dbCentralUserName).WithSSLRootCert(postgres.DatabaseCACertificatePathCentral).AsConnectionString(), nil
+	return dbConnection.GetConnectionForUserAndDB(dbCentralUserName, postgres.CentralDBName).WithSSLRootCert(postgres.DatabaseCACertificatePathCentral).AsConnectionString(), nil
 }
 
 func generateDBPassword() (string, error) {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Due to changes in ACS 4.2, some changes to the Central DB connection string in ACS CS are required.

The new connection strings should be backwards compatible with older ACS versions (ACS CS is currently running v4.1.3).

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] ~~Added test description under `Test manual`~~
- [ ] ~~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- [ ] ~~Add secret to app-interface Vault or Secrets Manager if necessary~~
- [x] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] ~~Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual

Tested RDS changes E2E - with both ACS v4.1 and v4.2.

Connection string from Central logs:
```
Migrator: 2023/09/08 16:25:35.546389 log.go:18: Info: connect to gorm: "host=rhacs-cjtkg9j3d8v001se2n8g-db-cluster.cluster-cz7zwsnynmtn.us-east-1.rds.amazonaws.com port=5432 user=rhacs_central dbname=central_active statement_timeout=1200000 client_encoding=UTF8 sslmode=verify-full sslrootcert=/usr/local/share/ca-certificates/00-rds-ca-bundle.crt pool_min_conns=10 pool_max_conns=90"
```

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
