### PR TITLE
Remove nodeSelector for logging operator collector

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -113,8 +113,6 @@ logging:
     - key: node-role.kubernetes.io/acscs-infra
       operator: Exists
       effect: NoSchedule
-  nodeSelector:
-    node-role.kubernetes.io/acscs-infra: ""
 
 # See available parameters in charts/audit-logs/values.yaml
 # - enabled flag is used to completely enable/disable logging sub-chart


### PR DESCRIPTION
## Description

With `nodeSelector` defined, collectors will be deployed only on nodes specified by that option. In the case of logging collectors, it is a DaemonSet, and we should have a collector pod running on every cluster node.

This PR is a follow-up on https://github.com/stackrox/acs-fleet-manager/pull/1499 

This issue was discovered on the integration cluster after checking the status of the deployment of the previous PR.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~[ ] Unit and integration tests added~
- [x] Added test description under `Test manual`
- ~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- ~[ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- ~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~
- ~[ ] Add secret to app-interface Vault or Secrets Manager if necessary~
- ~[ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~
- ~[ ] Check AWS limits are reasonable for changes provisioning new resources~

## Test manual

The same testing was done similar to PR: https://github.com/stackrox/acs-fleet-manager/pull/1499

1. Remove nodeSelector from test values.yaml
2. Run `helm template rhacs-terraform-logging --debug --namespace rhacs --values ./acs-terraform-logging-values.yaml . | yq 'select(document_index == 8) | .spec'`

Got result:
```
managementState: "Managed"
collection:
  tolerations:
    - effect: NoSchedule
      key: node-role.kubernetes.io/acscs-infra
      operator: Exists
  type: "fluentd"
  fluentd: {}

```
