### PR TITLE
ROX-20479: adding all possible fleet-manager-active hostnames to envoy config

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -861,7 +861,10 @@ objects:
             filter_chains:
             - filter_chain_match:
                 server_names:
+                  - "fleet-manager-active"
+                  - "fleet-manager-active.${NAMESPACE}"
                   - "fleet-manager-active.${NAMESPACE}.svc"
+                  - "fleet-manager-active.${NAMESPACE}.svc.cluster"
                   - "fleet-manager-active.${NAMESPACE}.svc.cluster.local"
                   - "romndkjdq62p7sr.api.integration.openshift.com"
               transport_socket:


### PR DESCRIPTION
Adding all possible fleet-manager-active hostnames that the router might use to envoy config