### PR TITLE
ROX-20479: only use active-tls cert

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -880,8 +880,6 @@ objects:
                     tls_certificates:
                     - certificate_chain: {filename: "/secrets/active-tls/tls.crt"}
                       private_key: {filename: "/secrets/active-tls/tls.key"}
-                    - certificate_chain: {filename: "/secrets/active-tls/tls.crt"}
-                      private_key: {filename: "/secrets/active-tls/tls.key"}
               filters:
               - name: envoy.filters.network.http_connection_manager
                 typed_config:
@@ -936,8 +934,6 @@ objects:
                   full_scan_certs_on_sni_mismatch: true
                   common_tls_context:
                     tls_certificates:
-                    - certificate_chain: {filename: "/secrets/tls/tls.crt"}
-                      private_key: {filename: "/secrets/tls/tls.key"}
                     - certificate_chain: {filename: "/secrets/active-tls/tls.crt"}
                       private_key: {filename: "/secrets/active-tls/tls.key"}
               filters:


### PR DESCRIPTION
Trying to only use the active-fleet-manager cert for debugging envoy