### PR TITLE
ROX-21779 Add envoy active listener

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -859,87 +859,15 @@ objects:
                 address: 0.0.0.0
                 port_value: 9001
             listener_filters:
-            - name: tls_inspector
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
             filter_chains:
-            - filter_chain_match:
-                server_names:
-                  - "fleet-manager-active"
-                  - "fleet-manager-active.${NAMESPACE}"
-                  - "fleet-manager-active.${NAMESPACE}.svc"
-                  - "fleet-manager-active.${NAMESPACE}.svc.cluster"
-                  - "fleet-manager-active.${NAMESPACE}.svc.cluster.local"
-                  - "romndkjdq62p7sr.api.integration.openshift.com"
-              transport_socket:
-                name: envoy.transport_sockets.tls
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
-                  full_scan_certs_on_sni_mismatch: true
-                  common_tls_context:
-                    tls_certificates:
-                    - certificate_chain: {filename: "/secrets/active-tls/tls.crt"}
-                      private_key: {filename: "/secrets/active-tls/tls.key"}
-                    - certificate_chain: {filename: "/secrets/active-tls/tls.crt"}
-                      private_key: {filename: "/secrets/active-tls/tls.key"}
-              filters:
-              - name: envoy.filters.network.http_connection_manager
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                  access_log:
-                  - name: envoy.access_loggers.file
-                    typed_config:
-                      "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                      path: /dev/stdout
-                  stat_prefix: ingress
-                  route_config:
-                    name: backend
-                    virtual_hosts:
-                    - name: all
-                      domains:
-                      - "*"
-                      routes:
-                      - name: default
-                        match:
-                          prefix: /
-                        route:
-                          cluster: backend
-                        # Add security headers.
-                        typed_per_filter_config:
-                          lua_security_headers:
-                            "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
-                            source_code:
-                              inline_string: |
-                                function envoy_on_response(response_handle)
-                                  contentSecurityPolicy = "default-src 'none'; script-src 'self'; img-src 'self'; style-src 'self'; connect-src 'self'";
-                                  response_handle:headers():add("Content-Security-Policy", contentSecurityPolicy);
-                                  response_handle:headers():add("X-Frame-Options", "deny");
-                                  response_handle:headers():add("X-XSS-Protection", "1; mode=block");
-                                  response_handle:headers():add("X-Content-Type-Options", "nosniff");
-                                  response_handle:headers():add("Referrer-Policy", "no-referrer");
-                                  response_handle:headers():add("X-Download-Options", "noopen");
-                                  response_handle:headers():add("X-DNS-Prefetch-Control", "off");
-                                  response_handle:headers():add("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
-                                end
-                  http_filters:
-                  - name: lua_security_headers
-                    typed_config:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-                  - name: envoy.filters.http.router
-                    typed_config:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-
             - transport_socket:
                 name: envoy.transport_sockets.tls
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
-                  full_scan_certs_on_sni_mismatch: true
                   common_tls_context:
                     tls_certificates:
                     - certificate_chain: {filename: "/secrets/tls/tls.crt"}
                       private_key: {filename: "/secrets/tls/tls.key"}
-                    - certificate_chain: {filename: "/secrets/active-tls/tls.crt"}
-                      private_key: {filename: "/secrets/active-tls/tls.key"}
               filters:
               - name: envoy.filters.network.http_connection_manager
                 typed_config:
@@ -1059,6 +987,73 @@ objects:
                   #         href: "/api/rhacs/v1/errors/429"
                   #         code: "CENTRALS-MGMT-429"
                   #         reason: "Too Many Requests"
+
+          # We need a second listener on a different port, because the openshift ingress does
+          # not forward SNI headers, and envoy is not able to determine which certificate to use
+          # for TLS termination. So we need a whole new listener with a different port.
+          # This has the same config as the 9001 listener, but listens on port 9002 and uses
+          # the fleet-manager-active.<ns>.svc certificate.
+          - name: ingress-active
+            address:
+              socket_address:
+                address: 0.0.0.0
+                port_value: 9002
+            listener_filters:
+            filter_chains:
+            - transport_socket:
+                name: envoy.transport_sockets.tls
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+                  common_tls_context:
+                    tls_certificates:
+                    - certificate_chain: {filename: "/secrets/active-tls/tls.crt"}
+                      private_key: {filename: "/secrets/active-tls/tls.key"}
+              filters:
+              - name: envoy.filters.network.http_connection_manager
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                  access_log:
+                  - name: envoy.access_loggers.file
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                      path: /dev/stdout
+                  stat_prefix: ingress
+                  route_config:
+                    name: backend
+                    virtual_hosts:
+                    - name: all
+                      domains:
+                      - "*"
+                      routes:
+                      - name: default
+                        match:
+                          prefix: /
+                        route:
+                          cluster: backend
+                        # Add security headers.
+                        typed_per_filter_config:
+                          lua_security_headers:
+                            "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
+                            source_code:
+                              inline_string: |
+                                function envoy_on_response(response_handle)
+                                  contentSecurityPolicy = "default-src 'none'; script-src 'self'; img-src 'self'; style-src 'self'; connect-src 'self'";
+                                  response_handle:headers():add("Content-Security-Policy", contentSecurityPolicy);
+                                  response_handle:headers():add("X-Frame-Options", "deny");
+                                  response_handle:headers():add("X-XSS-Protection", "1; mode=block");
+                                  response_handle:headers():add("X-Content-Type-Options", "nosniff");
+                                  response_handle:headers():add("Referrer-Policy", "no-referrer");
+                                  response_handle:headers():add("X-Download-Options", "noopen");
+                                  response_handle:headers():add("X-DNS-Prefetch-Control", "off");
+                                  response_handle:headers():add("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+                                end
+                  http_filters:
+                  - name: lua_security_headers
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
   - kind: Deployment
     apiVersion: apps/v1
@@ -1409,6 +1404,9 @@ objects:
             - name: api-envoy
               protocol: TCP
               containerPort: 9001
+            - name: api-envoy-active
+              protocol: TCP
+              containerPort: 9002
             - name: metrics-envoy
               protocol: TCP
               containerPort: 9000
@@ -1508,8 +1506,8 @@ objects:
         app: fleet-manager
         fleet-manager-active: "true"
       ports:
-        - port: 9001
-          targetPort: 9001
+        - port: 9002
+          targetPort: 9002
           protocol: TCP
 
   # Services for diagnostic ports (not part of main service because we


### PR DESCRIPTION
Openshift ingress does not forward SNI headers, so envoy is unable to distinguish requests coming from fleet-manager-envoy vs fleet-manager-active services, and unable to resolve the correct certificate. 

The solution is to add a separate listener on a different port, to server the fleet-manager-active service and use the correct certificate. 