### PR TITLE
ROX-20479: fix fleet-manager-active cert

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -558,13 +558,6 @@
         "is_verified": false,
         "line_number": 702,
         "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "templates/service-template.yml",
-        "hashed_secret": "9d51dabe59aa776bef2909d3689374ebb93ab2be",
-        "is_verified": false,
-        "line_number": 744
       }
     ],
     "test/support/certs.json": [
@@ -593,5 +586,5 @@
       }
     ]
   },
-  "generated_at": "2024-01-11T17:41:29Z"
+  "generated_at": "2024-01-16T06:04:44Z"
 }

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -868,9 +868,9 @@ objects:
                       private_key:
                         filename: /secrets/tls/tls.key
                     - certificate_chain:
-                        filename: /secrets/tls-active/tls.crt
+                        filename: /secrets/active-tls/tls.crt
                       private_key:
-                        filename: /secrets/tls-active/tls.key
+                        filename: /secrets/active-tls/tls.key
               filters:
               - name: envoy.filters.network.http_connection_manager
                 typed_config:

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -741,7 +741,7 @@ objects:
       annotations:
         qontract.recycle: "true"
     data:
-      main.yaml: |
+      main.yaml: | # pragma: allowlist secret
         # The administration endpoint uses a Unix socket instead of TCP in order
         # to avoid exposing it outside of the pod. Requests for metrics and
         # probes will go via an HTTP listener that only accepts requests for the
@@ -867,6 +867,10 @@ objects:
                         filename: /secrets/tls/tls.crt
                       private_key:
                         filename: /secrets/tls/tls.key
+                    - certificate_chain:
+                        filename: /secrets/tls-active/tls.crt
+                      private_key:
+                        filename: /secrets/tls-active/tls.key
               filters:
               - name: envoy.filters.network.http_connection_manager
                 typed_config:
@@ -1073,6 +1077,9 @@ objects:
           - name: envoy-tls
             secret:
               secretName: fleet-manager-envoy-tls # pragma: allowlist secret
+          - name: active-tls
+            secret:
+              secretName: fleet-manager-active-tls # pragma: allowlist secret
           - name: envoy-unix-sockets
             emptyDir:
               medium: Memory
@@ -1335,6 +1342,8 @@ objects:
             volumeMounts:
             - name: envoy-tls
               mountPath: /secrets/tls
+            - name: active-tls
+              mountPath: /secrets/active-tls
             - name: envoy-config
               mountPath: /configs/envoy
             - name: envoy-unix-sockets


### PR DESCRIPTION
Mounting a tls secret for the "active" fleet-manager service, otherwise routing to this service fails