### PR TITLE
Do not inject feature flag defaults into Kubernetes Deployments

### DIFF
--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -287,7 +287,10 @@ inject_exported_env_vars() {
     local namespace="$1"
     local deployment="$2"
 
-    flags=$(printenv | grep -e "RHACS_*")
+    # Retrieve all environment variables prefixed with RHACS_ except those which also carry the _DEFAULT suffix
+    # (these are variables used for the defaulting logic of the development tooling and are not expected to end
+    # up in the pod specs).
+    flags=$(printenv | grep -e '^RHACS_' | grep -v '^RHACS_[^=]*_DEFAULT=')
     for flag in $flags
     do
         $KUBECTL -n "$namespace" set env "deployment/$deployment" "$flag"


### PR DESCRIPTION
## Description

The deployment tooling uses a mechanism to inject all `RHACS_`-prefixed variables into the pod specs, but this currently also includes those variables ending with `_DEFAULT`, which are internal variables used for the defaulting logic of the deployment tooling. This PR filters them out before injecting into the pod environments.

## Checklist (Definition of Done)

- ~~[ ] Unit and integration tests added~~
- ~~[ ] Added test description under `Test manual`~~
- ~~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- ~~[ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~~
- ~~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- ~~[ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
- ~~[ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
- ~~[ ] Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual

Execute `~/.openshift-ci/tests/e2e.sh` and verify that the created fleet-manager pod does not contained any environment variables of the form `RHACS_..._DEFAULT`.

