### PR TITLE
ROX-16664: backup central encryption key

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -265,18 +265,21 @@ var _ = Describe("Central", func() {
 				Fail("central not created")
 			}
 
-			expectedSecrets := []string{"central-tls", "central-db-password", "central-encryption-key"}
+			// We don't expect central-db-password secret here, because it will not be created in case of
+			// running with disabled managed DB
+			expectedSecrets := []string{"central-tls", "central-encryption-key"}
 			secretsStored := []string{}
 			Eventually(func() error {
-				res, _, err := client.PrivateAPI().GetCentral(context.Background(), createdCentral.Id)
+				privateCentral, _, err := client.PrivateAPI().GetCentral(context.Background(), createdCentral.Id)
 				if err != nil {
 					return err
 				}
 
-				if len(res.Metadata.SecretsStored) != len(expectedSecrets) {
-					return fmt.Errorf("unexpected number of secrets, want: %d, got: %d", len(expectedSecrets), len(res.Metadata.SecretsStored))
+				if len(privateCentral.Metadata.SecretsStored) != len(expectedSecrets) {
+					return fmt.Errorf("unexpected number of secrets, want: %d, got: %d", len(expectedSecrets), len(privateCentral.Metadata.SecretsStored))
 				}
 
+				secretsStored = privateCentral.Metadata.SecretsStored // pragma: allowlist secret
 				return nil
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Succeed())
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -260,6 +260,29 @@ var _ = Describe("Central", func() {
 			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Succeed())
 		})
 
+		It("should backup important secrets in FM database", func() {
+			if createdCentral == nil {
+				Fail("central not created")
+			}
+
+			expectedSecrets := []string{"central-tls", "central-db-password", "central-encryption-key"}
+			secretsStored := []string{}
+			Eventually(func() error {
+				res, _, err := client.PrivateAPI().GetCentral(context.Background(), createdCentral.Id)
+				if err != nil {
+					return err
+				}
+
+				if len(res.Metadata.SecretsStored) != len(expectedSecrets) {
+					return fmt.Errorf("unexpected number of secrets, want: %d, got: %d", len(expectedSecrets), len(res.Metadata.SecretsStored))
+				}
+
+				return nil
+			}).WithTimeout(waitTimeout).WithPolling(defaultPolling).Should(Succeed())
+
+			Expect(secretsStored).Should(ContainElements(expectedSecrets))
+		})
+
 		// TODO(ROX-11368): Add test to eventually reach ready state
 		// TODO(ROX-11368): create test to check that Central and Scanner are healthy
 		// TODO(ROX-11368): Create test to check Central is correctly exposed

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -1191,7 +1191,7 @@ func (r *CentralReconciler) ensureEncryptionKeySecretExists(ctx context.Context,
 
 func (r *CentralReconciler) populateEncryptionKeySecret(secret *corev1.Secret) error {
 	if secret.Data != nil {
-		if _, ok := secret.Data["encryptionKey"]; ok {
+		if _, ok := secret.Data["encryption-key"]; ok {
 			// secret already populated with encryption key skip operation
 			return nil
 		}
@@ -1203,7 +1203,7 @@ func (r *CentralReconciler) populateEncryptionKeySecret(secret *corev1.Secret) e
 	}
 
 	b64Key := base64.StdEncoding.EncodeToString(encryptionKey)
-	secret.Data = map[string][]byte{"encryptionKey": []byte(b64Key)}
+	secret.Data = map[string][]byte{"encryption-key": []byte(b64Key)}
 	return nil
 }
 

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -880,7 +880,7 @@ func (r *CentralReconciler) collectReconciliationStatus(ctx context.Context, rem
 
 func (r *CentralReconciler) areSecretsStored(secretsStored []string) bool {
 	secretsStoredSize := len(secretsStored)
-	expectedSecrets := k8s.GetWatchedSecrets()
+	expectedSecrets := r.secretBackup.GetWatchedSecrets()
 	if secretsStoredSize != len(expectedSecrets) {
 		return false
 	}
@@ -1701,6 +1701,7 @@ func NewCentralReconciler(k8sClient ctrlClient.Client, fleetmanagerClient *fleet
 	secretCipher cipher.Cipher, encryptionKeyGenerator cipher.KeyGenerator,
 	opts CentralReconcilerOptions,
 ) *CentralReconciler {
+
 	return &CentralReconciler{
 		client:                 k8sClient,
 		fleetmanagerClient:     fleetmanagerClient,
@@ -1709,7 +1710,7 @@ func NewCentralReconciler(k8sClient ctrlClient.Client, fleetmanagerClient *fleet
 		useRoutes:              opts.UseRoutes,
 		wantsAuthProvider:      opts.WantsAuthProvider,
 		routeService:           k8s.NewRouteService(k8sClient),
-		secretBackup:           k8s.NewSecretBackup(k8sClient),
+		secretBackup:           k8s.NewSecretBackup(k8sClient, opts.ManagedDBEnabled),
 		secretCipher:           secretCipher, // pragma: allowlist secret
 		egressProxyImage:       opts.EgressProxyImage,
 		telemetry:              opts.Telemetry,

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -857,9 +857,9 @@ func TestCentralEncryptionKeyIsGenerated(t *testing.T) {
 	key := client.ObjectKey{Namespace: simpleManagedCentral.Metadata.Namespace, Name: centralEncryptionKeySecretName}
 	err = fakeClient.Get(context.TODO(), key, &centralEncryptionSecret)
 	require.NoError(t, err)
-	require.Contains(t, centralEncryptionSecret.Data, "encryptionKey")
+	require.Contains(t, centralEncryptionSecret.Data, "encryption-key")
 
-	encKey, err := base64.StdEncoding.DecodeString(string(centralEncryptionSecret.Data["encryptionKey"]))
+	encKey, err := base64.StdEncoding.DecodeString(string(centralEncryptionSecret.Data["encryption-key"]))
 	require.NoError(t, err)
 	expectedKeyLen := len(encKey)
 	require.Equal(t, expectedKeyLen, len(encKey))

--- a/fleetshard/pkg/k8s/secret.go
+++ b/fleetshard/pkg/k8s/secret.go
@@ -49,7 +49,7 @@ func (s *SecretBackup) GetWatchedSecrets() []string {
 // watched by SecretServices
 func (s *SecretBackup) CollectSecrets(ctx context.Context, namespace string) (map[string]*corev1.Secret, error) {
 	secrets := map[string]*corev1.Secret{}
-	for _, secretname := range defaultSecretsToWatch { // pragma: allowlist secret
+	for _, secretname := range s.secretsToWatch { // pragma: allowlist secret
 		secret, err := getSecret(ctx, s.client, secretname, namespace)
 		if err != nil {
 			return nil, err

--- a/fleetshard/pkg/k8s/secret.go
+++ b/fleetshard/pkg/k8s/secret.go
@@ -11,13 +11,15 @@ import (
 )
 
 const (
-	centralTLSSecretName        = "central-tls"         // pragma: allowlist secret
-	centralDBPasswordSecretName = "central-db-password" // pragma: allowlist secret
+	centralTLSSecretName           = "central-tls"            // pragma: allowlist secret
+	centralDBPasswordSecretName    = "central-db-password"    // pragma: allowlist secret
+	centralEncryptionKeySecretName = "central-encryption-key" // pragma: allowlist secret
 )
 
 var secretsToWatch = []string{
 	centralTLSSecretName,
 	centralDBPasswordSecretName,
+	centralEncryptionKeySecretName,
 }
 
 // SecretBackup is responsible for reading secrets to Backup for a tenant.

--- a/fleetshard/pkg/k8s/secret.go
+++ b/fleetshard/pkg/k8s/secret.go
@@ -16,26 +16,31 @@ const (
 	centralEncryptionKeySecretName = "central-encryption-key" // pragma: allowlist secret
 )
 
-var secretsToWatch = []string{
+var defaultSecretsToWatch = []string{
 	centralTLSSecretName,
-	centralDBPasswordSecretName,
 	centralEncryptionKeySecretName,
 }
 
 // SecretBackup is responsible for reading secrets to Backup for a tenant.
 type SecretBackup struct {
-	client ctrlClient.Client
+	client         ctrlClient.Client
+	secretsToWatch []string
 }
 
 // NewSecretBackup creates a new instance of SecretService.
-func NewSecretBackup(client ctrlClient.Client) *SecretBackup {
-	return &SecretBackup{client: client}
+func NewSecretBackup(client ctrlClient.Client, managedDB bool) *SecretBackup {
+	secretsToWatch := defaultSecretsToWatch // pragma: allowlist secret
+	if managedDB {
+		secretsToWatch = append(secretsToWatch, centralDBPasswordSecretName)
+	}
+
+	return &SecretBackup{client: client, secretsToWatch: secretsToWatch} // pragma: allowlist secret
 }
 
 // GetWatchedSecrets return a sorted list of secrets watched by this package
-func GetWatchedSecrets() []string {
-	secrets := make([]string, len(secretsToWatch))
-	copy(secrets, secretsToWatch)
+func (s *SecretBackup) GetWatchedSecrets() []string {
+	secrets := make([]string, len(s.secretsToWatch))
+	copy(secrets, s.secretsToWatch)
 	sort.Strings(secrets)
 	return secrets
 }
@@ -44,7 +49,7 @@ func GetWatchedSecrets() []string {
 // watched by SecretServices
 func (s *SecretBackup) CollectSecrets(ctx context.Context, namespace string) (map[string]*corev1.Secret, error) {
 	secrets := map[string]*corev1.Secret{}
-	for _, secretname := range secretsToWatch { // pragma: allowlist secret
+	for _, secretname := range defaultSecretsToWatch { // pragma: allowlist secret
 		secret, err := getSecret(ctx, s.client, secretname, namespace)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Description

Depends on #1285 and #1295 .

This PR add the `central-encryption-key` secret to the list of secrets that should be backed up in fleetmanagers database. It also adds an E2E test to test all expected secrets get backed up.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [x] Add secret to app-interface Vault or Secrets Manager if necessary
- [x] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [x] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

```
# Test with local FM, FS and OSD cluster in dev AWS account
# Flip the PubliclyAccessible flag in rds.go

make binary
make db/teardown db/setup db/migrate

./fleet-manager serve --enable-central-external-certificate --dataplane-cluster-config-file ./dev/config/dataplane-cluster-configuration-infractl-osd.yaml --force-leader --central-idp-client-id ""

# Start fleetshard-sync in another terminal
# Prepare environment
export CLUSTER_NAME=local_cluster                 
export MANAGED_DB_ENABLED=true
export AWS_AUTH_HELPER=aws-saml
export CREATE_AUTHPROVIDER=true

./dev/env/scripts/exec_fleetshard_sync.sh

# In another terminal
./scripts/create-central.sh

# Wait for provisioning state and fleetshard first reconciliation
# See that the key was generated and is 32 bytes 
kubectl get secrets -n rhacs-ck6p6969rus49ma6iko0 central-encryption-key -o yaml | yq .data.encryptionKey | base64 -d | base64 -d | wc -c
# Store secret for comparison later on
kubectl get secrets -n rhacs-ck6p6969rus49ma6iko0 central-encryption-key -o yaml | yq .data.encryptionKey > firstKey.txt

# Wait for ready state and creation of routes
# Check fleetshard-sync logs for status report of secrets
# Check that all "central-db-password" "central-tls" and "central-encryption-key" were reported
# search for "Secrets:map[central" to find the message

# Delete the tenant
export OCM_TOKEN=$(ocm token)
export central_id=<your-central-id>

./scripts/fmcurl "rhacs/v1/centrals/$central_id?async=true" -XDELETE -v

# Wait for full deletion, get admin tokens in the meantime
rhoas login --auth-url=https://auth.redhat.com/auth/realms/EmployeeIDP 
export OCM_TOKEN=$(rhoas authtoken)

# Restore from backup
./scripts/fmcurl "rhacs/v1/admin/centrals/$central_id/restore" -XPOST -v 

# Restore should run through successful, after restore get the restored key
```

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
