### PR TITLE
ROX-16664: add KeyGenerator interface and implementations

### DIFF
--- a/fleetshard/pkg/cipher/aes256_cipher.go
+++ b/fleetshard/pkg/cipher/aes256_cipher.go
@@ -65,3 +65,20 @@ func (a AES256Cipher) Decrypt(ciphertext []byte) ([]byte, error) {
 
 	return plaintext, nil
 }
+
+// AES256KeyGenerator implements the KeyGenerator interface for AES256 keys
+type AES256KeyGenerator struct{}
+
+// Generate generates a Key compatible for AES256 ciphers
+func (g AES256KeyGenerator) Generate() ([]byte, error) {
+	return generateAESKey(32)
+}
+
+func generateAESKey(size int) ([]byte, error) {
+	key := make([]byte, size)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		return nil, fmt.Errorf("generating random bytes for AES key: %w", err)
+	}
+
+	return key, nil
+}

--- a/fleetshard/pkg/cipher/aes256_cipher_test.go
+++ b/fleetshard/pkg/cipher/aes256_cipher_test.go
@@ -1,27 +1,16 @@
 package cipher
 
 import (
-	"crypto/rand"
-	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func generateKey() ([]byte, error) {
-	key := make([]byte, 32)
-	if _, err := io.ReadFull(rand.Reader, key); err != nil {
-		return nil, err
-	}
-
-	return key, nil
-}
-
 // TestDifferentCipherForSamePlaintext tests the correct usage of nonce
 // to ensure encrypting the same plaintext twice does not yield the same cipher text
 func TestAES256DifferentCipherForSamePlaintext(t *testing.T) {
 	plaintext := []byte("test plaintext")
-	key, err := generateKey()
+	key, err := generateAESKey(32)
 	require.NoError(t, err, "generating key")
 
 	aes, err := NewAES256Cipher(key)
@@ -36,7 +25,7 @@ func TestAES256DifferentCipherForSamePlaintext(t *testing.T) {
 
 func TestAES256EncryptDecryptMatch(t *testing.T) {
 	plaintext := []byte("test plaintext")
-	key, err := generateKey()
+	key, err := generateAESKey(32)
 	require.NoError(t, err, "generating key")
 
 	aes, err := NewAES256Cipher(key)
@@ -49,4 +38,12 @@ func TestAES256EncryptDecryptMatch(t *testing.T) {
 	require.NoError(t, err, "decrypting ciphertext")
 
 	require.Equal(t, string(plaintext), string(decrypted), "decrypted string does not match plaintext")
+}
+
+func TestAES256Generator(t *testing.T) {
+	generator := AES256KeyGenerator{}
+
+	key, err := generator.Generate()
+	require.NoError(t, err)
+	require.Equal(t, 32, len(key))
 }

--- a/fleetshard/pkg/cipher/key_generator.go
+++ b/fleetshard/pkg/cipher/key_generator.go
@@ -1,0 +1,7 @@
+package cipher
+
+// KeyGenerator defines a Generate method to generate encryption keys
+// that can be used for symmetric encryption
+type KeyGenerator interface {
+	Generate() ([]byte, error)
+}

--- a/fleetshard/pkg/cipher/kms_cipher.go
+++ b/fleetshard/pkg/cipher/kms_cipher.go
@@ -96,6 +96,21 @@ type KMSDataKeyGenerator struct {
 	kmsDataKeySpec string
 }
 
+// NewKMSDataKeyGenerator initiates a AWS KMS session and
+// returns a new instance of KMSDataKeyGenerator
+func NewKMSDataKeyGenerator(keyID, keySpec string) (*KMSDataKeyGenerator, error) {
+	sess, err := session.NewSession()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create session for KMS client %w", err)
+	}
+
+	return &KMSDataKeyGenerator{
+		keyID:          keyID,
+		kms:            kms.New(sess),
+		kmsDataKeySpec: keySpec,
+	}, nil
+}
+
 // Generate generates a KMS data key with the KMSDataKeyGenerator configuration
 func (g KMSDataKeyGenerator) Generate() ([]byte, error) {
 	dateKeyOut, err := g.kms.GenerateDataKey(&kms.GenerateDataKeyInput{KeyId: &g.keyID, KeySpec: &g.kmsDataKeySpec})

--- a/fleetshard/pkg/cipher/kms_cipher.go
+++ b/fleetshard/pkg/cipher/kms_cipher.go
@@ -88,3 +88,20 @@ func (k kmsCipher) Decrypt(ciphertext []byte) ([]byte, error) {
 
 	return plaintext, nil
 }
+
+// KMSDataKeyGenerator implements KeyGenerator using AWS KMS
+type KMSDataKeyGenerator struct {
+	keyID          string
+	kms            *kms.KMS
+	kmsDataKeySpec string
+}
+
+// Generate generates a KMS data key with the KMSDataKeyGenerator configuration
+func (g KMSDataKeyGenerator) Generate() ([]byte, error) {
+	dateKeyOut, err := g.kms.GenerateDataKey(&kms.GenerateDataKeyInput{KeyId: &g.keyID, KeySpec: &g.kmsDataKeySpec})
+	if err != nil {
+		return nil, fmt.Errorf("generating kms data key: %w", err)
+	}
+
+	return dateKeyOut.Plaintext, nil
+}

--- a/fleetshard/pkg/cipher/kms_cipher_test.go
+++ b/fleetshard/pkg/cipher/kms_cipher_test.go
@@ -38,7 +38,8 @@ func TestKMSDataKeyGenerator(t *testing.T) {
 
 	keyID := os.Getenv("SECRET_ENCRYPTION_KEY_ID")
 	require.NotEmpty(t, keyID, "SECRET_ENCRYPTION_KEY_ID not set")
-	generator := KMSDataKeyGenerator{keyID: keyID, kmsDataKeySpec: kms.DataKeySpecAes256}
+	generator, err := NewKMSDataKeyGenerator(keyID, kms.DataKeySpecAes256)
+	require.NoError(t, err)
 
 	key, err := generator.Generate()
 	require.NoError(t, err)

--- a/fleetshard/pkg/cipher/kms_cipher_test.go
+++ b/fleetshard/pkg/cipher/kms_cipher_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,4 +29,18 @@ func TestKMSEncryptDecrypt(t *testing.T) {
 
 	require.NotEqual(t, plaintext, string(ciphertextB))
 	require.Equal(t, plaintext, string(decrypted))
+}
+
+func TestKMSDataKeyGenerator(t *testing.T) {
+	if os.Getenv("RUN_AWS_INTEGRATION") != "true" {
+		t.Skip("Skip KMS tests. Set RUN_AWS_INTEGRATION=true env variable to enable KMS tests.")
+	}
+
+	keyID := os.Getenv("SECRET_ENCRYPTION_KEY_ID")
+	require.NotEmpty(t, keyID, "SECRET_ENCRYPTION_KEY_ID not set")
+	generator := KMSDataKeyGenerator{keyID: keyID, kmsDataKeySpec: kms.DataKeySpecAes256}
+
+	key, err := generator.Generate()
+	require.NoError(t, err)
+	require.Equal(t, 32, len(key))
 }


### PR DESCRIPTION
## Description
This PR adds a `KeyGenerator` interface and respective `AES256KeyGenerator` and `KMSDataKeyGenerator` implementations of the interface.

This implementations will later be used to generate a encryption key to provide to a managed central tenant in order to encrypt secrets stored in its DB.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

CI and local unit tests are sufficient.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
