### PR TITLE
dogfooding: set collector collection method to core BPF

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/README.md
+++ b/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/README.md
@@ -17,7 +17,7 @@ The following commands generate `crds/secured-cluster.yaml`:
 ```
 git clone git@github.com:stackrox/stackrox.git
 cd stackrox/operator
-git checkout 3.74.0
+git checkout 4.3.1
 kustomize build config/crd > crds/secured-cluster.yaml
 ```
 

--- a/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/crds/secured-cluster.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/crds/secured-cluster.yaml
@@ -2,8 +2,1131 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
+  name: centrals.platform.stackrox.io
+spec:
+  group: platform.stackrox.io
+  names:
+    kind: Central
+    listKind: CentralList
+    plural: centrals
+    singular: central
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Central is the configuration template for the central services.
+          This includes the API server, persistent storage, and the web UI, as well
+          as the image scanner.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CentralSpec defines the desired state of Central
+            properties:
+              central:
+                description: Settings for the Central component, which is responsible
+                  for all user interaction.
+                properties:
+                  adminPasswordGenerationDisabled:
+                    description: Disable admin password generation. Do not use this
+                      for first-time installations, as you will have no way to perform
+                      initial setup and configuration of alternative authentication
+                      methods.
+                    type: boolean
+                  adminPasswordSecret:
+                    description: Specify a secret that contains the administrator
+                      password in the "password" data item. If omitted, the operator
+                      will auto-generate a password and store it in the "password"
+                      item in the "central-htpasswd" secret.
+                    properties:
+                      name:
+                        description: The name of the referenced secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  db:
+                    description: Settings for Central DB, which is responsible for
+                      data persistence.
+                    properties:
+                      configOverride:
+                        description: Config map containing postgresql.conf and pg_hba.conf
+                          that will be used if modifications need to be applied.
+                        properties:
+                          name:
+                            description: The name of the referenced config map.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      connectionString:
+                        description: 'NOTE: Connecting to an external database is
+                          in Technology Preview. Specify a connection string that
+                          corresponds to an external database. If set, the operator
+                          will not manage Central DB. When using this option, you
+                          must explicitly set a password secret; automatically generating
+                          a password will not be supported.'
+                        type: string
+                      isEnabled:
+                        default: Default
+                        description: Deprecated field. It is no longer necessary to
+                          specify it. This field will be removed in a future release.
+                          Central is configured to use PostgreSQL by default.
+                        enum:
+                        - Default
+                        - Enabled
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: If you want this component to only run on specific
+                          nodes, you can configure a node selector here.
+                        type: object
+                      passwordSecret:
+                        description: Specify a secret that contains the password in
+                          the "password" data item. This can only be used when specifying
+                          a connection string manually. When omitted, the operator
+                          will auto-generate a DB password and store it in the "password"
+                          item in the "central-db-password" secret.
+                        properties:
+                          name:
+                            description: The name of the referenced secret.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      persistence:
+                        description: Configures how Central DB should store its persistent
+                          data. You can choose between using a persistent volume claim
+                          (recommended default), and a host path.
+                        properties:
+                          hostPath:
+                            description: Stores persistent data on a directory on
+                              the host. This is not recommended, and should only be
+                              used together with a node selector (only available in
+                              YAML view).
+                            properties:
+                              path:
+                                description: The path on the host running Central.
+                                type: string
+                            type: object
+                          persistentVolumeClaim:
+                            description: Uses a Kubernetes persistent volume claim
+                              (PVC) to manage the storage location of persistent data.
+                              Recommended for most users.
+                            properties:
+                              claimName:
+                                default: central-db
+                                description: The name of the PVC to manage persistent
+                                  data. If no PVC with the given name exists, it will
+                                  be created. Defaults to "central-db" if not set.
+                                type: string
+                              size:
+                                description: The size of the persistent volume when
+                                  created through the claim. If a claim was automatically
+                                  created, this can be used after the initial deployment
+                                  to resize (grow) the volume (only supported by some
+                                  storage class controllers).
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                type: string
+                              storageClassName:
+                                description: The name of the storage class to use
+                                  for the PVC. If your cluster is not configured with
+                                  a default storage class, you must select a value
+                                  here.
+                                type: string
+                            type: object
+                        type: object
+                      resources:
+                        description: Allows overriding the default resource settings
+                          for this component. Please consult the documentation for
+                          an overview of default resource requirements and a sizing
+                          guide.
+                        properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable. It can only be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                      tolerations:
+                        description: If you want this component to only run on specific
+                          nodes, you can configure tolerations of tainted nodes.
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  declarativeConfiguration:
+                    description: Configures resources within Central in a declarative
+                      manner.
+                    properties:
+                      configMaps:
+                        description: List of config maps containing declarative configuration.
+                        items:
+                          description: LocalConfigMapReference is a reference to a
+                            config map within the same namespace.
+                          properties:
+                            name:
+                              description: The name of the referenced config map.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      secrets:
+                        description: List of secrets containing declarative configuration.
+                        items:
+                          description: LocalSecretReference is a reference to a secret
+                            within the same namespace.
+                          properties:
+                            name:
+                              description: The name of the referenced secret.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  defaultTLSSecret:
+                    description: By default, Central will only serve an internal TLS
+                      certificate, which means that you will need to handle TLS termination
+                      at the ingress or load balancer level. If you want to terminate
+                      TLS in Central and serve a custom server certificate, you can
+                      specify a secret containing the certificate and private key
+                      here.
+                    properties:
+                      name:
+                        description: The name of the referenced secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  exposure:
+                    description: Here you can configure if you want to expose central
+                      through a node port, a load balancer, or an OpenShift route.
+                    properties:
+                      loadBalancer:
+                        description: Expose Central through a load balancer service.
+                        properties:
+                          enabled:
+                            default: false
+                            type: boolean
+                          ip:
+                            description: If you have a static IP address reserved
+                              for your load balancer, you can enter it here.
+                            type: string
+                          port:
+                            default: 443
+                            description: Defaults to 443 if not set.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                        type: object
+                      nodePort:
+                        description: Expose Central through a node port.
+                        properties:
+                          enabled:
+                            default: false
+                            type: boolean
+                          port:
+                            description: Use this to specify an explicit node port.
+                              Most users should leave this empty.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                        type: object
+                      route:
+                        description: Expose Central through an OpenShift route.
+                        properties:
+                          enabled:
+                            default: false
+                            type: boolean
+                          host:
+                            description: Specify a custom hostname for the central
+                              route. If unspecified, an appropriate default value
+                              will be automatically chosen by OpenShift route operator.
+                            type: string
+                        type: object
+                    type: object
+                  monitoring:
+                    description: Configures monitoring endpoint for Central. The monitoring
+                      endpoint allows other services to collect metrics from Central,
+                      provided in Prometheus compatible format.
+                    properties:
+                      exposeEndpoint:
+                        description: Expose the monitoring endpoint. A new service,
+                          "monitoring", with port 9090, will be created as well as
+                          a network policy allowing inbound connections to the port.
+                        enum:
+                        - Enabled
+                        - Disabled
+                        type: string
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: If you want this component to only run on specific
+                      nodes, you can configure a node selector here.
+                    type: object
+                  notifierSecretsEncryption:
+                    description: Configures the encryption of notifier secrets stored
+                      in the Central DB.
+                    properties:
+                      enabled:
+                        default: false
+                        description: Enables the encryption of notifier secrets stored
+                          in the Central DB. An encryption key must be provided in
+                          a secret called `central-encryption-key` in the Central
+                          namespace, with the key stored in the `encryption-key` data
+                          field.
+                        type: boolean
+                    type: object
+                  persistence:
+                    description: Configures how Central should store its persistent
+                      data. You can choose between using a persistent volume claim
+                      (recommended default), and a host path.
+                    properties:
+                      hostPath:
+                        description: Stores persistent data on a directory on the
+                          host. This is not recommended, and should only be used together
+                          with a node selector (only available in YAML view).
+                        properties:
+                          path:
+                            description: The path on the host running Central.
+                            type: string
+                        type: object
+                      persistentVolumeClaim:
+                        description: Uses a Kubernetes persistent volume claim (PVC)
+                          to manage the storage location of persistent data. Recommended
+                          for most users.
+                        properties:
+                          claimName:
+                            default: stackrox-db
+                            description: The name of the PVC to manage persistent
+                              data. If no PVC with the given name exists, it will
+                              be created. Defaults to "stackrox-db" if not set.
+                            type: string
+                          size:
+                            description: The size of the persistent volume when created
+                              through the claim. If a claim was automatically created,
+                              this can be used after the initial deployment to resize
+                              (grow) the volume (only supported by some storage class
+                              controllers).
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            type: string
+                          storageClassName:
+                            description: The name of the storage class to use for
+                              the PVC. If your cluster is not configured with a default
+                              storage class, you must select a value here.
+                            type: string
+                        type: object
+                    type: object
+                  resources:
+                    description: Allows overriding the default resource settings for
+                      this component. Please consult the documentation for an overview
+                      of default resource requirements and a sizing guide.
+                    properties:
+                      claims:
+                        description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: Name must match the name of one entry in
+                                pod.spec.resourceClaims of the Pod where this field
+                                is used. It makes that resource available inside a
+                                container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. Requests cannot exceed
+                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  telemetry:
+                    description: Configures telemetry settings for Central. If enabled,
+                      Central transmits telemetry and diagnostic data to a remote
+                      storage backend.
+                    properties:
+                      enabled:
+                        default: true
+                        description: Specifies if Telemetry is enabled.
+                        type: boolean
+                      storage:
+                        description: Defines the telemetry storage backend for Central.
+                        properties:
+                          endpoint:
+                            description: Storage API endpoint.
+                            type: string
+                          key:
+                            description: Storage API key. If not set, telemetry is
+                              disabled.
+                            type: string
+                        type: object
+                    type: object
+                  tolerations:
+                    description: If you want this component to only run on specific
+                      nodes, you can configure tolerations of tainted nodes.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              customize:
+                description: Customizations to apply on all Central Services components.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Custom annotations to set on all managed objects.
+                    type: object
+                  envVars:
+                    description: Custom environment variables to set on managed pods'
+                      containers.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Custom labels to set on all managed objects.
+                    type: object
+                type: object
+              egress:
+                description: Settings related to outgoing network traffic.
+                properties:
+                  connectivityPolicy:
+                    default: Online
+                    description: Configures whether Red Hat Advanced Cluster Security
+                      should run in online or offline (disconnected) mode. In offline
+                      mode, automatic updates of vulnerability definitions and kernel
+                      modules are disabled.
+                    enum:
+                    - Online
+                    - Offline
+                    type: string
+                type: object
+              imagePullSecrets:
+                description: Additional image pull secrets to be taken into account
+                  for pulling images.
+                items:
+                  description: LocalSecretReference is a reference to a secret within
+                    the same namespace.
+                  properties:
+                    name:
+                      description: The name of the referenced secret.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              misc:
+                description: Miscellaneous settings.
+                properties:
+                  createSCCs:
+                    description: Set this to true to have the operator create SecurityContextConstraints
+                      (SCCs) for the operands. This isn't usually needed, and may
+                      interfere with other workloads.
+                    type: boolean
+                type: object
+              monitoring:
+                description: Monitoring configuration.
+                properties:
+                  openshift:
+                    description: OpenShiftMonitoring defines settings related to OpenShift
+                      Monitoring
+                    properties:
+                      enabled:
+                        default: true
+                        type: boolean
+                    required:
+                    - enabled
+                    type: object
+                type: object
+              overlays:
+                description: Overlays
+                items:
+                  description: "K8sObjectOverlay is an overlay that applies a set
+                    of patches to a resource. It targets a resource by its API version,
+                    kind, and name, and applies a list of patches to this resource.
+                    \n # Examples \n ## Adding an annotation to a resource \n apiVersion:
+                    v1 kind: ServiceAccount name: central patches: - path: metadata.annotations.eks\\.amazonaws\\.com/role-arn
+                    value: \"\\\"arn:aws:iam:1234:role\\\"\" \n ## Adding an environment
+                    variable to a deployment \n apiVersion: apps/v1 kind: Deployment
+                    name: central patches: - path: spec.template.spec.containers[name:central].env[-1]
+                    value: | name: MY_ENV_VAR value: value \n ## Adding an ingress
+                    to a network policy \n apiVersion: networking.k8s.io/v1 kind:
+                    NetworkPolicy name: allow-ext-to-central patches: - path: spec.ingress[-1]
+                    value: | ports: - port: 999 protocol: TCP \n ## Changing the value
+                    of a configMap \n apiVersion: v1 kind: ConfigMap name: central-endpoints
+                    patches: - path: data value: | endpoints.yaml: | disableDefault:
+                    false \n ## Adding a container to a deployment \n apiVersion:
+                    apps/v1 kind: Deployment name: central patches: - path: spec.template.spec.containers[-1]
+                    value: | name: nginx image: nginx ports: - containerPort: 8000
+                    name: http protocol: TCP"
+                  properties:
+                    apiVersion:
+                      description: Resource API version.
+                      type: string
+                    kind:
+                      description: Resource kind.
+                      type: string
+                    name:
+                      description: Name of resource.
+                      type: string
+                    patches:
+                      description: List of patches to apply to resource.
+                      items:
+                        description: K8sObjectOverlayPatch defines a patch to apply
+                          to a resource.
+                        properties:
+                          path:
+                            description: Path of the form a.[key1:value1].b.[:value2]
+                              Where [key1:value1] is a selector for a key-value pair
+                              to identify a list element and [:value] is a value selector
+                              to identify a list element in a leaf list. All path
+                              intermediate nodes must exist.
+                            type: string
+                          value:
+                            description: Value to add, delete or replace. For add,
+                              the path should be a new leaf. For delete, value should
+                              be unset. For replace, path should reference an existing
+                              node. All values are strings but are converted into
+                              appropriate type based on schema.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              scanner:
+                description: Settings for the Scanner component, which is responsible
+                  for vulnerability scanning of container images.
+                properties:
+                  analyzer:
+                    description: Settings pertaining to the analyzer deployment, such
+                      as for autoscaling.
+                    properties:
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: If you want this component to only run on specific
+                          nodes, you can configure a node selector here.
+                        type: object
+                      resources:
+                        description: Allows overriding the default resource settings
+                          for this component. Please consult the documentation for
+                          an overview of default resource requirements and a sizing
+                          guide.
+                        properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable. It can only be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                      scaling:
+                        description: Controls the number of analyzer replicas and
+                          autoscaling.
+                        properties:
+                          autoScaling:
+                            default: Enabled
+                            description: When enabled, the number of analyzer replicas
+                              is managed dynamically based on the load, within the
+                              limits specified below.
+                            enum:
+                            - Enabled
+                            - Disabled
+                            type: string
+                          maxReplicas:
+                            default: 5
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          minReplicas:
+                            default: 2
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          replicas:
+                            default: 3
+                            description: When autoscaling is disabled, the number
+                              of replicas will always be configured to match this
+                              value.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                        type: object
+                      tolerations:
+                        description: If you want this component to only run on specific
+                          nodes, you can configure tolerations of tainted nodes.
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  db:
+                    description: Settings pertaining to the database used by the Red
+                      Hat Advanced Cluster Security Scanner.
+                    properties:
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: If you want this component to only run on specific
+                          nodes, you can configure a node selector here.
+                        type: object
+                      resources:
+                        description: Allows overriding the default resource settings
+                          for this component. Please consult the documentation for
+                          an overview of default resource requirements and a sizing
+                          guide.
+                        properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable. It can only be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                      tolerations:
+                        description: If you want this component to only run on specific
+                          nodes, you can configure tolerations of tainted nodes.
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  monitoring:
+                    description: Configures monitoring endpoint for Scanner. The monitoring
+                      endpoint allows other services to collect metrics from Scanner,
+                      provided in Prometheus compatible format.
+                    properties:
+                      exposeEndpoint:
+                        description: Expose the monitoring endpoint. A new service,
+                          "monitoring", with port 9090, will be created as well as
+                          a network policy allowing inbound connections to the port.
+                        enum:
+                        - Enabled
+                        - Disabled
+                        type: string
+                    type: object
+                  scannerComponent:
+                    description: If you do not want to deploy the Red Hat Advanced
+                      Cluster Security Scanner, you can disable it here (not recommended).
+                      By default, the scanner is enabled. If you do so, all the settings
+                      in this section will have no effect.
+                    enum:
+                    - Enabled
+                    - Disabled
+                    type: string
+                type: object
+              tls:
+                description: Allows you to specify additional trusted Root CAs.
+                properties:
+                  additionalCAs:
+                    items:
+                      description: AdditionalCA defines a certificate for an additional
+                        Certificate Authority.
+                      properties:
+                        content:
+                          description: PEM format
+                          type: string
+                        name:
+                          description: Must be a valid file basename
+                          type: string
+                      required:
+                      - content
+                      - name
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: CentralStatus defines the observed state of Central.
+            properties:
+              central:
+                description: CentralComponentStatus describes status specific to the
+                  central component.
+                properties:
+                  adminPassword:
+                    description: AdminPassword stores information related to the auto-generated
+                      admin password.
+                    properties:
+                      adminPasswordSecretReference:
+                        description: AdminPasswordSecretReference contains reference
+                          for the admin password
+                        type: string
+                      info:
+                        description: Info stores information on how to obtain the
+                          admin password.
+                        type: string
+                    type: object
+                type: object
+              conditions:
+                items:
+                  description: StackRoxCondition defines a condition for a StackRox
+                    custom resource.
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      description: ConditionReason is a type of values of condition
+                        reason.
+                      type: string
+                    status:
+                      description: ConditionStatus is a type of values of condition
+                        status.
+                      type: string
+                    type:
+                      description: ConditionType is a type of values of condition
+                        type.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              deployedRelease:
+                description: StackRoxRelease describes the Helm "release" that was
+                  most recently applied.
+                properties:
+                  version:
+                    type: string
+                type: object
+              productVersion:
+                description: The deployed version of the product.
+                type: string
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: securedclusters.platform.stackrox.io
 spec:
   group: platform.stackrox.io
