### PR TITLE
Fix falky profiling test

### DIFF
--- a/pkg/server/profiler/profiler_server.go
+++ b/pkg/server/profiler/profiler_server.go
@@ -39,23 +39,30 @@ var (
 // SingletonPprofServer returns the PprofServer
 func SingletonPprofServer() *PprofServer {
 	oncePprofServer.Do(func() {
-		router := mux.NewRouter()
-		router.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
-		router.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
-		router.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
-		router.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
-		router.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
-		router.Handle("/debug/pprof/{cmd}", http.HandlerFunc(pprof.Index)) // special handling for Gorilla mux
-		httpServer := &http.Server{
-			Addr:    "localhost:6060",
-			Handler: router,
-		}
-
-		pprofServerInstance = &PprofServer{
-			httpServer: httpServer,
-		}
+		pprofServerInstance = newPprofServer()
 	})
 	return pprofServerInstance
+}
+
+func getRouter() *mux.Router {
+	router := mux.NewRouter()
+	router.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
+	router.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+	router.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+	router.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+	router.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+	router.Handle("/debug/pprof/{cmd}", http.HandlerFunc(pprof.Index)) // special handling for Gorilla mux
+	return router
+}
+
+func newPprofServer() *PprofServer {
+	httpServer := &http.Server{
+		Addr:    "localhost:6060",
+		Handler: getRouter(),
+	}
+	return &PprofServer{
+		httpServer: httpServer,
+	}
 }
 
 // Stop ...

--- a/pkg/server/profiler/profiler_server_test.go
+++ b/pkg/server/profiler/profiler_server_test.go
@@ -12,19 +12,16 @@ func TestPprofProfiler(t *testing.T) {
 	server := SingletonPprofServer()
 	server.Start()
 
-	for {
-		conn, err := net.DialTimeout("tcp", net.JoinHostPort("localhost", "6060"), 5*time.Second)
-		require.NoError(t, err)
-		if conn != nil {
-			require.NoError(t, conn.Close())
-			break
-		}
-		time.Sleep(50 * time.Millisecond)
+	// Test server is reachable
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort("localhost", "6060"), 60*time.Second)
+	require.NoError(t, err)
+	if conn != nil {
+		require.NoError(t, conn.Close())
 	}
 
 	// Test server was stopped
 	server.Stop()
-	conn, err := net.DialTimeout("tcp", net.JoinHostPort("localhost", "6060"), 5*time.Second)
+	conn, err = net.DialTimeout("tcp", net.JoinHostPort("localhost", "6060"), 2*time.Second)
 	require.Error(t, err)
 	require.Nil(t, conn)
 }


### PR DESCRIPTION
## Description

Fix flaky test, removing retries instead use timeout for dialing the profiling endpoint.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual
