### PR TITLE
ROX-20479: fleet-manager-active certs

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -852,9 +852,12 @@ objects:
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
                   common_tls_context:
+                    sni: fleet-manager.${NAMESPACE}.svc
                     tls_certificates:
                     - certificate_chain: {filename: "/secrets/tls/tls.crt"}
                       private_key: {filename: "/secrets/tls/tls.key"}
+                    - certificate_chain: {filename: "/secrets/active-tls/tls.crt"}
+                      private_key: {filename: "/secrets/active-tls/tls.key"}
               filters:
               - name: envoy.filters.network.http_connection_manager
                 typed_config:


### PR DESCRIPTION
Adding the cert for the fleet-manager-active so that the fleet-manager-active route can establish TLS with the envoy sidecar