### PR TITLE
Set the same image fleetshard sync tag as the operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -565,7 +565,7 @@ image/push/internal: docker/login/internal
 
 image/build/fleetshard-operator: IMAGE_REF="$(external_image_registry)/fleetshard-operator:$(image_tag)"
 image/build/fleetshard-operator:
-	$(DOCKER) build -t $(IMAGE_REF) ${PROJECT_PATH}/dp-terraform/helm
+	$(DOCKER) build -t $(IMAGE_REF) --build-arg FLEETSHARD_SYNC_IMAGE_TAG=$(image_tag) ${PROJECT_PATH}/dp-terraform/helm
 .PHONY: image/build/fleetshard-operator
 
 image/push/fleetshard-operator: IMAGE_REF="$(external_image_registry)/fleetshard-operator:$(image_tag)"

--- a/dp-terraform/helm/Dockerfile
+++ b/dp-terraform/helm/Dockerfile
@@ -23,6 +23,8 @@ RUN microdnf install gzip tar && \
     cd rhacs-terraform/charts && for filename in *.tgz; do tar -xf "$filename" && rm -f "$filename"; done && \
     yq -i 'del(.securityContext.runAsUser) | del(.webhook.securityContext.runAsUser) | del(.certController.securityContext.runAsUser)' external-secrets/values.yaml
 
+ARG FLEETSHARD_SYNC_IMAGE_TAG=main
+RUN yq -i ".fleetshardSync.image.tag = strenv(FLEETSHARD_SYNC_IMAGE_TAG)" rhacs-terraform/values.yaml
 
 FROM quay.io/operator-framework/helm-operator:v1.32.0
 

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: fleetshard-sync
       containers:
       - name: fleetshard-sync
-        image: {{ .Values.fleetshardSync.image | quote }}
+        image: "{{ .Values.fleetshardSync.image.repo }}:{{ .Values.fleetshardSync.image.tag }}"
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/fleetshard-sync

--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -160,7 +160,8 @@ invoke_helm "${SCRIPT_DIR}" rhacs-terraform \
   --set acsOperator.channel="${OPERATOR_CHANNEL}" \
   --set acsOperator.version="${OPERATOR_VERSION}" \
   --set acsOperator.upstream="${OPERATOR_USE_UPSTREAM}" \
-  --set fleetshardSync.image="quay.io/${FLEETSHARD_SYNC_ORG}/${FLEETSHARD_SYNC_IMAGE}:${FLEETSHARD_SYNC_TAG}" \
+  --set fleetshardSync.image.repo="quay.io/${FLEETSHARD_SYNC_ORG}/${FLEETSHARD_SYNC_IMAGE}" \
+  --set fleetshardSync.image.tag="${FLEETSHARD_SYNC_TAG}" \
   --set fleetshardSync.authType="RHSSO" \
   --set fleetshardSync.clusterId="${CLUSTER_ID}" \
   --set fleetshardSync.clusterName="${CLUSTER_NAME}" \

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -3,7 +3,9 @@
 # Declare variables to be passed into your templates.
 
 fleetshardSync:
-  image: "quay.io/app-sre/acs-fleet-manager:59142fe"
+  image:
+    repo: "quay.io/app-sre/acs-fleet-manager"
+    tag: "main"
   # Can be either OCM, RHSSO, STATIC_TOKEN. When choosing RHSSO, make sure the clientId/secret is set. By default, uses RHSSO.
   authType: "RHSSO"
   # OCM refresh token, only required in combination with authType=OCM.

--- a/dp-terraform/ocm/install_addon.sh
+++ b/dp-terraform/ocm/install_addon.sh
@@ -23,6 +23,9 @@ init_chamber
 
 load_external_config secured-cluster SECURED_CLUSTER_
 
+PROMETHEUS_MEMORY_LIMIT=${PROMETHEUS_MEMORY_LIMIT:-"20Gi"}
+PROMETHEUS_MEMORY_REQUEST=${PROMETHEUS_MEMORY_REQUEST:-"20Gi"}
+
 case $ENVIRONMENT in
   dev)
     FM_ENDPOINT="http://fleet-manager.rhacs.svc.cluster.local:8000"
