### PR TITLE
Fix integration tests and enable them back on CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,6 @@
 ```
 # To run tests locally run:
 make db/teardown db/setup db/migrate
-make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
+make ocm/setup
 make verify lint binary test test/integration
 ```

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,7 +118,7 @@ jobs:
           GOPATH=$(go env GOPATH)
           export GOPATH
           export PATH=${PATH}:$GOPATH/bin
-          make verify binary test
+          make verify binary test test/integration
         timeout-minutes: 14
   build-push-images:
     name: "Build and push fleet* images to quay.io"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,6 @@ jobs:
       CENTRAL_TLS_CERT: central_tls_cert # pragma: allowlist secret - dummy value
       CENTRAL_TLS_KEY: central_tls_key # pragma: allowlist secret - dummy value
       # So that OCM secrets are initialised
-      DOCKER_PR_CHECK: true
       TEST_TIMEOUT: 30m
     services:
       postgres:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,6 @@ jobs:
       # Dummy Central TLS env variables
       CENTRAL_TLS_CERT: central_tls_cert # pragma: allowlist secret - dummy value
       CENTRAL_TLS_KEY: central_tls_key # pragma: allowlist secret - dummy value
-      # So that OCM secrets are initialised
       TEST_TIMEOUT: 30m
     services:
       postgres:

--- a/Makefile
+++ b/Makefile
@@ -660,22 +660,12 @@ observatorium/token-refresher/setup:
 	@echo The Observatorium token refresher is now running on 'http://localhost:${PORT}'
 .PHONY: observatorium/token-refresher/setup
 
-# OCM login
-ocm/login:
-	@ocm login --url="$(SERVER_URL)" --token="$(OCM_OFFLINE_TOKEN)"
-.PHONY: ocm/login
-
-# Setup OCM_OFFLINE_TOKEN and
-# OCM Client ID and Secret should be set only when running inside docker in integration ENV)
-ocm/setup: OCM_CLIENT_ID ?= badger
-ocm/setup: OCM_CLIENT_SECRET ?= badger
+# Setup dummy OCM_OFFLINE_TOKEN for integration testing
+ocm/setup: OCM_OFFLINE_TOKEN ?= "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c" # pragma: allowlist secret
 ocm/setup:
 	@echo -n "$(OCM_OFFLINE_TOKEN)" > secrets/ocm-service.token
 	@echo -n "" > secrets/ocm-service.clientId
 	@echo -n "" > secrets/ocm-service.clientSecret
-ifeq ($(OCM_ENV), integration)
-	@if [[ -n "$(DOCKER_PR_CHECK)" ]]; then echo -n "$(OCM_CLIENT_ID)" > secrets/ocm-service.clientId; echo -n "$(OCM_CLIENT_SECRET)" > secrets/ocm-service.clientSecret; fi;
-endif
 .PHONY: ocm/setup
 
 # create project where the service will be deployed in an OpenShift cluster


### PR DESCRIPTION
## Description
Remove ocm client credentials and replace them by the offline token.
Reason: even though ocm **server** is mocked on integration(-test) environment it still uses real OAuth token endpoint to authenticate in RHSSO if client credentials are set. Using an offline token allows to bypass the call to the real service.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
