### PR TITLE
Add pprof server to fleet-manager and unlimited evals in testing&develop

### DIFF
--- a/cmd/fleet-manager/main_test.go
+++ b/cmd/fleet-manager/main_test.go
@@ -38,7 +38,7 @@ func TestInjections(t *testing.T) {
 
 	var bootList []environments.BootService
 	env.MustResolve(&bootList)
-	Expect(len(bootList)).To(Equal(6))
+	Expect(len(bootList)).To(Equal(7))
 
 	_, ok := bootList[0].(*server.APIServer)
 	Expect(ok).To(Equal(true))

--- a/cmd/fleet-manager/main_test.go
+++ b/cmd/fleet-manager/main_test.go
@@ -44,9 +44,9 @@ func TestInjections(t *testing.T) {
 	Expect(ok).To(Equal(true))
 	_, ok = bootList[1].(*server.MetricsServer)
 	Expect(ok).To(Equal(true))
-	_, ok = bootList[2].(*server.HealthCheckServer)
+	_, ok = bootList[3].(*server.HealthCheckServer)
 	Expect(ok).To(Equal(true))
-	_, ok = bootList[3].(*workers.LeaderElectionManager)
+	_, ok = bootList[4].(*workers.LeaderElectionManager)
 	Expect(ok).To(Equal(true))
 
 	var workerList []workers.Worker

--- a/dev/config/dataplane-cluster-configuration-crc.yaml
+++ b/dev/config/dataplane-cluster-configuration-crc.yaml
@@ -11,7 +11,7 @@ clusters:
    region: standalone
    schedulable: true
    status: ready
-   central_instance_limit: 5
+   central_instance_limit: 9999
    provider_type: standalone
    supported_instance_type: "eval,standard"
    cluster_dns: apps-crc.testing

--- a/dev/config/dataplane-cluster-configuration-dockerdesktop.yaml
+++ b/dev/config/dataplane-cluster-configuration-dockerdesktop.yaml
@@ -14,4 +14,4 @@ clusters:
    provider_type: standalone
    supported_instance_type: "eval,standard"
    cluster_dns: kubernetes.docker.internal
-   central_instance_limit: 5
+   central_instance_limit: 9999

--- a/dev/config/dataplane-cluster-configuration-kind.yaml
+++ b/dev/config/dataplane-cluster-configuration-kind.yaml
@@ -14,4 +14,4 @@ clusters:
    provider_type: standalone
    supported_instance_type: "eval,standard"
    cluster_dns: kubernetes.docker.internal
-   central_instance_limit: 5
+   central_instance_limit: 99999

--- a/dev/config/dataplane-cluster-configuration-minikube.yaml
+++ b/dev/config/dataplane-cluster-configuration-minikube.yaml
@@ -24,7 +24,7 @@ clusters:
    region: standalone
    schedulable: true
    status: ready
-   central_instance_limit: 5
+   central_instance_limit: 9999
    provider_type: standalone
    supported_instance_type: "eval,standard"
    cluster_dns: cluster.local

--- a/dev/config/dataplane-cluster-configuration-rancherdesktop.yaml
+++ b/dev/config/dataplane-cluster-configuration-rancherdesktop.yaml
@@ -24,7 +24,7 @@ clusters:
    region: standalone
    schedulable: true
    status: ready
-   central_instance_limit: 5
+   central_instance_limit: 9999
    provider_type: standalone
    supported_instance_type: "eval,standard"
    cluster_dns: cluster.local

--- a/dev/env/manifests/fleet-manager/03-fleet-manager-service.yaml
+++ b/dev/env/manifests/fleet-manager/03-fleet-manager-service.yaml
@@ -16,6 +16,9 @@ spec:
     - name: metrics
       port: 8080
       targetPort: 8080
+    - name: pprof
+      port: 6060
+      targetPort: 6060
   selector:
     application: fleet-manager
 status:

--- a/dev/env/manifests/shared/03-configmap-config.yaml
+++ b/dev/env/manifests/shared/03-configmap-config.yaml
@@ -13,7 +13,7 @@ data:
         provider_type: standalone
         supported_instance_type: "eval,standard"
         cluster_dns: "$CLUSTER_DNS"
-        central_instance_limit: 5
+        central_instance_limit: 99999
   fleetshard-authz-org-ids-development.yaml: |-
     # RH ACS Organization (returned for personal tokens obtained by ocm token).
     - "11009103"

--- a/internal/dinosaur/pkg/services/clusters.go
+++ b/internal/dinosaur/pkg/services/clusters.go
@@ -3,6 +3,7 @@ package services
 import (
 	"encoding/json"
 	"errors"
+
 	constants2 "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/clusters"

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	"github.com/stackrox/acs-fleet-manager/pkg/environments"
 	"sync"
 	"time"
 

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/acs-fleet-manager/pkg/client/iam"
 	dynamicClientAPI "github.com/stackrox/acs-fleet-manager/pkg/client/redhatsso/api"
 	"github.com/stackrox/acs-fleet-manager/pkg/client/redhatsso/dynamicclients"
+	"github.com/stackrox/acs-fleet-manager/pkg/environments"
 
 	dinosaurConstants "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"github.com/stackrox/acs-fleet-manager/pkg/environments"
 	"sync"
 	"time"
 
@@ -212,7 +213,8 @@ func (k *dinosaurService) DetectInstanceType(dinosaurRequest *dbapi.CentralReque
 
 // reserveQuota - reserves quota for the given dinosaur request. If a RHACS quota has been assigned, it will try to reserve RHACS quota, otherwise it will try with RHACSTrial
 func (k *dinosaurService) reserveQuota(ctx context.Context, dinosaurRequest *dbapi.CentralRequest) (subscriptionID string, err *errors.ServiceError) {
-	if dinosaurRequest.InstanceType == types.EVAL.String() {
+	if dinosaurRequest.InstanceType == types.EVAL.String() &&
+		(environments.GetEnvironmentStrFromEnv() == environments.DevelopmentEnv || environments.GetEnvironmentStrFromEnv() == environments.TestingEnv) == false {
 		if !k.dinosaurConfig.Quota.AllowEvaluatorInstance {
 			return "", errors.NewWithCause(errors.ErrorForbidden, err, "central eval instances are not allowed")
 		}

--- a/pkg/providers/core.go
+++ b/pkg/providers/core.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackrox/acs-fleet-manager/pkg/logger"
 	"github.com/stackrox/acs-fleet-manager/pkg/quotamanagement"
 	"github.com/stackrox/acs-fleet-manager/pkg/server"
+	"github.com/stackrox/acs-fleet-manager/pkg/server/profiler"
 	"github.com/stackrox/acs-fleet-manager/pkg/services/account"
 	"github.com/stackrox/acs-fleet-manager/pkg/services/authorization"
 	"github.com/stackrox/acs-fleet-manager/pkg/services/sentry"
@@ -98,6 +99,7 @@ func ServiceProviders() di.Option {
 		// Types registered as a BootService are started when the env is started
 		di.Provide(server.NewAPIServer, di.As(new(environments.BootService))),
 		di.Provide(server.NewMetricsServer, di.As(new(environments.BootService))),
+		di.Provide(profiler.SingletonPprofServer, di.As(new(environments.BootService))),
 		di.Provide(server.NewHealthCheckServer, di.As(new(environments.BootService))),
 		di.Provide(workers.NewLeaderElectionManager, di.As(new(environments.BootService))),
 		di.Provide(services.NewTelemetry, di.As(new(environments.BootService))),

--- a/pkg/server/profiler/profiler_server.go
+++ b/pkg/server/profiler/profiler_server.go
@@ -1,0 +1,51 @@
+package profiler
+
+import (
+	"fmt"
+	"github.com/stackrox/acs-fleet-manager/pkg/environments"
+	"github.com/stackrox/acs-fleet-manager/pkg/server"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"sync"
+)
+
+var _ server.Server = &PprofServer{}
+var _ environments.BootService = &PprofServer{}
+
+type PprofServer struct{}
+
+func (p *PprofServer) Start() {
+	go p.Run()
+}
+
+var (
+	oncePprofServer     sync.Once
+	pprofServerInstance *PprofServer
+)
+
+// SingletonPprofServer returns the PprofServer
+func SingletonPprofServer() *PprofServer {
+	oncePprofServer.Do(func() {
+		pprofServerInstance = &PprofServer{}
+	})
+	return pprofServerInstance
+}
+
+func (p *PprofServer) Stop() {
+}
+
+func (p *PprofServer) Listen() (net.Listener, error) {
+	return nil, nil
+}
+
+func (p *PprofServer) Serve(listener net.Listener) {
+}
+
+func (p *PprofServer) Run() {
+	handler := pprof.Handler("pprof")
+	err := http.ListenAndServe("localhost:6060", handler)
+	if err != nil {
+		panic(fmt.Sprintf("starting pprof server failed %s", err))
+	}
+}

--- a/pkg/server/profiler/profiler_server.go
+++ b/pkg/server/profiler/profiler_server.go
@@ -2,11 +2,14 @@
 package profiler
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
 	"net/http/pprof"
 	"sync"
+
+	"github.com/golang/glog"
 
 	"github.com/gorilla/mux"
 	"github.com/stackrox/acs-fleet-manager/pkg/environments"
@@ -17,7 +20,9 @@ var _ server.Server = &PprofServer{}
 var _ environments.BootService = &PprofServer{}
 
 // PprofServer ...
-type PprofServer struct{}
+type PprofServer struct {
+	httpServer *http.Server
+}
 
 // Start ...
 func (p *PprofServer) Start() {
@@ -32,13 +37,31 @@ var (
 // SingletonPprofServer returns the PprofServer
 func SingletonPprofServer() *PprofServer {
 	oncePprofServer.Do(func() {
-		pprofServerInstance = &PprofServer{}
+		router := mux.NewRouter()
+		router.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
+		router.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+		router.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+		router.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+		router.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+		router.Handle("/debug/pprof/{cmd}", http.HandlerFunc(pprof.Index)) // special handling for Gorilla mux
+		httpServer := &http.Server{
+			Addr:    "localhost:6060",
+			Handler: router,
+		}
+
+		pprofServerInstance = &PprofServer{
+			httpServer: httpServer,
+		}
 	})
 	return pprofServerInstance
 }
 
 // Stop ...
 func (p *PprofServer) Stop() {
+	err := p.httpServer.Shutdown(context.Background())
+	if err != nil {
+		glog.Warningf("Unable to stop profiling server: %s", err)
+	}
 }
 
 // Listen ...
@@ -52,15 +75,7 @@ func (p *PprofServer) Serve(listener net.Listener) {
 
 // Run ...
 func (p *PprofServer) Run() {
-	router := mux.NewRouter()
-	router.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
-	router.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
-	router.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
-	router.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
-	router.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
-	router.Handle("/debug/pprof/{cmd}", http.HandlerFunc(pprof.Index)) // special handling for Gorilla mux
-
-	err := http.ListenAndServe("localhost:6060", router)
+	err := p.httpServer.ListenAndServe()
 	if err != nil {
 		panic(fmt.Sprintf("starting pprof server failed %s", err))
 	}

--- a/pkg/server/profiler/profiler_server.go
+++ b/pkg/server/profiler/profiler_server.go
@@ -2,6 +2,7 @@ package profiler
 
 import (
 	"fmt"
+	"github.com/gorilla/mux"
 	"github.com/stackrox/acs-fleet-manager/pkg/environments"
 	"github.com/stackrox/acs-fleet-manager/pkg/server"
 	"net"
@@ -43,8 +44,15 @@ func (p *PprofServer) Serve(listener net.Listener) {
 }
 
 func (p *PprofServer) Run() {
-	handler := pprof.Handler("pprof")
-	err := http.ListenAndServe("localhost:6060", handler)
+	router := mux.NewRouter()
+	router.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
+	router.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+	router.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+	router.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+	router.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+	router.Handle("/debug/pprof/{cmd}", http.HandlerFunc(pprof.Index)) // special handling for Gorilla mux
+
+	err := http.ListenAndServe("localhost:6060", router)
 	if err != nil {
 		panic(fmt.Sprintf("starting pprof server failed %s", err))
 	}

--- a/pkg/server/profiler/profiler_server.go
+++ b/pkg/server/profiler/profiler_server.go
@@ -9,6 +9,8 @@ import (
 	"net/http/pprof"
 	"sync"
 
+	"github.com/pkg/errors"
+
 	"github.com/golang/glog"
 
 	"github.com/gorilla/mux"
@@ -76,7 +78,7 @@ func (p *PprofServer) Serve(listener net.Listener) {
 // Run ...
 func (p *PprofServer) Run() {
 	err := p.httpServer.ListenAndServe()
-	if err != nil {
-		panic(fmt.Sprintf("starting pprof server failed %s", err))
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+		glog.Fatalf(fmt.Sprintf("starting pprof server failed %s", err))
 	}
 }

--- a/pkg/server/profiler/profiler_server.go
+++ b/pkg/server/profiler/profiler_server.go
@@ -1,21 +1,25 @@
+// Package profiler provides profiling tools for debugging.
 package profiler
 
 import (
 	"fmt"
-	"github.com/gorilla/mux"
-	"github.com/stackrox/acs-fleet-manager/pkg/environments"
-	"github.com/stackrox/acs-fleet-manager/pkg/server"
 	"net"
 	"net/http"
 	"net/http/pprof"
 	"sync"
+
+	"github.com/gorilla/mux"
+	"github.com/stackrox/acs-fleet-manager/pkg/environments"
+	"github.com/stackrox/acs-fleet-manager/pkg/server"
 )
 
 var _ server.Server = &PprofServer{}
 var _ environments.BootService = &PprofServer{}
 
+// PprofServer ...
 type PprofServer struct{}
 
+// Start ...
 func (p *PprofServer) Start() {
 	go p.Run()
 }
@@ -33,16 +37,20 @@ func SingletonPprofServer() *PprofServer {
 	return pprofServerInstance
 }
 
+// Stop ...
 func (p *PprofServer) Stop() {
 }
 
+// Listen ...
 func (p *PprofServer) Listen() (net.Listener, error) {
 	return nil, nil
 }
 
+// Serve ...
 func (p *PprofServer) Serve(listener net.Listener) {
 }
 
+// Run ...
 func (p *PprofServer) Run() {
 	router := mux.NewRouter()
 	router.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))

--- a/pkg/server/profiler/profiler_server_test.go
+++ b/pkg/server/profiler/profiler_server_test.go
@@ -1,0 +1,30 @@
+package profiler
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPprofProfiler(t *testing.T) {
+	server := SingletonPprofServer()
+	server.Start()
+
+	for {
+		conn, err := net.DialTimeout("tcp", net.JoinHostPort("localhost", "6060"), 5*time.Second)
+		require.NoError(t, err)
+		if conn != nil {
+			require.NoError(t, conn.Close())
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Test server was stopped
+	server.Stop()
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort("localhost", "6060"), 5*time.Second)
+	require.Error(t, err)
+	require.Nil(t, conn)
+}

--- a/scripts/create-central.sh
+++ b/scripts/create-central.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -eo pipefail
+name=${1:-"test-central-1"}
 
-echo "Creating central tenant: test-central-1"
+echo "Creating central tenant: $name"
+
 
 # shellcheck disable=SC1001
 curl -X POST -H "Authorization: Bearer $(ocm token)" -H "Content-Type: application/json" \
   http://127.0.0.1:8000/api/rhacs/v1/centrals\?async\=true \
-  -d '{"name": "test-central-1", "multi_az": true, "cloud_provider": "standalone", "region": "standalone"}'
+  -d '{"name": "'${name}'", "multi_az": true, "cloud_provider": "standalone", "region": "standalone"}'

--- a/scripts/create-central.sh
+++ b/scripts/create-central.sh
@@ -8,4 +8,4 @@ echo "Creating central tenant: $name"
 # shellcheck disable=SC1001
 curl -X POST -H "Authorization: Bearer $(ocm token)" -H "Content-Type: application/json" \
   http://127.0.0.1:8000/api/rhacs/v1/centrals\?async\=true \
-  -d '{"name": "'${name}'", "multi_az": true, "cloud_provider": "standalone", "region": "standalone"}'
+  -d '{"name": "'"${name}"'", "multi_az": true, "cloud_provider": "standalone", "region": "standalone"}'

--- a/scripts/fmcurl
+++ b/scripts/fmcurl
@@ -14,4 +14,9 @@ shift
 # Normalize
 resource=$(echo "$resource" | sed -e 's/^\///;')
 FM_URL="${FM_URL:-http://localhost:8000}"
-curl -LH "Authorization: Bearer ${OCM_TOKEN}" "$FM_URL/api/${resource}" "$@" | jq .
+
+if [[ "$resource" != "metrics" ]]; then
+  resource="api/$resource"
+fi
+
+curl -LH "Authorization: Bearer ${OCM_TOKEN}" "$FM_URL/${resource}" "$@" | jq .

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -1479,3 +1479,17 @@ objects:
       - port: 9000
         targetPort: 9000
         name: metrics-envoy
+
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: fleet-manager-pprof
+      labels:
+        app: fleet-manager
+        port: pprof
+    spec:
+      selector:
+        app: fleet-manager
+      ports:
+        - port: 6060
+          targetPort: 6060

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -1479,17 +1479,3 @@ objects:
       - port: 9000
         targetPort: 9000
         name: metrics-envoy
-
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      name: fleet-manager-pprof
-      labels:
-        app: fleet-manager
-        port: pprof
-    spec:
-      selector:
-        app: fleet-manager
-      ports:
-        - port: 6060
-          targetPort: 6060


### PR DESCRIPTION
## Description
 - Add pprof server to fleet-manager on port 6060
 - Add name parameter to `create-central.sh`
 - Allow more instance for eval instances in development
 - Increase data-plane capacity in development

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

 - /