@@ -33,6 +36,8 @@ case $ENVIRONMENT in
     FLEETSHARD_SYNC_MEMORY_REQUEST="${FLEETSHARD_SYNC_MEMORY_REQUEST:-"512Mi"}"
     FLEETSHARD_SYNC_CPU_LIMIT="${FLEETSHARD_SYNC_CPU_LIMIT:-"500m"}"
     FLEETSHARD_SYNC_MEMORY_LIMIT="${FLEETSHARD_SYNC_MEMORY_LIMIT:-"512Mi"}"
+    PROMETHEUS_MEMORY_LIMIT="30Gi"
+    PROMETHEUS_MEMORY_REQUEST="30Gi"
     SECURED_CLUSTER_ENABLED="false"
     ;;
 
@@ -45,7 +50,7 @@ case $ENVIRONMENT in
     FLEETSHARD_SYNC_MEMORY_REQUEST="${FLEETSHARD_SYNC_MEMORY_REQUEST:-"1024Mi"}"
     FLEETSHARD_SYNC_CPU_LIMIT="${FLEETSHARD_SYNC_CPU_LIMIT:-"1000m"}"
     FLEETSHARD_SYNC_MEMORY_LIMIT="${FLEETSHARD_SYNC_MEMORY_LIMIT:-"1024Mi"}"
-    SECURED_CLUSTER_ENABLED="false"  # TODO(ROX-18908): enable
+    SECURED_CLUSTER_ENABLED="true"
     ;;
 
   stage)
@@ -84,15 +89,7 @@ if [[ $CLUSTER_ENVIRONMENT != "$ENVIRONMENT" ]]; then
     exit 2
 fi
 
-FLEETSHARD_SYNC_ORG="app-sre"
-FLEETSHARD_SYNC_IMAGE="acs-fleet-manager"
-FLEETSHARD_SYNC_TAG="$(make --quiet --no-print-directory -C "${ROOT_DIR}" tag)"
-
-if [[ "${ADDON_DRY_RUN:-}" == "true" ]]; then
-    "${ROOT_DIR}/scripts/check_image_exists.sh" "${FLEETSHARD_SYNC_ORG}" "${FLEETSHARD_SYNC_IMAGE}" "${FLEETSHARD_SYNC_TAG}" 0 || echo >&2 "Ignoring failed image check in dry-run mode."
-else
-    "${ROOT_DIR}/scripts/check_image_exists.sh" "${FLEETSHARD_SYNC_ORG}" "${FLEETSHARD_SYNC_IMAGE}" "${FLEETSHARD_SYNC_TAG}"
-fi
+FLEETSHARD_OPERATOR_TAG="$(make --quiet --no-print-directory -C "${ROOT_DIR}" tag)"
 
 echo "Loading external config: audit-logs/${CLUSTER_NAME}"
 load_external_config "audit-logs/${CLUSTER_NAME}" AUDIT_LOGS_
