### PR TITLE
Native arm64 docker build with buildkit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,6 +138,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Critical for correct image detection in Makefile
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build and push fleet-manager-tools image to quay.io
         if: github.event_name == 'push'
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,4 +146,4 @@ jobs:
       - name: Build and push fleetshard-operator image to quay.io
         run: make image/push/fleetshard-operator
       - name: Build and push fleet-manager image to quay.io
-        run: make image/push/fleet-manager
+        run: make image/push/fleet-manager IMAGE_PLATFORM=linux/amd64,linux/arm64

--- a/.openshift-ci/e2e-runtime/Dockerfile
+++ b/.openshift-ci/e2e-runtime/Dockerfile
@@ -5,12 +5,12 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
 RUN dnf update -y --disablerepo=\* --enablerepo=baseos,appstream && dnf -y install procps make which git gettext jq gcc && dnf clean all && rm -rf /var/cache/dnf
 
-COPY --from=registry.access.redhat.com/ubi8/go-toolset:1.20 /usr/lib/golang /usr/lib/golang
+COPY --from=registry.access.redhat.com/ubi8/go-toolset:1.20 /usr/lib/golang /usr/local/go
 COPY --from=quay.io/openshift/origin-cli:4.13 /usr/bin/oc /usr/bin
 COPY --from=quay.io/operator-framework/operator-sdk:v1.25 /usr/local/bin/operator-sdk /usr/local/bin
 
 ENV GOPATH=/go
-ENV GOROOT=/usr/lib/golang
+ENV GOROOT=/usr/local/go
 ENV PATH="${GOROOT}/bin:${PATH}"
 
 RUN ln -s /usr/bin/oc /usr/bin/kubectl

--- a/.openshift-ci/e2e-runtime/Dockerfile
+++ b/.openshift-ci/e2e-runtime/Dockerfile
@@ -5,12 +5,12 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
 RUN dnf update -y --disablerepo=\* --enablerepo=baseos,appstream && dnf -y install procps make which git gettext jq gcc && dnf clean all && rm -rf /var/cache/dnf
 
-COPY --from=registry.access.redhat.com/ubi8/go-toolset:1.20 /usr/lib/golang /usr/local/go
+COPY --from=registry.ci.openshift.org/openshift/release:golang-1.20 /usr/lib/golang /usr/lib/golang
 COPY --from=quay.io/openshift/origin-cli:4.13 /usr/bin/oc /usr/bin
 COPY --from=quay.io/operator-framework/operator-sdk:v1.25 /usr/local/bin/operator-sdk /usr/local/bin
 
 ENV GOPATH=/go
-ENV GOROOT=/usr/local/go
+ENV GOROOT=/usr/lib/golang
 ENV PATH="${GOROOT}/bin:${PATH}"
 
 RUN ln -s /usr/bin/oc /usr/bin/kubectl

--- a/.openshift-ci/e2e-runtime/Dockerfile
+++ b/.openshift-ci/e2e-runtime/Dockerfile
@@ -5,12 +5,12 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
 RUN dnf update -y --disablerepo=\* --enablerepo=baseos,appstream && dnf -y install procps make which git gettext jq gcc && dnf clean all && rm -rf /var/cache/dnf
 
-COPY --from=registry.ci.openshift.org/openshift/release:golang-1.20 /usr/lib/golang /usr/lib/golang
+COPY --from=registry.ci.openshift.org/openshift/release:golang-1.20 /usr/local/go /usr/local/go
 COPY --from=quay.io/openshift/origin-cli:4.13 /usr/bin/oc /usr/bin
 COPY --from=quay.io/operator-framework/operator-sdk:v1.25 /usr/local/bin/operator-sdk /usr/local/bin
 
 ENV GOPATH=/go
-ENV GOROOT=/usr/lib/golang
+ENV GOROOT=/usr/local/go
 ENV PATH="${GOROOT}/bin:${PATH}"
 
 RUN ln -s /usr/bin/oc /usr/bin/kubectl

