### PR TITLE
Bump ACS Operator memory

### DIFF
--- a/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-deployment.yaml
+++ b/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-deployment.yaml
@@ -128,10 +128,10 @@ spec:
           resources:
             limits:
               cpu: 2
-              memory: 1Gi
+              memory: 2Gi
             requests:
               cpu: 1
-              memory: 200Mi
+              memory: 1Gi
           securityContext:
             allowPrivilegeEscalation: false
           terminationMessagePath: /dev/termination-log


### PR DESCRIPTION
Request from 200MiB to 1GiB (high water mark), limit from 1GiB to 2GiB

Context: https://redhat-internal.slack.com/archives/C0313JYKH8W/p1699347566433479?thread_ts=1699298965.136549&cid=C0313JYKH8W

No tests performed.