### PR TITLE
ROX-19328 - Add gitops validate CLI command

### DIFF
--- a/cmd/acsfleetctl/main.go
+++ b/cmd/acsfleetctl/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/cmd/admin"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/cmd/centrals"
+	gitopsCmd "github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/gitops/cmd"
 )
 
 func main() {
@@ -26,4 +27,5 @@ func main() {
 func setupSubCommands(rootCmd *cobra.Command) {
 	rootCmd.AddCommand(centrals.NewCentralsCommand())
 	rootCmd.AddCommand(admin.NewAdminCommand())
+	rootCmd.AddCommand(gitopsCmd.NewGitOpsCommand())
 }

--- a/fleetshard/pkg/central/operator/config.go
+++ b/fleetshard/pkg/central/operator/config.go
@@ -2,6 +2,8 @@ package operator
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
 	"sigs.k8s.io/yaml"
 )
@@ -22,6 +24,20 @@ func parseConfig(content []byte) (OperatorConfigs, error) {
 		return OperatorConfigs{}, fmt.Errorf("unmarshalling operator config %w", err)
 	}
 	return out, nil
+}
+
+// ReadConfigs reads OperatorConfigs from a given file path.
+func ReadConfigs(path string) (OperatorConfigs, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return OperatorConfigs{}, fmt.Errorf("Failed reading gitops config at path %s: %w", path, err)
+	}
+
+	configs, err := parseConfig(content)
+	if err != nil {
+		return OperatorConfigs{}, fmt.Errorf("Failed parsing configs: %w", err)
+	}
+	return configs, nil
 }
 
 // OperatorConfigs represents all operators and the CRD which should be installed in a data-plane cluster.

--- a/internal/dinosaur/pkg/gitops/cmd/validate.go
+++ b/internal/dinosaur/pkg/gitops/cmd/validate.go
@@ -1,0 +1,59 @@
+// Package cmd ...
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/operator"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// NewGitOpsCommand creates a new gitops command.
+func NewGitOpsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:              "gitops",
+		Short:            "Perform actions like validation on the gitops config.",
+		Long:             "Perform actions like validation on the gitops config.",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {},
+	}
+	cmd.AddCommand(
+		newValidateCommand(),
+	)
+
+	return cmd
+}
+
+func newValidateCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "validate",
+		Short: "Validate the gitops config.",
+		Long:  "Validate the gitops config.",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 1 {
+				glog.Errorf("gitops file path expected as first argument")
+				return
+			}
+
+			configs, err := operator.ReadConfigs(args[0])
+			if err != nil {
+				glog.Errorf("validation failed reading configs: %s", err)
+				return
+			}
+
+			fieldPath := &field.Path{}
+			errors := operator.Validate(fieldPath, configs)
+			if len(errors) > 0 {
+				glog.Errorf("gitops validation failed")
+				for _, err := range errors {
+					glog.Error(err)
+				}
+				os.Exit(1)
+			}
+
+			fmt.Println("validation successful")
+		},
+	}
+}

--- a/internal/dinosaur/pkg/gitops/cmd/validate.go
+++ b/internal/dinosaur/pkg/gitops/cmd/validate.go
@@ -34,13 +34,13 @@ func newValidateCommand() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 1 {
 				glog.Errorf("gitops file path expected as first argument")
-				return
+				os.Exit(1)
 			}
 
 			configs, err := operator.ReadConfigs(args[0])
 			if err != nil {
 				glog.Errorf("validation failed reading configs: %s", err)
-				return
+				os.Exit(1)
 			}
 
 			fieldPath := &field.Path{}


### PR DESCRIPTION
## Description
[ROX-19328](https://issues.redhat.com//browse/ROX-19328) - Add gitops validate CLI command

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

 - Use acsfleetctl to validate config files in gitops repo
