### PR TITLE
ROX-19692: Add a release preparation workflow.

### DIFF
--- a/.github/workflows/start-release.yaml
+++ b/.github/workflows/start-release.yaml
@@ -1,0 +1,45 @@
+name: Start release
+on:
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: 'Commit to merge into the stage branch (branch name, tag name or SHA)'
+        required: true
+        default: 'main'
+        type: string
+      release_version:
+        description: 'Release version in the format YYYY-MM-DD.N'
+        required: true
+        default: 'YYYY-MM-DD.1'
+        type: string
+
+jobs:
+  prepare-stage-pr:
+    runs-on: ubuntu-latest
+    name: Prepare stage PR
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    # action-create-branch does not accept symbolic refs, so we need to parse it here.
+    - name: Canonicalize the commit ID
+      run: |
+        echo "commit_hash=$(git rev-parse --verify --quiet 'remotes/origin/${{ inputs.commit }}' || git rev-parse --verify --quiet '${{ inputs.commit }}')" >> "$GITHUB_ENV"
+
+    - name: Create Release Candidate branch
+      uses: peterjgrainger/action-create-branch@v2.3.0
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      with:
+        branch: 'rc-${{ inputs.release_version }}'
+        sha: '${{ env.commit_hash }}'
+
+    - name: Open a pull request
+      uses: tretuna/sync-branches@1.4.0
+      with:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        FROM_BRANCH: 'rc-${{ inputs.release_version }}'
+        TO_BRANCH: 'stage'


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

A workflow to be triggered manually to prepare a PR to be merged to `stage` branch as part of the release.

Inspired by [a similar workflow in the observability-artifacts repo](https://github.com/stackrox/rhacs-observability-resources/blob/master/.github/workflows/sync.yaml), but with support for specifying a commit or branch.

Once merged, I will clone the PR to the AWS config repo.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~Unit and integration tests added~
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...): **Updating release checklist in progress**
- [x] ~CI and all relevant tests are passing~
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~
- [x] ~Add secret to app-interface Vault or Secrets Manager if necessary~
- [x] ~RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~
- [x] ~Check AWS limits are reasonable for changes provisioning new resources~

## Test manual

Tested quite extensively [in my fork](https://github.com/porridge/acs-fleet-manager/actions/workflows/start-release.yaml). [Example PR](https://github.com/porridge/acs-fleet-manager/pull/8).