### PR TITLE
dev scripts: Add delay before patching ServiceAccounts to include Image Pull Secrets

### DIFF
--- a/dev/env/scripts/install_operator.sh
+++ b/dev/env/scripts/install_operator.sh
@@ -74,10 +74,9 @@ if [[ "$OPERATOR_SOURCE" == "quay" ]]; then
 
     # Apparently we potentially have to wait longer than the default of 60s sometimes...
     wait_for_resource_to_appear "$STACKROX_OPERATOR_NAMESPACE" "serviceaccount" "rhacs-operator-controller-manager" 180
+    sleep 10 # Wait for ServiceAccount created by OLM to settle, otherwise the patching below might have no effect.
     inject_ips "$STACKROX_OPERATOR_NAMESPACE" "rhacs-operator-controller-manager" "quay-ips"
-
-    # Wait for rhacs-operator pods to be created. Possibly the imagePullSecrets were not picked up yet, which is why we respawn them:
-    sleep 2
+    # Possibly the imagePullSecrets were not picked up yet, which is why we respawn them:
     $KUBECTL -n "$STACKROX_OPERATOR_NAMESPACE" delete pod -l app=rhacs-operator
 elif [[ "$OPERATOR_SOURCE" == "marketplace" ]]; then
     apply "${MANIFESTS_DIR}"/rhacs-operator/marketplace/*.yaml


### PR DESCRIPTION
## Description

While debugging an (unrelated, it seems) issue about image pull secrets not being properly propagated within the e2e test suite, I stumbled upon this issue here.

The PR seems weird, I agree, but what I was able to observe (reproducible) is the following: when the patching of the Service Account happens immediately after creation of the Service Account, the patching won't be effective. I believe this is due to OLM (creating this Service Account, I believe) updating this Service Account shortly after creation and hence overwriting what the patching tried to achieve. I was still able to reproduce the issue of undoing the patching with a 5s delay, but not with a 10s delay. :-/ I did not dig deeper into OLM to figure out exactly what is going on and what is the logic here, since this did not have a priority for me right now.

## Test manual

* Prepare environment for running e2e test suite.
* Execute `bootstrap.sh` script and verify that the ServiceAccount points to Quay image pull secrets.
