### PR TITLE
Fixed race condition in integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,9 +54,7 @@ jobs:
     name: "Verify & Test"
     runs-on: ubuntu-latest
     env:
-      # TODO make sure that the secrets are configured for your repository
       OCM_ENV: integration
-      E2E: "true"
       # Dummy SSO variables
       SSO_CLIENT_ID: ${{ secrets.SSO_CLIENT_ID }}
       SSO_CLIENT_SECRET: ${{ secrets.SSO_CLIENT_SECRET }}

--- a/.openshift-ci/tests/e2e-test.sh
+++ b/.openshift-ci/tests/e2e-test.sh
@@ -19,11 +19,6 @@ fi
 up.sh
 
 log "Environment up and running"
-log "Waiting for fleet-manager to complete leader election..."
-# Don't have a better way yet to wait until fleet-manager has completed the leader election.
-$KUBECTL -n "$ACSCS_NAMESPACE" logs -l application=fleet-manager -c fleet-manager -f --tail=-1 |
-    grep -q --line-buffered --max-count=1 'started leading' || true
-sleep 1
 
 FAIL=0
 if [[ "$SKIP_TESTS" == "true" ]]; then

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -493,70 +493,70 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "13032f402fed753c2248419ea4f69f99931f6dbc",
         "is_verified": false,
-        "line_number": 522
+        "line_number": 526
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "30025f80f6e22cdafb85db387d50f90ea884576a",
         "is_verified": false,
-        "line_number": 522
+        "line_number": 526
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "355f24fd038bcaf85617abdcaa64af51ed19bbcf",
         "is_verified": false,
-        "line_number": 522
+        "line_number": 526
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "3d8a1dcd2c3c765ce35c9a9552d23273cc4ddace",
         "is_verified": false,
-        "line_number": 522
+        "line_number": 526
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "4ac7b0522761eba972467942cd5cd7499dd2c361",
         "is_verified": false,
-        "line_number": 522
+        "line_number": 526
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "7639ab2a6bcf2ea30a055a99468c9cd844d4c22a",
         "is_verified": false,
-        "line_number": 522
+        "line_number": 526
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "b56360daf4793d2a74991a972b34d95bc00fb2da",
         "is_verified": false,
-        "line_number": 522
+        "line_number": 526
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "c9a73ef9ee8ce9f38437227801c70bcc6740d1a1",
         "is_verified": false,
-        "line_number": 522
+        "line_number": 526
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "14736999d9940728c5294277831a702f7882dece",
         "is_verified": false,
-        "line_number": 559
+        "line_number": 563
       },
       {
         "type": "Secret Keyword",
         "filename": "templates/service-template.yml",
         "hashed_secret": "4e199b4a1c40b497a95fcd1cd896351733849949",
         "is_verified": false,
-        "line_number": 706,
+        "line_number": 710,
         "is_secret": false
       }
     ],
@@ -586,5 +586,5 @@
       }
     ]
   },
-  "generated_at": "2024-01-17T10:24:51Z"
+  "generated_at": "2024-01-17T16:46:11Z"
 }

--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -142,7 +142,7 @@ init() {
     export RHACS_TARGETED_OPERATOR_UPGRADES=${RHACS_TARGETED_OPERATOR_UPGRADES:-$RHACS_TARGETED_OPERATOR_UPGRADES_DEFAULT}
     export RHACS_GITOPS_ENABLED=${RHACS_GITOPS_ENABLED:-$RHACS_GITOPS_ENABLED_DEFAULT}
 
-    local fleet_manager_command="/usr/local/bin/fleet-manager serve --force-leader --api-server-bindaddress=0.0.0.0:8000 --health-check-server-bindaddress=0.0.0.0:8083 --enable-central-external-certificate=$ENABLE_CENTRAL_EXTERNAL_CERTIFICATE --central-domain-name='$CENTRAL_DOMAIN_NAME'"
+    local fleet_manager_command="/usr/local/bin/fleet-manager serve --api-server-bindaddress=0.0.0.0:8000 --health-check-server-bindaddress=0.0.0.0:8083 --enable-central-external-certificate=$ENABLE_CENTRAL_EXTERNAL_CERTIFICATE --central-domain-name='$CENTRAL_DOMAIN_NAME'"
     FLEET_MANAGER_CONTAINER_COMMAND_DEFAULT="${fleet_manager_command} || { sleep 120; false; }"
     FLEETSHARD_SYNC_CONTAINER_COMMAND_DEFAULT="/usr/local/bin/fleetshard-sync"
     export FLEET_MANAGER_CONTAINER_COMMAND=${FLEET_MANAGER_CONTAINER_COMMAND:-$FLEET_MANAGER_CONTAINER_COMMAND_DEFAULT}

--- a/internal/dinosaur/pkg/environments/development.go
+++ b/internal/dinosaur/pkg/environments/development.go
@@ -39,5 +39,6 @@ func NewDevelopmentEnvLoader() environments.EnvLoader {
 		"central-idp-client-id":                           "rhacs-ms-dev",
 		"central-idp-issuer":                              "https://sso.stage.redhat.com/auth/realms/redhat-external",
 		"admin-authz-config-file":                         "config/admin-authz-roles-dev.yaml",
+		"enable-leader-election":                          "false",
 	}
 }

--- a/internal/dinosaur/pkg/environments/integration.go
+++ b/internal/dinosaur/pkg/environments/integration.go
@@ -29,6 +29,7 @@ func (b IntegrationEnvLoader) Defaults() map[string]string {
 		"enable-https":                        "false",
 		"enable-metrics-https":                "false",
 		"enable-terms-acceptance":             "false",
+		"enable-leader-election":              "false",
 		"ocm-debug":                           "false",
 		"enable-ocm-mock":                     "true",
 		"ocm-mock-mode":                       ocm.MockModeEmulateServer,

--- a/pkg/db/dinosaur.go
+++ b/pkg/db/dinosaur.go
@@ -4,4 +4,5 @@ import "time"
 
 // DinosaurAdditionalLeasesExpireTime Set new additional leases expire time to a minute later from now so that the old "dinosaur" leases finishes
 // its execution before the new jobs kicks in.
+// Not used in leader election anymore, kept for database migrations
 var DinosaurAdditionalLeasesExpireTime = time.Now().Add(1 * time.Minute)

--- a/pkg/server/server_config.go
+++ b/pkg/server/server_config.go
@@ -19,20 +19,21 @@ type ServerConfig struct {
 	// For production it is "https://api.openshift.com"
 	PublicHostURL         string `json:"public_url"`
 	EnableTermsAcceptance bool   `json:"enable_terms_acceptance"`
-	ForceLeader           bool   `json:"force_leader"`
+	EnableLeaderElection  bool   `json:"enable_leader_election"`
 }
 
 // NewServerConfig ...
 func NewServerConfig() *ServerConfig {
 	return &ServerConfig{
-		BindAddress:    "localhost:8000",
-		EnableHTTPS:    false,
-		JwksURL:        "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs",
-		JwksFile:       "config/jwks-file.json",
-		TokenIssuerURL: "https://sso.redhat.com/auth/realms/redhat-external",
-		HTTPSCertFile:  "",
-		HTTPSKeyFile:   "",
-		PublicHostURL:  "http://localhost",
+		BindAddress:          "localhost:8000",
+		EnableHTTPS:          false,
+		JwksURL:              "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs",
+		JwksFile:             "config/jwks-file.json",
+		TokenIssuerURL:       "https://sso.redhat.com/auth/realms/redhat-external",
+		HTTPSCertFile:        "",
+		HTTPSKeyFile:         "",
+		PublicHostURL:        "http://localhost",
+		EnableLeaderElection: true,
 	}
 }
 
@@ -47,8 +48,7 @@ func (s *ServerConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.JwksFile, "jwks-file", s.JwksFile, "File containing the the JSON web token signing certificates.")
 	fs.StringVar(&s.TokenIssuerURL, "token-issuer-url", s.TokenIssuerURL, "A token issuer URL. Used to validate if a JWT token used for public endpoints was issued from the given URL.")
 	fs.StringVar(&s.PublicHostURL, "public-host-url", s.PublicHostURL, "Public http host URL of the service")
-	fs.BoolVar(&s.ForceLeader, "force-leader", s.ForceLeader, "Disable leader election (for testing)")
-	fs.MarkHidden("force-leader")
+	fs.BoolVar(&s.EnableLeaderElection, "enable-leader-election", s.EnableLeaderElection, "Enable leader election")
 }
 
 // ReadFiles ...

--- a/pkg/serviceregistration/service.go
+++ b/pkg/serviceregistration/service.go
@@ -2,56 +2,42 @@ package serviceregistration
 
 import (
 	"context"
-	"github.com/golang/glog"
-	"github.com/stackrox/acs-fleet-manager/pkg/workers"
-	"k8s.io/client-go/kubernetes/fake"
-	"os"
 
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
+	"github.com/golang/glog"
+	"github.com/stackrox/acs-fleet-manager/pkg/server"
+	"github.com/stackrox/acs-fleet-manager/pkg/workers"
 )
 
 // Service is the service for service registration
 type Service struct {
-	ctx     context.Context
-	cancel  context.CancelFunc
-	workers []workers.Worker
+	ctx          context.Context
+	cancel       func()
+	workers      []workers.Worker
+	serverConfig *server.ServerConfig
 }
 
 // NewService returns a new Service.
-func NewService(workers []workers.Worker) *Service {
+func NewService(workers []workers.Worker, serverConfig *server.ServerConfig) *Service {
 	return &Service{
-		workers: workers,
+		workers:      workers,
+		serverConfig: serverConfig,
 	}
 }
 
 // Start implements Service.Start
 func (s *Service) Start() {
 	glog.Info("starting service registration")
-	s.ctx, s.cancel = context.WithCancel(context.Background())
-	var client kubernetes.Interface
-	var namespaceName, podName string
-	if e2e, _ := os.LookupEnv("E2E"); e2e == "true" {
-		client = fake.NewSimpleClientset()
-		namespaceName = "e2e-namespace"
-		podName = "e2e-test-pod"
-	} else {
-		config, err := rest.InClusterConfig()
-		if err != nil {
-			panic(err)
+	if !s.serverConfig.EnableLeaderElection {
+		glog.Info("leader election disabled")
+		s.cancel = func() {
+			stopWorkers(s.workers)
 		}
-		var ok bool
-		client = kubernetes.NewForConfigOrDie(config)
-		namespaceName, ok = os.LookupEnv("NAMESPACE_NAME")
-		if !ok {
-			panic("NAMESPACE_NAME not set")
-		}
-		podName, ok = os.LookupEnv("POD_NAME")
-		if !ok {
-			panic("POD_NAME not set")
-		}
+		startWorkers(s.workers)
+		return
 	}
-	l := newWorker(namespaceName, podName, client, s.workers)
+
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	l := newWorker(s.workers)
 	if err := l.run(s.ctx); err != nil {
 		glog.Errorf("error running leader election: %v", err)
 		panic(err)

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -422,6 +422,10 @@ parameters:
   description: Whether to enable targeted operator upgrades
   value: "false"
 
+- name: ENABLE_LEADER_ELECTION
+  description: Enable leader election
+  value: "true"
+
 objects:
   - kind: ConfigMap
     apiVersion: v1
@@ -1368,6 +1372,7 @@ objects:
             - --central-request-internal-user-agents=${CENTRAL_REQUEST_INTERNAL_USER_AGENTS}
             - --telemetry-endpoint=${TELEMETRY_ENDPONT}
             - --telemetry-storage-key-secret-file=/secrets/fleet-manager-credentials/telemetry.storageKey
+            - --enable-leader-election=${ENABLE_LEADER_ELECTION}
             - -v=${GLOG_V}
             resources:
               requests:

--- a/test/helper.go
+++ b/test/helper.go
@@ -114,8 +114,6 @@ func NewHelperWithHooks(t *testing.T, httpServer *httptest.Server, configuration
 
 	env.MustResolveAll(&ocmConfig, &serverConfig, &iamConfig, &centralConfig)
 
-	db.DinosaurAdditionalLeasesExpireTime = time.Now().Add(-time.Minute) // set dinosaurs lease as expired so that a new leader is elected for each of the leases
-
 	// Create a new helper
 	authHelper, err := auth.NewAuthHelper(jwtKeyFile, jwtCAFile, serverConfig.TokenIssuerURL)
 	if err != nil {


### PR DESCRIPTION
By disabling the leader election in integration(-test) environment

It seems that it happens with delay, after the test is already run. This result in starting workers **after** the test teardown which includes database migrations rollback. That result in longer test run time and errors like:
```
E0117 16:41:38.123802   80357 reconciler.go:56] failed to list accepted centrals: RHACS-MGMT-9: failed to list by status

 caused by: ERROR: column central_requests.internal does not exist (SQLSTATE 42703)
```


## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
