### PR TITLE
Specify reconcile interval in workers

### DIFF
--- a/pkg/workers/reconciler.go
+++ b/pkg/workers/reconciler.go
@@ -12,9 +12,6 @@ import (
 	"github.com/golang/glog"
 )
 
-// RepeatInterval ...
-var RepeatInterval = 30 * time.Second
-
 // Reconciler ...
 type Reconciler struct {
 	di.Inject
@@ -26,7 +23,7 @@ func (r *Reconciler) Start(worker Worker) {
 	worker.GetSyncGroup().Add(1)
 	worker.SetIsRunning(true)
 
-	ticker := time.NewTicker(RepeatInterval)
+	ticker := time.NewTicker(worker.GetRepeatInterval())
 	go func() {
 		// starts reconcile immediately and then on every repeat interval
 		glog.V(1).Infoln(fmt.Sprintf("Initial reconciliation loop for %T [%s]", worker, worker.GetID()))

--- a/pkg/workers/worker_interface.go
+++ b/pkg/workers/worker_interface.go
@@ -2,10 +2,15 @@ package workers
 
 import (
 	"sync"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/stackrox/acs-fleet-manager/pkg/metrics"
 )
+
+// DefaultRepeatInterval is default interval with which workers Reconcile() method will be called.
+// It is variable and not constant so that we could easily change this value in tests.
+var DefaultRepeatInterval = 30 * time.Second
 
 // Worker ...
 //
@@ -20,6 +25,7 @@ type Worker interface {
 	GetSyncGroup() *sync.WaitGroup
 	IsRunning() bool
 	SetIsRunning(val bool)
+	GetRepeatInterval() time.Duration
 }
 
 // BaseWorker ...
@@ -74,4 +80,8 @@ func (b *BaseWorker) StopWorker(w Worker) {
 	b.Reconciler.Stop(w)
 	metrics.ResetMetricsForCentralManagers()
 	metrics.SetLeaderWorkerMetric(b.WorkerType, false)
+}
+
+func (b *BaseWorker) GetRepeatInterval() time.Duration {
+	return DefaultRepeatInterval
 }

--- a/test/helper.go
+++ b/test/helper.go
@@ -127,7 +127,7 @@ func NewHelperWithHooks(t *testing.T, httpServer *httptest.Server, configuration
 
 	// Set server if provided
 	if httpServer != nil && ocmConfig.MockMode == ocm.MockModeEmulateServer {
-		workers.RepeatInterval = 1 * time.Second
+		workers.DefaultRepeatInterval = 1 * time.Second
 		fmt.Printf("Setting OCM base URL to %s\n", httpServer.URL)
 		ocmConfig.BaseURL = httpServer.URL
 		ocmConfig.AmsURL = httpServer.URL


### PR DESCRIPTION
## Description
By redefining `GetRepeatInterval`, worker can increase or decrease the frequency of reconcile calls. That is important for grace period worker https://github.com/stackrox/acs-fleet-manager/pull/1248, for example, as it produces mass calls to AMS and should not be called every 30 seconds

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

1. CI
