### PR TITLE
ROX-21596: add PVC for alertmanager

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
@@ -82,6 +82,14 @@ spec:
       limits:
         memory: {{ .Values.grafanaOperator.resources.limits.memory | quote }}
   storage:
+    alertmanager:
+      volumeClaimTemplate:
+        metadata:
+          name: alertmanager
+        spec:
+          resources:
+            requests:
+              storage: {{ .Values.alertManager.resources.requests.storage | quote }}
     prometheus:
       volumeClaimTemplate:
         metadata:
@@ -89,5 +97,4 @@ spec:
         spec:
           resources:
             requests:
-              storage: 250Gi
-        status: {}
+              storage: {{ .Values.prometheus.resources.requests.storage | quote }}

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
@@ -40,6 +40,7 @@ prometheus:
     requests:
       cpu: 1500m
       memory: 20Gi
+      storage: 250Gi
     limits:
       memory: 20Gi
 
@@ -72,6 +73,7 @@ alertManager:
     requests:
       cpu: 200m
       memory: 256Mi
+      storage: 20Gi
     limits:
       memory: 256Mi
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Add a PVC to the alertmanager deployment. This should prevent silences getting lost after pod restarts. Also did a small refactoring of the Prometheus PVC by introducing values for it.