### PR TITLE
ROX-21118: change `expired_at` via API

### DIFF
--- a/internal/dinosaur/pkg/api/admin/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/admin/private/api/openapi.yaml
@@ -320,6 +320,57 @@ paths:
       security:
       - Bearer: []
       summary: Return the details of Central instance by ID
+  /api/rhacs/v1/admin/centrals/{id}/expired-at:
+    post:
+      operationId: updateCentralExpiredAtById
+      parameters:
+      - description: The ID of record
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - explode: true
+        in: query
+        name: timestamp
+        required: false
+        schema:
+          type: string
+        style: form
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Central'
+          description: Central updated by ID
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Auth token is invalid
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: User is not authorised to access the service
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: No Central found with the specified ID
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unexpected error occurred
+      security:
+      - Bearer: []
+      summary: Set `expired_at` central property
   /api/rhacs/v1/admin/centrals/{id}/rotate-secrets:
     post:
       parameters:

--- a/internal/dinosaur/pkg/api/admin/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/admin/private/api/openapi.yaml
@@ -625,6 +625,10 @@ components:
         updated_at:
           format: date-time
           type: string
+        expired_at:
+          format: date-time
+          nullable: true
+          type: string
         failed_reason:
           type: string
         organisation_id:

--- a/internal/dinosaur/pkg/api/admin/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/admin/private/api/openapi.yaml
@@ -321,7 +321,7 @@ paths:
       - Bearer: []
       summary: Return the details of Central instance by ID
   /api/rhacs/v1/admin/centrals/{id}/expired-at:
-    post:
+    patch:
       operationId: updateCentralExpiredAtById
       parameters:
       - description: The ID of record
@@ -377,7 +377,7 @@ paths:
           description: Unexpected error occurred
       security:
       - Bearer: []
-      summary: Set `expired_at` central property
+      summary: Update `expired_at` central property
   /api/rhacs/v1/admin/centrals/{id}/rotate-secrets:
     post:
       parameters:

--- a/internal/dinosaur/pkg/api/admin/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/admin/private/api/openapi.yaml
@@ -337,6 +337,13 @@ paths:
         schema:
           type: string
         style: form
+      - explode: true
+        in: query
+        name: reason
+        required: true
+        schema:
+          type: string
+        style: form
       responses:
         "200":
           content:

