### PR TITLE
obscure data in fleetshard-sync status logs

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -246,7 +246,9 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		return nil, errors.Wrapf(err, "setting central reconcilation cache")
 	}
 
-	glog.Infof("Returning central status %+v", status)
+	logStatus := status
+	logStatus.Secrets = obscureSecrets(status.Secrets)
+	glog.Infof("Returning central status %+v", logStatus)
 
 	return status, nil
 }
@@ -1602,4 +1604,14 @@ func NewCentralReconciler(k8sClient ctrlClient.Client, fleetmanagerClient *fleet
 
 		resourcesChart: resourcesChart,
 	}
+}
+
+func obscureSecrets(secrets map[string]string) map[string]string {
+	obscuredSecrets := make(map[string]string, len(secrets))
+
+	for key := range secrets {
+		obscuredSecrets[key] = "secret-value"
+	}
+
+	return obscuredSecrets
 }


### PR DESCRIPTION
## Description
To keep logs more clean we remove logged encrypted secrets before info logging the status of a reconciliation.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~~[ ] Unit and integration tests added~~
- ~~[ ] Added test description under `Test manual`~~
- ~~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- ~~[ ] CI and all relevant tests are passing~~
- ~~[ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~~
- ~~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- ~~[ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
- ~~[ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
- ~~[ ] Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual

CI is sufficient.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
