### PR TITLE
chore(observability): remove cpu limits

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
@@ -50,35 +50,30 @@ spec:
         cpu: {{ .Values.alertManager.resources.requests.cpu | quote }}
         memory: {{ .Values.alertManager.resources.requests.memory | quote }}
       limits:
-        cpu: {{ .Values.alertManager.resources.limits.cpu | quote }}
         memory: {{ .Values.alertManager.resources.limits.memory | quote }}
     prometheusResourceRequirement:
       requests:
         cpu: {{ .Values.prometheus.resources.requests.cpu | quote }}
         memory: {{ .Values.prometheus.resources.requests.memory | quote }}
       limits:
-        cpu: {{ .Values.prometheus.resources.limits.cpu | quote }}
         memory: {{ .Values.prometheus.resources.limits.memory | quote }}
     prometheusOperatorResourceRequirement:
       requests:
         cpu: {{ .Values.prometheusOperator.resources.requests.cpu | quote }}
         memory: {{ .Values.prometheusOperator.resources.requests.memory | quote }}
       limits:
-        cpu: {{ .Values.prometheusOperator.resources.limits.cpu | quote }}
         memory: {{ .Values.prometheusOperator.resources.limits.memory | quote }}
     grafanaResourceRequirement:
       requests:
         cpu: {{ .Values.grafana.resources.requests.cpu | quote }}
         memory: {{ .Values.grafana.resources.requests.memory | quote }}
       limits:
-        cpu: {{ .Values.grafana.resources.limits.cpu | quote }}
         memory: {{ .Values.grafana.resources.limits.memory | quote }}
     grafanaOperatorResourceRequirement:
       requests:
         cpu: {{ .Values.grafanaOperator.resources.requests.cpu | quote }}
         memory: {{ .Values.grafanaOperator.resources.requests.memory | quote }}
       limits:
-        cpu: {{ .Values.grafanaOperator.resources.limits.cpu | quote }}
         memory: {{ .Values.grafanaOperator.resources.limits.memory | quote }}
   storage:
     prometheus:

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
@@ -43,7 +43,6 @@ observabilityOperator:
       cpu: "500m"
       memory: "2048Mi"
     limits:
-      cpu: "500m"
       memory: "2048Mi"
 
 prometheus:
@@ -52,7 +51,6 @@ prometheus:
       cpu: 1500m
       memory: 18Gi
     limits:
-      cpu: 1500m
       memory: 18Gi
 
 prometheusOperator:
@@ -61,7 +59,6 @@ prometheusOperator:
       cpu: 200m
       memory: 256Mi
     limits:
-      cpu: 200m
       memory: 256Mi
 
 grafana:
@@ -70,7 +67,6 @@ grafana:
       cpu: 500m
       memory: 1024Mi
     limits:
-      cpu: 500m
       memory: 1024Mi
 
 grafanaOperator:
@@ -79,7 +75,6 @@ grafanaOperator:
       cpu: 200m
       memory: 256Mi
     limits:
-      cpu: 200m
       memory: 256Mi
 
 alertManager:
@@ -88,5 +83,4 @@ alertManager:
       cpu: 200m
       memory: 256Mi
     limits:
-      cpu: 200m
       memory: 256Mi


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Remove CPU limits from observability components to prevent unnecessary throttling.

Note that the Grafana pod has been throttling despite idling since Grafana was updated to `10.2.0`. This behavior is not understood, but throttling due to CPU limits is undesired anyway.