### PR TITLE
ROX-2063: change operator deployment to enable heap profiling

### DIFF
--- a/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-deployment.yaml
+++ b/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-deployment.yaml
@@ -61,6 +61,13 @@ spec:
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=127.0.0.1:8080
           env:
+            - name: ENABLE_PROFILING
+              value: 'true'
+            - name: HEAP_DUMP_PARENT_DIR
+              value: /dump
+            - name: PROFILING_THRESHOLD_FRACTION
+              value: '0.50'
+            - name:
             - name: ENABLE_WEBHOOKS
               value: "false"
             - name: RELATED_IMAGE_MAIN
@@ -100,6 +107,9 @@ spec:
             {{- end }}
           image: "{{ .image }}"
           imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: dump-volume
+              mountPath: /dump
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -143,6 +153,9 @@ spec:
         runAsNonRoot: true
       serviceAccount: rhacs-operator-controller-manager
       serviceAccountName: rhacs-operator-controller-manager
+      volumes:
+        - name: dump-volume
+          emptyDir: {}
       terminationGracePeriodSeconds: 10
 ---
 {{- end }}

--- a/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-deployment.yaml
+++ b/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-deployment.yaml
@@ -67,7 +67,6 @@ spec:
               value: /dump
             - name: PROFILING_THRESHOLD_FRACTION
               value: '0.50'
-            - name:
             - name: ENABLE_WEBHOOKS
               value: "false"
             - name: RELATED_IMAGE_MAIN


### PR DESCRIPTION
## Description

We have high memory usage for operators manager container in prod. With this PR I active the heap profiling feature of the operator so that operators writes heap dumps once it's memory usage gets to 50% of the configured limits.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~~[ ] Unit and integration tests added~~
- ~~[ ] Added test description under `Test manual`~~
- ~~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
- ~~[ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~~
- ~~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- ~~[ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
- ~~[ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
- ~~[ ] Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual

CI

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
