### PR TITLE
Add helm dependencies to Dockerfile

### DIFF
--- a/dp-terraform/helm/Dockerfile
+++ b/dp-terraform/helm/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR ${HOME}
 
 RUN curl -L --retry 10 --silent --show-error --fail -o /usr/local/bin/helm \
     "https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest/helm-linux-amd64" && \
-    chmod +x /usr/local/bin/helm
+    chmod +x /usr/local/bin/helm && \
+    helm version
 
 RUN helm repo add external-secrets "https://charts.external-secrets.io/" && \
     helm dependencies build ${HOME}/rhacs-terraform

--- a/dp-terraform/helm/Dockerfile
+++ b/dp-terraform/helm/Dockerfile
@@ -11,6 +11,19 @@ RUN curl -L --retry 10 --silent --show-error --fail -o /usr/local/bin/helm \
 RUN helm repo add external-secrets "https://charts.external-secrets.io/" && \
     helm dependencies build ${HOME}/rhacs-terraform
 
+# Workaround for deleting securityContext.runAsUser from the dependent chart
+# see: https://github.com/operator-framework/operator-sdk/issues/6635
+RUN microdnf install gzip tar && \
+    curl -L --retry 10 --silent --show-error --fail -o /tmp/yq_linux_amd64.tar.gz \
+        "https://github.com/mikefarah/yq/releases/download/v4.35.2/yq_linux_amd64.tar.gz" && \
+        tar -xzf /tmp/yq_linux_amd64.tar.gz ./yq_linux_amd64 && \
+        mv yq_linux_amd64 /usr/local/bin/yq && \
+        chmod +x /usr/local/bin/yq && \
+        rm /tmp/yq_linux_amd64.tar.gz && \
+    cd rhacs-terraform/charts && for filename in *.tgz; do tar -xf "$filename" && rm -f "$filename"; done && \
+    yq -i 'del(.securityContext.runAsUser) | del(.webhook.securityContext.runAsUser) | del(.certController.securityContext.runAsUser)' external-secrets/values.yaml
+
+
 FROM quay.io/operator-framework/helm-operator:v1.32.0
 
 ENV HOME=/opt/helm

--- a/dp-terraform/helm/Dockerfile
+++ b/dp-terraform/helm/Dockerfile
@@ -1,6 +1,18 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8 as build
+ENV HOME=/opt/helm
+COPY rhacs-terraform  ${HOME}/rhacs-terraform
+WORKDIR ${HOME}
+
+RUN curl -L --retry 10 --silent --show-error --fail -o /usr/local/bin/helm \
+    "https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest/helm-linux-amd64" && \
+    chmod +x /usr/local/bin/helm
+
+RUN helm repo add external-secrets "https://charts.external-secrets.io/" && \
+    helm dependencies build ${HOME}/rhacs-terraform
+
 FROM quay.io/operator-framework/helm-operator:v1.32.0
 
 ENV HOME=/opt/helm
 COPY watches.yaml ${HOME}/watches.yaml
-COPY rhacs-terraform  ${HOME}/rhacs-terraform
+COPY --from=build ${HOME}/rhacs-terraform ${HOME}/rhacs-terraform
 WORKDIR ${HOME}


### PR DESCRIPTION
## Description
Fleetshard operator lacks external secrets dependency in the image. The following changes have been added:

1. Add the external secrets dependency secrets operator can’t work without the external secrets dependency
2. Delete the default `securityContext.runAsUser` from the subchart. External secrets operator sets user id as 1000 by default which is prohibited by openshift (without extra scc config). If you delete the key then openshift assigns a user id from a range, so from security perspective it should be better. The null value I set for `securityContext.runAsUser` in root `values.yaml` works in helm but not in the operator. Most likely because the older version of helm is used in operator-sdk. I submitted a bug report to operator sdk and made a workaround to remove the default key(s) from the dependency.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
