### PR TITLE
fix(authz): update roles for admin auth

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -462,70 +462,70 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "13032f402fed753c2248419ea4f69f99931f6dbc",
         "is_verified": false,
-        "line_number": 557
+        "line_number": 564
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "30025f80f6e22cdafb85db387d50f90ea884576a",
         "is_verified": false,
-        "line_number": 557
+        "line_number": 564
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "355f24fd038bcaf85617abdcaa64af51ed19bbcf",
         "is_verified": false,
-        "line_number": 557
+        "line_number": 564
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "3d8a1dcd2c3c765ce35c9a9552d23273cc4ddace",
         "is_verified": false,
-        "line_number": 557
+        "line_number": 564
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "4ac7b0522761eba972467942cd5cd7499dd2c361",
         "is_verified": false,
-        "line_number": 557
+        "line_number": 564
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "7639ab2a6bcf2ea30a055a99468c9cd844d4c22a",
         "is_verified": false,
-        "line_number": 557
+        "line_number": 564
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "b56360daf4793d2a74991a972b34d95bc00fb2da",
         "is_verified": false,
-        "line_number": 557
+        "line_number": 564
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "c9a73ef9ee8ce9f38437227801c70bcc6740d1a1",
         "is_verified": false,
-        "line_number": 557
+        "line_number": 564
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "14736999d9940728c5294277831a702f7882dece",
         "is_verified": false,
-        "line_number": 594
+        "line_number": 601
       },
       {
         "type": "Secret Keyword",
         "filename": "templates/service-template.yml",
         "hashed_secret": "4e199b4a1c40b497a95fcd1cd896351733849949",
         "is_verified": false,
-        "line_number": 681,
+        "line_number": 688,
         "is_secret": false
       },
       {
@@ -533,7 +533,7 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "9d51dabe59aa776bef2909d3689374ebb93ab2be",
         "is_verified": false,
-        "line_number": 725
+        "line_number": 732
       }
     ],
     "test/support/certs.json": [
@@ -564,5 +564,5 @@
       }
     ]
   },
-  "generated_at": "2023-09-06T14:19:26Z"
+  "generated_at": "2023-09-15T13:53:14Z"
 }

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -525,6 +525,10 @@ objects:
           roles:
             - "acs-general-engineering"
             - "acs-fleet-manager-admin-full"
+        - method: POST
+          roles:
+            - "acs-general-engineering"
+            - "acs-fleet-manager-admin-full"
       admin-authz-roles-prod.yaml: |-
         - method: GET
           roles:
@@ -536,6 +540,9 @@ objects:
             - "acs-fleet-manager-admin-full"
             - "acs-fleet-manager-admin-write"
         - method: DELETE
+          roles:
+            - "acs-fleet-manager-admin-full"
+        - method: POST
           roles:
             - "acs-fleet-manager-admin-full"
   - kind: ConfigMap


### PR DESCRIPTION
## Description

This fixes the missing authZ config on prod / staging. The config that is applied isn't actually the one under `config`, but rather the one in the template. The template one can be theoretically overwritten by app-interface, which we do, but not in this case.

The `config` stuff is _only_ used for local deployment.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual


```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
