### PR TITLE
Call /current_account before reserving quota

### DIFF
--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -107,7 +107,7 @@ func (h adminCentralHandler) Create(w http.ResponseWriter, r *http.Request) {
 			ValidateScannerSpec(ctx, &centralRequest, &convCentral),
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
-			svcErr := h.service.RegisterDinosaurJob(&convCentral)
+			svcErr := h.service.RegisterDinosaurJob(nil, &convCentral)
 			h.telemetry.RegisterTenant(ctx, &convCentral, true, svcErr.AsError())
 
 			if svcErr != nil {

--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -107,7 +107,7 @@ func (h adminCentralHandler) Create(w http.ResponseWriter, r *http.Request) {
 			ValidateScannerSpec(ctx, &centralRequest, &convCentral),
 		},
 		Action: func() (interface{}, *errors.ServiceError) {
-			svcErr := h.service.RegisterDinosaurJob(nil, &convCentral)
+			svcErr := h.service.RegisterDinosaurJob(ctx, &convCentral)
 			h.telemetry.RegisterTenant(ctx, &convCentral, true, svcErr.AsError())
 
 			if svcErr != nil {

--- a/internal/dinosaur/pkg/handlers/dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/dinosaur.go
@@ -89,7 +89,7 @@ func (h dinosaurHandler) Create(w http.ResponseWriter, r *http.Request) {
 			if arrays.Contains(h.centralRequestConfig.InternalUserAgents, r.UserAgent()) {
 				convCentral.Internal = true
 			}
-			svcErr := h.service.RegisterDinosaurJob(convCentral)
+			svcErr := h.service.RegisterDinosaurJob(ctx, convCentral)
 			// Do not track centrals created from internal services.
 			if !convCentral.Internal {
 				h.telemetry.RegisterTenant(ctx, convCentral, false, svcErr.AsError())

--- a/internal/dinosaur/pkg/services/dinosaurservice_moq.go
+++ b/internal/dinosaur/pkg/services/dinosaurservice_moq.go
@@ -933,7 +933,7 @@ func (mock *DinosaurServiceMock) RegisterDinosaurDeprovisionJobCalls() []struct 
 }
 
 // RegisterDinosaurJob calls RegisterDinosaurJobFunc.
-func (mock *DinosaurServiceMock) RegisterDinosaurJob(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError {
+func (mock *DinosaurServiceMock) RegisterDinosaurJob(ctx context.Context, dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError {
 	if mock.RegisterDinosaurJobFunc == nil {
 		panic("DinosaurServiceMock.RegisterDinosaurJobFunc: method is nil but DinosaurService.RegisterDinosaurJob was just called")
 	}

--- a/internal/dinosaur/pkg/services/dinosaurservice_moq.go
+++ b/internal/dinosaur/pkg/services/dinosaurservice_moq.go
@@ -79,7 +79,7 @@ var _ DinosaurService = &DinosaurServiceMock{}
 //			RegisterDinosaurDeprovisionJobFunc: func(ctx context.Context, id string) *serviceError.ServiceError {
 //				panic("mock out the RegisterDinosaurDeprovisionJob method")
 //			},
-//			RegisterDinosaurJobFunc: func(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError {
+//			RegisterDinosaurJobFunc: func(ctx context.Context, dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError {
 //				panic("mock out the RegisterDinosaurJob method")
 //			},
 //			RestoreFunc: func(ctx context.Context, id string) *serviceError.ServiceError {
@@ -162,7 +162,7 @@ type DinosaurServiceMock struct {
 	RegisterDinosaurDeprovisionJobFunc func(ctx context.Context, id string) *serviceError.ServiceError
 
 	// RegisterDinosaurJobFunc mocks the RegisterDinosaurJob method.
-	RegisterDinosaurJobFunc func(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError
+	RegisterDinosaurJobFunc func(ctx context.Context, dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError
 
 	// RestoreFunc mocks the Restore method.
 	RestoreFunc func(ctx context.Context, id string) *serviceError.ServiceError
@@ -280,6 +280,8 @@ type DinosaurServiceMock struct {
 		}
 		// RegisterDinosaurJob holds details about calls to the RegisterDinosaurJob method.
 		RegisterDinosaurJob []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
 			// DinosaurRequest is the dinosaurRequest argument value.
 			DinosaurRequest *dbapi.CentralRequest
 		}
@@ -938,14 +940,16 @@ func (mock *DinosaurServiceMock) RegisterDinosaurJob(ctx context.Context, dinosa
 		panic("DinosaurServiceMock.RegisterDinosaurJobFunc: method is nil but DinosaurService.RegisterDinosaurJob was just called")
 	}
 	callInfo := struct {
+		Ctx             context.Context
 		DinosaurRequest *dbapi.CentralRequest
 	}{
+		Ctx:             ctx,
 		DinosaurRequest: dinosaurRequest,
 	}
 	mock.lockRegisterDinosaurJob.Lock()
 	mock.calls.RegisterDinosaurJob = append(mock.calls.RegisterDinosaurJob, callInfo)
 	mock.lockRegisterDinosaurJob.Unlock()
-	return mock.RegisterDinosaurJobFunc(dinosaurRequest)
+	return mock.RegisterDinosaurJobFunc(ctx, dinosaurRequest)
 }
 
 // RegisterDinosaurJobCalls gets all the calls that were made to RegisterDinosaurJob.
@@ -953,9 +957,11 @@ func (mock *DinosaurServiceMock) RegisterDinosaurJob(ctx context.Context, dinosa
 //
 //	len(mockedDinosaurService.RegisterDinosaurJobCalls())
 func (mock *DinosaurServiceMock) RegisterDinosaurJobCalls() []struct {
+	Ctx             context.Context
 	DinosaurRequest *dbapi.CentralRequest
 } {
 	var calls []struct {
+		Ctx             context.Context
 		DinosaurRequest *dbapi.CentralRequest
 	}
 	mock.lockRegisterDinosaurJob.RLock()

--- a/internal/dinosaur/pkg/services/quota.go
+++ b/internal/dinosaur/pkg/services/quota.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/dinosaurs/types"
 	"github.com/stackrox/acs-fleet-manager/pkg/errors"
@@ -13,7 +14,7 @@ type QuotaService interface {
 	// CheckIfQuotaIsDefinedForInstanceType checks if quota is defined for the given instance type
 	CheckIfQuotaIsDefinedForInstanceType(dinosaur *dbapi.CentralRequest, instanceType types.DinosaurInstanceType) (bool, *errors.ServiceError)
 	// ReserveQuota reserves a quota for a user and return the reservation id or an error in case of failure
-	ReserveQuota(dinosaur *dbapi.CentralRequest, instanceType types.DinosaurInstanceType) (string, *errors.ServiceError)
+	ReserveQuota(ctx context.Context, dinosaur *dbapi.CentralRequest, instanceType types.DinosaurInstanceType) (string, *errors.ServiceError)
 	// DeleteQuota deletes a reserved quota
 	DeleteQuota(subscriptionID string) *errors.ServiceError
 }

--- a/internal/dinosaur/pkg/services/quota/ams_quota_service_test.go
+++ b/internal/dinosaur/pkg/services/quota/ams_quota_service_test.go
@@ -200,7 +200,7 @@ func Test_AMSCheckQuota(t *testing.T) {
 			gomega.Expect(sq).To(gomega.Equal(tt.args.hasStandardQuota))
 			gomega.Expect(eq).To(gomega.Equal(tt.args.hasEvalQuota))
 
-			_, err = quotaService.ReserveQuota(dinosaur, tt.args.dinosaurInstanceType)
+			_, err = quotaService.ReserveQuota(nil, dinosaur, tt.args.dinosaurInstanceType)
 			gomega.Expect(err != nil).To(gomega.Equal(tt.wantErr))
 		})
 	}
@@ -656,7 +656,7 @@ func Test_AMSReserveQuota(t *testing.T) {
 				CloudAccountID: tt.args.cloudAccountID,
 				CloudProvider:  utils.IfThenElse(tt.args.cloudProviderID == "", "cloudProviderID", tt.args.cloudProviderID),
 			}
-			subID, err := quotaService.ReserveQuota(dinosaur, types.STANDARD)
+			subID, err := quotaService.ReserveQuota(nil, dinosaur, types.STANDARD)
 			gomega.Expect(subID).To(gomega.Equal(tt.want))
 			gomega.Expect(err != nil).To(gomega.Equal(tt.wantErr))
 

--- a/internal/dinosaur/pkg/services/quota/ams_quota_service_test.go
+++ b/internal/dinosaur/pkg/services/quota/ams_quota_service_test.go
@@ -1,6 +1,7 @@
 package quota
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -19,6 +20,8 @@ import (
 
 	"github.com/pkg/errors"
 )
+
+var emptyCtx = context.Background()
 
 func Test_AMSCheckQuota(t *testing.T) {
 	type fields struct {
@@ -200,7 +203,7 @@ func Test_AMSCheckQuota(t *testing.T) {
 			gomega.Expect(sq).To(gomega.Equal(tt.args.hasStandardQuota))
 			gomega.Expect(eq).To(gomega.Equal(tt.args.hasEvalQuota))
 
-			_, err = quotaService.ReserveQuota(nil, dinosaur, tt.args.dinosaurInstanceType)
+			_, err = quotaService.ReserveQuota(emptyCtx, dinosaur, tt.args.dinosaurInstanceType)
 			gomega.Expect(err != nil).To(gomega.Equal(tt.wantErr))
 		})
 	}
@@ -656,7 +659,7 @@ func Test_AMSReserveQuota(t *testing.T) {
 				CloudAccountID: tt.args.cloudAccountID,
 				CloudProvider:  utils.IfThenElse(tt.args.cloudProviderID == "", "cloudProviderID", tt.args.cloudProviderID),
 			}
-			subID, err := quotaService.ReserveQuota(nil, dinosaur, types.STANDARD)
+			subID, err := quotaService.ReserveQuota(emptyCtx, dinosaur, types.STANDARD)
 			gomega.Expect(subID).To(gomega.Equal(tt.want))
 			gomega.Expect(err != nil).To(gomega.Equal(tt.wantErr))
 

--- a/internal/dinosaur/pkg/services/quota/quota_management_list_service.go
+++ b/internal/dinosaur/pkg/services/quota/quota_management_list_service.go
@@ -1,6 +1,7 @@
 package quota
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/stackrox/acs-fleet-manager/pkg/quotamanagement"
@@ -41,7 +42,7 @@ func (q QuotaManagementListService) CheckIfQuotaIsDefinedForInstanceType(dinosau
 }
 
 // ReserveQuota ...
-func (q QuotaManagementListService) ReserveQuota(dinosaur *dbapi.CentralRequest, instanceType types.DinosaurInstanceType) (string, *errors.ServiceError) {
+func (q QuotaManagementListService) ReserveQuota(ctx context.Context, dinosaur *dbapi.CentralRequest, instanceType types.DinosaurInstanceType) (string, *errors.ServiceError) {
 	if !q.quotaManagementList.EnableInstanceLimitControl {
 		return "", nil
 	}

--- a/internal/dinosaur/pkg/services/quota/quota_management_list_service.go
+++ b/internal/dinosaur/pkg/services/quota/quota_management_list_service.go
@@ -42,7 +42,7 @@ func (q QuotaManagementListService) CheckIfQuotaIsDefinedForInstanceType(dinosau
 }
 
 // ReserveQuota ...
-func (q QuotaManagementListService) ReserveQuota(ctx context.Context, dinosaur *dbapi.CentralRequest, instanceType types.DinosaurInstanceType) (string, *errors.ServiceError) {
+func (q QuotaManagementListService) ReserveQuota(_ context.Context, dinosaur *dbapi.CentralRequest, instanceType types.DinosaurInstanceType) (string, *errors.ServiceError) {
 	if !q.quotaManagementList.EnableInstanceLimitControl {
 		return "", nil
 	}

--- a/internal/dinosaur/pkg/services/quota/quota_management_list_service_test.go
+++ b/internal/dinosaur/pkg/services/quota/quota_management_list_service_test.go
@@ -370,7 +370,7 @@ func Test_QuotaManagementListReserveQuota(t *testing.T) {
 				Owner:          "username",
 				OrganisationID: "org-id",
 			}
-			_, err := quotaService.ReserveQuota(dinosaur, tt.args.instanceType)
+			_, err := quotaService.ReserveQuota(nil, dinosaur, tt.args.instanceType)
 			gomega.Expect(tt.wantErr).To(gomega.Equal(err))
 		})
 	}

--- a/internal/dinosaur/pkg/services/quota/quota_management_list_service_test.go
+++ b/internal/dinosaur/pkg/services/quota/quota_management_list_service_test.go
@@ -1,6 +1,7 @@
 package quota
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -370,7 +371,7 @@ func Test_QuotaManagementListReserveQuota(t *testing.T) {
 				Owner:          "username",
 				OrganisationID: "org-id",
 			}
-			_, err := quotaService.ReserveQuota(nil, dinosaur, tt.args.instanceType)
+			_, err := quotaService.ReserveQuota(context.Background(), dinosaur, tt.args.instanceType)
 			gomega.Expect(tt.wantErr).To(gomega.Equal(err))
 		})
 	}

--- a/internal/dinosaur/pkg/services/quotaservice_moq.go
+++ b/internal/dinosaur/pkg/services/quotaservice_moq.go
@@ -27,7 +27,7 @@ var _ QuotaService = &QuotaServiceMock{}
 //			DeleteQuotaFunc: func(subscriptionID string) *serviceError.ServiceError {
 //				panic("mock out the DeleteQuota method")
 //			},
-//			ReserveQuotaFunc: func(dinosaur *dbapi.CentralRequest, instanceType types.DinosaurInstanceType) (string, *serviceError.ServiceError) {
+//			ReserveQuotaFunc: func(ctx context.Context, dinosaur *dbapi.CentralRequest, instanceType types.DinosaurInstanceType) (string, *serviceError.ServiceError) {
 //				panic("mock out the ReserveQuota method")
 //			},
 //		}
@@ -44,7 +44,7 @@ type QuotaServiceMock struct {
 	DeleteQuotaFunc func(subscriptionID string) *serviceError.ServiceError
 
 	// ReserveQuotaFunc mocks the ReserveQuota method.
-	ReserveQuotaFunc func(dinosaur *dbapi.CentralRequest, instanceType types.DinosaurInstanceType) (string, *serviceError.ServiceError)
+	ReserveQuotaFunc func(ctx context.Context, dinosaur *dbapi.CentralRequest, instanceType types.DinosaurInstanceType) (string, *serviceError.ServiceError)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -62,6 +62,8 @@ type QuotaServiceMock struct {
 		}
 		// ReserveQuota holds details about calls to the ReserveQuota method.
 		ReserveQuota []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
 			// Dinosaur is the dinosaur argument value.
 			Dinosaur *dbapi.CentralRequest
 			// InstanceType is the instanceType argument value.
@@ -147,16 +149,18 @@ func (mock *QuotaServiceMock) ReserveQuota(ctx context.Context, dinosaur *dbapi.
 		panic("QuotaServiceMock.ReserveQuotaFunc: method is nil but QuotaService.ReserveQuota was just called")
 	}
 	callInfo := struct {
+		Ctx          context.Context
 		Dinosaur     *dbapi.CentralRequest
 		InstanceType types.DinosaurInstanceType
 	}{
+		Ctx:          ctx,
 		Dinosaur:     dinosaur,
 		InstanceType: instanceType,
 	}
 	mock.lockReserveQuota.Lock()
 	mock.calls.ReserveQuota = append(mock.calls.ReserveQuota, callInfo)
 	mock.lockReserveQuota.Unlock()
-	return mock.ReserveQuotaFunc(dinosaur, instanceType)
+	return mock.ReserveQuotaFunc(ctx, dinosaur, instanceType)
 }
 
 // ReserveQuotaCalls gets all the calls that were made to ReserveQuota.
@@ -164,10 +168,12 @@ func (mock *QuotaServiceMock) ReserveQuota(ctx context.Context, dinosaur *dbapi.
 //
 //	len(mockedQuotaService.ReserveQuotaCalls())
 func (mock *QuotaServiceMock) ReserveQuotaCalls() []struct {
+	Ctx          context.Context
 	Dinosaur     *dbapi.CentralRequest
 	InstanceType types.DinosaurInstanceType
 } {
 	var calls []struct {
+		Ctx          context.Context
 		Dinosaur     *dbapi.CentralRequest
 		InstanceType types.DinosaurInstanceType
 	}

--- a/internal/dinosaur/pkg/services/quotaservice_moq.go
+++ b/internal/dinosaur/pkg/services/quotaservice_moq.go
@@ -4,6 +4,7 @@
 package services
 
 import (
+	"context"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/dinosaurs/types"
 	serviceError "github.com/stackrox/acs-fleet-manager/pkg/errors"
@@ -141,7 +142,7 @@ func (mock *QuotaServiceMock) DeleteQuotaCalls() []struct {
 }
 
 // ReserveQuota calls ReserveQuotaFunc.
-func (mock *QuotaServiceMock) ReserveQuota(dinosaur *dbapi.CentralRequest, instanceType types.DinosaurInstanceType) (string, *serviceError.ServiceError) {
+func (mock *QuotaServiceMock) ReserveQuota(ctx context.Context, dinosaur *dbapi.CentralRequest, instanceType types.DinosaurInstanceType) (string, *serviceError.ServiceError) {
 	if mock.ReserveQuotaFunc == nil {
 		panic("QuotaServiceMock.ReserveQuotaFunc: method is nil but QuotaService.ReserveQuota was just called")
 	}

--- a/pkg/client/ocm/client_moq.go
+++ b/pkg/client/ocm/client_moq.go
@@ -424,6 +424,11 @@ type ClientMock struct {
 	lockUpdateSyncSet                 sync.RWMutex
 }
 
+func (mock *ClientMock) GetCurrentAccount(overrideAuthToken string) (*amsv1.Account, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 // ClusterAuthorization calls ClusterAuthorizationFunc.
 func (mock *ClientMock) ClusterAuthorization(cb *amsv1.ClusterAuthorizationRequest) (*amsv1.ClusterAuthorizationResponse, error) {
 	if mock.ClusterAuthorizationFunc == nil {

--- a/pkg/client/ocm/client_moq.go
+++ b/pkg/client/ocm/client_moq.go
@@ -71,6 +71,9 @@ var _ Client = &ClientMock{}
 //			GetClusterStatusFunc: func(id string) (*clustersmgmtv1.ClusterStatus, error) {
 //				panic("mock out the GetClusterStatus method")
 //			},
+//			GetCurrentAccountFunc: func(userToken string) (*amsv1.Account, error) {
+//				panic("mock out the GetCurrentAccount method")
+//			},
 //			GetCustomerCloudAccountsFunc: func(organizationID string, quotaIDs []string) ([]*amsv1.CloudAccount, error) {
 //				panic("mock out the GetCustomerCloudAccounts method")
 //			},
@@ -167,6 +170,9 @@ type ClientMock struct {
 
 	// GetClusterStatusFunc mocks the GetClusterStatus method.
 	GetClusterStatusFunc func(id string) (*clustersmgmtv1.ClusterStatus, error)
+
+	// GetCurrentAccountFunc mocks the GetCurrentAccount method.
+	GetCurrentAccountFunc func(userToken string) (*amsv1.Account, error)
 
 	// GetCustomerCloudAccountsFunc mocks the GetCustomerCloudAccounts method.
 	GetCustomerCloudAccountsFunc func(organizationID string, quotaIDs []string) ([]*amsv1.CloudAccount, error)
@@ -304,6 +310,11 @@ type ClientMock struct {
 			// ID is the id argument value.
 			ID string
 		}
+		// GetCurrentAccount holds details about calls to the GetCurrentAccount method.
+		GetCurrentAccount []struct {
+			// UserToken is the userToken argument value.
+			UserToken string
+		}
 		// GetCustomerCloudAccounts holds details about calls to the GetCustomerCloudAccounts method.
 		GetCustomerCloudAccounts []struct {
 			// OrganizationID is the organizationID argument value.
@@ -409,6 +420,7 @@ type ClientMock struct {
 	lockGetClusterDNS                 sync.RWMutex
 	lockGetClusterIngresses           sync.RWMutex
 	lockGetClusterStatus              sync.RWMutex
+	lockGetCurrentAccount             sync.RWMutex
 	lockGetCustomerCloudAccounts      sync.RWMutex
 	lockGetExistingClusterMetrics     sync.RWMutex
 	lockGetIdentityProviderList       sync.RWMutex
@@ -422,11 +434,6 @@ type ClientMock struct {
 	lockSetComputeNodes               sync.RWMutex
 	lockUpdateAddonParameters         sync.RWMutex
 	lockUpdateSyncSet                 sync.RWMutex
-}
-
-func (mock *ClientMock) GetCurrentAccount(overrideAuthToken string) (*amsv1.Account, error) {
-	//TODO implement me
-	panic("implement me")
 }
 
 // ClusterAuthorization calls ClusterAuthorizationFunc.
@@ -988,6 +995,38 @@ func (mock *ClientMock) GetClusterStatusCalls() []struct {
 	mock.lockGetClusterStatus.RLock()
 	calls = mock.calls.GetClusterStatus
 	mock.lockGetClusterStatus.RUnlock()
+	return calls
+}
+
+// GetCurrentAccount calls GetCurrentAccountFunc.
+func (mock *ClientMock) GetCurrentAccount(userToken string) (*amsv1.Account, error) {
+	if mock.GetCurrentAccountFunc == nil {
+		panic("ClientMock.GetCurrentAccountFunc: method is nil but Client.GetCurrentAccount was just called")
+	}
+	callInfo := struct {
+		UserToken string
+	}{
+		UserToken: userToken,
+	}
+	mock.lockGetCurrentAccount.Lock()
+	mock.calls.GetCurrentAccount = append(mock.calls.GetCurrentAccount, callInfo)
+	mock.lockGetCurrentAccount.Unlock()
+	return mock.GetCurrentAccountFunc(userToken)
+}
+
+// GetCurrentAccountCalls gets all the calls that were made to GetCurrentAccount.
+// Check the length with:
+//
+//	len(mockedClient.GetCurrentAccountCalls())
+func (mock *ClientMock) GetCurrentAccountCalls() []struct {
+	UserToken string
+} {
+	var calls []struct {
+		UserToken string
+	}
+	mock.lockGetCurrentAccount.RLock()
+	calls = mock.calls.GetCurrentAccount
+	mock.lockGetCurrentAccount.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
## Description
This PR adds a call to `/current_account` [API endpoint](https://api.openshift.com/?urls.primaryName=Accounts%20management%20service#/default/get_api_accounts_mgmt_v1_current_account).

The reason behind this hack is that when an organization is just created, it might take up to 30 minutes for AMS to populate quota data—calling `/current_account` forces AMS to populate this data earlier.

Since this is optimization and not a requirement to reserve quota, the errors are logged and not returned to the customer.

It is possible to optimize the performance by calling `/current_account` only once per user or organization. However, I would suggest to do it in a follow-up.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

1. `make deploy/bootstrap`
2. Specify `CM_SERVICE_CLIENT_ID_DEFAULT` and `OCM_SERVICE_CLIENT_SECRET_DEFAULT`
3. Modify `fleet_manager_command` in https://github.com/stackrox/acs-fleet-manager/blob/35c22dffb47f1ed57ad968bc932c594e53ba5e26/dev/env/scripts/lib.sh to
```
local fleet_manager_command="/usr/local/bin/fleet-manager serve --force-leader --api-server-bindaddress=0.0.0.0:8000 --health-check-server-bindaddress=0.0.0.0:8083 --kubeconfig=/secrets/kubeconfig --enable-central-external-certificate=$ENABLE_CENTRAL_EXTERNAL_CERTIFICATE --central-domain-name='$CENTRAL_DOMAIN_NAME' --gitops-config-path='/gitops-config/config.yaml' --quota-type=ams --ams-base-url=https://api.openshift.com --enable-ocm-mock=false"
```
4. POST new central:
```
{"name":"test-on-cluster","cloud_provider":"standalone","region":"standalone","multi_az":true}
```
and get `Cloud account ID is not set up properly` error. 
5. Look into the logs and see there's no errors related to calling `/current_account`
