### PR TITLE
Refactor operator config to use field.Error

### DIFF
--- a/fleetshard/pkg/central/operator/config_test.go
+++ b/fleetshard/pkg/central/operator/config_test.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"testing"
 )
 
@@ -31,10 +32,64 @@ func TestGetOperatorConfig(t *testing.T) {
 	assert.Equal(t, "quay.io/rhacs-eng/stackrox-operator:4.1.1", conf.Configs[0].Image)
 }
 
-func TestValidate(t *testing.T) {
+func TestValidateShouldSucceed(t *testing.T) {
 	conf, err := parseConfig(getExampleConfig())
 	require.NoError(t, err)
 
-	errors := Validate(conf)
-	assert.Len(t, errors, 0)
+	err = Validate(field.NewPath("rhacsOperator"), conf)
+	require.Nil(t, err)
+}
+
+func TestGetOperatorConfigFailsValidation(t *testing.T) {
+	testCases := map[string]struct {
+		getConfig func(*testing.T, OperatorConfigs) OperatorConfigs
+		contains  string
+	}{
+		"should fail with invalid baseURL not able to download CRD": {
+			getConfig: func(t *testing.T, config OperatorConfigs) OperatorConfigs {
+				config.CRD.BaseURL = "not an url"
+				return config
+			},
+			contains: "failed downloading chart files",
+		},
+		"should fail with invalid git ref": {
+			getConfig: func(t *testing.T, config OperatorConfigs) OperatorConfigs {
+				config.Configs = []OperatorConfig{
+					{GitRef: "%^-invalid", Image: "quay.io/rhacs-eng/test:4.0.0", HelmValues: ""},
+				}
+				return config
+			},
+			contains: "failed to parse images: label selector %^-invalid is not valid",
+		},
+		"should fail with invalid image": {
+			getConfig: func(t *testing.T, config OperatorConfigs) OperatorConfigs {
+				config.Configs = []OperatorConfig{
+					{GitRef: "4.0.0", Image: "quay.io//invalid", HelmValues: ""},
+				}
+				return config
+			},
+			contains: "failed to parse images: invalid reference format",
+		},
+		"should fail with invalid helm values": {
+			getConfig: func(t *testing.T, config OperatorConfigs) OperatorConfigs {
+				config.Configs = []OperatorConfig{
+					{GitRef: "4.0.0", Image: "quay.io/rhacs-eng/test:4.0.0", HelmValues: "invalid YAML"},
+				}
+				return config
+			},
+			contains: "Unmarshalling Helm values failed for operator 4.0.0",
+		},
+	}
+
+	for key, testCase := range testCases {
+		t.Run(key, func(t *testing.T) {
+			config, err := parseConfig(getExampleConfig())
+			require.NoError(t, err)
+
+			err = Validate(field.NewPath("rhacsOperator"), testCase.getConfig(t, config))
+			require.NotNil(t, err)
+			require.NotEmpty(t, testCase.contains)
+			assert.Contains(t, err.Error(), testCase.contains)
+		})
+	}
 }

--- a/fleetshard/pkg/central/operator/upgrade.go
+++ b/fleetshard/pkg/central/operator/upgrade.go
@@ -118,7 +118,10 @@ func (u *ACSOperatorManager) RenderChart(operators OperatorConfigs) ([]*unstruct
 		}
 	}
 
-	u.resourcesChart = charts.MustGetChart("rhacs-operator", dynamicTemplatesUrls)
+	u.resourcesChart, err = charts.GetChart("rhacs-operator", dynamicTemplatesUrls)
+	if err != nil {
+		return nil, fmt.Errorf("failed getting chart: %w", err)
+	}
 	objs, err := charts.RenderToObjects(releaseName, ACSOperatorNamespace, u.resourcesChart, chartVals)
 	if err != nil {
 		return nil, fmt.Errorf("failed rendering operator chart: %w", err)

--- a/internal/dinosaur/pkg/gitops/config.go
+++ b/internal/dinosaur/pkg/gitops/config.go
@@ -2,6 +2,7 @@
 package gitops
 
 import (
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/operator"
 	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/yaml"
@@ -9,7 +10,8 @@ import (
 
 // Config represents the gitops configuration
 type Config struct {
-	Centrals CentralsConfig `json:"centrals"`
+	Centrals       CentralsConfig           `json:"centrals"`
+	RHACSOperators operator.OperatorConfigs `json:"rhacsOperators"`
 }
 
 // CentralsConfig represents the declarative configuration for Central instances defaults and overrides.
@@ -32,6 +34,7 @@ type CentralOverride struct {
 func ValidateConfig(config Config) field.ErrorList {
 	var errs field.ErrorList
 	errs = append(errs, validateCentralsConfig(field.NewPath("centrals"), config.Centrals)...)
+	errs = append(errs, operator.Validate(field.NewPath("rhacsOperator"), config.RHACSOperators))
 	return errs
 }
 

--- a/internal/dinosaur/pkg/gitops/config.go
+++ b/internal/dinosaur/pkg/gitops/config.go
@@ -2,7 +2,6 @@
 package gitops
 
 import (
-	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/operator"
 	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/yaml"
@@ -10,8 +9,7 @@ import (
 
 // Config represents the gitops configuration
 type Config struct {
-	Centrals       CentralsConfig           `json:"centrals"`
-	RHACSOperators operator.OperatorConfigs `json:"rhacsOperators"`
+	Centrals CentralsConfig `json:"centrals"`
 }
 
 // CentralsConfig represents the declarative configuration for Central instances defaults and overrides.
@@ -34,7 +32,6 @@ type CentralOverride struct {
 func ValidateConfig(config Config) field.ErrorList {
 	var errs field.ErrorList
 	errs = append(errs, validateCentralsConfig(field.NewPath("centrals"), config.Centrals)...)
-	errs = append(errs, operator.Validate(field.NewPath("rhacsOperator"), config.RHACSOperators))
 	return errs
 }
 


### PR DESCRIPTION
## Description

This is the first PR to add the operator configurations to the gitops config.
Refactor operator config to use field.Error to match gitops configuration.

 - Add more test cases for validate function
 - Refactor function to use `field.Error` instead of `error`
 - Use `GetChart` instead of `MustGetChart` to avoid runtime panics when provided an invalid configuration via GitOps

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

 - Added unit tests