@@ -118,27 +115,21 @@ OCM_PAYLOAD=$(cat << EOF
             { "id": "acscsEnvironment", "value": "${ENVIRONMENT}" },
             { "id": "auditLogsLogGroupName", "value": "${AUDIT_LOGS_LOG_GROUP_NAME:-}" },
             { "id": "auditLogsRoleArn", "value": "${AUDIT_LOGS_ROLE_ARN:-}" },
-            { "id": "fleetshardSyncAuthType", "value": "RHSSO" },
-            { "id": "fleetshardSyncImageTag", "value": "quay.io/${FLEETSHARD_SYNC_ORG}/${FLEETSHARD_SYNC_IMAGE}:${FLEETSHARD_SYNC_TAG}" },
+            { "id": "fleetshardOperatorImageTag", "value": "${FLEETSHARD_OPERATOR_TAG}" },
             { "id": "fleetshardSyncAwsRegion", "value": "${CLUSTER_REGION}" },
             { "id": "fleetshardSyncFleetManagerEndpoint", "value": "${FM_ENDPOINT}" },
-            { "id": "fleetshardSyncManagedDbEnabled", "value": "true" },
-            { "id": "fleetshardSyncManagedDbPerformanceInsights", "value": "true" },
             { "id": "fleetshardSyncManagedDbSecurityGroup", "value": "${CLUSTER_MANAGED_DB_SECURITY_GROUP}" },
             { "id": "fleetshardSyncManagedDbSubnetGroup", "value": "${CLUSTER_MANAGED_DB_SUBNET_GROUP}" },
-            { "id": "fleetshardSyncRedHatSsoEndpoint", "value": "https://sso.redhat.com" },
-            { "id": "fleetshardSyncRedHatSsoRealm", "value": "redhat-external" },
             { "id": "fleetshardSyncResourcesLimitsCpu", "value": "${FLEETSHARD_SYNC_CPU_LIMIT}" },
             { "id": "fleetshardSyncResourcesLimitsMemory", "value": "${FLEETSHARD_SYNC_MEMORY_LIMIT}" },
             { "id": "fleetshardSyncResourcesRequestsCpu", "value": "${FLEETSHARD_SYNC_CPU_REQUEST}" },
             { "id": "fleetshardSyncResourcesRequestsMemory", "value": "${FLEETSHARD_SYNC_MEMORY_REQUEST}" },
             { "id": "fleetshardSyncSecretEncryptionKeyId", "value": "${CLUSTER_SECRET_ENCRYPTION_KEY_ID}" },
-            { "id": "fleetshardSyncSecretEncryptionType", "value": "kms" },
-            { "id": "loggingAwsRegion", "value": "us-east-1" },
             { "id": "loggingGroupPrefix", "value": "${CLUSTER_NAME}" },
             { "id": "observabilityGithubTag", "value": "${OBSERVABILITY_GITHUB_TAG}" },
-            { "id": "observabilityObservatoriumAuthType", "value": "redhat" },
             { "id": "observabilityObservatoriumGateway", "value": "${OBSERVABILITY_OBSERVATORIUM_GATEWAY}" },
+            { "id": "observabilityPrometheusResourcesLimitsMemory", "value" : "${PROMETHEUS_MEMORY_LIMIT}" },
+            { "id": "observabilityPrometheusResourcesRequestsMemory", "value": "${PROMETHEUS_MEMORY_REQUEST}" }
             { "id": "observabilityOperatorVersion", "value": "${OBSERVABILITY_OPERATOR_VERSION}" },
             { "id": "securedClusterCentralEndpoint", "value": "${SECURED_CLUSTER_CENTRAL_ENDPOINT}" },
             { "id": "securedClusterEnabled", "value": "${SECURED_CLUSTER_ENABLED}" },

--- a/dp-terraform/ocm/install_addon.sh
+++ b/dp-terraform/ocm/install_addon.sh
@@ -129,7 +129,7 @@ OCM_PAYLOAD=$(cat << EOF
             { "id": "observabilityGithubTag", "value": "${OBSERVABILITY_GITHUB_TAG}" },
             { "id": "observabilityObservatoriumGateway", "value": "${OBSERVABILITY_OBSERVATORIUM_GATEWAY}" },
             { "id": "observabilityPrometheusResourcesLimitsMemory", "value" : "${PROMETHEUS_MEMORY_LIMIT}" },
-            { "id": "observabilityPrometheusResourcesRequestsMemory", "value": "${PROMETHEUS_MEMORY_REQUEST}" }
+            { "id": "observabilityPrometheusResourcesRequestsMemory", "value": "${PROMETHEUS_MEMORY_REQUEST}" },
             { "id": "observabilityOperatorVersion", "value": "${OBSERVABILITY_OPERATOR_VERSION}" },
             { "id": "securedClusterCentralEndpoint", "value": "${SECURED_CLUSTER_CENTRAL_ENDPOINT}" },
             { "id": "securedClusterEnabled", "value": "${SECURED_CLUSTER_ENABLED}" },


### PR DESCRIPTION
## Description
This change sets the fleetshard-sync image tag for the operator the same as the operator tag.
Additionally, I've made a cleanup of the `install_addon.sh` script and ported the recent changes from `terraform_cluster.sh`.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
