### PR TITLE
Enable cluster logging operator collectors on infra nodes

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -113,6 +113,9 @@ logging:
     - key: node-role.kubernetes.io/acscs-infra
       operator: Exists
       effect: NoSchedule
+    - key: node-role.kubernetes.io/infra
+      operator: Exists
+      effect: NoSchedule
 
 # See available parameters in charts/audit-logs/values.yaml
 # - enabled flag is used to completely enable/disable logging sub-chart


### PR DESCRIPTION
## Description

After validating #1501 on the integration cluster, I found that `infra` nodes do not contain a logging operator collector.

I think this is a problem with the logging operator running on the OSD cluster because OSD has `infra` nodes, and the cluster logging operator (CLO) does not take that into consideration.

This PR should fix that problem.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~[ ] Unit and integration tests added~
- ~[ ] Added test description under `Test manual`~
- ~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- ~[ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- ~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~
- ~[ ] Add secret to app-interface Vault or Secrets Manager if necessary~
- ~[ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~
- ~[ ] Check AWS limits are reasonable for changes provisioning new resources~

## Test manual

I didn't test it. The easiest way is to validate it on the integration cluster because it contains nodes with the `infra` role.