@@ -83,11 +1206,39 @@ spec:
                     description: If you want this component to only run on specific
                       nodes, you can configure a node selector here.
                     type: object
+                  replicas:
+                    default: 3
+                    description: The number of replicas of the admission control pod.
+                    format: int32
+                    minimum: 1
+                    type: integer
                   resources:
                     description: Allows overriding the default resource settings for
                       this component. Please consult the documentation for an overview
                       of default resource requirements and a sizing guide.
                     properties:
+                      claims:
+                        description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: Name must match the name of one entry in
+                                pod.spec.resourceClaims of the Pod where this field
+                                is used. It makes that resource available inside a
+                                container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       limits:
                         additionalProperties:
                           anyOf:
@@ -108,7 +1259,8 @@ spec:
                         description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          to an implementation-defined value. Requests cannot exceed
+                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
                   timeoutSeconds:
@@ -355,6 +1507,75 @@ spec:
                       interfere with other workloads.
                     type: boolean
                 type: object
+              monitoring:
+                description: Monitoring configuration.
+                properties:
+                  openshift:
+                    description: OpenShiftMonitoring defines settings related to OpenShift
+                      Monitoring
+                    properties:
+                      enabled:
+                        default: true
+                        type: boolean
+                    required:
+                    - enabled
+                    type: object
+                type: object
+              overlays:
+                description: Overlays
+                items:
+                  description: "K8sObjectOverlay is an overlay that applies a set
+                    of patches to a resource. It targets a resource by its API version,
+                    kind, and name, and applies a list of patches to this resource.
+                    \n # Examples \n ## Adding an annotation to a resource \n apiVersion:
+                    v1 kind: ServiceAccount name: central patches: - path: metadata.annotations.eks\\.amazonaws\\.com/role-arn
+                    value: \"\\\"arn:aws:iam:1234:role\\\"\" \n ## Adding an environment
+                    variable to a deployment \n apiVersion: apps/v1 kind: Deployment
+                    name: central patches: - path: spec.template.spec.containers[name:central].env[-1]
+                    value: | name: MY_ENV_VAR value: value \n ## Adding an ingress
+                    to a network policy \n apiVersion: networking.k8s.io/v1 kind:
+                    NetworkPolicy name: allow-ext-to-central patches: - path: spec.ingress[-1]
+                    value: | ports: - port: 999 protocol: TCP \n ## Changing the value
+                    of a configMap \n apiVersion: v1 kind: ConfigMap name: central-endpoints
+                    patches: - path: data value: | endpoints.yaml: | disableDefault:
+                    false \n ## Adding a container to a deployment \n apiVersion:
+                    apps/v1 kind: Deployment name: central patches: - path: spec.template.spec.containers[-1]
+                    value: | name: nginx image: nginx ports: - containerPort: 8000
+                    name: http protocol: TCP"
+                  properties:
+                    apiVersion:
+                      description: Resource API version.
+                      type: string
+                    kind:
+                      description: Resource kind.
+                      type: string
+                    name:
+                      description: Name of resource.
+                      type: string
+                    patches:
+                      description: List of patches to apply to resource.
+                      items:
+                        description: K8sObjectOverlayPatch defines a patch to apply
+                          to a resource.
+                        properties:
+                          path:
+                            description: Path of the form a.[key1:value1].b.[:value2]
+                              Where [key1:value1] is a selector for a key-value pair
+                              to identify a list element and [:value] is a value selector
+                              to identify a list element in a leaf list. All path
+                              intermediate nodes must exist.
+                            type: string
+                          value:
+                            description: Value to add, delete or replace. For add,
+                              the path should be a new leaf. For delete, value should
+                              be unset. For replace, path should reference an existing
+                              node. All values are strings but are converted into
+                              appropriate type based on schema.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
               perNode:
                 description: Settings for the components running on each node in the
                   cluster (Collector and Compliance).
