### PR TITLE
ROX-13622: dev env: Update Ginkgo CLI invocation to not use deprecated option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,7 @@ test/e2e: $(GINKGO_BIN)
 		--race --trace \
 		--json-report=e2e-report.json \
 		--timeout=$(TEST_TIMEOUT) \
-		--slow-spec-threshold=5m \
+		--poll-progress-after=5m \
 		 ./e2e/...
 .PHONY: test/e2e
 


### PR DESCRIPTION
## Description

Ginkgo is currently invoked with the `--slow-spec-threshold` parameter. This parameter is deprecated nowadays and can be replaced with `--poll-progress-after`. See https://issues.redhat.com/browse/ROX-13622.

## Test manual

* Setup e2e test env
* execute `.openshift-ci/tests/e2e.sh`
