### PR TITLE
Remove kubeconfig from fleet-manager

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -533,7 +533,7 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "9d51dabe59aa776bef2909d3689374ebb93ab2be",
         "is_verified": false,
-        "line_number": 745
+        "line_number": 744
       }
     ],
     "test/support/certs.json": [
@@ -564,5 +564,5 @@
       }
     ]
   },
-  "generated_at": "2024-01-09T13:44:27Z"
+  "generated_at": "2024-01-10T15:22:39Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -709,7 +709,6 @@ deploy/secrets:
 		-p CENTRAL_TLS_CERT="$(shell ([ -s './secrets/central-tls.crt' ] && [ -z '${CENTRAL_TLS_CERT}' ]) && cat ./secrets/central-tls.crt || echo '${CENTRAL_TLS_CERT}')" \
 		-p CENTRAL_TLS_KEY="$(shell ([ -s './secrets/central-tls.key' ] && [ -z '${CENTRAL_TLS_KEY}' ]) && cat ./secrets/central-tls.key || echo '${CENTRAL_TLS_KEY}')" \
 		-p OBSERVABILITY_CONFIG_ACCESS_TOKEN="$(shell ([ -s './secrets/observability-config-access.token' ] && [ -z '${OBSERVABILITY_CONFIG_ACCESS_TOKEN}' ]) && cat ./secrets/observability-config-access.token || echo '${OBSERVABILITY_CONFIG_ACCESS_TOKEN}')" \
-		-p KUBE_CONFIG="${KUBE_CONFIG}" \
 		-p OBSERVABILITY_RHSSO_LOGS_CLIENT_ID="$(shell ([ -s './secrets/rhsso-logs.clientId' ] && [ -z '${OBSERVABILITY_RHSSO_LOGS_CLIENT_ID}' ]) && cat ./secrets/rhsso-logs.clientId || echo '${OBSERVABILITY_RHSSO_LOGS_CLIENT_ID}')" \
 		-p OBSERVABILITY_RHSSO_LOGS_SECRET="$(shell ([ -s './secrets/rhsso-logs.clientSecret' ] && [ -z '${OBSERVABILITY_RHSSO_LOGS_SECRET}' ]) && cat ./secrets/rhsso-logs.clientSecret || echo '${OBSERVABILITY_RHSSO_LOGS_SECRET}')" \
 		-p OBSERVABILITY_RHSSO_METRICS_CLIENT_ID="$(shell ([ -s './secrets/rhsso-metrics.clientId' ] && [ -z '${OBSERVABILITY_RHSSO_METRICS_CLIENT_ID}' ]) && cat ./secrets/rhsso-metrics.clientId || echo '${OBSERVABILITY_RHSSO_METRICS_CLIENT_ID}')" \

--- a/config/dataplane-cluster-configuration.yaml
+++ b/config/dataplane-cluster-configuration.yaml
@@ -6,7 +6,7 @@
 #- This list is ordered, any new cluster should be appended at the end.
 #e.g.:
 #clusters:
-#  - name: anyname # This field is required for a standalone cluster i.e when the provider_type is "standalone". The value has to match the cluster / context name in the given kubeconfig file via the `--kubeconfig` flag.
+#  - name: anyname # This field is required for a standalone cluster i.e when the provider_type is "standalone".
 #    cluster_id: 1jp6kdr7k0sjbe5adck2prjur8f39378  #This field is required
 #    cloud_provider: aws
 #    region: us-east-1

--- a/dev/config/dataplane-cluster-configuration-minikube.yaml
+++ b/dev/config/dataplane-cluster-configuration-minikube.yaml
@@ -6,7 +6,7 @@
 #- This list is ordered, any new cluster should be appended at the end.
 #e.g.:
 #clusters:
-#  - name: anyname # This field is required for a standalone cluster i.e when the provider_type is "standalone". The value has to match the cluster / context name in the given kubeconfig file via the `--kubeconfig` flag.
+#  - name: anyname # This field is required for a standalone cluster i.e when the provider_type is "standalone".
 #    cluster_id: 1jp6kdr7k0sjbe5adck2prjur8f39378  #This field is required
 #    cloud_provider: aws
 #    region: us-east-1

