### PR TITLE
ROX-20479: fleet-manager-active certs

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -856,7 +856,7 @@ objects:
                     - certificate_chain: {filename: "/secrets/tls/tls.crt"}
                       private_key: {filename: "/secrets/tls/tls.key"}
                     - certificate_chain: {filename: "/secrets/active-tls/tls.crt"}
-                      private_key: {filename: "/secrets/tls/active-tls.key"}
+                      private_key: {filename: "/secrets/active-tls/tls.key"}
               filters:
               - name: envoy.filters.network.http_connection_manager
                 typed_config:


### PR DESCRIPTION
Fix the wrong envoy tls path