### PR TITLE
ROX-20795: probe telemetry configuration

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -346,14 +346,16 @@ func (r *CentralReconciler) applyTelemetry(remoteCentral *private.ManagedCentral
 	if central.Spec.Central == nil {
 		central.Spec.Central = &v1alpha1.CentralComponentSpec{}
 	}
-	// Telemetry will only be enabled if the storage key is set _and_ the central is not an "internal" central created
-	// from internal clients such as probe service or others.
-	telemetryEnabled := r.telemetry.StorageKey != "" && !remoteCentral.Metadata.Internal
+	// Telemetry is always enabled, but the key is set to DISABLED for probe and other internal instances.
+	key := r.telemetry.StorageKey
+	if remoteCentral.Metadata.Internal {
+		key = "DISABLED"
+	}
 	telemetry := &v1alpha1.Telemetry{
-		Enabled: pointer.Bool(telemetryEnabled),
+		Enabled: pointer.Bool(true),
 		Storage: &v1alpha1.TelemetryStorage{
 			Endpoint: &r.telemetry.StorageEndpoint,
-			Key:      &r.telemetry.StorageKey,
+			Key:      &key,
 		},
 	}
 	central.Spec.Central.Telemetry = telemetry

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -347,8 +347,9 @@ func (r *CentralReconciler) applyTelemetry(remoteCentral *private.ManagedCentral
 		central.Spec.Central = &v1alpha1.CentralComponentSpec{}
 	}
 	// Telemetry is always enabled, but the key is set to DISABLED for probe and other internal instances.
+	// Cloud-service specificity: empty key also disables telemetry to prevent reporting to the self-managed bucket.
 	key := r.telemetry.StorageKey
-	if remoteCentral.Metadata.Internal {
+	if remoteCentral.Metadata.Internal || key == "" {
 		key = "DISABLED"
 	}
 	telemetry := &v1alpha1.Telemetry{

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -1959,23 +1959,25 @@ func Test_getCentralConfig_telemetry(t *testing.T) {
 		assert func(t *testing.T, c *v1alpha1.Central)
 	}{
 		{
-			name: "should disable telemetry when no storage key is set",
+			name: "telemetry enabled, but DISABLED when no storage key is set",
 			args: args{
 				isInternal: false,
 				storageKey: "",
 			},
 			assert: func(t *testing.T, c *v1alpha1.Central) {
-				assert.False(t, *c.Spec.Central.Telemetry.Enabled)
+				assert.True(t, *c.Spec.Central.Telemetry.Enabled)
+				assert.Equal(t, "DISABLED", *c.Spec.Central.Telemetry.Storage.Key)
 			},
 		},
 		{
-			name: "should disable telemetry when managed central is internal",
+			name: "should DISABLE telemetry key when managed central is internal",
 			args: args{
 				isInternal: true,
 				storageKey: "foo",
 			},
 			assert: func(t *testing.T, c *v1alpha1.Central) {
-				assert.False(t, *c.Spec.Central.Telemetry.Enabled)
+				assert.True(t, *c.Spec.Central.Telemetry.Enabled)
+				assert.Equal(t, "DISABLED", *c.Spec.Central.Telemetry.Storage.Key)
 			},
 		},
 		{
@@ -1985,18 +1987,18 @@ func Test_getCentralConfig_telemetry(t *testing.T) {
 				storageKey: "foo",
 			},
 			assert: func(t *testing.T, c *v1alpha1.Central) {
-				assert.False(t, *c.Spec.Central.Telemetry.Enabled)
+				assert.True(t, *c.Spec.Central.Telemetry.Enabled)
+				assert.Equal(t, "foo", *c.Spec.Central.Telemetry.Storage.Key)
 			},
 		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			r := &CentralReconciler{}
-			if tc.args.isInternal {
-				r.telemetry = config.Telemetry{
+			r := &CentralReconciler{
+				telemetry: config.Telemetry{
 					StorageKey: tc.args.storageKey,
-				}
+				},
 			}
 			c := &v1alpha1.Central{}
 			mc := &private.ManagedCentral{
@@ -2184,10 +2186,10 @@ metadata:
 							},
 						},
 						Telemetry: &v1alpha1.Telemetry{
-							Enabled: pointer.Bool(false),
+							Enabled: pointer.Bool(true),
 							Storage: &v1alpha1.TelemetryStorage{
 								Endpoint: pointer.String(""),
-								Key:      pointer.String(""),
+								Key:      pointer.String("DISABLED"),
 							},
 						},
 					},

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -1069,11 +1069,15 @@ func TestTelemetryOptionsAreSetInCR(t *testing.T) {
 			require.NoError(t, err)
 
 			require.NotNil(t, central.Spec.Central.Telemetry.Enabled)
-			assert.Equal(t, tc.enabled, *central.Spec.Central.Telemetry.Enabled)
+			assert.True(t, *central.Spec.Central.Telemetry.Enabled)
 			require.NotNil(t, central.Spec.Central.Telemetry.Storage.Endpoint)
 			assert.Equal(t, tc.telemetry.StorageEndpoint, *central.Spec.Central.Telemetry.Storage.Endpoint)
 			require.NotNil(t, central.Spec.Central.Telemetry.Storage.Key)
-			assert.Equal(t, tc.telemetry.StorageKey, *central.Spec.Central.Telemetry.Storage.Key)
+			if tc.telemetry.StorageKey == "" {
+				assert.Equal(t, "DISABLED", *central.Spec.Central.Telemetry.Storage.Key)
+			} else {
+				assert.Equal(t, tc.telemetry.StorageKey, *central.Spec.Central.Telemetry.Storage.Key)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

In the context of cloud services, we want to have Telemetry always configured, except for the internal instances, such as probes.
Therefore, the proposed change sets the TelemetryEnabled property to true (which essentially enables telemetry configuration), and disables telemetry collection by setting "DISABLED" value for the key.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] ~Add secret to app-interface Vault or Secrets Manager if necessary~
- [ ] ~RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~
- [ ] ~Check AWS limits are reasonable for changes provisioning new resources~

## Test manual

CI, unit tests.