--- a/internal/dinosaur/pkg/api/admin/private/api_default.go
+++ b/internal/dinosaur/pkg/api/admin/private/api_default.go
@@ -869,3 +869,130 @@ func (a *DefaultApiService) GetCentrals(ctx _context.Context, localVarOptionals 
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+
+// UpdateCentralExpiredAtByIdOpts Optional parameters for the method 'UpdateCentralExpiredAtById'
+type UpdateCentralExpiredAtByIdOpts struct {
+	Timestamp optional.String
+}
+
+/*
+UpdateCentralExpiredAtById Set `expired_at` central property
+  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+  - @param id The ID of record
+  - @param optional nil or *UpdateCentralExpiredAtByIdOpts - Optional Parameters:
+  - @param "Timestamp" (optional.String) -
+
+@return Central
+*/
+func (a *DefaultApiService) UpdateCentralExpiredAtById(ctx _context.Context, id string, localVarOptionals *UpdateCentralExpiredAtByIdOpts) (Central, *_nethttp.Response, error) {
+	var (
+		localVarHTTPMethod   = _nethttp.MethodPost
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+		localVarReturnValue  Central
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/api/rhacs/v1/admin/centrals/{id}/expired-at"
+	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", _neturl.QueryEscape(parameterToString(id, "")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+
+	if localVarOptionals != nil && localVarOptionals.Timestamp.IsSet() {
+		localVarQueryParams.Add("timestamp", parameterToString(localVarOptionals.Timestamp.Value(), ""))
+	}
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 401 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 403 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 404 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 500 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}

--- a/internal/dinosaur/pkg/api/admin/private/api_default.go
+++ b/internal/dinosaur/pkg/api/admin/private/api_default.go
@@ -876,7 +876,7 @@ type UpdateCentralExpiredAtByIdOpts struct {
 }
 
 /*
-UpdateCentralExpiredAtById Set `expired_at` central property
+UpdateCentralExpiredAtById Update `expired_at` central property
   - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
   - @param id The ID of record
   - @param reason
@@ -887,7 +887,7 @@ UpdateCentralExpiredAtById Set `expired_at` central property
 */
 func (a *DefaultApiService) UpdateCentralExpiredAtById(ctx _context.Context, id string, reason string, localVarOptionals *UpdateCentralExpiredAtByIdOpts) (Central, *_nethttp.Response, error) {
 	var (
-		localVarHTTPMethod   = _nethttp.MethodPost
+		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string

--- a/internal/dinosaur/pkg/api/admin/private/api_default.go
+++ b/internal/dinosaur/pkg/api/admin/private/api_default.go
@@ -879,12 +879,13 @@ type UpdateCentralExpiredAtByIdOpts struct {
 UpdateCentralExpiredAtById Set `expired_at` central property
   - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
   - @param id The ID of record
+  - @param reason
   - @param optional nil or *UpdateCentralExpiredAtByIdOpts - Optional Parameters:
   - @param "Timestamp" (optional.String) -
 
 @return Central
 */
-func (a *DefaultApiService) UpdateCentralExpiredAtById(ctx _context.Context, id string, localVarOptionals *UpdateCentralExpiredAtByIdOpts) (Central, *_nethttp.Response, error) {
+func (a *DefaultApiService) UpdateCentralExpiredAtById(ctx _context.Context, id string, reason string, localVarOptionals *UpdateCentralExpiredAtByIdOpts) (Central, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -905,6 +906,7 @@ func (a *DefaultApiService) UpdateCentralExpiredAtById(ctx _context.Context, id 
 	if localVarOptionals != nil && localVarOptionals.Timestamp.IsSet() {
 		localVarQueryParams.Add("timestamp", parameterToString(localVarOptionals.Timestamp.Value(), ""))
 	}
+	localVarQueryParams.Add("reason", parameterToString(reason, ""))
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/internal/dinosaur/pkg/api/admin/private/model_central.go
+++ b/internal/dinosaur/pkg/api/admin/private/model_central.go
@@ -31,6 +31,7 @@ type Central struct {
 	Host           string               `json:"host,omitempty"`
 	CreatedAt      time.Time            `json:"created_at,omitempty"`
 	UpdatedAt      time.Time            `json:"updated_at,omitempty"`
+	ExpiredAt      *time.Time           `json:"expired_at,omitempty"`
 	FailedReason   string               `json:"failed_reason,omitempty"`
 	OrganisationId string               `json:"organisation_id,omitempty"`
 	SubscriptionId string               `json:"subscription_id,omitempty"`

--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -239,7 +239,7 @@ func (h adminCentralHandler) SetExpiredAt(w http.ResponseWriter, r *http.Request
 	cfg := &handlers.HandlerConfig{
 		Action: func() (i interface{}, serviceError *errors.ServiceError) {
 			id := mux.Vars(r)["id"]
-			ts := mux.Vars(r)["timestamp"]
+			ts := r.PostForm.Get("timestamp")
 			central := &dbapi.CentralRequest{ClusterID: id}
 			expired_at, err := time.Parse(time.RFC3339, ts)
 			if err != nil {

--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -38,8 +38,8 @@ type AdminCentralHandler interface {
 	Restore(w http.ResponseWriter, r *http.Request)
 	// RotateSecrets rotates secrets within central
 	RotateSecrets(w http.ResponseWriter, r *http.Request)
-	// SetExpiredAt sets the expired_at central property
-	SetExpiredAt(w http.ResponseWriter, r *http.Request)
+	// PatchExpiredAt sets the expired_at central property
+	PatchExpiredAt(w http.ResponseWriter, r *http.Request)
 }
 
 type adminCentralHandler struct {
@@ -237,7 +237,7 @@ func (h adminCentralHandler) RotateSecrets(w http.ResponseWriter, r *http.Reques
 	handlers.Handle(w, r, cfg, http.StatusOK)
 }
 
-func (h adminCentralHandler) SetExpiredAt(w http.ResponseWriter, r *http.Request) {
+func (h adminCentralHandler) PatchExpiredAt(w http.ResponseWriter, r *http.Request) {
 	cfg := &handlers.HandlerConfig{
 		Action: func() (i interface{}, serviceError *errors.ServiceError) {
 			reason := r.PostFormValue("reason")
@@ -257,13 +257,9 @@ func (h adminCentralHandler) SetExpiredAt(w http.ResponseWriter, r *http.Request
 			}
 			glog.Warningf("Setting expired_at to %q for central %q: %s", ts, id, reason)
 			central := &dbapi.CentralRequest{Meta: api.Meta{ID: id}}
-			svcErr := h.service.Updates(central, map[string]interface{}{
+			return nil, h.service.Updates(central, map[string]interface{}{
 				"expired_at": &expired_at,
 			})
-			if svcErr != nil {
-				glog.Warningf("error: ", svcErr)
-			}
-			return nil, svcErr
 		},
 	}
 	handlers.Handle(w, r, cfg, http.StatusOK)

--- a/internal/dinosaur/pkg/handlers/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/handlers/admin_dinosaur.go
@@ -255,7 +255,7 @@ func (h adminCentralHandler) PatchExpiredAt(w http.ResponseWriter, r *http.Reque
 					return nil, errors.NewWithCause(errors.ErrorBadRequest, err, "Cannot parse timestamp: %s", err.Error())
 				}
 			}
-			glog.Warningf("Setting expired_at to %q for central %q: %s", ts, id, reason)
+			glog.Warningf("Setting expired_at to %q for central %q: %s", expired_at, id, reason)
 			central := &dbapi.CentralRequest{Meta: api.Meta{ID: id}}
 			return nil, h.service.Updates(central, map[string]interface{}{
 				"expired_at": &expired_at,

--- a/internal/dinosaur/pkg/presenters/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/presenters/admin_dinosaur.go
@@ -25,6 +25,7 @@ func PresentDinosaurRequestAdminEndpoint(request *dbapi.CentralRequest, _ accoun
 		Host:          request.GetUIHost(), // TODO(ROX-11990): Split the Host in Fleet Manager Public API to UI and Data hosts
 		CreatedAt:     request.CreatedAt,
 		UpdatedAt:     request.UpdatedAt,
+		ExpiredAt:     request.ExpiredAt,
 		FailedReason:  request.FailedReason,
 		InstanceType:  request.InstanceType,
 	}, nil

--- a/internal/dinosaur/pkg/routes/route_loader.go
+++ b/internal/dinosaur/pkg/routes/route_loader.go
@@ -255,7 +255,7 @@ func (s *options) buildAPIBaseRouter(mainRouter *mux.Router, basePath string, op
 	adminCentralsRouter.HandleFunc("/{id}/rotate-secrets", adminCentralHandler.RotateSecrets).
 		Name(logger.NewLogEvent("admin-rotate-central-secrets", "[admin] rotate central secrets by id").ToString()).
 		Methods(http.MethodPost)
-	adminCentralsRouter.HandleFunc("/{id}/expired-at", adminCentralHandler.SetExpiredAt).
+	adminCentralsRouter.HandleFunc("/{id}/expired-at", adminCentralHandler.PatchExpiredAt).
 		Name(logger.NewLogEvent("admin-expired-at", "[admin] set `expired_at` central property").ToString()).
 		Methods(http.MethodPost)
 

--- a/internal/dinosaur/pkg/routes/route_loader.go
+++ b/internal/dinosaur/pkg/routes/route_loader.go
@@ -255,6 +255,9 @@ func (s *options) buildAPIBaseRouter(mainRouter *mux.Router, basePath string, op
 	adminCentralsRouter.HandleFunc("/{id}/rotate-secrets", adminCentralHandler.RotateSecrets).
 		Name(logger.NewLogEvent("admin-rotate-central-secrets", "[admin] rotate central secrets by id").ToString()).
 		Methods(http.MethodPost)
+	adminCentralsRouter.HandleFunc("/{id}/expired-at", adminCentralHandler.SetExpiredAt).
+		Name(logger.NewLogEvent("admin-expired-at", "[admin] set `expired_at` central property").ToString()).
+		Methods(http.MethodPost)
 
 	adminCreateRouter := adminCentralsRouter.NewRoute().Subrouter()
 	adminCreateRouter.HandleFunc("", adminCentralHandler.Create).Methods(http.MethodPost)

--- a/openapi/fleet-manager-private-admin.yaml
+++ b/openapi/fleet-manager-private-admin.yaml
@@ -257,7 +257,6 @@ paths:
             application/json:
               schema:
                 $ref: 'fleet-manager.yaml#/components/schemas/Error'
-
   '/api/rhacs/v1/admin/centrals/{id}/rotate-secrets':
     post:
       summary: Rotate RHSSO client of a central tenant
@@ -406,6 +405,10 @@ components:
             updated_at:
               format: date-time
               type: string
+            expired_at:
+              format: date-time
+              type: string
+              nullable: true
             failed_reason:
               type: string
             organisation_id:

--- a/openapi/fleet-manager-private-admin.yaml
+++ b/openapi/fleet-manager-private-admin.yaml
@@ -218,6 +218,11 @@ paths:
           schema:
             type: string
           required: false
+        - in: query
+          name: reason
+          schema:
+            type: string
+          required: true
       security:
         - Bearer: [ ]
       operationId: updateCentralExpiredAtById

--- a/openapi/fleet-manager-private-admin.yaml
+++ b/openapi/fleet-manager-private-admin.yaml
@@ -209,8 +209,8 @@ paths:
               schema:
                 $ref: 'fleet-manager.yaml#/components/schemas/Error'
   '/api/rhacs/v1/admin/centrals/{id}/expired-at':
-    post:
-      summary: Set `expired_at` central property
+    patch:
+      summary: Update `expired_at` central property
       parameters:
         - $ref: "fleet-manager.yaml#/components/parameters/id"
         - in: query

--- a/openapi/fleet-manager-private-admin.yaml
+++ b/openapi/fleet-manager-private-admin.yaml
@@ -208,6 +208,51 @@ paths:
             application/json:
               schema:
                 $ref: 'fleet-manager.yaml#/components/schemas/Error'
+  '/api/rhacs/v1/admin/centrals/{id}/expired-at':
+    post:
+      summary: Set `expired_at` central property
+      parameters:
+        - $ref: "fleet-manager.yaml#/components/parameters/id"
+        - in: query
+          name: timestamp
+          schema:
+            type: string
+          required: false
+      security:
+        - Bearer: [ ]
+      operationId: updateCentralExpiredAtById
+      responses:
+        "200":
+          description: Central updated by ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Central'
+        "401":
+          description: Auth token is invalid
+          content:
+            application/json:
+              schema:
+                $ref: 'fleet-manager.yaml#/components/schemas/Error'
+        "403":
+          description: User is not authorised to access the service
+          content:
+            application/json:
+              schema:
+                $ref: 'fleet-manager.yaml#/components/schemas/Error'
+        "404":
+          description: No Central found with the specified ID
+          content:
+            application/json:
+              schema:
+                $ref: 'fleet-manager.yaml#/components/schemas/Error'
+        "500":
+          description: Unexpected error occurred
+          content:
+            application/json:
+              schema:
+                $ref: 'fleet-manager.yaml#/components/schemas/Error'
+
   '/api/rhacs/v1/admin/centrals/{id}/rotate-secrets':
     post:
       summary: Rotate RHSSO client of a central tenant


### PR DESCRIPTION
```console
$ curl -H "Authorization: Bearer $STATIC_TOKEN_ADMIN" \
"http://localhost:8000/api/rhacs/v1/admin/centrals/cl75fu8bs0bd6k334h0g/expired-at" \
-d "timestamp=2024-01-02T13:45:56Z" \
-d "reason=test" -X PATCH
```
Logs:
```
W1127 09:29:41.074361      13 admin_dinosaur.go:258] Setting expired_at to "2024-01-02T13:45:56Z" for central "cl75fu8bs0bd6k334h0g": test
I1127 09:29:41.076758      13 framework.go:51] user='rhacs-ms-test@redhat.com' action='admin-expired-at' src_ip='127.0.0.1:60156' session='20873d12-aae8-4d3b-9c14-44a5a253c367' tx_id='631' opid='cli631dfh90d6k12pjdg' operation ended successfully
```

`expired_at` field in GET centrals:
```console
$ curl -H "Authorization: Bearer $STATIC_TOKEN_ADMIN" "http://localhost:8000/api/rhacs/v1/admin/centrals"
```
```json
{
  "kind": "CentralList",
  "page": 1,
  "size": 1,
  "total": 1,
  "items": [
    {
      "id": "cl75fu8bs0bd6k334h0g",
      "kind": "CentralRequest",
      "href": "/api/rhacs/v1/centrals/cl75fu8bs0bd6k334h0g",
      "status": "ready",
      "cloud_provider": "aws",
      "multi_az": true,
      "region": "us-east-1",
      "owner": "acscs-trial-expiration-test-prod",
      "name": "test-central-1",
      "host": "acs-cl75fu8bs0bd6k334h0g.cluster.local",
      "created_at": "2023-11-10T16:19:06.767675Z",
      "updated_at": "2023-11-27T14:22:24.692756Z",
      "expired_at": "2024-01-02T13:45:56Z",
      "failed_reason": "Creation time went over the timeout. Interrupting central initialization.",
      "instance_type": "standard"
    }
  ]
}
```