### PR TITLE
ROX-19811: Set label selector to dogfooding secured cluster CR

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-cr.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-cr.yaml
@@ -4,6 +4,9 @@ metadata:
   name: stackrox-secured-cluster-services
   namespace: {{ include "secured-cluster.namespace" . }}
   labels:
+    # Only one ACS Operator should reconcile a single CR instance.
+    # Label selector mechanism helps to specify which ACS Operator should reconcile the instance.
+    # The dogfooding instance has to be reconciled only by operator with `rhacs.redhat.com/selector=dogfooding` label selector.
     rhacs.redhat.com/selector: dogfooding
 spec:
   {{- if .Values.pullSecret }}

--- a/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-cr.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-cr.yaml
@@ -3,6 +3,8 @@ kind: SecuredCluster
 metadata:
   name: stackrox-secured-cluster-services
   namespace: {{ include "secured-cluster.namespace" . }}
+  labels:
+    rhacs.redhat.com/selector: dogfooding
 spec:
   {{- if .Values.pullSecret }}
   imagePullSecrets:


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Set label selector value to Dogfooding secured cluster CR. It's necessary to specify which operator should reconcile the instance

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
~~- [ ] Added test description under `Test manual`~~
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
~~- [ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
~~- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
~~- [ ] Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual

N/A