--- a/dev/config/dataplane-cluster-configuration-rancherdesktop.yaml
+++ b/dev/config/dataplane-cluster-configuration-rancherdesktop.yaml
@@ -6,7 +6,7 @@
 #- This list is ordered, any new cluster should be appended at the end.
 #e.g.:
 #clusters:
-#  - name: anyname # This field is required for a standalone cluster i.e when the provider_type is "standalone". The value has to match the cluster / context name in the given kubeconfig file via the `--kubeconfig` flag.
+#  - name: anyname # This field is required for a standalone cluster i.e when the provider_type is "standalone".
 #    cluster_id: 1jp6kdr7k0sjbe5adck2prjur8f39378  #This field is required
 #    cloud_provider: aws
 #    region: us-east-1

--- a/dev/env/manifests/fleet-manager/01-fleet-manager-secrets.yaml
+++ b/dev/env/manifests/fleet-manager/01-fleet-manager-secrets.yaml
@@ -30,5 +30,3 @@ stringData:
   rhsso-metrics.clientSecret: ""
   central-tls.crt: ""
   central-tls.key: ""
-  kubeconfig: |
-    ${KUBE_CONFIG}

--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -142,7 +142,7 @@ init() {
     export RHACS_TARGETED_OPERATOR_UPGRADES=${RHACS_TARGETED_OPERATOR_UPGRADES:-$RHACS_TARGETED_OPERATOR_UPGRADES_DEFAULT}
     export RHACS_GITOPS_ENABLED=${RHACS_GITOPS_ENABLED:-$RHACS_GITOPS_ENABLED_DEFAULT}
 
-    local fleet_manager_command="/usr/local/bin/fleet-manager serve --force-leader --api-server-bindaddress=0.0.0.0:8000 --health-check-server-bindaddress=0.0.0.0:8083 --kubeconfig=/secrets/kubeconfig --enable-central-external-certificate=$ENABLE_CENTRAL_EXTERNAL_CERTIFICATE --central-domain-name='$CENTRAL_DOMAIN_NAME'"
+    local fleet_manager_command="/usr/local/bin/fleet-manager serve --force-leader --api-server-bindaddress=0.0.0.0:8000 --health-check-server-bindaddress=0.0.0.0:8083 --enable-central-external-certificate=$ENABLE_CENTRAL_EXTERNAL_CERTIFICATE --central-domain-name='$CENTRAL_DOMAIN_NAME'"
     FLEET_MANAGER_CONTAINER_COMMAND_DEFAULT="${fleet_manager_command} || { sleep 120; false; }"
     FLEETSHARD_SYNC_CONTAINER_COMMAND_DEFAULT="/usr/local/bin/fleetshard-sync"
     export FLEET_MANAGER_CONTAINER_COMMAND=${FLEET_MANAGER_CONTAINER_COMMAND:-$FLEET_MANAGER_CONTAINER_COMMAND_DEFAULT}

--- a/docs/development/running-fleet-manager.md
+++ b/docs/development/running-fleet-manager.md
@@ -29,20 +29,12 @@ Write a Cloud provider configuration file that matches the cloud provider and re
 
 Enable a cluster configuration file for the OSD cluster, see `dev/config/dataplane-cluster-configuration-infractl-osd.yaml` for an example OSD cluster running in GCP. Again, see the cluster creation logs for possibly missing required fields.
 
-Download the kubeconfig for the cluster. Without this the fleet manager will refuse to use the cluster.
-
-```bash
-CLUSTER=... # your cluster's name
-infractl artifacts "${CLUSTER}" --download-dir "~/infra/${CLUSTER}"
-```
-
 Launch the fleet manager using those configuration files:
 
 ```bash
 make binary && ./fleet-manager serve \
    --dataplane-cluster-config-file=$(pwd)/dev/config/dataplane-cluster-configuration-infractl-osd.yaml \
    --providers-config-file=$(pwd)/dev/config/provider-configuration-infractl-osd.yaml \
-   --kubeconfig="~/infra/${CLUSTER}/kubeconfig" \
    2>&1 | tee fleet-manager-serve.log
 ```
 

--- a/docs/legacy/data-plane-osd-cluster-options.md
+++ b/docs/legacy/data-plane-osd-cluster-options.md
@@ -54,8 +54,6 @@ fleet-manager allows provisioning of dinosaurs in an already preexisting standal
  - `region` the cloud region where the standalone cluster is provisioned
  - ... rest of the options
 
-> NOTE: `kubeconfig` path can be configured via the `--kubeconfig` CLI flag. Otherwise is defaults to `$HOME/.kube/config`
-
 > NOTE: [OLM](https://github.com/operator-framework/operator-lifecycle-manager#installation) in the destination standalone cluster/s is a prerequisite to be able to install dinosaur operator and fleetshard operators
 
 ## Configuring OSD Cluster Creation and AutoScaling

--- a/docs/legacy/feature-flags.md
+++ b/docs/legacy/feature-flags.md
@@ -108,7 +108,6 @@ This lists the feature flags and their sub-configurations to enable/disable and 
 
 ## Dataplane Cluster Management
 - **enable-ready-dataplane-clusters-reconcile**: Enables reconciliation of data plane clusters in a `Ready` state.
-- **kubeconfig**: A path to kubeconfig file used to communicate with standalone dataplane clusters.
 - **dataplane-cluster-scaling-type**: Sets the behaviour of how the service manages and scales OSD clusters (options: `manual`, `auto` or `none`).
     > For more information on the different dataplane cluster scaling types and their behaviour, see the [dataplane osd cluster options](./data-plane-osd-cluster-options.md) documentation.
 

--- a/internal/dinosaur/test/helper.go
+++ b/internal/dinosaur/test/helper.go
@@ -65,8 +65,6 @@ func NewDinosaurHelperWithHooks(t *testing.T, server *httptest.Server, configura
 			dinosaurConfig.CentralLifespan.EnableDeletionOfExpiredCentral = true
 			observabilityConfiguration.EnableMock = true
 			dataplaneClusterConfig.DataPlaneClusterScalingType = config.NoScaling // disable scaling by default as it will be activated in specific tests
-			dataplaneClusterConfig.RawKubernetesConfig = nil                      // disable applying resources for standalone clusters
-
 			// Integration tests require a valid OCM client. This requires OCM service account credentials to be set.
 			ocmConfig.EnableMock = false
 			ocmConfig.ReadFiles()

--- a/templates/secrets-template.yml
+++ b/templates/secrets-template.yml
@@ -74,9 +74,6 @@ parameters:
 - name: OBSERVABILITY_CONFIG_ACCESS_TOKEN
   description: Access token for the observability configuration repo
 
-- name: KUBE_CONFIG
-  description: Kubeconfig content for standalone dataplane clusters communication
-
 - name: OBSERVABILITY_RHSSO_LOGS_CLIENT_ID
   description: Red Hat SSO Logs client id for observability stack
 
@@ -127,7 +124,6 @@ objects:
     aws.route53accesskey: ${ROUTE53_ACCESS_KEY}
     aws.route53secretaccesskey: ${ROUTE53_SECRET_ACCESS_KEY}
     observability-config-access.token: ${OBSERVABILITY_CONFIG_ACCESS_TOKEN}
-    kubeconfig: ${KUBE_CONFIG}
 
 - apiVersion: v1
   kind: Secret

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -712,7 +712,6 @@ objects:
       aws.route53accesskey: badger
       aws.route53secretaccesskey: badger
       observability-config-access.token: badger
-      kubeconfig: badger
   - apiVersion: v1
     kind: ConfigMap
     metadata:
@@ -1271,7 +1270,6 @@ objects:
             - --cluster-openshift-version=${CLUSTER_OPENSHIFT_VERSION}
             - --cluster-compute-machine-type=${CLUSTER_COMPUTE_MACHINE_TYPE}
             - --dataplane-cluster-config-file=${DATAPLANE_CLUSTER_CONFIG_FILE}
-            - --kubeconfig=/secrets/fleet-manager-credentials/kubeconfig
             - --fleetshard-poll-interval=${FLEETSHARD_POLL_INTERVAL}
             - --fleetshard-resync-interval=${FLEETSHARD_RESYNC_INTERVAL}
             - --allow-evaluator-instance=${ALLOW_EVALUATOR_INSTANCE}


### PR DESCRIPTION
## Description
Since we're not going to support cluster mgmt in Fleet Manager we can remove kubeconfig parameter that is required for managing standalone clusters.

The presence of this parameter can be annoying, because we need to modify kubeconfig every time we need to add a new cluster. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
