### PR TITLE
Update squid proxy image

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -26,7 +26,7 @@ fleetshardSync:
     endpoint: "https://sso.redhat.com"
     realm: "redhat-external"
   egressProxy:
-    image: "registry.redhat.io/openshift4/ose-egress-http-proxy:v4.11.0"
+    image: "registry.redhat.io/openshift4/ose-egress-http-proxy:v4.11.0-202310101543.p0.gf1330f6.assembly.stream"
   auditLogs:
     enabled: true
     skipTLSVerify: true


### PR DESCRIPTION
## Description
Try setting an explicit tag for the squid proxy image and see if all existing deployments update themselves.

We currently have two different images on the `int` [cluster](https://acs-cii18grublkv81uil8gg.acs.rhcloud.com/main/vulnerabilities/workload-cves?entityTab=Image&sortOption[field]=Image&sortOption[direction]=desc&s[IMAGE][0]=registry.redhat.io/openshift4/ose-egress-http-proxy:v4.11.0&s[CLUSTER][0]=acs-int-us-01) so after this PR is merged we expect only one.

## Checklist (Definition of Done)
Irrelevant for this PR.

## Test manual

None: integration cluster is our litmus test.
