### PR TITLE
Remove deprecated OwnerAccountID field

### DIFF
--- a/internal/dinosaur/pkg/api/dbapi/central_request_types.go
+++ b/internal/dinosaur/pkg/api/dbapi/central_request_types.go
@@ -39,9 +39,6 @@ type CentralRequest struct {
 	SubscriptionID string `json:"subscription_id"`
 	// Owner is the Red Hat SSO login name of the user who created the instance. It is either the email, or the user name, depending on what the user chose to login with. It's displayed in the console UI.
 	Owner string `json:"owner" gorm:"index"`
-	// OwnerAccountID is used in telemetry, it is the account_id claim of the Red Hat SSO token.
-	// Deprecated: Use user_id claim in telemetry.
-	OwnerAccountID string `json:"owner_account_id"`
 	// OwnerUserID is the subject claim (confusingly it is NOT the user_id claim) of the Red Hat SSO token.
 	OwnerUserID string `json:"owner_user_id"`
 

--- a/internal/dinosaur/pkg/handlers/validation.go
+++ b/internal/dinosaur/pkg/handlers/validation.go
@@ -108,7 +108,6 @@ func ValidateDinosaurClaims(ctx context.Context, dinosaurRequestPayload *public.
 
 		dinosaurRequest.Owner, _ = claims.GetUsername()
 		dinosaurRequest.OrganisationID, _ = claims.GetOrgID()
-		dinosaurRequest.OwnerAccountID, _ = claims.GetAccountID()
 		dinosaurRequest.OwnerUserID, _ = claims.GetSubject()
 
 		return nil

--- a/pkg/auth/acs_claims.go
+++ b/pkg/auth/acs_claims.go
@@ -28,14 +28,6 @@ func (c *ACSClaims) GetUsername() (string, error) {
 		tenantUsernameClaim, alternateTenantUsernameClaim)
 }
 
-// GetAccountID ...
-func (c *ACSClaims) GetAccountID() (string, error) {
-	if accountID, ok := (*c)[tenantAccountIDClaim].(string); ok {
-		return accountID, nil
-	}
-	return "", fmt.Errorf("can't find %q attribute in claims", tenantAccountIDClaim)
-}
-
 // GetUserID returns the user id of the Red Hat account associated to the token.
 func (c *ACSClaims) GetUserID() (string, error) {
 	if idx, val := arrays.FindFirst(func(x interface{}) bool { return x != nil },

--- a/pkg/auth/acs_claims_test.go
+++ b/pkg/auth/acs_claims_test.go
@@ -94,43 +94,6 @@ func TestACSClaims_GetUsername(t *testing.T) {
 	}
 }
 
-func TestACSClaims_GetAccountId(t *testing.T) {
-	const (
-		claimAccountID = "12345"
-	)
-	tests := map[string]struct {
-		claims    ACSClaims
-		accountID string
-		error     bool
-	}{
-		"should yield account_id when claim is set": {
-			claims: ACSClaims(jwt.MapClaims{
-				"account_id": claimAccountID,
-			}),
-			accountID: claimAccountID,
-		},
-		"should yield error when no claim is set": {
-			claims: ACSClaims(jwt.MapClaims{}),
-			error:  true,
-		},
-		"should yield error when non-string value is set": {
-			claims: ACSClaims(jwt.MapClaims{
-				"account_id": 12345,
-			}),
-			error: true,
-		},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			accountID, err := tt.claims.GetAccountID()
-
-			assert.Equal(t, tt.error, err != nil)
-			assert.Equal(t, tt.accountID, accountID)
-		})
-	}
-}
-
 func TestACSClaims_GetOrgId(t *testing.T) {
 	const (
 		claimOrgID = "12345"

--- a/pkg/auth/context_test.go
+++ b/pkg/auth/context_test.go
@@ -7,36 +7,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestContext_GetAccountIdFromClaims(t *testing.T) {
-	tests := []struct {
-		name   string
-		claims ACSClaims
-		want   string
-	}{
-		{
-			name:   "Should return empty when tenantAccountIdClaim is empty",
-			claims: ACSClaims{},
-			want:   "",
-		},
-		{
-			name: "Should return when tenantAccountIdClaim is not empty",
-			claims: ACSClaims{
-				tenantAccountIDClaim: "Test_account_id",
-			},
-			want: "Test_account_id",
-		},
-	}
-
-	RegisterTestingT(t)
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			accountID, _ := tt.claims.GetAccountID()
-			Expect(accountID).To(Equal(tt.want))
-		})
-	}
-}
-
 func TestContext_GetUserIdFromClaims(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Description

Remove OwnerAccountID field

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