--- a/.openshift-ci/e2e-runtime/Dockerfile
+++ b/.openshift-ci/e2e-runtime/Dockerfile
@@ -5,13 +5,13 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
 RUN dnf update -y --disablerepo=\* --enablerepo=baseos,appstream && dnf -y install procps make which git gettext jq gcc && dnf clean all && rm -rf /var/cache/dnf
 
-COPY --from=registry.ci.openshift.org/openshift/release:golang-1.20 /usr/local/go /usr/local/go
+COPY --from=registry.access.redhat.com/ubi8/go-toolset:1.20 /usr/lib/golang /usr/lib/golang
 COPY --from=quay.io/openshift/origin-cli:4.13 /usr/bin/oc /usr/bin
 COPY --from=quay.io/operator-framework/operator-sdk:v1.25 /usr/local/bin/operator-sdk /usr/local/bin
 
 ENV GOPATH=/go
-ENV GOROOT=/usr/local/go
-ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOROOT=/usr/lib/golang
+ENV PATH="${GOROOT}/bin:${PATH}"
 
 RUN ln -s /usr/bin/oc /usr/bin/kubectl
 

--- a/.openshift-ci/e2e-runtime/e2e_dockerized.sh
+++ b/.openshift-ci/e2e-runtime/e2e_dockerized.sh
@@ -22,7 +22,6 @@ AWS_SESSION_TOKEN=$(aws configure get aws_session_token --profile=saml)
 FLEET_MANAGER_IMAGE=$(make -s -C "$GITROOT" full-image-tag)
 
 # Run the necessary docker actions out of the container
-preload_dependency_images
 ensure_fleet_manager_image_exists
 
 docker build -t acscs-e2e -f "$GITROOT/.openshift-ci/e2e-runtime/Dockerfile" "${GITROOT}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:1.20 AS build
 
-WORKDIR /opt/acscs/src
-
-ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /opt/acscs/rds_ca/aws-rds-ca-global-bundle.pem
+USER root
+RUN mkdir /src /rds_ca
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /rds_ca/aws-rds-ca-global-bundle.pem
+WORKDIR /src
 
 RUN go env -w GOCACHE=/go/.cache; \
     go env -w GOMODCACHE=/go/pkg/mod
@@ -28,8 +29,8 @@ RUN useradd -u 1001 unprivilegeduser
 # Switch to non-root user
 USER unprivilegeduser
 
-COPY --chown=unprivilegeduser --from=build /opt/acscs/src/fleet-manager /opt/acscs/src/fleetshard-sync /usr/local/bin/
-COPY --chown=unprivilegeduser --from=build /opt/acscs/rds_ca /usr/local/share/ca-certificates
+COPY --chown=unprivilegeduser --from=build /src/fleet-manager /src/fleetshard-sync /usr/local/bin/
+COPY --chown=unprivilegeduser --from=build /rds_ca /usr/local/share/ca-certificates
 
 EXPOSE 8000
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.ci.openshift.org/openshift/release:golang-1.20 AS build
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:1.20 AS build
 
 RUN mkdir /src /rds_ca
 ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /rds_ca/aws-rds-ca-global-bundle.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.20 AS build
+FROM --platform=$BUILDPLATFORM registry.ci.openshift.org/openshift/release:golang-1.20 AS build
 
 RUN mkdir /src /rds_ca
 ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /rds_ca/aws-rds-ca-global-bundle.pem
@@ -11,11 +11,11 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 
 COPY . ./
 
-ARG GOARCH
+ARG TARGETARCH
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/go/.cache/ \
-    make binary GOOS=linux GOARCH=${GOARCH}
+    make binary GOOS=linux GOARCH=${TARGETARCH}
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9 as standard
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ARG TARGETARCH
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/go/.cache/ \
-    make binary GOOS=linux GOARCH=${TARGETARCH} GOARGS="-buildvcs=false"
+    make binary GOOS=linux GOARCH=${TARGETARCH}
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9 as standard
 

--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.20 AS build
+FROM registry.access.redhat.com/ubi8/go-toolset:1.20 AS build
 
 RUN mkdir /src
 WORKDIR /src

