### PR TITLE
ROX-20479: fleet-manager-active certs

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -855,8 +855,6 @@ objects:
                     tls_certificates:
                     - certificate_chain: {filename: "/secrets/tls/tls.crt"}
                       private_key: {filename: "/secrets/tls/tls.key"}
-                    - certificate_chain: {filename: "/secrets/active-tls/tls.crt"}
-                      private_key: {filename: "/secrets/active-tls/tls.key"}
               filters:
               - name: envoy.filters.network.http_connection_manager
                 typed_config:


### PR DESCRIPTION
remove the 2nd tls cert on envoy gateway