### PR TITLE
Remove AuthConfig worker, instead call in `PrepareDinosaurRequest` directly

### DIFF
--- a/cmd/fleet-manager/main_test.go
+++ b/cmd/fleet-manager/main_test.go
@@ -51,7 +51,7 @@ func TestInjections(t *testing.T) {
 
 	var workerList []workers.Worker
 	env.MustResolve(&workerList)
-	Expect(workerList).To(HaveLen(9))
+	Expect(workerList).To(HaveLen(8))
 }
 
 func createServicesCommand(env *environments.Env) *cobra.Command {


### PR DESCRIPTION
## Description

**Motivation**

The AuthConfigManager is currently executed as a separate worker in its own goroutine which blocked the removal of the preparing worker in https://github.com/stackrox/acs-fleet-manager/pull/1491. 
This was because  `PrepareDinosaurRequest` blocked the [provisioning process indirectly](https://github.com/stackrox/acs-fleet-manager/pull/1493/files#diff-080490e019286b765c01a138eab3a47c8dd81e8c5c942fc8545be9d8fa8ae4e9R344-R347) which creates implicit dependencies between different workers.

In this PR the augmentation of the auth configuration is a directly done in the preparing reconciler.

**Effects**

- Remove `AuthConfigManager` is removed as worker and called directly in `PrepareDinosaurRequest` .
- Faster Central provisioning, preparing state is not dependent on another worker anymore
- The AuthConfig is still retried but as part of the preparing worker

**Breaking change**

 - The auth configuration is not reconciled on Central's in `ready` state anymore.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

 - CI
 - Integration environment prober to test dynamic clients