### PR TITLE
Switch egress-proxy to a floating tag

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -24,7 +24,7 @@ fleetshardSync:
     endpoint: "https://sso.redhat.com"
     realm: "redhat-external"
   egressProxy:
-    image: "registry.redhat.io/openshift4/ose-egress-http-proxy:v4.11.0-202310101543.p0.gf1330f6.assembly.stream"
+    image: "registry.redhat.io/openshift4/ose-egress-http-proxy:v4.14"
   auditLogs:
     enabled: true
     skipTLSVerify: true

--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
@@ -44,6 +44,7 @@ spec:
               weight: 100
       containers:
       - name: egress-proxy
+        imagePullPolicy: Always
         image: {{ .Values.egressProxy.image }}
         command:
         - "squid"


### PR DESCRIPTION
## Description
Previously in https://github.com/stackrox/acs-fleet-manager/pull/1411 we switched egress-proxy to a specific image to forcefully update all egress-proxy images on all data plane clusters. This has its own disadvantages, for instance, one needs to bump the image regularly.

This PR attempts a different strategy: floating image tag with "always" pull policy. While this does not guarantee that all deployments have the same image at a given point of time, we expect it to eventually update all egress-proxy images on, say, cluster upgrade events.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] CI and all relevant tests are passing
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

None, CI run and testing on stage.
