### PR TITLE
ROX-20053: Set controller-runtime logger

### DIFF
--- a/fleetshard/main.go
+++ b/fleetshard/main.go
@@ -3,8 +3,10 @@ package main
 
 import (
 	"flag"
+	"github.com/stackrox/acs-fleet-manager/pkg/logger"
 	"os"
 	"os/signal"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/golang/glog"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/config"
@@ -42,6 +44,7 @@ func main() {
 
 	glog.Info("Creating k8s client...")
 	k8sClient := k8s.CreateClientOrDie()
+	ctrl.SetLogger(logger.NewKubeAPILogger())
 	glog.Info("Creating runtime...")
 	runtime, err := runtime.NewRuntime(config, k8sClient)
 	if err != nil {

--- a/fleetshard/main.go
+++ b/fleetshard/main.go
@@ -3,22 +3,22 @@ package main
 
 import (
 	"flag"
-	"github.com/stackrox/acs-fleet-manager/pkg/logger"
 	"os"
 	"os/signal"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/golang/glog"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/config"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/fleetshardmetrics"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/runtime"
+	"github.com/stackrox/acs-fleet-manager/pkg/logger"
 	"golang.org/x/sys/unix"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 func main() {
 	// This is needed to make `glog` believe that the flags have already been parsed, otherwise
-	// every log messages is prefixed by an error message stating the the flags haven't been
+	// every log messages is prefixed by an error message stating the flags haven't been
 	// parsed.
 	_ = flag.CommandLine.Parse([]string{})
 
@@ -78,5 +78,5 @@ func main() {
 	}
 
 	glog.Infof("Caught %s signal", sig)
-	glog.Info("fleetshard application has been stopped")
+	glog.Info("Fleetshard-sync application has been stopped")
 }

--- a/pkg/logger/kubeapi_logger.go
+++ b/pkg/logger/kubeapi_logger.go
@@ -1,3 +1,8 @@
+// Kube controller-runtime client uses structured logr.Logger under the hood.
+// ACSCS services use glog unstructured logging.
+// This file contains a wrapper which helps to send structured logr.Logger logs to glog logSink.
+// This wrapper can be removed once ACSCS service move to structured logging instead of glog
+
 package logger
 
 import (

--- a/pkg/logger/kubeapi_logger.go
+++ b/pkg/logger/kubeapi_logger.go
@@ -1,0 +1,33 @@
+package logger
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	"github.com/golang/glog"
+	"strings"
+)
+
+const msgKeyPattern = "msg\"="
+
+// NewKubeAPILogger creates a new logr.Logger instance which uses a glog.Warning as log message sink.
+// This logger should be passed to controller-runtime client. The client will use it to print log messages.
+func NewKubeAPILogger() logr.Logger {
+	return funcr.New(func(prefix, args string) {
+		logMsg := sanitizeLog(args)
+		if prefix != "" {
+			glog.Warningf("%s: %s\n", prefix, logMsg)
+		} else {
+			glog.Warningln(logMsg)
+		}
+	}, funcr.Options{})
+}
+
+// sanitizeLog removes redundant builtin logr.Logger log keys from the log message.
+// Only `msg` value is worth to log eventually
+func sanitizeLog(log string) string {
+	at := strings.Index(log, msgKeyPattern)
+	if at > 0 {
+		return log[at+len(msgKeyPattern):]
+	}
+	return log
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

`controller-runtime` client invokes  an instance of structured logr.Logger if there is something worth to log. If `logr.logger` instance is not provided then it fails with `[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.` error. This PR adds a `logr.Logger` instance to `controller-runtime` client.
Fleetshard-sync doesn't use structured logging and `logr.Logger` is a structured logger. So a small wrapper is introduced to use glog as log sink in `logr.Logger` instance

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
- [x] Added test description under `Test manual`
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
~~- [ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
~~- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
~~- [ ] Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual

```
scripts/install_operator_canary.sh
....
# Create an ACS instance and check the fleetshard-sync logs
...
I1009 16:50:41.953866       1 reconciler.go:726] Creating Central rhacs-cki2u17akssg01vgkb0g/testrun
W1009 16:50:42.020574       1 kubeapi_logger.go:18] KubeAPIWarningLogger: "unknown field \"spec.central.declarativeConfiguration\""
W1009 16:50:42.020647       1 kubeapi_logger.go:18] KubeAPIWarningLogger: "unknown field \"spec.central.telemetry\""
...
```
