### PR TITLE
ROX-19905: Fix external-secrets securitycontext

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -175,16 +175,16 @@ external-secrets:
     repository: quay.io/app-sre/external-secrets
     tag: v0.9.5
   securityContext:
-    runAsUser: 1001130000
+    runAsUser: null
   webhook:
     securityContext:
-      runAsUser: 1001130001
+      runAsUser: null
     image:
       repository: quay.io/app-sre/external-secrets
       tag: v0.9.5
   certController:
     securityContext:
-      runAsUser: 1001130002
+      runAsUser: null
     image:
       repository: quay.io/app-sre/external-secrets
       tag: v0.9.5


### PR DESCRIPTION
## Description
Fixes the issue with the wrong service accounts range
```
pods "rhacs-external-secrets-webhook-867d7f9b6f-" is forbidden: unable to validate against any security context constraint: [provider "anyuid": Forbidden: not usable by user or serviceaccount, provider restricted-v2: .containers[0].runAsUser: Invalid value: 1001130001: must be in the ranges: [1001050000, 1001059999], provider "restricted": Forbidden: not usable by user or serviceaccount, provider "nonroot-v2": Forbidden: not usable by user or serviceaccount, provider
```

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