--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi8/go-toolset:1.20 AS build
-
+USER root
 RUN mkdir /src
 WORKDIR /src
 COPY . ./

--- a/Makefile
+++ b/Makefile
@@ -501,8 +501,7 @@ docker/login/internal:
 # Build the image using by specifying a specific image target within the Dockerfile.
 image/build: IMAGE_REF="$(external_image_registry)/$(image_repository):$(image_tag)"
 image/build:
-	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) buildx build -t $(IMAGE_REF) --platform $(IMAGE_PLATFORM) .
-	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) tag $(IMAGE_REF) $(SHORT_IMAGE_REF)
+	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) buildx build -t $(IMAGE_REF) -t $(SHORT_IMAGE_REF) --platform $(IMAGE_PLATFORM) --load .
 	@echo "New image tag: $(SHORT_IMAGE_REF). You might want to"
 	@echo "export FLEET_MANAGER_IMAGE=$(SHORT_IMAGE_REF)"
 ifeq ("$(CLUSTER_TYPE)","kind")

--- a/Makefile
+++ b/Makefile
@@ -501,7 +501,7 @@ docker/login/internal:
 # Build the image using by specifying a specific image target within the Dockerfile.
 image/build: IMAGE_REF="$(external_image_registry)/$(image_repository):$(image_tag)"
 image/build:
-	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) buildx build -t $(IMAGE_REF) -t $(SHORT_IMAGE_REF) --platform $(IMAGE_PLATFORM) --load .
+	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) buildx build -t $(IMAGE_REF) -t $(SHORT_IMAGE_REF) --platform $(IMAGE_PLATFORM) $(BUILDX_BUILD_ARGS) .
 	@echo "New image tag: $(SHORT_IMAGE_REF). You might want to"
 	@echo "export FLEET_MANAGER_IMAGE=$(SHORT_IMAGE_REF)"
 ifeq ("$(CLUSTER_TYPE)","kind")
@@ -536,9 +536,8 @@ image/push: image/push/fleet-manager image/push/probe
 .PHONY: image/push
 
 image/push/fleet-manager: IMAGE_REF="$(external_image_registry)/$(image_repository):$(image_tag)"
+image/push/fleet-manager: BUILDX_BUILD_ARGS=--push
 image/push/fleet-manager: image/build
-	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) push $(IMAGE_REF)
-	@echo
 	@echo "Image was pushed as $(IMAGE_REF). You might want to"
 	@echo "export FLEET_MANAGER_IMAGE=$(IMAGE_REF)"
 .PHONY: image/push/fleet-manager

--- a/dev/env/scripts/docker.sh
+++ b/dev/env/scripts/docker.sh
@@ -61,7 +61,7 @@ ensure_fleet_manager_image_exists() {
                 # Attempt to build this image.
                 if [[ "$FLEET_MANAGER_IMAGE" == "$(make -s -C "${GITROOT}" full-image-tag)" ]]; then
                         log "Building local image..."
-                        make -C "${GITROOT}" image/build GOARCH="$(go env GOARCH)" # supports arm64
+                        make -C "${GITROOT}" image/build
                 else
                     die "Cannot find image '${FLEET_MANAGER_IMAGE}' and don't know how to build it"
                 fi

--- a/probe/Dockerfile
+++ b/probe/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.20 AS build
+FROM registry.access.redhat.com/ubi8/go-toolset:1.20 AS build
 
 ENV GOFLAGS="-mod=mod"
 

--- a/probe/Dockerfile
+++ b/probe/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi8/go-toolset:1.20 AS build
-
+USER root
 ENV GOFLAGS="-mod=mod"
 
 RUN mkdir /src


### PR DESCRIPTION
## Description
This PR adds native support for arm64. arm64 images are now pushed from GHA. 
The main problem is that "registry.ci.openshift.org/openshift/release:golang-1.20" doesn't have arm64 image variant.
I also did a few improvements to the buildkit build to support multi-platform builds.
More details: https://docs.docker.com/build/guide/multi-platform/

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup OCM_OFFLINE_TOKEN=<ocm-offline-token> OCM_ENV=development
make verify lint binary test test/integration
```
