### PR TITLE
Fix typo in the idp setup doc

### DIFF
--- a/docs/development/setup-aws-idp-on-osd.md
+++ b/docs/development/setup-aws-idp-on-osd.md
@@ -54,7 +54,7 @@ S3 bucket name has the following pattern: `<osdClusterName>-<randomAlphanumeric>
     ```
 1. Change the cluster authentication
     ```shell
-    oc apply -f ./dev-dp-idp/manifests/cluster-authentication-02-config.yaml
+    oc apply -f ./$OUTPUT_DIR/manifests/cluster-authentication-02-config.yaml
     ```
 1. Make sure that the cluster authentication has an appropriate url pointing to the S3 bucket
     ```shell


### PR DESCRIPTION
## Description
Small oneline fix

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
