### PR TITLE
fixed typo causing skip of DNS creation in restore

### DIFF
--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -3,12 +3,13 @@ package services
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
+
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/rhsso"
 	"github.com/stackrox/acs-fleet-manager/pkg/client/iam"
 	dynamicClientAPI "github.com/stackrox/acs-fleet-manager/pkg/client/redhatsso/api"
 	"github.com/stackrox/acs-fleet-manager/pkg/client/redhatsso/dynamicclients"
-	"sync"
-	"time"
 
 	dinosaurConstants "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
@@ -812,7 +813,7 @@ func (k *dinosaurService) Restore(ctx context.Context, id string) *errors.Servic
 		"Routes",
 		"Status",
 		"RoutesCreated",
-		"RouteCreationID",
+		"RoutesCreationID",
 		"DeletedAt",
 		"DeletionTimestamp",
 		"ClientID",
@@ -827,7 +828,7 @@ func (k *dinosaurService) Restore(ctx context.Context, id string) *errors.Servic
 	resetRequest.Status = dinosaurConstants.CentralRequestStatusPreparing.String()
 	resetRequest.CreatedAt = time.Now()
 
-	if err := dbConn.Unscoped().Model(&centralRequest).Select(columnsToReset).Updates(resetRequest).Error; err != nil {
+	if err := dbConn.Unscoped().Model(resetRequest).Select(columnsToReset).Updates(resetRequest).Error; err != nil {
 		return errors.NewWithCause(errors.ErrorGeneral, err, "Unable to reset CentralRequest status")
 	}
 


### PR DESCRIPTION
## Description
This PR fixes route creation when restoring a central tenant through the `admin/centrals/$id/restore` endpoint.

Because of the typo the `routes_creation_id` / `RoutesCreationID` was not set to "", which led to skipping creation of DNS routes when restoring a central tenant.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
~~- [ ] Added test description under `Test manual`~~
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
~~- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~~
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
~~- [ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
~~- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
~~- [ ] Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual

CI is sufficient

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
