### PR TITLE
ROX-16664: create central encryption secret

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -123,6 +123,18 @@ var _ = Describe("Central", func() {
 			Expect(tenantLabelFound).To(BeTrue())
 		})
 
+		It("should generate a central-encryption-key secret", func() {
+			if createdCentral == nil {
+				Fail("central not created")
+			}
+
+			Eventually(func() error {
+				keySecret := &corev1.Secret{}
+				return k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: "central-encryption-key", Namespace: namespaceName}, keySecret)
+			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Succeed())
+
+		})
+
 		It("should create central in its namespace on a managed cluster", func() {
 			if createdCentral == nil {
 				Fail("central not created")

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -78,6 +78,8 @@ const (
 	centralDbOverrideConfigMap = "central-db-override"
 	centralDeletePollInterval  = 5 * time.Second
 
+	centralEncryptionKeySecretName = "central-encryption-key" // pragma: allowlist secret
+
 	sensibleDeclarativeConfigSecretName = "cloud-service-sensible-declarative-configs" // pragma: allowlist secret
 	manualDeclarativeConfigSecretName   = "cloud-service-manual-declarative-configs"   // pragma: allowlist secret
 
@@ -102,21 +104,22 @@ type CentralReconcilerOptions struct {
 // CentralReconciler is a reconciler tied to a one Central instance. It installs, updates and deletes Central instances
 // in its Reconcile function.
 type CentralReconciler struct {
-	client             ctrlClient.Client
-	fleetmanagerClient *fleetmanager.Client
-	central            private.ManagedCentral
-	status             *int32
-	lastCentralHash    [16]byte
-	useRoutes          bool
-	Resources          bool
-	routeService       *k8s.RouteService
-	secretBackup       *k8s.SecretBackup
-	secretCipher       cipher.Cipher
-	egressProxyImage   string
-	telemetry          config.Telemetry
-	clusterName        string
-	environment        string
-	auditLogging       config.AuditLogging
+	client                 ctrlClient.Client
+	fleetmanagerClient     *fleetmanager.Client
+	central                private.ManagedCentral
+	status                 *int32
+	lastCentralHash        [16]byte
+	useRoutes              bool
+	Resources              bool
+	routeService           *k8s.RouteService
+	secretBackup           *k8s.SecretBackup
+	secretCipher           cipher.Cipher
+	egressProxyImage       string
+	telemetry              config.Telemetry
+	clusterName            string
+	environment            string
+	auditLogging           config.AuditLogging
+	encryptionKeyGenerator cipher.KeyGenerator
 
 	managedDBEnabled            bool
 	managedDBProvisioningClient cloudprovider.DBClient
@@ -175,6 +178,11 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	}
 
 	err = r.restoreCentralSecrets(ctx, remoteCentral)
+	if err != nil {
+		return nil, err
+	}
+
+	err = r.ensureEncryptionKeySecretExists(ctx, remoteCentralNamespace)
 	if err != nil {
 		return nil, err
 	}
@@ -1177,6 +1185,27 @@ func (r *CentralReconciler) ensureNamespaceDeleted(ctx context.Context, name str
 	return false, nil
 }
 
+func (r *CentralReconciler) ensureEncryptionKeySecretExists(ctx context.Context, remoteCentralNamespace string) error {
+	return r.ensureSecretExists(ctx, remoteCentralNamespace, centralEncryptionKeySecretName, r.populateEncryptionKeySecret)
+}
+
+func (r *CentralReconciler) populateEncryptionKeySecret(secret *corev1.Secret) error {
+	if secret.Data != nil {
+		if _, ok := secret.Data["encryptionKey"]; ok {
+			// secret already populated with encryption key skip operation
+			return nil
+		}
+	}
+
+	encryptionKey, err := r.encryptionKeyGenerator.Generate()
+	if err != nil {
+		return fmt.Errorf("generating encryption key: %w", err)
+	}
+
+	secret.Data = map[string][]byte{"encryptionKey": encryptionKey}
+	return nil
+}
+
 func (r *CentralReconciler) getCentralDBConnectionString(ctx context.Context, remoteCentral *private.ManagedCentral) (string, error) {
 	centralDBUserExists, err := r.centralDBUserExists(ctx, remoteCentral.Metadata.Namespace)
 	if err != nil {
@@ -1668,24 +1697,25 @@ func (r *CentralReconciler) ensureSecretExists(
 // NewCentralReconciler ...
 func NewCentralReconciler(k8sClient ctrlClient.Client, fleetmanagerClient *fleetmanager.Client, central private.ManagedCentral,
 	managedDBProvisioningClient cloudprovider.DBClient, managedDBInitFunc postgres.CentralDBInitFunc,
-	secretCipher cipher.Cipher,
+	secretCipher cipher.Cipher, encryptionKeyGenerator cipher.KeyGenerator,
 	opts CentralReconcilerOptions,
 ) *CentralReconciler {
 	return &CentralReconciler{
-		client:             k8sClient,
-		fleetmanagerClient: fleetmanagerClient,
-		central:            central,
-		status:             pointer.Int32(FreeStatus),
-		useRoutes:          opts.UseRoutes,
-		wantsAuthProvider:  opts.WantsAuthProvider,
-		routeService:       k8s.NewRouteService(k8sClient),
-		secretBackup:       k8s.NewSecretBackup(k8sClient),
-		secretCipher:       secretCipher, // pragma: allowlist secret
-		egressProxyImage:   opts.EgressProxyImage,
-		telemetry:          opts.Telemetry,
-		clusterName:        opts.ClusterName,
-		environment:        opts.Environment,
-		auditLogging:       opts.AuditLogging,
+		client:                 k8sClient,
+		fleetmanagerClient:     fleetmanagerClient,
+		central:                central,
+		status:                 pointer.Int32(FreeStatus),
+		useRoutes:              opts.UseRoutes,
+		wantsAuthProvider:      opts.WantsAuthProvider,
+		routeService:           k8s.NewRouteService(k8sClient),
+		secretBackup:           k8s.NewSecretBackup(k8sClient),
+		secretCipher:           secretCipher, // pragma: allowlist secret
+		egressProxyImage:       opts.EgressProxyImage,
+		telemetry:              opts.Telemetry,
+		clusterName:            opts.ClusterName,
+		environment:            opts.Environment,
+		auditLogging:           opts.AuditLogging,
+		encryptionKeyGenerator: encryptionKeyGenerator,
 
 		managedDBEnabled:            opts.ManagedDBEnabled,
 		managedDBProvisioningClient: managedDBProvisioningClient,

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -1202,7 +1202,8 @@ func (r *CentralReconciler) populateEncryptionKeySecret(secret *corev1.Secret) e
 		return fmt.Errorf("generating encryption key: %w", err)
 	}
 
-	secret.Data = map[string][]byte{"encryptionKey": encryptionKey}
+	b64Key := base64.StdEncoding.EncodeToString(encryptionKey)
+	secret.Data = map[string][]byte{"encryptionKey": []byte(b64Key)}
 	return nil
 }
 

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -859,10 +859,10 @@ func TestCentralEncryptionKeyIsGenerated(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, centralEncryptionSecret.Data, "encryptionKey")
 
-	decodedKeyLen := base64.StdEncoding.DecodedLen(len(centralEncryptionSecret.Data["encryptionKey"]))
-	expectedKeyLen := 32
-	require.Equal(t, expectedKeyLen, decodedKeyLen)
-
+	encKey, err := base64.StdEncoding.DecodeString(string(centralEncryptionSecret.Data["encryptionKey"]))
+	require.NoError(t, err)
+	expectedKeyLen := len(encKey)
+	require.Equal(t, expectedKeyLen, len(encKey))
 }
 
 func TestChartResourcesAreAddedAndUpdated(t *testing.T) {

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -144,6 +144,7 @@ func getClientTrackerAndReconciler(
 		managedDBClient,
 		centralDBInitFunc,
 		createBase64Cipher(t),
+		cipher.AES256KeyGenerator{},
 		reconcilerOptions,
 	)
 	return fakeClient, tracker, reconciler
@@ -345,10 +346,11 @@ func TestReconcileLastHashNotUpdatedOnError(t *testing.T) {
 	}, centralDeploymentObject()).Build()
 
 	r := CentralReconciler{
-		status:         pointer.Int32(0),
-		client:         fakeClient,
-		central:        private.ManagedCentral{},
-		resourcesChart: resourcesChart,
+		status:                 pointer.Int32(0),
+		client:                 fakeClient,
+		central:                private.ManagedCentral{},
+		resourcesChart:         resourcesChart,
+		encryptionKeyGenerator: cipher.AES256KeyGenerator{},
 	}
 
 	_, err := r.Reconcile(context.TODO(), simpleManagedCentral)

--- a/fleetshard/pkg/cipher/cipher.go
+++ b/fleetshard/pkg/cipher/cipher.go
@@ -4,6 +4,7 @@ package cipher
 import (
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/config"
 )
 
@@ -28,4 +29,19 @@ func NewCipher(config *config.Config) (Cipher, error) {
 	}
 
 	return nil, fmt.Errorf("no Cipher implementation for SecretEncryption.Type: %s", encryptionType)
+}
+
+// NewKeyGenerator return a new object implementing KeyGenerator based on the type defined in config
+func NewKeyGenerator(config *config.Config) (KeyGenerator, error) {
+	encryptionType := config.SecretEncryption.Type
+
+	if encryptionType == "local" {
+		return AES256KeyGenerator{}, nil
+	}
+
+	if encryptionType == "kms" {
+		return NewKMSDataKeyGenerator(config.SecretEncryption.KeyID, kms.DataKeySpecAes256)
+	}
+
+	return nil, fmt.Errorf("no KeyGenerator implementation for SecretEncryption.Type: %s", encryptionType)
 }


### PR DESCRIPTION
## Description
Depends on #1285. This PR adds logic to the central reconciler in fleetshard-sync to generate a data encryption key secret for each tenant.

The KeyGenerator used is generated with the AES256KeyGenerator or the KMSKeyGenerator depending on fleetshard-sync configuration. (default: AES256KeyGenerator)

After central implements the required features this data encryption key will be used to encrypt notifier secrets in central tenant databases.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [x] Add secret to app-interface Vault or Secrets Manager if necessary
- [x] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [x] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

See #1296.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
