### PR TITLE
activate encrypted notifier secrets

### DIFF
--- a/fleetshard/main.go
+++ b/fleetshard/main.go
@@ -43,6 +43,7 @@ func main() {
 	glog.Infof("ManagedDB.Enabled: %t", config.ManagedDB.Enabled)
 	glog.Infof("ManagedDB.SecurityGroup: %s", config.ManagedDB.SecurityGroup)
 	glog.Infof("ManagedDB.SubnetGroup: %s", config.ManagedDB.SubnetGroup)
+	glog.Infof("EncryptionType: %s", config.SecretEncryption.Type)
 	if len(config.TenantImagePullSecret) > 0 {
 		glog.Infof("Image pull secret configured, will be injected into tenant namespaces.")
 	}

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -350,6 +350,9 @@ func (r *CentralReconciler) getLegacyInstanceConfig(remoteCentral *private.Manag
 				DeploymentSpec: v1alpha1.DeploymentSpec{
 					Resources: &centralResources,
 				},
+				NotifierSecretsEncryption: &v1alpha1.NotifierSecretsEncryption{
+					Enabled: pointer.Bool(true),
+				},
 			},
 			Scanner: &v1alpha1.ScannerComponentSpec{
 				Analyzer: &v1alpha1.ScannerAnalyzerComponent{


### PR DESCRIPTION
## Description
This PR activates the notifier secret encryption for central tenants by default.

Only merge it after the CR used in DP clusters was upgraded to the CR of ACS 4.3 release, otherwise the CRs created by FS will not compatible to CRs registered in the cluster.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
