### PR TITLE
Add expiration date worker lease via migrations

### DIFF
--- a/internal/dinosaur/pkg/migrations/20231212140000_add_expiration_lease_type.go
+++ b/internal/dinosaur/pkg/migrations/20231212140000_add_expiration_lease_type.go
@@ -1,0 +1,35 @@
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/stackrox/acs-fleet-manager/pkg/api"
+	"github.com/stackrox/acs-fleet-manager/pkg/db"
+	"gorm.io/gorm"
+)
+
+const expirationDateLeaseType = "expiration_date_worker"
+
+// addCentralAuthLease adds a leader lease value for the central_auth_config lease and its
+// worker.
+// It is similar to addLeaderLease.
+func addExpirationLeaseType() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "20231212140000",
+		Migrate: func(tx *gorm.DB) error {
+			// Set an initial already expired lease for expiration_date_worker.
+			err := tx.Create(&api.LeaderLease{
+				Expires:   &db.DinosaurAdditionalLeasesExpireTime,
+				LeaseType: expirationDateLeaseType,
+				Leader:    api.NewID(),
+			}).Error
+
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return nil
+		},
+	}
+}

--- a/internal/dinosaur/pkg/migrations/migrations.go
+++ b/internal/dinosaur/pkg/migrations/migrations.go
@@ -50,6 +50,7 @@ func getMigrations() []*gormigrate.Migration {
 		addSecretFieldToCentralRequests(),
 		removeCentralAndScannerOverrides(),
 		addExpiredAtFieldToCentralRequests(),
+		addExpirationLeaseType(),
 	}
 }
 

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/expiration_date_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/expiration_date_mgr.go
@@ -16,6 +16,8 @@ import (
 	"github.com/stackrox/acs-fleet-manager/pkg/workers"
 )
 
+const leaseType = "expiration_date_worker"
+
 // ExpirationDateManager set's the `expired_at` central request property to the
 // current time when the quota allowance returned from AMS equals to 0.
 type ExpirationDateManager struct {
@@ -30,7 +32,7 @@ func NewExpirationDateManager(centralService services.DinosaurService, quotaServ
 	return &ExpirationDateManager{
 		BaseWorker: workers.BaseWorker{
 			ID:         uuid.New().String(),
-			WorkerType: "expiration_date_worker",
+			WorkerType: leaseType,
 			Reconciler: workers.Reconciler{},
 		},
 		centralService:      centralService,

--- a/internal/dinosaur/providers.go
+++ b/internal/dinosaur/providers.go
@@ -66,6 +66,9 @@ func ServiceProviders() di.Option {
 		di.Provide(clusters.NewDefaultProviderFactory, di.As(new(clusters.ProviderFactory))),
 		di.Provide(routes.NewRouteLoader),
 		di.Provide(quota.NewDefaultQuotaServiceFactory),
+		// IMPORTANT:
+		// Each new manager lease should be added to the database via migration,
+		// otherwise manager will never start properly.
 		di.Provide(workers.NewClusterManager, di.As(new(workers.Worker))),
 		di.Provide(dinosaurmgrs.NewDinosaurManager, di.As(new(workers.Worker))),
 		di.Provide(dinosaurmgrs.NewAcceptedCentralManager, di.As(new(workers.Worker))),


### PR DESCRIPTION
## Description
Without this migration, new `expiration_date_mgr` introduced in https://github.com/stackrox/acs-fleet-manager/pull/1248 won't work on already deployed `fleet-manager`:
```
I1211 18:30:38.096596       1 leader_election_mgr.go:128] failed to acquire leader lease: expected to find a lease entry, found none for :expiration_date_worker
```

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

1. TBD local test
