### PR TITLE
Skip image build and push for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,7 +125,7 @@ jobs:
     needs: [pre-commit, verify-test]
     # Skip for external contributions.
     if: |
-      github.event_name == 'push' || !github.event.pull_request.head.repo.fork
+      github.event_name == 'push' || (!github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]')
     steps:
       - name: Login to Quay.io
         uses: docker/login-action@v3


### PR DESCRIPTION
## Description
This change fixes dependabot build by skipping image builds for dependabot. Example #1456 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
