### PR TITLE
Change the scope for requesting dynamic clients.

### DIFF
--- a/pkg/client/redhatsso/dynamicclients/client.go
+++ b/pkg/client/redhatsso/dynamicclients/client.go
@@ -9,7 +9,7 @@ import (
 
 // NewDynamicClientsAPI returns new instance of dynamic clients sso.redhat.com API client.
 func NewDynamicClientsAPI(realmConfig *iam.IAMRealmConfig) *api.AcsTenantsApiService {
-	httpClient := redhatsso.NewSSOAuthHTTPClient(realmConfig, "api.iam.clients")
+	httpClient := redhatsso.NewSSOAuthHTTPClient(realmConfig, "api.iam.clients.acs")
 	configuration := &api.Configuration{
 		BasePath:  realmConfig.BaseURL + realmConfig.APIEndpointURI,
 		UserAgent: "RHACS-Fleet-Manager/1.0",


### PR DESCRIPTION
## Description
As requested by the CIAM team, change the scope for requesting RHSSO dynamic clients to "api.iam.clients.acs" from "api.iam.clients".

## Checklist (Definition of Done)
None, a trivial change that will fail miserably if something does not work.

## Test manual

CI run. 
