### PR TITLE
chore: reduce resync period

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
@@ -11,7 +11,7 @@ github:
   tag: "master"
 
 clusterName: ""
-resyncPeriod: "1h"
+resyncPeriod: "10m"
 retention: "45d"
 
 # Credentials for Observatorium https://observatorium.io/ instance


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Reduce the resync period from 1 hour to 10 minutes. The resync period defines the interval in which the observability operator reconciles the observability config with https://github.com/stackrox/rhacs-observability-resources. The reason for the reduction is that a 1 hour can be a bit too long when waiting for the reconciliation. 10 minutes should be more convenient, while still being sufficiently far away from any rate limits.