### PR TITLE
ROX-20654 Add SCC to allow using ephemeral volumes

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/scc.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/scc.yaml
@@ -2,7 +2,13 @@ apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   annotations:
-    kubernetes.io/description: ephemeral-volumes allows pods to use ephemeral volumes
+    kubernetes.io/description: ephemeral allows pods to use the node's ephemeral storage.
   name: ephemeral-volumes
 volumes:
   - ephemeral
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny

--- a/dp-terraform/helm/rhacs-terraform/templates/scc.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/scc.yaml
@@ -2,8 +2,8 @@ apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   annotations:
-    kubernetes.io/description: ephemeral allows pods to use the node's ephemeral storage.
-  name: ephemeral-volumes
+    kubernetes.io/description: custom-acscs-ephemeral-volumes allows pods to use the node's ephemeral storage. This is needed until the clusters are upgraded to 4.12 where the anyuid SCC allows using ephemeral volumes by default
+  name: custom-acscs-ephemeral-volumes
 volumes:
   - ephemeral
 runAsUser:

--- a/dp-terraform/helm/rhacs-terraform/templates/scc.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/scc.yaml
@@ -1,0 +1,8 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: ephemeral-volumes allows pods to use ephemeral volumes
+  name: ephemeral-volumes
+volumes:
+  - ephemeral


### PR DESCRIPTION
~For some reason~ Because the stage/prod clusters are running an older version of openshift (4.11), the anyuid SCC does not allow ephemeral volumes by default. Adding a custom SCC so that we can use ephemeral volumes.