### PR TITLE
Fix tolerations for logging collectors to work on ACSCS infra nodes

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/logging/templates/01-logging-03-cluster-logging.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/templates/01-logging-03-cluster-logging.yaml
@@ -10,15 +10,14 @@ metadata:
 spec:
   managementState: "Managed"
   collection:
-    logs:
-      {{- if .Values.tolerations }}
-      tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
-      {{- end }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
-      {{- end }}
-      {{- if .Values.resources }}
-      resources: {{ toYaml .Values.resources | nindent 8 }}
-      {{- end }}
-      type: "fluentd"
-      fluentd: {}
+    {{- if .Values.tolerations }}
+    tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
+    {{- end }}
+    {{- if .Values.nodeSelector }}
+    nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
+    {{- end }}
+    {{- if .Values.resources }}
+    resources: {{ toYaml .Values.resources | nindent 8 }}
+    {{- end }}
+    type: "fluentd"
+    fluentd: {}

--- a/dp-terraform/helm/rhacs-terraform/charts/logging/templates/01-logging-03-cluster-logging.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/templates/01-logging-03-cluster-logging.yaml
@@ -11,13 +11,13 @@ spec:
   managementState: "Managed"
   collection:
     {{- if .Values.tolerations }}
-    tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
+    tolerations: {{ toYaml .Values.tolerations | nindent 6 }}
     {{- end }}
     {{- if .Values.nodeSelector }}
-    nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
+    nodeSelector: {{ toYaml .Values.nodeSelector | nindent 6 }}
     {{- end }}
     {{- if .Values.resources }}
-    resources: {{ toYaml .Values.resources | nindent 8 }}
+    resources: {{ toYaml .Values.resources | nindent 6 }}
     {{- end }}
     type: "fluentd"
     fluentd: {}


### PR DESCRIPTION
## Description

Currently, tolerations are not set on openshift-logging collector pods. Because of that, logs from apps running on `acscs-infra` nodes are not collected.

Based on [API documentation](https://docs.openshift.com/container-platform/4.12/logging/api_reference/logging-5-6-reference.html), `tolerations` can be set under:
`.spec.collection.logs.fluentd.tolerations` (DEPRECATED)
or 
`.spec.collection.tolerations`

Since the `logs` property is deprecated, this PR removes it. With that, we should solve two issues:
1. tolerations will be set to correct property in CR
2. deprecated property will not be used anymore

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~[ ] Unit and integration tests added~
- [x] Added test description under `Test manual`
- ~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- ~[ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- ~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~
- ~[ ] Add secret to app-interface Vault or Secrets Manager if necessary~
- ~[ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~
- ~[ ] Check AWS limits are reasonable for changes provisioning new resources~

## Test manual

Tested only results generated with helm:
```
helm template rhacs-terraform-logging --debug --namespace rhacs --values ./acs-terraform-logging-values.yaml . | yq 'select(document_index == 8)  | .spec'
```

Results with `tolerations` provided in the values file:
```
managementState: "Managed"
collection:
  tolerations:
    - effect: NoSchedule
      key: node-role.kubernetes.io/acscs-infra
      operator: Exists
  nodeSelector:
    node-role.kubernetes.io/acscs-infra: ""
  type: "fluentd"
  fluentd: {}
```

Without tolerations provided:
```
managementState: "Managed"
collection:
  type: "fluentd"
  fluentd: {}
```