@@ -366,23 +1587,24 @@ spec:
                       collection:
                         default: EBPF
                         description: The method for system-level data collection.
-                          Kernel module is recommended. If you select "NoCollection",
-                          you will not be able to see any information about network
-                          activity and process executions. The remaining settings
-                          in these section will not have any effect.
+                          EBPF is recommended. If you select "NoCollection", you will
+                          not be able to see any information about network activity
+                          and process executions. The remaining settings in these
+                          section will not have any effect.
                         enum:
                         - EBPF
-                        - KernelModule
+                        - CORE_BPF
                         - NoCollection
+                        - KernelModule
                         type: string
                       imageFlavor:
                         default: Regular
                         description: The image flavor to use for collector. "Regular"
-                          images are bigger in size, but contain kernel modules for
-                          most kernels. If you use the "Slim" image flavor, you must
-                          ensure that your Central instance is connected to the internet,
-                          or regularly receives Collector Support Package updates
-                          (for further instructions, please refer to the documentation).
+                          images are bigger in size, but contain probes for most kernels.
+                          If you use the "Slim" image flavor, you must ensure that
+                          your Central instance is connected to the internet, or regularly
+                          receives Collector Support Package updates (for further
+                          instructions, please refer to the documentation).
                         enum:
                         - Regular
                         - Slim
