### PR TITLE
run egress proxy as a non-root user

### DIFF
--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
@@ -51,8 +51,8 @@ spec:
         - "-f"
         - "/etc/squid/squid.conf"
         securityContext:
-          runAsGroup: 0
-          runAsUser: 500
+          runAsGroup: 1000690000
+          runAsUser: 1000690000
         ports:
         - containerPort: 3128
           protocol: TCP

--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
@@ -50,6 +50,9 @@ spec:
         - "-N"
         - "-f"
         - "/etc/squid/squid.conf"
+        securityContext:
+          runAsGroup: 0
+          runAsUser: 500
         ports:
         - containerPort: 3128
           protocol: TCP


### PR DESCRIPTION
## Description
During dog fooding review, we detected that we are getting violations reported due to egress-proxy running as root. As we do not need it to bind to a priviledged port, this seems like a low hanging fruit to fix. I picked an arbitrary user id (500), but this can be adjusted if needed.

## Checklist (Definition of Done)
- [ ] CI and all relevant tests are passing
- [X] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

CI e2e test should be sufficient.
Once rolled to integration, we should be able to manually verify this on the ACS CS dogfooding instance. Violations for the root user for egress-proxy deployments are expected to be gone.