### PR TITLE
ROX-19562: Add annotations to rate limit managed-central routes traffic

### DIFF
--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	openshiftRouteV1 "github.com/openshift/api/route/v1"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/config"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/public"
@@ -46,6 +47,14 @@ var (
 
 const defaultTimeout = 5 * time.Minute
 
+var (
+	routeConfig = &config.RouteConfig{
+		ConcurrentTCP: 32,
+		RateHTTP:      128,
+		RateTCP:       16,
+	}
+)
+
 func getWaitTimeout() time.Duration {
 	timeoutStr, ok := os.LookupEnv("WAIT_TIMEOUT")
 	if ok {
@@ -77,7 +86,7 @@ func TestE2E(t *testing.T) {
 // TODO: Deploy fleet-manager, fleetshard-sync and database into a cluster
 var _ = BeforeSuite(func() {
 	k8sClient = k8s.CreateClientOrDie()
-	routeService = k8s.NewRouteService(k8sClient)
+	routeService = k8s.NewRouteService(k8sClient, routeConfig)
 	var err error
 	routesEnabled, err = k8s.IsRoutesResourceEnabled(k8sClient)
 	Expect(err).ToNot(HaveOccurred())

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	Telemetry             Telemetry
 	AuditLogging          AuditLogging
 	SecretEncryption      SecretEncryption
+	RouteParameters       RouteConfig
 }
 
 // ManagedDB for configuring managed DB specific parameters
@@ -70,10 +71,18 @@ type Telemetry struct {
 	StorageKey      string `env:"TELEMETRY_STORAGE_KEY"`
 }
 
-// SecretEncryption defines paramaters to configure encryption of tenant secrest
+// SecretEncryption defines parameters to configure encryption of tenant secrets.
 type SecretEncryption struct {
 	Type  string `env:"SECRET_ENCRYPTION_TYPE" envDefault:"local"`
 	KeyID string `env:"SECRET_ENCRYPTION_KEY_ID"`
+}
+
+// RouteConfig defines parameters to configure routes.
+type RouteConfig struct {
+	ThrottlingEnabled bool `env:"ROUTE_ENABLE_THROTTLING" envDefault:"true"`
+	ConcurrentTCP     int  `env:"ROUTE_CONCURRENT_TCP_CONNECTIONS" envDefault:"32"`
+	RateHTTP          int  `env:"ROUTE_HTTP_REQUEST_RATE" envDefault:"128"`
+	RateTCP           int  `env:"ROUTE_TCP_NEW_CONNECTION_RATE" envDefault:"16"`
 }
 
 // GetConfig retrieves the current runtime configuration from the environment and returns it.

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -80,9 +80,9 @@ type SecretEncryption struct {
 // RouteConfig defines parameters to configure routes.
 type RouteConfig struct {
 	ThrottlingEnabled bool `env:"ROUTE_ENABLE_THROTTLING" envDefault:"true"`
-	ConcurrentTCP     int  `env:"ROUTE_CONCURRENT_TCP_CONNECTIONS" envDefault:"32"`
-	RateHTTP          int  `env:"ROUTE_HTTP_REQUEST_RATE" envDefault:"128"`
-	RateTCP           int  `env:"ROUTE_TCP_NEW_CONNECTION_RATE" envDefault:"16"`
+	ConcurrentTCP     int  `env:"ROUTE_CONCURRENT_TCP_CONNECTIONS" envDefault:"512"`
+	RateHTTP          int  `env:"ROUTE_HTTP_REQUEST_RATE" envDefault:"32768"`
+	RateTCP           int  `env:"ROUTE_TCP_NEW_CONNECTION_RATE" envDefault:"256"`
 }
 
 // GetConfig retrieves the current runtime configuration from the environment and returns it.

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -80,9 +80,28 @@ type SecretEncryption struct {
 // RouteConfig defines parameters to configure routes.
 type RouteConfig struct {
 	ThrottlingEnabled bool `env:"ROUTE_ENABLE_THROTTLING" envDefault:"true"`
-	ConcurrentTCP     int  `env:"ROUTE_CONCURRENT_TCP_CONNECTIONS" envDefault:"512"`
-	RateHTTP          int  `env:"ROUTE_HTTP_REQUEST_RATE" envDefault:"32768"`
-	RateTCP           int  `env:"ROUTE_TCP_NEW_CONNECTION_RATE" envDefault:"512"`
+	ConcurrentTCP     int  `env:"ROUTE_CONCURRENT_TCP_CONNECTIONS" envDefault:"131072"`
+	RateHTTP          int  `env:"ROUTE_HTTP_REQUEST_RATE" envDefault:"131072"`
+	RateTCP           int  `env:"ROUTE_TCP_NEW_CONNECTION_RATE" envDefault:"131072"`
+	// The RateHTTP default value was computed based on the prometheus monitoring values.
+	// The query to retrieve the value focuses on `haproxy_backend_http_responses_total`.
+	// Actual query (maximum seen around 10k in 5 minutes):
+	// sum(
+	//  increase(
+	//   haproxy_backend_http_responses_total{exported_namespace=~"rhacs-.*",route="managed-central-reencrypt"}[5m]
+	//  )
+	// ) by (exported_namespace)
+	//
+	// The ConcurrentTCP value was computed similarly using the haproxy_backend_connections_total metric.
+	// Actual query (maximum seed around 11k in 5 minutes):
+	// sum(
+	//  irate(
+	//   haproxy_backend_connections_total{exported_namespace=~"rhacs-.*",route="managed-central-reencrypt"}[5m]
+	//  )
+	// ) by (exported_namespace)
+	//
+	// The RateTCP value is conservatively set to the same value as ConcurrentTCP.
+
 }
 
 // GetConfig retrieves the current runtime configuration from the environment and returns it.

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -82,7 +82,7 @@ type RouteConfig struct {
 	ThrottlingEnabled bool `env:"ROUTE_ENABLE_THROTTLING" envDefault:"true"`
 	ConcurrentTCP     int  `env:"ROUTE_CONCURRENT_TCP_CONNECTIONS" envDefault:"512"`
 	RateHTTP          int  `env:"ROUTE_HTTP_REQUEST_RATE" envDefault:"32768"`
-	RateTCP           int  `env:"ROUTE_TCP_NEW_CONNECTION_RATE" envDefault:"256"`
+	RateTCP           int  `env:"ROUTE_TCP_NEW_CONNECTION_RATE" envDefault:"512"`
 }
 
 // GetConfig retrieves the current runtime configuration from the environment and returns it.

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -100,6 +100,7 @@ type CentralReconcilerOptions struct {
 	Environment           string
 	AuditLogging          config.AuditLogging
 	TenantImagePullSecret string
+	RouteParameters       config.RouteConfig
 }
 
 // CentralReconciler is a reconciler tied to a one Central instance. It installs, updates and deletes Central instances
@@ -1676,7 +1677,7 @@ func NewCentralReconciler(k8sClient ctrlClient.Client, fleetmanagerClient *fleet
 		status:                 pointer.Int32(FreeStatus),
 		useRoutes:              opts.UseRoutes,
 		wantsAuthProvider:      opts.WantsAuthProvider,
-		routeService:           k8s.NewRouteService(k8sClient),
+		routeService:           k8s.NewRouteService(k8sClient, &opts.RouteParameters),
 		secretBackup:           k8s.NewSecretBackup(k8sClient, opts.ManagedDBEnabled),
 		secretCipher:           secretCipher, // pragma: allowlist secret
 		egressProxyImage:       opts.EgressProxyImage,

--- a/fleetshard/pkg/k8s/route.go
+++ b/fleetshard/pkg/k8s/route.go
@@ -147,12 +147,12 @@ func (s *RouteService) configureReencryptRoute(ctx context.Context, route *opens
 	annotatedRoute.Spec.Host = remoteCentral.Spec.UiEndpoint.Host
 
 	namespace := remoteCentral.Metadata.Namespace
-	centralTLSSecret, secretRetrievalErr := getSecret(ctx, s.client, centralTLSSecretName, namespace)
-	if secretRetrievalErr != nil {
+	centralTLSSecret, retrievalErr := getSecret(ctx, s.client, centralTLSSecretName, namespace)
+	if retrievalErr != nil {
 		wrappedErr := fmt.Errorf(
 			"getting central-tls secret for tenant %s: %w",
 			remoteCentral.Metadata.Name,
-			secretRetrievalErr,
+			retrievalErr,
 		)
 		return nil, wrappedErr
 	}

--- a/fleetshard/pkg/k8s/route_test.go
+++ b/fleetshard/pkg/k8s/route_test.go
@@ -3,10 +3,10 @@ package k8s
 import (
 	"context"
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 
 	openshiftRouteV1 "github.com/openshift/api/route/v1"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/config"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/testutils"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
 	"github.com/stackrox/rox/pkg/uuid"
@@ -14,11 +14,23 @@ import (
 	"github.com/stretchr/testify/require"
 	coreV1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
+	enabledLabelValue  = "true"
+	disabledLabelValue = "false"
+
+	baseConcurrentTCPStrVal = "32"
+	baseRateHTTPStrVal      = "128"
+	baseRateTCPStrVal       = "16"
+
+	updatedConcurrentTCPStrVal = "16"
+	updatedRateHTTPStrVal      = "512"
+	updatedRateTCPStrVal       = "8"
+
 	testNamespace           = "test-namespace"
 	testTargetHost          = "target-host"
 	testTargetReEncryptHost = "target-re-encrypt-host"
@@ -68,9 +80,7 @@ var (
 		},
 		Spec: passThroughRouteSpec,
 	}
-)
 
-var (
 	passThroughRouteExtractors = map[string]routeFieldExtractor{
 		"name":                          extractRouteObjectMetaName,
 		"namespace":                     extractRouteObjectMetaNamespace,
@@ -81,13 +91,29 @@ var (
 		"spec \"to\" kind":              extractRouteSpecToKind,
 		"spec \"to\" name":              extractRouteSpecToName,
 		"spec TLS termination":          extractRouteSpecTLSTermination,
+)
+
+var (
+	baseRouteParameters = &config.RouteConfig{
+		ThrottlingEnabled: true,
+		ConcurrentTCP:     32,
+		RateHTTP:          128,
+		RateTCP:           16,
+	}
+
+	updatedRouteParameters = &config.RouteConfig{
+		ThrottlingEnabled: false,
+		ConcurrentTCP:     16,
+		RateHTTP:          512,
+		RateTCP:           8,
 	}
 )
 
 func TestPassThroughRouteLifecycle(t *testing.T) {
+	const testNamespace = "test-namespace"
 	client := testutils.NewFakeClientBuilder(t).Build()
-	baseRouteService := NewRouteService(client)
-	updateRouteService := NewRouteService(client)
+	baseRouteService := NewRouteService(client, baseRouteParameters)
+	updateRouteService := NewRouteService(client, updatedRouteParameters)
 
 	// Test configuration
 	ctx := context.Background()
@@ -234,8 +260,8 @@ var (
 func TestReEncryptRouteLifecycle(t *testing.T) {
 	const testNamespace = "test-namespace"
 	client := testutils.NewFakeClientBuilder(t).Build()
-	baseRouteService := NewRouteService(client)
-	updateRouteService := NewRouteService(client)
+	baseRouteService := NewRouteService(client, baseRouteParameters)
+	updateRouteService := NewRouteService(client, updatedRouteParameters)
 
 	// Test configuration
 	ctx := context.Background()

--- a/fleetshard/pkg/k8s/route_test.go
+++ b/fleetshard/pkg/k8s/route_test.go
@@ -112,19 +112,20 @@ var (
 
 var (
 	passThroughRouteExtractors = map[string]routeFieldExtractor{
-		"name":                                  extractRouteObjectMetaName,
-		"namespace":                             extractRouteObjectMetaNamespace,
-		"\"managed-by\" label":                  extractRouteManagedByLabel,
-		"\"rate-limit-connections\" annotation": extractRouteEnableRateLimitAnnotation,
-		"\"rate-limit-connections.concurrent-tcp\" annotation": extractRouteConcurrentConnectionsAnnotation,
-		"\"rate-limit-connections.rate-http\" annotation":      extractRouteRateHTTPAnnotation,
-		"\"rate-limit-connections.rate-tcp\" annotation":       extractRouteRateTCPAnnotation,
-		"spec host":                     extractRouteSpecHost,
-		"spec target port type":         extractRouteSpecTargetPortType,
-		"spec target port string value": extractRouteSpecTargetPortStrVal,
-		"spec \"to\" kind":              extractRouteSpecToKind,
-		"spec \"to\" name":              extractRouteSpecToName,
-		"spec TLS termination":          extractRouteSpecTLSTermination,
+		`name`:                          extractRouteObjectMetaName,
+		`namespace`:                     extractRouteObjectMetaNamespace,
+		`"managed-by" label`:            extractRouteManagedByLabel,
+		`spec host`:                     extractRouteSpecHost,
+		`spec target port type`:         extractRouteSpecTargetPortType,
+		`spec target port string value`: extractRouteSpecTargetPortStrVal,
+		`spec "to" kind`:                extractRouteSpecToKind,
+		`spec "to" name`:                extractRouteSpecToName,
+		`spec TLS termination`:          extractRouteSpecTLSTermination,
+		// Rate limit annotations
+		`"rate-limit-connections" annotation`:                extractRouteEnableRateLimitAnnotation,
+		`"rate-limit-connections.concurrent-tcp" annotation`: extractRouteConcurrentConnectionsAnnotation,
+		`"rate-limit-connections.rate-http" annotation`:      extractRouteRateHTTPAnnotation,
+		`"rate-limit-connections.rate-tcp" annotation`:       extractRouteRateTCPAnnotation,
 	}
 )
 
@@ -267,23 +268,24 @@ var (
 	}
 
 	reEncryptRouteExtractors = map[string]routeFieldExtractor{
-		"name":                                  extractRouteObjectMetaName,
-		"namespace":                             extractRouteObjectMetaNamespace,
-		"\"managed-by\" label":                  extractRouteManagedByLabel,
-		"\"rate-limit-connections\" annotation": extractRouteEnableRateLimitAnnotation,
-		"\"rate-limit-connections.concurrent-tcp\" annotation": extractRouteConcurrentConnectionsAnnotation,
-		"\"rate-limit-connections.rate-http\" annotation":      extractRouteRateHTTPAnnotation,
-		"\"rate-limit-connections.rate-tcp\" annotation":       extractRouteRateTCPAnnotation,
-		"\"timeout\" annotation":                               extractRouteReEncryptTimeoutAnnotation,
-		"spec host":                                            extractRouteSpecHost,
-		"spec target port type":                                extractRouteSpecTargetPortType,
-		"spec target port string value":                        extractRouteSpecTargetPortStrVal,
-		"spec \"to\" kind":                                     extractRouteSpecToKind,
-		"spec \"to\" name":                                     extractRouteSpecToName,
-		"spec TLS termination":                                 extractRouteSpecTLSTermination,
-		"spec TLS destination CA certificate":                  extractRouteSpecTLSDestinationCACertificate,
-		"spec TLS key":                                         extractRouteSpecTLSKey,
-		"spec TLS certificate":                                 extractRouteSpecTLSCertificate,
+		`name`:                                extractRouteObjectMetaName,
+		`namespace`:                           extractRouteObjectMetaNamespace,
+		`"managed-by" label`:                  extractRouteManagedByLabel,
+		`"timeout" annotation`:                extractRouteReEncryptTimeoutAnnotation,
+		`spec host`:                           extractRouteSpecHost,
+		`spec target port type`:               extractRouteSpecTargetPortType,
+		`spec target port string value`:       extractRouteSpecTargetPortStrVal,
+		`spec "to" kind`:                      extractRouteSpecToKind,
+		`spec "to" name`:                      extractRouteSpecToName,
+		`spec TLS termination`:                extractRouteSpecTLSTermination,
+		`spec TLS destination CA certificate`: extractRouteSpecTLSDestinationCACertificate,
+		`spec TLS key`:                        extractRouteSpecTLSKey,
+		`spec TLS certificate`:                extractRouteSpecTLSCertificate,
+		// Rate limit annotations
+		`"rate-limit-connections" annotation`:                extractRouteEnableRateLimitAnnotation,
+		`"rate-limit-connections.concurrent-tcp" annotation`: extractRouteConcurrentConnectionsAnnotation,
+		`"rate-limit-connections.rate-http" annotation`:      extractRouteRateHTTPAnnotation,
+		`"rate-limit-connections.rate-tcp" annotation`:       extractRouteRateTCPAnnotation,
 	}
 )
 
@@ -396,39 +398,31 @@ func extractRouteManagedByLabel(route *openshiftRouteV1.Route) string {
 	return route.ObjectMeta.Labels[ManagedByLabelKey]
 }
 
-func extractRouteEnableRateLimitAnnotation(route *openshiftRouteV1.Route) string {
+func extractRouteAnnotation(route *openshiftRouteV1.Route, key string) string {
 	if route.ObjectMeta.Annotations == nil {
 		return ""
 	}
-	return route.ObjectMeta.Annotations[enableRateLimitAnnotationKey]
+	return route.ObjectMeta.Annotations[key]
+}
+
+func extractRouteEnableRateLimitAnnotation(route *openshiftRouteV1.Route) string {
+	return extractRouteAnnotation(route, enableRateLimitAnnotationKey)
 }
 
 func extractRouteConcurrentConnectionsAnnotation(route *openshiftRouteV1.Route) string {
-	if route.ObjectMeta.Annotations == nil {
-		return ""
-	}
-	return route.ObjectMeta.Annotations[concurrentConnectionAnnotationKey]
+	return extractRouteAnnotation(route, concurrentConnectionAnnotationKey)
 }
 
 func extractRouteRateHTTPAnnotation(route *openshiftRouteV1.Route) string {
-	if route.ObjectMeta.Annotations == nil {
-		return ""
-	}
-	return route.ObjectMeta.Annotations[rateHTTPAnnotationKey]
+	return extractRouteAnnotation(route, rateHTTPAnnotationKey)
 }
 
 func extractRouteRateTCPAnnotation(route *openshiftRouteV1.Route) string {
-	if route.ObjectMeta.Annotations == nil {
-		return ""
-	}
-	return route.ObjectMeta.Annotations[rateTCPAnnotationKey]
+	return extractRouteAnnotation(route, rateTCPAnnotationKey)
 }
 
 func extractRouteReEncryptTimeoutAnnotation(route *openshiftRouteV1.Route) string {
-	if route.ObjectMeta.Annotations == nil {
-		return ""
-	}
-	return route.ObjectMeta.Annotations[centralReencryptTimeoutAnnotationKey]
+	return extractRouteAnnotation(route, centralReencryptTimeoutAnnotationKey)
 }
 
 func extractRouteSpecHost(route *openshiftRouteV1.Route) string {

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -139,6 +139,7 @@ func (r *Runtime) Start() error {
 		Environment:           r.config.Environment,
 		AuditLogging:          r.config.AuditLogging,
 		TenantImagePullSecret: r.config.TenantImagePullSecret, // pragma: allowlist secret
+		RouteParameters:       r.config.RouteParameters,
 	}
 
 	ticker := concurrency.NewRetryTicker(func(ctx context.Context) (timeToNextTick time.Duration, err error) {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

In order to protect against (D)DOS attacks, the OpenShift routes to Central managed by FleetShard sync are being annotated in order to activate traffic throttling features.

The default values were derived from the haproxy metrics available in the current ACS CS instances.
- The most busy central shows a total HTTP response count of 9 averaged over a 5 minute period.
Assuming all the averaged requests were a burst of concurrent requests, these could have been about 3000 requests.
Adding a safety 10 factor, and using powers of two as throttling value, the default would be 32768 concurrent requests.
- The most busy central reported up to 43 concurrent connections on a 5 minute period. The limit derived from here is 512 concurrent connections, allowing at most the half as being established at the same time.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