@@ -393,6 +1615,28 @@ spec:
                           an overview of default resource requirements and a sizing
                           guide.
                         properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable. It can only be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                           limits:
                             additionalProperties:
                               anyOf:
@@ -414,7 +1658,7 @@ spec:
                               compute resources required. If Requests is omitted for
                               a container, it defaults to Limits if that is explicitly
                               specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
                     type: object
@@ -428,6 +1672,28 @@ spec:
                           an overview of default resource requirements and a sizing
                           guide.
                         properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable. It can only be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                           limits:
                             additionalProperties:
                               anyOf:
@@ -449,7 +1715,64 @@ spec:
                               compute resources required. If Requests is omitted for
                               a container, it defaults to Limits if that is explicitly
                               specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                    type: object
+                  nodeInventory:
+                    description: Settings for the Node-Inventory container, which
+                      is responsible for scanning the Nodes' filesystem.
+                    properties:
+                      resources:
+                        description: Allows overriding the default resource settings
+                          for this component. Please consult the documentation for
+                          an overview of default resource requirements and a sizing
+                          guide.
+                        properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable. It can only be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
                     type: object
@@ -465,6 +1788,10 @@ spec:
                     - AvoidTaints
                     type: string
                 type: object
+              registryOverride:
+                description: Set this parameter to override the default registry in
+                  images. For example, nginx:latest -> <registry override>/library/nginx:latest
+                type: string
               scanner:
                 description: Settings for the Scanner component, which is responsible
                   for vulnerability scanning of container images stored in a cluster-local
