### PR TITLE
ROX-20479: fix fleet-manager service label

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -1417,7 +1417,7 @@ objects:
       name: fleet-manager-active
       labels:
         app: fleet-manager
-        port: api
+        port: api-envoy
       annotations:
         description: Exposes and load balances the fleet-manager pods. Only targets the active fleet-manager pod.
         service.alpha.openshift.io/serving-cert-secret-name: fleet-manager-envoy-tls


### PR DESCRIPTION
Fixing the fleet-manager (active) service label to match the other fleet-manager-envoy service labels.