### PR TITLE
Disable automounting for egress proxy

### DIFF
--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
@@ -32,6 +32,7 @@ spec:
       annotations:
         config-hash: {{ .Files.Get "config/squid.conf" | sha256sum | quote }}
     spec:
+      automountServiceAccountToken: false
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:


### PR DESCRIPTION
## Description
The dogfooding ACSCS instance regularly generates an alert for the "Pod Service Account Token Automatically Mounted" policy violation on egress-proxy deployment. This PR follows the guidance of the violated policy and updates the deployment with `automountServiceAccountToken: false`. Note that according to [this StackOverflow answer](https://stackoverflow.com/questions/44505461/how-to-configure-a-non-default-serviceaccount-on-a-deployment), updating pod spec in the deployment is fine.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~Unit and integration tests added~
- [x] Added test description under `Test manual`
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [ ] ~Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] ~Add secret to app-interface Vault or Secrets Manager if necessary~
- [ ] ~RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~
- [ ] ~Check AWS limits are reasonable for changes provisioning new resources~

## Test manual

No testing has been performed. Ideally, we would see alerts number drop for the integration data plane, however, we don't have it integrated in the dogfooding instance yet.
