### PR TITLE
ROX-20542: disable http/2 in operator kube-rbac-proxy to mitigate CVE-2023-44487

### DIFF
--- a/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-deployment.yaml
+++ b/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-deployment.yaml
@@ -30,6 +30,7 @@ spec:
       containers:
         - args:
             - --secure-listen-address=0.0.0.0:8443
+            - --http2-disable
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=0
@@ -40,7 +41,7 @@ spec:
               value: quay.io/rhacs-eng
             - name: OPERATOR_CONDITION_NAME
               value: rhacs-operator.v3.74.0
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13
           imagePullPolicy: IfNotPresent
           name: kube-rbac-proxy
           ports:


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Because the operator is now installed with a Helm chart, ACS CS will not pick up this change from the next ACS releases, so I'll do it manually (for now). The reasoning for the change is documented [here](https://docs.google.com/document/d/1F99glzhX2i2Ppe5Qq3M-Po_jSSUiVssqFyWRhVm1X3o/edit?usp=sharing)

I'm also switching to the downstream `kube-rbac-proxy` image, because we're currently using downstream ACS images.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

I verified that the image supports the new `--http2-disable` flag by running:
`docker run --rm  registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13 --http2-disable`

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
