### PR TITLE
Cache rendered centrals

### DIFF
--- a/internal/dinosaur/pkg/gitops/service.go
+++ b/internal/dinosaur/pkg/gitops/service.go
@@ -3,12 +3,12 @@ package gitops
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/util"
 	"strings"
 	"sync"
 	"text/template"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/util"
 	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"sigs.k8s.io/yaml"

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/config"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/gitops"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"sigs.k8s.io/yaml"
 )
 
 // ManagedCentralPresenter helper service which converts Central DB representation to the private API representation
@@ -32,14 +31,9 @@ func NewManagedCentralPresenter(config *config.CentralConfig, gitopsService gito
 // PresentManagedCentral converts DB representation of Central to the private API representation
 func (c *ManagedCentralPresenter) PresentManagedCentral(from *dbapi.CentralRequest) (private.ManagedCentral, error) {
 
-	centralCR, err := c.gitopsService.GetCentral(centralParamsFromRequest(from))
+	centralYaml, err := c.gitopsService.GetCentral(centralParamsFromRequest(from))
 	if err != nil {
 		return private.ManagedCentral{}, errors.Wrap(err, "failed to apply GitOps overrides to Central")
-	}
-
-	centralYaml, err := yaml.Marshal(centralCR)
-	if err != nil {
-		return private.ManagedCentral{}, errors.Wrap(err, "failed to marshal Central CR")
 	}
 
 	res := private.ManagedCentral{


### PR DESCRIPTION
## Description

This PR adds a cache for the rendered Centrals in the GitOps service.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

 - Unit tests
 - Manual
    - Deploy Fleet-Manager
    - Delete fleetshard-sync deployment (to prevent scheduling Centrals)
    - Execute to create Centrals: `for i in {1..1500}; do ./scripts/create-central.sh "test-central-${i}"; done`
    - Export your OCM token (`export OCM_TOKEN=$(ocm token)`
    - Run `./scripts/fmcurl rhacs/v1/agent-clusters/1234567890abcdef1234567890abcdef/centrals`
       - Expect long response time
   -  Run `./scripts/fmcurl rhacs/v1/agent-clusters/1234567890abcdef1234567890abcdef/centrals`
       - Run again, faster response time
