### PR TITLE
ROX-20479: fix fleet-manager-active cert label

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -1420,7 +1420,7 @@ objects:
         port: api-envoy
       annotations:
         description: Exposes and load balances the fleet-manager pods. Only targets the active fleet-manager pod.
-        service.alpha.openshift.io/serving-cert-secret-name: fleet-manager-envoy-tls
+        service.alpha.openshift.io/serving-cert-secret-name: fleet-manager-active-tls
     spec:
       selector:
         app: fleet-manager


### PR DESCRIPTION
services cannot share the same `serving-cert-secret-name` otherwise this results in a conflict where tls secrets cannot be reconciled. Creating an additional serving cert for the active fleet-manager