### PR TITLE
fix ForceReconcile, add unit and e2e tests

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -291,7 +291,7 @@ var _ = Describe("Central", func() {
 				Fail("central not created")
 			}
 
-			_, _, err := client.AdminAPI().UpdateCentralById(
+			_, _, err := adminAPI.UpdateCentralById(
 				context.Background(),
 				createdCentral.Id,
 				private.CentralUpdateRequest{ForceReconcile: "true"})

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -286,6 +286,22 @@ var _ = Describe("Central", func() {
 			Expect(secretsStored).Should(ContainElements(expectedSecrets))
 		})
 
+		It("should set ForceReconcile through admin API", func() {
+			if createdCentral == nil {
+				Fail("central not created")
+			}
+
+			_, _, err := client.AdminAPI().UpdateCentralById(
+				context.Background(),
+				createdCentral.Id,
+				private.CentralUpdateRequest{ForceReconcile: "true"})
+
+			Expect(err).To(BeNil())
+
+			privateCentral, _, err := client.PrivateAPI().GetCentral(context.Background(), createdCentral.Id)
+			Expect(err).To(BeNil())
+			Expect(privateCentral.ForceReconcile).To(Equal("true"))
+		})
 		// TODO(ROX-11368): Add test to eventually reach ready state
 		// TODO(ROX-11368): create test to check that Central and Scanner are healthy
 		// TODO(ROX-11368): Create test to check Central is correctly exposed

--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -288,12 +288,7 @@ func updateCentralRequest(request *dbapi.CentralRequest, strategicPatch []byte) 
 	if err != nil {
 		return fmt.Errorf("unmarshalling strategic merge patch: %w", err)
 	}
-	// only keep central and scanner keys
-	for k := range patchMap {
-		if k != "central" && k != "scanner" {
-			delete(patchMap, k)
-		}
-	}
+
 	patchBytes, err := json.Marshal(patchMap)
 	if err != nil {
 		return fmt.Errorf("marshalling strategic merge patch: %w", err)
@@ -308,12 +303,12 @@ func updateCentralRequest(request *dbapi.CentralRequest, strategicPatch []byte) 
 		scannerBytes = string(request.Scanner)
 	}
 
-	var originalBytes = fmt.Sprintf("{\"central\":%s,\"scanner\":%s,\"forceReconcile\":\"%s\"}", centralBytes, scannerBytes, request.ForceReconcile)
+	var originalBytes = fmt.Sprintf("{\"central\":%s,\"scanner\":%s,\"force_reconcile\":\"%s\"}", centralBytes, scannerBytes, request.ForceReconcile)
 
 	type Original struct {
 		Central        *dbapi.CentralSpec `json:"central,omitempty"`
 		Scanner        *dbapi.ScannerSpec `json:"scanner,omitempty"`
-		ForceReconcile string             `json:"forceReconcile,omitempty"`
+		ForceReconcile string             `json:"force_reconcile,omitempty"`
 	}
 
 	// apply the patch

--- a/internal/dinosaur/pkg/handlers/admin_dinosaur_test.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur_test.go
@@ -165,19 +165,19 @@ func Test_updateCentralRequest(t *testing.T) {
 			patch:       `{"scanner":{"analyzer":{"resources":{"limits":null}}}}`,
 			wantScanner: `{"analyzer":{"resources":{"requests":{"cpu":"1","memory":"1"}},"scaling":{}},"db":{"resources":{}}}`,
 		}, {
-			name:               "replacing forceReconcile",
-			state:              `{"forceReconcile":"foo"}`,
-			patch:              `{"forceReconcile":"bar"}`,
+			name:               "replacing force_reconcile",
+			state:              `{"force_reconcile":"foo"}`,
+			patch:              `{"force_reconcile":"bar"}`,
 			wantForceReconcile: "bar",
 		}, {
-			name:               "unsetting forceReconcile",
-			state:              `{"forceReconcile":"foo"}`,
-			patch:              `{"forceReconcile":null}`,
+			name:               "unsetting force_reconcile",
+			state:              `{"force_reconcile":"foo"}`,
+			patch:              `{"force_reconcile":null}`,
 			wantForceReconcile: "",
 		}, {
-			name:               "setting forceReconcile to empty string",
-			state:              `{"forceReconcile":"foo"}`,
-			patch:              `{"forceReconcile":""}`,
+			name:               "setting force_reconcile to empty string",
+			state:              `{"force_reconcile":"foo"}`,
+			patch:              `{"force_reconcile":""}`,
 			wantForceReconcile: "",
 		}, {
 			name:  "should fail if the patch is invalid json",
@@ -217,6 +217,8 @@ func Test_updateCentralRequest(t *testing.T) {
 				if len(tt.wantCentral) > 0 {
 					assert.Equal(t, string(tt.wantCentral), string(request.Central))
 				}
+
+				assert.Equal(t, tt.wantForceReconcile, request.ForceReconcile)
 			}
 		})
 	}


### PR DESCRIPTION
## Description
This PR fixes a bug with strategic patch for the endpoint. `PATCH /api/rhacs/v1/admin/central/$tenant_id`. ForceReconcile in the database would never be set because it is deleted from the map used to merge the original requests values with the patch values.

Also adds an E2E test to make sure force_reconcile can always be set via API because it is required for a lot of SOPs to work properly.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non-relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [x] Add secret to app-interface Vault or Secrets Manager if necessary
- [x] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [x] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

only CI/local unit test

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
