### PR TITLE
Adding CODEOWNERS to semi-lock the Helm chart

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,10 @@
+# As of 2023-09-26 the Helm chart is being migrated to an Addon (Plug-n-Play Package).
+# Now that we are rolling out the Addon to our data plane clusters, the Helm chart
+# and package in the managed-tenants-bundle repository must be kept in sync.
+# To ensure this is done, we are semi-locking the helm chart directory.
+# Contact people: ebenshet@, ykovalev@, jmalsam@, mhess@
+# Contact channels: #acs-team-draco, #epic-acs-cs-addon
+# Tickets: https://issues.redhat.com/browse/ROX-11551
+#          https://issues.redhat.com/browse/ROX-17339
+# Addon code: https://gitlab.cee.redhat.com/service/managed-tenants-bundles/-/tree/main/addons/acs-fleetshard
+/dp-terraform/helm/ ebenshet@redhat.com ykovalev@redhat.com jmalsam@redhat.com mhess@redhat.com


### PR DESCRIPTION
## Description
Context: We are transitioning from Helm chart to Addon. Until the Helm chart is deprecated and deleted, we need to keep them in sync. This will ensure all changes are at least reviewed by those responsible for the transition to the Addon. It does *not* mean changes are locked; it just means the Addon needs to be updated as well.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

https://issues.redhat.com/browse/ROX-11551
https://issues.redhat.com/browse/ROX-17339
