### PR TITLE
Fix deploy to integration

### DIFF
--- a/deploy/helm/probe/deploy.sh
+++ b/deploy/helm/probe/deploy.sh
@@ -20,7 +20,7 @@ ENVIRONMENT=$1
 CLUSTER_NAME=$2
 PROBE_IMAGE_ORG="rhacs-eng"
 PROBE_IMAGE_NAME="blackbox-monitoring-probe-service"
-PROBE_IMAGE_TAG="$(make -C "${ROOT_DIR}" tag)"
+PROBE_IMAGE_TAG="$(make --quiet --no-print-directory -C "${ROOT_DIR}" tag)"
 PROBE_IMAGE="quay.io/${PROBE_IMAGE_ORG}/${PROBE_IMAGE_NAME}:${PROBE_IMAGE_TAG}"
 
 init_chamber

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -117,7 +117,7 @@ fi
 
 FLEETSHARD_SYNC_ORG="app-sre"
 FLEETSHARD_SYNC_IMAGE="acs-fleet-manager"
-FLEETSHARD_SYNC_TAG="$(make -C "${ROOT_DIR}" tag)"
+FLEETSHARD_SYNC_TAG="$(make --quiet --no-print-directory -C "${ROOT_DIR}" tag)"
 
 if [[ "${HELM_DRY_RUN:-}" == "true" ]]; then
     "${ROOT_DIR}/scripts/check_image_exists.sh" "${FLEETSHARD_SYNC_ORG}" "${FLEETSHARD_SYNC_IMAGE}" "${FLEETSHARD_SYNC_TAG}" 0 || echo >&2 "Ignoring failed image check in dry-run mode."

--- a/dp-terraform/ocm/install_addon.sh
+++ b/dp-terraform/ocm/install_addon.sh
@@ -90,7 +90,7 @@ fi
 
 FLEETSHARD_SYNC_ORG="app-sre"
 FLEETSHARD_SYNC_IMAGE="acs-fleet-manager"
-FLEETSHARD_SYNC_TAG="$(make -C "${ROOT_DIR}" tag)"
+FLEETSHARD_SYNC_TAG="$(make --quiet --no-print-directory -C "${ROOT_DIR}" tag)"
 
 if [[ "${ADDON_DRY_RUN:-}" == "true" ]]; then
     "${ROOT_DIR}/scripts/check_image_exists.sh" "${FLEETSHARD_SYNC_ORG}" "${FLEETSHARD_SYNC_IMAGE}" "${FLEETSHARD_SYNC_TAG}" 0 || echo >&2 "Ignoring failed image check in dry-run mode."


### PR DESCRIPTION
## Description
Add extra flags to `make tag` to suppress unexpected output.

```
url: (3) URL using bad/illegal format or missing URL
Image acs-fleet-manager tag make: Entering directory '/home/runner/work/acs-fleet-manager/acs-fleet-manager'
0a4399f
make: Leaving directory '/home/runner/work/acs-fleet-manager/acs-fleet-manager' does not exist. Received the following response from quay API:
```
https://github.com/stackrox/acs-fleet-manager/actions/runs/6800037700/job/18487696298

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
