### PR TITLE
Cache rendered centrals v2

### DIFF
--- a/internal/dinosaur/pkg/gitops/config.go
+++ b/internal/dinosaur/pkg/gitops/config.go
@@ -83,7 +83,7 @@ func tryRenderDummyCentralWithPatch(patch string) error {
 			},
 		},
 	}
-	if _, err := renderCentral(dummyParams, dummyConfig); err != nil {
+	if _, err := RenderCentral(dummyParams, dummyConfig); err != nil {
 		return err
 	}
 	return nil

--- a/internal/dinosaur/pkg/gitops/service.go
+++ b/internal/dinosaur/pkg/gitops/service.go
@@ -11,30 +11,8 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// Service applies GitOps configuration to Central instances.
-type Service interface {
-	GetCentral(ctx CentralParams) (v1alpha1.Central, error)
-}
-
-type service struct {
-	configProvider ConfigProvider
-}
-
-// NewService returns a new Service.
-func NewService(configProvider ConfigProvider) Service {
-	return &service{configProvider: configProvider}
-}
-
-// GetCentral returns a Central instance with the given parameters.
-func (s *service) GetCentral(params CentralParams) (v1alpha1.Central, error) {
-	cfg, err := s.configProvider.Get()
-	if err != nil {
-		return v1alpha1.Central{}, errors.Wrap(err, "failed to get GitOps configuration")
-	}
-	return renderCentral(params, cfg)
-}
-
-func renderCentral(params CentralParams, config Config) (v1alpha1.Central, error) {
+// RenderCentral renders a Central instance for the given GitOps configuration and parameters.
+func RenderCentral(params CentralParams, config Config) (v1alpha1.Central, error) {
 	central, err := renderDefaultCentral(params)
 	if err != nil {
 		return v1alpha1.Central{}, errors.Wrap(err, "failed to get default Central instance")

--- a/internal/dinosaur/pkg/gitops/service_test.go
+++ b/internal/dinosaur/pkg/gitops/service_test.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func TestService_GetCentral(t *testing.T) {
+func TestRenderCentral(t *testing.T) {
 	tests := []struct {
 		name   string
 		config Config
@@ -117,8 +117,7 @@ func TestService_GetCentral(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := NewService(newMockProvider(tt.config))
-			got, err := svc.GetCentral(tt.params)
+			got, err := RenderCentral(tt.params, tt.config)
 			tt.assert(t, got, err)
 		})
 	}

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -1,45 +1,107 @@
 package presenters
 
 import (
+	"context"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/util"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/config"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/gitops"
-	"k8s.io/apimachinery/pkg/api/resource"
+	"golang.org/x/sync/errgroup"
 	"sigs.k8s.io/yaml"
 )
 
 // ManagedCentralPresenter helper service which converts Central DB representation to the private API representation
 type ManagedCentralPresenter struct {
 	centralConfig *config.CentralConfig
-	gitopsService gitops.Service
+	gitopsConfig  gitops.ConfigProvider
 }
 
 // NewManagedCentralPresenter creates a new instance of ManagedCentralPresenter
-func NewManagedCentralPresenter(config *config.CentralConfig, gitopsService gitops.Service) *ManagedCentralPresenter {
+func NewManagedCentralPresenter(
+	config *config.CentralConfig,
+	gitopsConfig gitops.ConfigProvider,
+) *ManagedCentralPresenter {
 	return &ManagedCentralPresenter{
 		centralConfig: config,
-		gitopsService: gitopsService,
+		gitopsConfig:  gitopsConfig,
 	}
+}
+
+// PresentManagedCentrals converts DB representation of multiple Centrals to the private API representation in parallel
+func (c *ManagedCentralPresenter) PresentManagedCentrals(ctx context.Context, from []*dbapi.CentralRequest) ([]private.ManagedCentral, error) {
+	gitopsConfig, err := c.gitopsConfig.Get()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get GitOps configuration")
+	}
+	ret := make([]private.ManagedCentral, len(from))
+	g, ctx := errgroup.WithContext(ctx)
+	const maxParallel = 50
+	locks := make(chan struct{}, maxParallel)
+	for i := range from {
+		index := i
+		g.Go(func() error {
+			select {
+			case locks <- struct{}{}:
+			case <-ctx.Done():
+				//nolint:wrapcheck
+				return ctx.Err()
+			}
+			var err error
+			ret[index], err = c.presentManagedCentral(gitopsConfig, from[index])
+			<-locks
+
+			return err
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, errors.Wrap(err, "failed to convert central requests to managed centrals")
+	}
+	return ret, nil
 }
 
 // PresentManagedCentral converts DB representation of Central to the private API representation
 func (c *ManagedCentralPresenter) PresentManagedCentral(from *dbapi.CentralRequest) (private.ManagedCentral, error) {
-
-	centralCR, err := c.gitopsService.GetCentral(centralParamsFromRequest(from))
+	gitopsConfig, err := c.gitopsConfig.Get()
 	if err != nil {
-		return private.ManagedCentral{}, errors.Wrap(err, "failed to apply GitOps overrides to Central")
+		return private.ManagedCentral{}, errors.Wrap(err, "failed to get GitOps configuration")
+	}
+	return c.presentManagedCentral(gitopsConfig, from)
+}
+
+// PresentManagedCentralWithSecrets return a private.ManagedCentral including secret data
+func (c *ManagedCentralPresenter) PresentManagedCentralWithSecrets(from *dbapi.CentralRequest) (private.ManagedCentral, error) {
+	managedCentral, err := c.PresentManagedCentral(from)
+	if err != nil {
+		return private.ManagedCentral{}, err
+	}
+	secretInterfaceMap, err := from.Secrets.Object()
+	secretStringMap := make(map[string]string, len(secretInterfaceMap))
+
+	if err != nil {
+		return managedCentral, errors.Wrapf(err, "failed to get Secrets for central request as map %q/%s", from.Name, from.ID)
 	}
 
-	centralYaml, err := yaml.Marshal(centralCR)
+	for k, v := range secretInterfaceMap {
+		secretStringMap[k] = fmt.Sprintf("%v", v)
+	}
+
+	managedCentral.Metadata.Secrets = secretStringMap // pragma: allowlist secret
+	return managedCentral, nil
+}
+
+func (c *ManagedCentralPresenter) presentManagedCentral(gitopsConfig gitops.Config, from *dbapi.CentralRequest) (private.ManagedCentral, error) {
+	centralParams := centralParamsFromRequest(from)
+	centralYaml, err := getCentralYaml(gitopsConfig, centralParams)
 	if err != nil {
-		return private.ManagedCentral{}, errors.Wrap(err, "failed to marshal Central CR")
+		return private.ManagedCentral{}, errors.Wrap(err, "failed to get Central YAML")
 	}
 
 	res := private.ManagedCentral{
@@ -91,48 +153,6 @@ func (c *ManagedCentralPresenter) PresentManagedCentral(from *dbapi.CentralReque
 	return res, nil
 }
 
-// PresentManagedCentralWithSecrets return a private.ManagedCentral including secret data
-func (c *ManagedCentralPresenter) PresentManagedCentralWithSecrets(from *dbapi.CentralRequest) (private.ManagedCentral, error) {
-	managedCentral, err := c.PresentManagedCentral(from)
-	if err != nil {
-		return private.ManagedCentral{}, err
-	}
-	secretInterfaceMap, err := from.Secrets.Object()
-	secretStringMap := make(map[string]string, len(secretInterfaceMap))
-
-	if err != nil {
-		return managedCentral, errors.Wrapf(err, "failed to get Secrets for central request as map %q/%s", from.Name, from.ID)
-	}
-
-	for k, v := range secretInterfaceMap {
-		secretStringMap[k] = fmt.Sprintf("%v", v)
-	}
-
-	managedCentral.Metadata.Secrets = secretStringMap // pragma: allowlist secret
-	return managedCentral, nil
-}
-
-func orDefaultQty(qty resource.Quantity, def resource.Quantity) *resource.Quantity {
-	if qty != (resource.Quantity{}) {
-		return &qty
-	}
-	return &def
-}
-
-func orDefaultString(s string, def string) string {
-	if s != "" {
-		return s
-	}
-	return def
-}
-
-func orDefaultInt32(i int32, def int32) int32 {
-	if i != 0 {
-		return i
-	}
-	return def
-}
-
 func getSecretNames(from *dbapi.CentralRequest) []string {
 	secrets, err := from.Secrets.Object()
 	if err != nil {
@@ -171,4 +191,154 @@ func centralParamsFromRequest(centralRequest *dbapi.CentralRequest) gitops.Centr
 		InstanceType:     centralRequest.InstanceType,
 		IsInternal:       centralRequest.Internal,
 	}
+}
+
+var locksByID = newKeyedMutex()
+var centralYamlCacheInstance = newCentralYamlCache()
+var renderFn = gitops.RenderCentral
+
+func getCentralYaml(gitopsConfig gitops.Config, centralParams gitops.CentralParams) ([]byte, error) {
+	centralID := centralParams.ID
+
+	// We obtain a lock for the central ID so that no other goroutine can render the central yaml for the same central
+	// at the same time.
+	lockByID := locksByID.getLockBy(centralID)
+	lockByID.Lock()
+	defer lockByID.Unlock()
+
+	// Computing the hash of both the gitops config and the incoming central params.
+	// This should be a deterministic way to detect when the output of the render function would change.
+	// In other words, the central YAML will always be the same for the same gitops config and central params.
+	hashes, err := newHashes(gitopsConfig, centralParams)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get hash for Central")
+	}
+
+	var centralYaml []byte
+	var shouldRender = true
+
+	// Check if the central yaml is in the cache and if it is, check if the hash matches
+	// If it does, we don't need to render it again
+	centralYamlCacheInstance.RLock()
+	entry, ok := centralYamlCacheInstance.entries[centralID]
+	centralYamlCacheInstance.RUnlock()
+	if ok {
+		if entry.hashes.equals(hashes) {
+			// The hash matches, we can use the cached central yaml
+			centralYaml = entry.centralYaml
+			shouldRender = false
+		}
+	}
+
+	if shouldRender {
+		// There was no matching cache entry, we need to render the central yaml.
+		centralCR, err := renderFn(centralParams, gitopsConfig)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to apply GitOps overrides to Central")
+		}
+		centralYaml, err = yaml.Marshal(centralCR)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to marshal Central CR")
+		}
+		// Locking the whole cache to add the new entry
+		centralYamlCacheInstance.Lock()
+		defer centralYamlCacheInstance.Unlock()
+		centralYamlCacheInstance.entries[centralID] = cacheEntry{
+			id:          centralID,
+			hashes:      hashes,
+			centralYaml: centralYaml,
+		}
+	}
+
+	return centralYaml, nil
+}
+
+type centralHashes struct {
+	gitopsConfigHash  string
+	centralParamsHash string
+}
+
+func (c centralHashes) equals(other centralHashes) bool {
+	return c.gitopsConfigHash == other.gitopsConfigHash && c.centralParamsHash == other.centralParamsHash
+}
+
+// newHashes computes the hash of the gitops config and the central params
+func newHashes(gitopsConfig gitops.Config, params gitops.CentralParams) (centralHashes, error) {
+	h1, err := util.MD5SumFromJSONStruct(gitopsConfig)
+	if err != nil {
+		return centralHashes{}, errors.Wrap(err, "failed to get hash for GitOps config")
+	}
+	h2, err := util.MD5SumFromJSONStruct(params)
+	if err != nil {
+		return centralHashes{}, errors.Wrap(err, "failed to get hash for Central params")
+	}
+	return centralHashes{
+		gitopsConfigHash:  fmt.Sprintf("%x", h1[:]),
+		centralParamsHash: fmt.Sprintf("%x", h2[:]),
+	}, nil
+}
+
+// keyedMutex is a mutex that can be locked by a key
+type keyedMutex struct {
+	locks map[string]*sync.Mutex
+	mLock sync.RWMutex
+}
+
+func newKeyedMutex() *keyedMutex {
+	return &keyedMutex{locks: make(map[string]*sync.Mutex)}
+}
+
+// getLockBy returns the lock for the given key. If the lock does not exist, it is created.
+func (k *keyedMutex) getLockBy(key string) *sync.Mutex {
+	k.mLock.RLock()
+	if ret, ok := k.locks[key]; ok {
+		k.mLock.RUnlock()
+		return ret
+	}
+	k.mLock.RUnlock()
+	k.mLock.Lock()
+	defer k.mLock.Unlock()
+	lock := &sync.Mutex{}
+	k.locks[key] = lock
+	return lock
+}
+
+// lock locks the lock for the given key
+func (k *keyedMutex) lock(key string) {
+	k.getLockBy(key).Lock()
+}
+
+// unlock unlocks the lock for the given key
+func (k *keyedMutex) unlock(key string) {
+	k.getLockBy(key).Unlock()
+}
+
+// tryLock tries to lock the lock for the given key
+func (k *keyedMutex) tryLock(key string) bool {
+	return k.getLockBy(key).TryLock()
+}
+
+// isLocked returns true if the lock for the given key is locked
+func (k *keyedMutex) isLocked(key string) bool {
+	tryLock := k.tryLock(key)
+	if tryLock {
+		k.unlock(key)
+	}
+	return !tryLock
+}
+
+// cacheEntry stores the central yaml and the hashes of the gitops config and the central params
+type cacheEntry struct {
+	id          string
+	hashes      centralHashes
+	centralYaml []byte
+}
+
+type centralYamlCache struct {
+	sync.RWMutex
+	entries map[string]cacheEntry
+}
+
+func newCentralYamlCache() *centralYamlCache {
+	return &centralYamlCache{entries: make(map[string]cacheEntry)}
 }

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -3,7 +3,6 @@ package presenters
 import (
 	"context"
 	"fmt"
-	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
 	"sort"
 	"sync"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/config"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/gitops"
+	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
 	"golang.org/x/sync/errgroup"
 	"sigs.k8s.io/yaml"
 )
@@ -304,14 +304,11 @@ func newKeyedMutex() *keyedMutex {
 
 // getLockBy returns the lock for the given key. If the lock does not exist, it is created.
 func (k *keyedMutex) getLockBy(key string) *sync.Mutex {
-	k.mLock.RLock()
-	if ret, ok := k.locks[key]; ok {
-		k.mLock.RUnlock()
-		return ret
-	}
-	k.mLock.RUnlock()
 	k.mLock.Lock()
 	defer k.mLock.Unlock()
+	if ret, ok := k.locks[key]; ok {
+		return ret
+	}
 	lock := &sync.Mutex{}
 	k.locks[key] = lock
 	return lock

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -295,7 +295,7 @@ func newHashes(gitopsConfig gitops.Config, params gitops.CentralParams) (central
 // keyedMutex is a mutex that can be locked by a key
 type keyedMutex struct {
 	locks map[string]*sync.Mutex
-	mLock sync.RWMutex
+	mLock sync.Mutex
 }
 
 func newKeyedMutex() *keyedMutex {

--- a/internal/dinosaur/pkg/presenters/managedcentral_test.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral_test.go
@@ -19,29 +19,29 @@ func TestShouldNotRenderTwiceForSameParams(t *testing.T) {
 	assert.Equal(t, 0, renderCount)
 
 	// first call should render once
-	getCentralYaml(gitopsConfig, params)
+	getCentralYaml(renderFn, gitopsConfig, params)
 	assert.Equal(t, 1, renderCount)
 
 	// second call should not render again
-	getCentralYaml(gitopsConfig, params)
+	getCentralYaml(renderFn, gitopsConfig, params)
 	assert.Equal(t, 1, renderCount)
 
 	// third call with different params should render again
 	params = gitops.CentralParams{ID: "foo"}
-	getCentralYaml(gitopsConfig, params)
+	getCentralYaml(renderFn, gitopsConfig, params)
 	assert.Equal(t, 2, renderCount)
 
 	// fourth call with same params should not render again
-	getCentralYaml(gitopsConfig, params)
+	getCentralYaml(renderFn, gitopsConfig, params)
 	assert.Equal(t, 2, renderCount)
 
 	// fifth call with different params should render again
 	gitopsConfig = gitops.Config{Centrals: gitops.CentralsConfig{Overrides: []gitops.CentralOverride{{InstanceIDs: []string{"foo"}}}}}
-	getCentralYaml(gitopsConfig, params)
+	getCentralYaml(renderFn, gitopsConfig, params)
 	assert.Equal(t, 3, renderCount)
 
 	// sixth call with same params should not render again
-	getCentralYaml(gitopsConfig, params)
+	getCentralYaml(renderFn, gitopsConfig, params)
 	assert.Equal(t, 3, renderCount)
 }
 
@@ -60,17 +60,17 @@ func TestShouldNotCacheOnError(t *testing.T) {
 	assert.Equal(t, 0, renderCount)
 
 	shouldThrow = true
-	getCentralYaml(gitopsConfig, params)
+	getCentralYaml(renderFn, gitopsConfig, params)
 	assert.Equal(t, 1, renderCount)
 
-	getCentralYaml(gitopsConfig, params)
+	getCentralYaml(renderFn, gitopsConfig, params)
 	assert.Equal(t, 2, renderCount)
 
 	shouldThrow = false
-	getCentralYaml(gitopsConfig, params)
+	getCentralYaml(renderFn, gitopsConfig, params)
 	assert.Equal(t, 3, renderCount)
 
-	getCentralYaml(gitopsConfig, params)
+	getCentralYaml(renderFn, gitopsConfig, params)
 	assert.Equal(t, 3, renderCount)
 }
 

--- a/internal/dinosaur/pkg/presenters/managedcentral_test.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral_test.go
@@ -12,7 +12,7 @@ func TestShouldNotRenderTwiceForSameParams(t *testing.T) {
 	var gitopsConfig = gitops.Config{}
 	var params = gitops.CentralParams{}
 	var renderCount = 0
-	renderFn = func(params gitops.CentralParams, config gitops.Config) (v1alpha1.Central, error) {
+	renderFn := func(params gitops.CentralParams, config gitops.Config) (v1alpha1.Central, error) {
 		renderCount++
 		return v1alpha1.Central{}, nil
 	}
@@ -50,7 +50,7 @@ func TestShouldNotCacheOnError(t *testing.T) {
 	var params = gitops.CentralParams{}
 	var renderCount = 0
 	var shouldThrow = false
-	renderFn = func(params gitops.CentralParams, config gitops.Config) (v1alpha1.Central, error) {
+	renderFn := func(params gitops.CentralParams, config gitops.Config) (v1alpha1.Central, error) {
 		renderCount++
 		if shouldThrow {
 			return v1alpha1.Central{}, assert.AnError

--- a/internal/dinosaur/pkg/presenters/managedcentral_test.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral_test.go
@@ -12,36 +12,38 @@ func TestShouldNotRenderTwiceForSameParams(t *testing.T) {
 	var gitopsConfig = gitops.Config{}
 	var params = gitops.CentralParams{}
 	var renderCount = 0
-	renderFn := func(params gitops.CentralParams, config gitops.Config) (v1alpha1.Central, error) {
+	r := newCachedCentralRenderer()
+	r.renderFn = func(params gitops.CentralParams, config gitops.Config) (v1alpha1.Central, error) {
 		renderCount++
 		return v1alpha1.Central{}, nil
 	}
+
 	assert.Equal(t, 0, renderCount)
 
 	// first call should render once
-	getCentralYaml(renderFn, gitopsConfig, params)
+	r.getCentralYaml(gitopsConfig, params)
 	assert.Equal(t, 1, renderCount)
 
 	// second call should not render again
-	getCentralYaml(renderFn, gitopsConfig, params)
+	r.getCentralYaml(gitopsConfig, params)
 	assert.Equal(t, 1, renderCount)
 
 	// third call with different params should render again
 	params = gitops.CentralParams{ID: "foo"}
-	getCentralYaml(renderFn, gitopsConfig, params)
+	r.getCentralYaml(gitopsConfig, params)
 	assert.Equal(t, 2, renderCount)
 
 	// fourth call with same params should not render again
-	getCentralYaml(renderFn, gitopsConfig, params)
+	r.getCentralYaml(gitopsConfig, params)
 	assert.Equal(t, 2, renderCount)
 
 	// fifth call with different params should render again
 	gitopsConfig = gitops.Config{Centrals: gitops.CentralsConfig{Overrides: []gitops.CentralOverride{{InstanceIDs: []string{"foo"}}}}}
-	getCentralYaml(renderFn, gitopsConfig, params)
+	r.getCentralYaml(gitopsConfig, params)
 	assert.Equal(t, 3, renderCount)
 
 	// sixth call with same params should not render again
-	getCentralYaml(renderFn, gitopsConfig, params)
+	r.getCentralYaml(gitopsConfig, params)
 	assert.Equal(t, 3, renderCount)
 }
 
@@ -50,27 +52,30 @@ func TestShouldNotCacheOnError(t *testing.T) {
 	var params = gitops.CentralParams{}
 	var renderCount = 0
 	var shouldThrow = false
-	renderFn := func(params gitops.CentralParams, config gitops.Config) (v1alpha1.Central, error) {
+
+	r := newCachedCentralRenderer()
+	r.renderFn = func(params gitops.CentralParams, config gitops.Config) (v1alpha1.Central, error) {
 		renderCount++
 		if shouldThrow {
 			return v1alpha1.Central{}, assert.AnError
 		}
 		return v1alpha1.Central{}, nil
 	}
+
 	assert.Equal(t, 0, renderCount)
 
 	shouldThrow = true
-	getCentralYaml(renderFn, gitopsConfig, params)
+	r.getCentralYaml(gitopsConfig, params)
 	assert.Equal(t, 1, renderCount)
 
-	getCentralYaml(renderFn, gitopsConfig, params)
+	r.getCentralYaml(gitopsConfig, params)
 	assert.Equal(t, 2, renderCount)
 
 	shouldThrow = false
-	getCentralYaml(renderFn, gitopsConfig, params)
+	r.getCentralYaml(gitopsConfig, params)
 	assert.Equal(t, 3, renderCount)
 
-	getCentralYaml(renderFn, gitopsConfig, params)
+	r.getCentralYaml(gitopsConfig, params)
 	assert.Equal(t, 3, renderCount)
 }
 

--- a/internal/dinosaur/pkg/presenters/managedcentral_test.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral_test.go
@@ -1,0 +1,91 @@
+package presenters
+
+import (
+	"testing"
+
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/gitops"
+	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldNotRenderTwiceForSameParams(t *testing.T) {
+	var gitopsConfig = gitops.Config{}
+	var params = gitops.CentralParams{}
+	var renderCount = 0
+	renderFn = func(params gitops.CentralParams, config gitops.Config) (v1alpha1.Central, error) {
+		renderCount++
+		return v1alpha1.Central{}, nil
+	}
+	assert.Equal(t, 0, renderCount)
+
+	// first call should render once
+	getCentralYaml(gitopsConfig, params)
+	assert.Equal(t, 1, renderCount)
+
+	// second call should not render again
+	getCentralYaml(gitopsConfig, params)
+	assert.Equal(t, 1, renderCount)
+
+	// third call with different params should render again
+	params = gitops.CentralParams{ID: "foo"}
+	getCentralYaml(gitopsConfig, params)
+	assert.Equal(t, 2, renderCount)
+
+	// fourth call with same params should not render again
+	getCentralYaml(gitopsConfig, params)
+	assert.Equal(t, 2, renderCount)
+
+	// fifth call with different params should render again
+	gitopsConfig = gitops.Config{Centrals: gitops.CentralsConfig{Overrides: []gitops.CentralOverride{{InstanceIDs: []string{"foo"}}}}}
+	getCentralYaml(gitopsConfig, params)
+	assert.Equal(t, 3, renderCount)
+
+	// sixth call with same params should not render again
+	getCentralYaml(gitopsConfig, params)
+	assert.Equal(t, 3, renderCount)
+}
+
+func TestShouldNotCacheOnError(t *testing.T) {
+	var gitopsConfig = gitops.Config{}
+	var params = gitops.CentralParams{}
+	var renderCount = 0
+	var shouldThrow = false
+	renderFn = func(params gitops.CentralParams, config gitops.Config) (v1alpha1.Central, error) {
+		renderCount++
+		if shouldThrow {
+			return v1alpha1.Central{}, assert.AnError
+		}
+		return v1alpha1.Central{}, nil
+	}
+	assert.Equal(t, 0, renderCount)
+
+	shouldThrow = true
+	getCentralYaml(gitopsConfig, params)
+	assert.Equal(t, 1, renderCount)
+
+	getCentralYaml(gitopsConfig, params)
+	assert.Equal(t, 2, renderCount)
+
+	shouldThrow = false
+	getCentralYaml(gitopsConfig, params)
+	assert.Equal(t, 3, renderCount)
+
+	getCentralYaml(gitopsConfig, params)
+	assert.Equal(t, 3, renderCount)
+}
+
+func TestKeyedMutexShouldLockByKey(t *testing.T) {
+	m := newKeyedMutex()
+
+	// locking "foo"
+	m.lock("foo")
+
+	// foo is locked
+	assert.True(t, m.isLocked("foo"))
+	assert.False(t, m.isLocked("bar"))
+
+	// unlock foo
+	m.unlock("foo")
+	assert.False(t, m.isLocked("foo"))
+
+}

--- a/internal/dinosaur/providers.go
+++ b/internal/dinosaur/providers.go
@@ -78,7 +78,6 @@ func ServiceProviders() di.Option {
 		di.Provide(dinosaurmgrs.NewCentralAuthConfigManager, di.As(new(workers.Worker))),
 		di.Provide(gitops.NewEmptyReader),
 		di.Provide(gitops.NewProvider),
-		di.Provide(gitops.NewService),
 		di.Provide(presenters.NewManagedCentralPresenter),
 	)
 }


### PR DESCRIPTION
Changes:
- Remove the gitops service. Replace with a function without receiver. 
- Add a function to the managedCentralPresenter to be able to render multiple centrals concurrently. (Moved that from the handler)
- Added a cache to store the rendered central YAML, keyed by central ID. 