### PR TITLE
ROX-19589: Use a context with deadline for initialization.

### DIFF
--- a/e2e/e2e_auth_test.go
+++ b/e2e/e2e_auth_test.go
@@ -72,7 +72,7 @@ var _ = Describe("AuthN/Z Fleet* components", func() {
 
 	Describe("OCM auth type", func() {
 		BeforeEach(func() {
-			auth, err := fleetmanager.NewOCMAuth(authOption.Ocm)
+			auth, err := fleetmanager.NewOCMAuth(context.Background(), authOption.Ocm)
 			Expect(err).ToNot(HaveOccurred())
 			fmClient, err := fleetmanager.NewClient(fleetManagerEndpoint, auth)
 			Expect(err).ToNot(HaveOccurred())
@@ -94,7 +94,7 @@ var _ = Describe("AuthN/Z Fleet* components", func() {
 
 	Describe("Static token auth type", func() {
 		BeforeEach(func() {
-			auth, err := fleetmanager.NewStaticAuth(authOption.Static)
+			auth, err := fleetmanager.NewStaticAuth(context.Background(), authOption.Static)
 			Expect(err).ToNot(HaveOccurred())
 			fmClient, err := fleetmanager.NewClient(fleetManagerEndpoint, auth)
 			Expect(err).ToNot(HaveOccurred())
@@ -122,7 +122,7 @@ var _ = Describe("AuthN/Z Fleet* components", func() {
 				Skip("RHSSO_SERVICE_ACCOUNT_CLIENT_ID / RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET not set, cannot initialize auth type")
 			}
 			// Create the auth type for RH SSO.
-			auth, err := fleetmanager.NewRHSSOAuth(rhSSOOpt)
+			auth, err := fleetmanager.NewRHSSOAuth(context.Background(), rhSSOOpt)
 			Expect(err).ToNot(HaveOccurred())
 			fmClient, err := fleetmanager.NewClient(fleetManagerEndpoint, auth)
 			Expect(err).ToNot(HaveOccurred())

--- a/e2e/e2e_canary_upgrade_test.go
+++ b/e2e/e2e_canary_upgrade_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Fleetshard-sync Targeted Upgrade", func() {
 			Skip("Skipping canary upgrade test")
 		}
 		option := fleetmanager.OptionFromEnv()
-		auth, err := fleetmanager.NewStaticAuth(fleetmanager.StaticOption{StaticToken: option.Static.StaticToken})
+		auth, err := fleetmanager.NewStaticAuth(context.Background(), fleetmanager.StaticOption{StaticToken: option.Static.StaticToken})
 		Expect(err).ToNot(HaveOccurred())
 		client, err = fleetmanager.NewClient(fleetManagerEndpoint, auth)
 		Expect(err).ToNot(HaveOccurred())

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -57,13 +57,13 @@ var _ = Describe("Central", func() {
 		}
 
 		option := fleetmanager.OptionFromEnv()
-		auth, err := fleetmanager.NewStaticAuth(fleetmanager.StaticOption{StaticToken: option.Static.StaticToken})
+		auth, err := fleetmanager.NewStaticAuth(context.Background(), fleetmanager.StaticOption{StaticToken: option.Static.StaticToken})
 		Expect(err).ToNot(HaveOccurred())
 		client, err = fleetmanager.NewClient(fleetManagerEndpoint, auth)
 		Expect(err).ToNot(HaveOccurred())
 
 		adminStaticToken := os.Getenv("STATIC_TOKEN_ADMIN")
-		adminAuth, err := fleetmanager.NewStaticAuth(fleetmanager.StaticOption{StaticToken: adminStaticToken})
+		adminAuth, err := fleetmanager.NewStaticAuth(context.Background(), fleetmanager.StaticOption{StaticToken: adminStaticToken})
 		Expect(err).ToNot(HaveOccurred())
 		adminClient, err := fleetmanager.NewClient(fleetManagerEndpoint, adminAuth)
 		adminAPI = adminClient.AdminAPI()

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -19,6 +19,7 @@ const (
 // Config contains this application's runtime configuration.
 type Config struct {
 	FleetManagerEndpoint string        `env:"FLEET_MANAGER_ENDPOINT" envDefault:"http://127.0.0.1:8000"`
+	StartupTimeout       time.Duration `env:"STARTUP_TIMEOUT" envDefault:"300s"`
 	ClusterID            string        `env:"CLUSTER_ID"`
 	ClusterName          string        `env:"CLUSTER_NAME"`
 	Environment          string        `env:"ENVIRONMENT"`

--- a/fleetshard/main.go
+++ b/fleetshard/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 	"os/signal"
@@ -32,7 +33,9 @@ func main() {
 		glog.Fatalf("Failed to load configuration: %v", err)
 	}
 
-	glog.Info("Starting application")
+	ctx, cancel := context.WithTimeout(context.Background(), config.StartupTimeout)
+	defer cancel()
+	glog.Infof("Starting application, timeout=%s", config.StartupTimeout)
 	glog.Infof("FleetManagerEndpoint: %s", config.FleetManagerEndpoint)
 	glog.Infof("ClusterID: %s", config.ClusterID)
 	glog.Infof("RuntimePollPeriod: %s", config.RuntimePollPeriod.String())
@@ -46,7 +49,7 @@ func main() {
 	k8sClient := k8s.CreateClientOrDie()
 	ctrl.SetLogger(logger.NewKubeAPILogger())
 	glog.Info("Creating runtime...")
-	runtime, err := runtime.NewRuntime(config, k8sClient)
+	runtime, err := runtime.NewRuntime(ctx, config, k8sClient)
 	if err != nil {
 		glog.Fatal(err)
 	}

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -61,7 +61,7 @@ type Runtime struct {
 }
 
 // NewRuntime creates a new runtime
-func NewRuntime(config *config.Config, k8sClient ctrlClient.Client) (*Runtime, error) {
+func NewRuntime(ctx context.Context, config *config.Config, k8sClient ctrlClient.Client) (*Runtime, error) {
 	authOption := fleetmanager.Option{
 		Sso: fleetmanager.RHSSOOption{
 			ClientID:     config.RHSSOClientID,
@@ -76,7 +76,7 @@ func NewRuntime(config *config.Config, k8sClient ctrlClient.Client) (*Runtime, e
 			StaticToken: config.StaticToken,
 		},
 	}
-	auth, err := fleetmanager.NewAuth(config.AuthType, authOption)
+	auth, err := fleetmanager.NewAuth(ctx, config.AuthType, authOption)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create fleet manager authentication")
 	}

--- a/internal/dinosaur/pkg/cmd/admin/centrals/list.go
+++ b/internal/dinosaur/pkg/cmd/admin/centrals/list.go
@@ -19,7 +19,7 @@ func NewAdminCentralsListCommand() *cobra.Command {
 		Short: "lists all managed central requests",
 		Long:  "lists all managed central requests",
 		Run: func(cmd *cobra.Command, args []string) {
-			runList(fleetmanagerclient.AuthenticatedClientWithRHOASToken(), cmd, args)
+			runList(fleetmanagerclient.AuthenticatedClientWithRHOASToken(cmd.Context()), cmd, args)
 		},
 	}
 	return cmd

--- a/internal/dinosaur/pkg/cmd/centrals/create.go
+++ b/internal/dinosaur/pkg/cmd/centrals/create.go
@@ -19,7 +19,7 @@ func NewCreateCommand() *cobra.Command {
 		Short: "Create a new central request",
 		Long:  "Create a new central request.",
 		Run: func(cmd *cobra.Command, args []string) {
-			runCreate(fleetmanagerclient.AuthenticatedClientWithOCM(), cmd, args)
+			runCreate(fleetmanagerclient.AuthenticatedClientWithOCM(cmd.Context()), cmd, args)
 		},
 	}
 

--- a/internal/dinosaur/pkg/cmd/centrals/delete.go
+++ b/internal/dinosaur/pkg/cmd/centrals/delete.go
@@ -17,7 +17,7 @@ func NewDeleteCommand() *cobra.Command {
 		Short: "Delete a central request",
 		Long:  "Delete a central request.",
 		Run: func(cmd *cobra.Command, args []string) {
-			runDelete(fleetmanagerclient.AuthenticatedClientWithOCM(), cmd, args)
+			runDelete(fleetmanagerclient.AuthenticatedClientWithOCM(cmd.Context()), cmd, args)
 		},
 	}
 

--- a/internal/dinosaur/pkg/cmd/centrals/get.go
+++ b/internal/dinosaur/pkg/cmd/centrals/get.go
@@ -18,7 +18,7 @@ func NewGetCommand() *cobra.Command {
 		Short: "Get a central request",
 		Long:  "Get a central request.",
 		Run: func(cmd *cobra.Command, args []string) {
-			runGet(fleetmanagerclient.AuthenticatedClientWithOCM(), cmd, args)
+			runGet(fleetmanagerclient.AuthenticatedClientWithOCM(cmd.Context()), cmd, args)
 		},
 	}
 	cmd.Flags().String(FlagID, "", "Central ID (required)")

--- a/internal/dinosaur/pkg/cmd/centrals/list.go
+++ b/internal/dinosaur/pkg/cmd/centrals/list.go
@@ -24,7 +24,7 @@ func NewListCommand() *cobra.Command {
 		Short: "lists all managed central requests",
 		Long:  "lists all managed central requests",
 		Run: func(cmd *cobra.Command, args []string) {
-			runList(fleetmanagerclient.AuthenticatedClientWithOCM(), cmd, args)
+			runList(fleetmanagerclient.AuthenticatedClientWithOCM(cmd.Context()), cmd, args)
 		},
 	}
 	cmd.Flags().String(FlagOwner, "test-user", "Username")

--- a/internal/dinosaur/pkg/cmd/fleetmanagerclient/client.go
+++ b/internal/dinosaur/pkg/cmd/fleetmanagerclient/client.go
@@ -2,6 +2,7 @@
 package fleetmanagerclient
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sync"
@@ -28,7 +29,7 @@ const (
 
 // AuthenticatedClientWithRHOASToken returns a rest client for fleet-manager API using a static OCM token for authentication.
 // This function should only be used for CLI commands.
-func AuthenticatedClientWithRHOASToken() *fleetmanager.Client {
+func AuthenticatedClientWithRHOASToken(ctx context.Context) *fleetmanager.Client {
 	rhoasToken := os.Getenv(rhoasTokenEnvVar)
 	if rhoasToken == "" {
 		panic(fmt.Sprintf("%s not set. Please set RHOAS token with 'export %s=<token>'", rhoasTokenEnvVar, rhoasTokenEnvVar))
@@ -40,7 +41,7 @@ func AuthenticatedClientWithRHOASToken() *fleetmanager.Client {
 	}
 
 	singletonRHOASTokenInstance.Do(func() {
-		auth, err := fleetmanager.NewAuth(fleetmanager.StaticTokenAuthName, fleetmanager.Option{
+		auth, err := fleetmanager.NewAuth(ctx, fleetmanager.StaticTokenAuthName, fleetmanager.Option{
 			Static: fleetmanager.StaticOption{
 				StaticToken: rhoasToken,
 			},
@@ -67,7 +68,7 @@ func AuthenticatedClientWithRHOASToken() *fleetmanager.Client {
 
 // AuthenticatedClientWithOCM returns a rest client to the fleet-manager and receives the OCM refresh token.
 // This function will panic on an error, designed to be used by the fleet-manager CLI.
-func AuthenticatedClientWithOCM() *fleetmanager.Client {
+func AuthenticatedClientWithOCM(ctx context.Context) *fleetmanager.Client {
 	ocmRefreshToken := os.Getenv(ocmRefreshTokenEnvVar)
 	if ocmRefreshToken == "" {
 		panic(fmt.Sprintf("%s not set. Please set OCM token with 'export %s=$(ocm token --refresh)'", ocmRefreshTokenEnvVar, ocmRefreshTokenEnvVar))
@@ -79,7 +80,7 @@ func AuthenticatedClientWithOCM() *fleetmanager.Client {
 	}
 
 	singletonOCMRefreshTokenInstance.Do(func() {
-		auth, err := fleetmanager.NewAuth(fleetmanager.OCMAuthName, fleetmanager.Option{
+		auth, err := fleetmanager.NewAuth(ctx, fleetmanager.OCMAuthName, fleetmanager.Option{
 			Ocm: fleetmanager.OCMOption{
 				RefreshToken: ocmRefreshToken,
 			},

--- a/pkg/client/fleetmanager/auth.go
+++ b/pkg/client/fleetmanager/auth.go
@@ -2,6 +2,7 @@
 package fleetmanager
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"sort"
@@ -20,7 +21,7 @@ type Auth interface {
 
 type authFactory interface {
 	GetName() string
-	CreateAuth(o Option) (Auth, error)
+	CreateAuth(ctx context.Context, o Option) (Auth, error)
 }
 
 // Option for the different Auth types.
@@ -60,18 +61,18 @@ func init() {
 }
 
 // NewAuth will return Auth that can be used to add authentication of a specific AuthType to be added to HTTP requests.
-func NewAuth(t string, opt Option) (Auth, error) {
-	return newAuth(t, opt)
+func NewAuth(ctx context.Context, t string, opt Option) (Auth, error) {
+	return newAuth(ctx, t, opt)
 }
 
-func newAuth(t string, opt Option) (Auth, error) {
+func newAuth(ctx context.Context, t string, opt Option) (Auth, error) {
 	factory, exists := authFactoryRegistry[t]
 	if !exists {
 		return nil, errors.Errorf("invalid auth type found: %q, must be one of [%s]",
 			t, strings.Join(getAllAuthTypes(), ","))
 	}
 
-	auth, err := factory.CreateAuth(opt)
+	auth, err := factory.CreateAuth(ctx, opt)
 	if err != nil {
 		return auth, fmt.Errorf("creating Auth: %w", err)
 	}
@@ -79,18 +80,18 @@ func newAuth(t string, opt Option) (Auth, error) {
 }
 
 // NewRHSSOAuth will return Auth that uses RH SSO to provide authentication for HTTP requests.
-func NewRHSSOAuth(opt RHSSOOption) (Auth, error) {
-	return newAuth(rhSSOFactory.GetName(), Option{Sso: opt})
+func NewRHSSOAuth(ctx context.Context, opt RHSSOOption) (Auth, error) {
+	return newAuth(ctx, rhSSOFactory.GetName(), Option{Sso: opt})
 }
 
 // NewOCMAuth will return Auth that uses OCM to provide authentication for HTTP requests.
-func NewOCMAuth(opt OCMOption) (Auth, error) {
-	return newAuth(ocmFactory.GetName(), Option{Ocm: opt})
+func NewOCMAuth(ctx context.Context, opt OCMOption) (Auth, error) {
+	return newAuth(ctx, ocmFactory.GetName(), Option{Ocm: opt})
 }
 
 // NewStaticAuth will return Auth that uses a static token to provide authentication for HTTP requests.
-func NewStaticAuth(opt StaticOption) (Auth, error) {
-	return newAuth(staticTokenFactory.GetName(), Option{Static: opt})
+func NewStaticAuth(ctx context.Context, opt StaticOption) (Auth, error) {
+	return newAuth(ctx, staticTokenFactory.GetName(), Option{Static: opt})
 }
 
 // OptionFromEnv creates an Option struct with populated values from environment variables.

--- a/pkg/client/fleetmanager/auth_ocm.go
+++ b/pkg/client/fleetmanager/auth_ocm.go
@@ -1,6 +1,7 @@
 package fleetmanager
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -34,7 +35,7 @@ func (f *ocmAuthFactory) GetName() string {
 }
 
 // CreateAuth ...
-func (f *ocmAuthFactory) CreateAuth(o Option) (Auth, error) {
+func (f *ocmAuthFactory) CreateAuth(ctx context.Context, o Option) (Auth, error) {
 	initialToken := o.Ocm.RefreshToken
 	if initialToken == "" {
 		return nil, errors.New("empty ocm token")
@@ -53,11 +54,11 @@ func (f *ocmAuthFactory) CreateAuth(o Option) (Auth, error) {
 	}
 
 	// Check if the connection can be established and tokens can be retrieved.
-	conn, err := builder.Build()
+	conn, err := builder.BuildContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("creating connection: %w", err)
 	}
-	_, _, err = conn.Tokens()
+	_, _, err = conn.TokensContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving tokens: %w", err)
 	}

--- a/pkg/client/fleetmanager/auth_rhsso.go
+++ b/pkg/client/fleetmanager/auth_rhsso.go
@@ -48,8 +48,12 @@ func (f *rhSSOAuthFactory) CreateAuth(ctx context.Context, o Option) (Auth, erro
 		TokenURL:     provider.Endpoint().TokenURL,
 		Scopes:       []string{"openid"},
 	}
+	// This context is used to retrieve tokens at points in time that are arbitrarily
+	// far in the future. Current OAuth2 API does not allow bounding the time of an individual
+	// token retrieval. https://github.com/golang/oauth2/issues/262
+	tokenCtx := context.Background()
 	return &rhSSOAuth{
-		tokenSource: cfg.TokenSource(ctx),
+		tokenSource: cfg.TokenSource(tokenCtx),
 	}, nil
 }
 

--- a/pkg/client/fleetmanager/auth_rhsso.go
+++ b/pkg/client/fleetmanager/auth_rhsso.go
@@ -35,9 +35,9 @@ func (f *rhSSOAuthFactory) GetName() string {
 }
 
 // CreateAuth creates an Auth using RH SSO.
-func (f *rhSSOAuthFactory) CreateAuth(o Option) (Auth, error) {
+func (f *rhSSOAuthFactory) CreateAuth(ctx context.Context, o Option) (Auth, error) {
 	issuer := fmt.Sprintf("%s/auth/realms/%s", o.Sso.Endpoint, o.Sso.Realm)
-	provider, err := oidc.NewProvider(context.Background(), issuer)
+	provider, err := oidc.NewProvider(ctx, issuer)
 	if err != nil {
 		return nil, errors.Wrapf(err, "retrieving open-id configuration from %q", issuer)
 	}
@@ -49,7 +49,7 @@ func (f *rhSSOAuthFactory) CreateAuth(o Option) (Auth, error) {
 		Scopes:       []string{"openid"},
 	}
 	return &rhSSOAuth{
-		tokenSource: cfg.TokenSource(context.Background()),
+		tokenSource: cfg.TokenSource(ctx),
 	}, nil
 }
 

--- a/pkg/client/fleetmanager/auth_static_token.go
+++ b/pkg/client/fleetmanager/auth_static_token.go
@@ -1,6 +1,7 @@
 package fleetmanager
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -29,7 +30,7 @@ func (f *staticTokenAuthFactory) GetName() string {
 }
 
 // CreateAuth ...
-func (f *staticTokenAuthFactory) CreateAuth(o Option) (Auth, error) {
+func (f *staticTokenAuthFactory) CreateAuth(ctx context.Context, o Option) (Auth, error) {
 	staticToken := o.Static.StaticToken
 	if staticToken == "" {
 		return nil, errors.New("no static token set")

--- a/probe/cmd/probe/main.go
+++ b/probe/cmd/probe/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 
 	"github.com/golang/glog"
@@ -34,7 +35,7 @@ func main() {
 		glog.Fatal(errors.New("unable to start metrics server"))
 	}
 
-	c, err := cli.New(config)
+	c, err := cli.New(context.Background(), config)
 	if err != nil {
 		glog.Fatal(err)
 	}

--- a/probe/internal/cli/cli.go
+++ b/probe/internal/cli/cli.go
@@ -28,8 +28,8 @@ type CLI struct {
 }
 
 // New creates a CLI.
-func New(config *config.Config) (*CLI, error) {
-	fleetManagerPublicAPI, err := fleetmanager.New(config)
+func New(ctx context.Context, config *config.Config) (*CLI, error) {
+	fleetManagerPublicAPI, err := fleetmanager.New(ctx, config)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create fleet manager client")
 	}

--- a/probe/pkg/fleetmanager/client.go
+++ b/probe/pkg/fleetmanager/client.go
@@ -2,14 +2,16 @@
 package fleetmanager
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
 	"github.com/stackrox/acs-fleet-manager/probe/config"
 )
 
 // New creates a new fleet manager client.
-func New(config *config.Config) (fleetmanager.PublicAPI, error) {
-	auth, err := fleetmanager.NewAuth(config.AuthType, fleetmanager.OptionFromEnv())
+func New(ctx context.Context, config *config.Config) (fleetmanager.PublicAPI, error) {
+	auth, err := fleetmanager.NewAuth(ctx, config.AuthType, fleetmanager.OptionFromEnv())
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create fleet manager authentication")
 	}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

The primary motivation is to prevent fleetshard from getting stuck indefinitely on startup in case of transient network issues. [ROX-19589](https://issues.redhat.com/browse/ROX-19589) contains more background.


**Note** that the first time this change was merged (#1229) it caused the probe to break, even though e2e test passed. The cause is not well understood, but this time I took a detailed look into how the {{ctx}} passed into each `New*Auth` function is used. I found a single child call which saved it for subsequent use after the current function exits, so I passed a background context there.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~Unit and integration tests added~
- [x] Added test description under `Test manual`
- [x] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~
- [x] ~Add secret to app-interface Vault or Secrets Manager if necessary~
- [x] ~RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~
- [x] ~Check AWS limits are reasonable for changes provisioning new resources~

## Test manual

There isn't much we can test manually here outside of CI. This time we're better prepared for any unexpected side-effects:
- the change will first land into a new integration environment
- probes for [different environments now use separate SSO orgs](https://issues.redhat.com/browse/ROX-19587) so different environments should not affect each other