@@ -486,6 +1813,28 @@ spec:
                           an overview of default resource requirements and a sizing
                           guide.
                         properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable. It can only be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                           limits:
                             additionalProperties:
                               anyOf:
@@ -507,7 +1856,7 @@ spec:
                               compute resources required. If Requests is omitted for
                               a container, it defaults to Limits if that is explicitly
                               specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
                       scaling:
@@ -602,6 +1951,28 @@ spec:
                           an overview of default resource requirements and a sizing
                           guide.
                         properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable. It can only be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                           limits:
                             additionalProperties:
                               anyOf:
@@ -623,7 +1994,7 @@ spec:
                               compute resources required. If Requests is omitted for
                               a container, it defaults to Limits if that is explicitly
                               specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
                       tolerations:
@@ -695,6 +2066,28 @@ spec:
                       this component. Please consult the documentation for an overview
                       of default resource requirements and a sizing guide.
                     properties:
+                      claims:
+                        description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: Name must match the name of one entry in
+                                pod.spec.resourceClaims of the Pod where this field
+                                is used. It makes that resource available inside a
+                                container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       limits:
                         additionalProperties:
                           anyOf:
@@ -715,7 +2108,8 @@ spec:
                         description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          to an implementation-defined value. Requests cannot exceed
+                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
                   tolerations:

--- a/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-cr.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-cr.yaml
@@ -40,6 +40,9 @@ spec:
       {{- if .Values.collector.resources }}
       resources: {{ toYaml .Values.collector.resources | nindent 8 }}
       {{- end }}
+      {{- if .Values.collector.collection }}
+      collection: {{ .Values.collector.collection | quote }}
+      {{- end }}
     compliance:
       {{- if .Values.compliance.resources }}
       resources: {{ toYaml .Values.compliance.resources | nindent 8 }}

--- a/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/values.yaml
@@ -20,6 +20,7 @@ collector:
       cpu: 10m
     limits:
       memory: 140Mi
+  collection: "CORE_BPF"
 compliance:
   resources:
     requests:


### PR DESCRIPTION
## Description

[Collector teams asked us ](https://redhat-internal.slack.com/archives/C0313JYKH8W/p1701855013791819)to set the collection method for our dogfooding instances to `CORE_BPF`.

In the same context I updated the CRD that is used for initial helm installation if no CRD in the cluster exists to a more recent version that support the `CORE_BPF` value for `spec.collector.collection`.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
