### PR TITLE
chore: drop cpu limits from egress proxy

### DIFF
--- a/fleetshard/pkg/central/charts/data/tenant-resources/values.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/values.yaml
@@ -6,7 +6,6 @@ egressProxy:
       cpu: 100m
       memory: 220Mi
     limits:
-      cpu: 200m
       memory: 220Mi
 labels: {}
 annotations: {}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Noticed that we still set cpu limits for the egress proxy. We already removed cpu limits from other deployments because it leads to unnecessary throttling. On example of that is in https://redhat.pagerduty.com/incidents/Q39LMR8IUSF7XG?utm_campaign=channel&utm_source=slack.
