### PR TITLE
fixed restore endpoint

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -246,7 +246,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		return nil, errors.Wrapf(err, "setting central reconcilation cache")
 	}
 
-	logStatus := status
+	logStatus := *status
 	logStatus.Secrets = obscureSecrets(status.Secrets)
 	glog.Infof("Returning central status %+v", logStatus)
 

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -824,6 +824,7 @@ func (k *dinosaurService) Restore(ctx context.Context, id string) *errors.Servic
 	// use a new central request, so that unset field for columnsToReset will automatically be set to the zero value
 	// this Update only changes columns listed in columnsToReset
 	resetRequest := &dbapi.CentralRequest{}
+	resetRequest.ID = centralRequest.ID
 	resetRequest.Status = dinosaurConstants.CentralRequestStatusPreparing.String()
 	resetRequest.CreatedAt = time.Now()
 


### PR DESCRIPTION
## Description

The admin API restore endpoint is not working, because #1253 and #1277 introduced a small bug.

There are no e2e tests for the restore yet, thus those bugs were not recognized.

1. ID was not set for the resetRequest, leading to a failed Update query because the primary key was not set
2. The logged status was not copied before it is obscured because it was a pointer and not a value, leading to a wrong backup data.

This should be merged before those PRs hit `prod` environment.

To make sure it is working now I followed the manual test of restore endpoint below.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
- [x] Added test description under `Test manual`
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
~~- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~~
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
~~- [ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
~~- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
~~- [ ] Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual

```
# Test with local FM, FS and OSD cluster in dev AWS account
# Flip the PubliclyAccessible flag in rds.go

make binary
make db/teardown db/setup db/migrate

./fleet-manager serve --enable-central-external-certificate --dataplane-cluster-config-file ./dev/config/dataplane-cluster-configuration-infractl-osd.yaml --force-leader --central-idp-client-id ""

# Start fleetshard-sync in another terminal
# Prepare environment
export CLUSTER_NAME=local_cluster                 
export MANAGED_DB_ENABLED=true
export AWS_AUTH_HELPER=aws-saml
export CREATE_AUTHPROVIDER=true

./dev/env/scripts/exec_fleetshard_sync.sh

# In another terminal
./scripts/create-central.sh

# Wait for provisioning state and fleetshard first reconciliation
# See that the key was generated and is 32 bytes 
kubectl get secrets -n rhacs-ck6p6969rus49ma6iko0 central-encryption-key -o yaml | yq .data.encryptionKey | base64 -d | base64 -d | wc -c
# Store secret for comparison later on
kubectl get secrets -n rhacs-ck6p6969rus49ma6iko0 central-encryption-key -o yaml | yq .data.encryptionKey > firstKey.txt

# Wait for ready state and creation of routes
# Check fleetshard-sync logs for status report of secrets
# Check that all "central-db-password" "central-tls" and "central-encryption-key" were reported
# search for "Secrets:map[central" to find the message

# Delete the tenant
export OCM_TOKEN=$(ocm token)
export central_id=<your-central-id>

./scripts/fmcurl "rhacs/v1/centrals/$central_id?async=true" -XDELETE -v

# Wait for full deletion, get admin tokens in the meantime
rhoas login --auth-url=https://auth.redhat.com/auth/realms/EmployeeIDP 
export OCM_TOKEN=$(rhoas authtoken)

# Restore from backup
./scripts/fmcurl "rhacs/v1/admin/centrals/$central_id/restore" -XPOST -v 

# Restore should run through successful, after restore get the restored key
```

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
