### PR TITLE
chore(dashboards): cover new cluster names in data sources regex

### DIFF
--- a/dashboards/grafana-dashboard-acs-fleet-manager-slos.configmap.yaml
+++ b/dashboards/grafana-dashboard-acs-fleet-manager-slos.configmap.yaml
@@ -996,7 +996,7 @@ data:
             "query": "prometheus",
             "queryValue": "",
             "refresh": 1,
-            "regex": "app-sre-stage-01-prometheus|app-sre-prod-04-prometheus",
+            "regex": "app-sre-stage-01-prometheus|app-sre-prod-04-prometheus|appsre.*",
             "skipUrlSync": false,
             "type": "datasource"
           },

--- a/dashboards/grafana-dashboard-acs-fleet-manager.configmap.yaml
+++ b/dashboards/grafana-dashboard-acs-fleet-manager.configmap.yaml
@@ -628,7 +628,7 @@ data:
             "query": "prometheus",
             "queryValue": "",
             "refresh": 1,
-            "regex": "app-sre-stage-01-prometheus|app-sre-prod-04-prometheus",
+            "regex": "app-sre-stage-01-prometheus|app-sre-prod-04-prometheus|appsre.*",
             "skipUrlSync": false,
             "type": "datasource"
           },


### PR DESCRIPTION
## Description

integration control plane moved to a new cluster. We need to relax the regex to see the new data source.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~Unit and integration tests added~
- [x] ~Added test description under `Test manual`~
- [x] ~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] ~CI and all relevant tests are passing~
- [x] ~Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- [x] ~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~
- [x] ~Add secret to app-interface Vault or Secrets Manager if necessary~
- [x] ~RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~
- [x] ~Check AWS limits are reasonable for changes provisioning new resources~

## Test manual

No tests :-(