### PR TITLE
ROX-20479: revert fleet-manager-active cert

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -867,10 +867,6 @@ objects:
                         filename: /secrets/tls/tls.crt
                       private_key:
                         filename: /secrets/tls/tls.key
-                    - certificate_chain:
-                        filename: /secrets/active-tls/tls.crt
-                      private_key:
-                        filename: /secrets/active-tls/tls.key
               filters:
               - name: envoy.filters.network.http_connection_manager
                 typed_config:


### PR DESCRIPTION
Reverting adding a 2nd tls cert to envoy as it is not supported