### PR TITLE
fix: remove observability operator cpu limit

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-05-subscription.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-05-subscription.yaml
@@ -18,5 +18,4 @@ spec:
         cpu: {{ .Values.observabilityOperator.resources.requests.cpu | quote }}
         memory: {{ .Values.observabilityOperator.resources.requests.memory | quote }}
       limits:
-        cpu: {{ .Values.observabilityOperator.resources.limits.cpu | quote }}
         memory: {{ .Values.observabilityOperator.resources.limits.memory | quote }}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Follow up to https://github.com/stackrox/acs-fleet-manager/pull/1426, where I missed the observability operator CPU limit. This should fix the error `Error: UPGRADE FAILED: error validating "": error validating data: unknown object type "nil" in Subscription.spec.config.resources.limits.cpu`.