### PR TITLE
Remove ignored operator resources in gitops config

### DIFF
--- a/dev/env/manifests/fleet-manager/04-gitops-config.yaml
+++ b/dev/env/manifests/fleet-manager/04-gitops-config.yaml
@@ -17,19 +17,12 @@ data:
           image: "quay.io/rhacs-eng/stackrox-operator:4.2.1-rc.3"
           centralLabelSelector: "rhacs.redhat.com/version-selector=4.2.1-rc.3"
           securedClusterReconcilerEnabled: false
-          resources:
-            requests:
-              cpu: 100m
-              memory: 200Mi
 
         - deploymentName: "rhacs-operator-4-2-1"
           image: "quay.io/rhacs-eng/stackrox-operator:4.2.1"
           centralLabelSelector: "rhacs.redhat.com/version-selector=4.2.1"
           securedClusterReconcilerEnabled: false
-          resources:
-            requests:
-              cpu: 100m
-              memory: 200Mi
+
     centrals:
       overrides:
         # Set label for all centrals to 4.2.1


### PR DESCRIPTION
Resources for operator are currently ignored in the helm chart