### PR TITLE
disable OpenShift monitoring for internal Centrals

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -286,6 +286,7 @@ func (r *CentralReconciler) applyCentralConfig(remoteCentral *private.ManagedCen
 	r.applyProxyConfig(central)
 	r.applyDeclarativeConfig(central)
 	r.applyAnnotations(central)
+	r.applyMonitoring(remoteCentral, central)
 	return nil
 }
 
@@ -357,6 +358,22 @@ func (r *CentralReconciler) applyTelemetry(remoteCentral *private.ManagedCentral
 		},
 	}
 	central.Spec.Central.Telemetry = telemetry
+}
+
+func (r *CentralReconciler) applyMonitoring(remoteCentral *private.ManagedCentral, central *v1alpha1.Central) {
+	if central.Spec.Central == nil {
+		central.Spec.Central = &v1alpha1.CentralComponentSpec{}
+	}
+	// Disable OpenShift monitoring for internal Centrals to avoid overloading Telemeter with probe service metrics.
+	if remoteCentral.Metadata.Internal {
+		if central.Spec.Monitoring == nil {
+			central.Spec.Monitoring = &v1alpha1.GlobalMonitoring{}
+		}
+		if central.Spec.Monitoring.OpenShiftMonitoring == nil {
+			central.Spec.Monitoring.OpenShiftMonitoring = &v1alpha1.OpenShiftMonitoring{}
+		}
+		central.Spec.Monitoring.OpenShiftMonitoring.Enabled = false
+	}
 }
 
 func (r *CentralReconciler) restoreCentralSecrets(ctx context.Context, remoteCentral private.ManagedCentral) error {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
This changes disables OpenShift monitoring for internal Centrals. This is done for these reasons:
* Probe instances are cleaned up immediately, so there is no need for any monitoring.
* Since probe instances are created very frequently, the collected metrics ramp up Prometheus storage.
* Prevent sending useless metrics to Telemeter once that is enabled.

Note that we still collect kube metrics, this just disables the metrics that are emitted by Central itself and collected by OpenShift monitoring.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

CI
