### PR TITLE
ROX-21779 Set new FM_ENDPOINT for stage and production

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
+++ b/dp-terraform/helm/rhacs-terraform/terraform_cluster.sh
@@ -68,7 +68,7 @@ case $ENVIRONMENT in
     ;;
 
   stage)
-    FM_ENDPOINT="https://xtr6hh3mg6zc80v.api.stage.openshift.com"
+    FM_ENDPOINT="https://gbrh0yv9ebhqegl.api.stage.openshift.com"
     OBSERVABILITY_GITHUB_TAG="stage"
     OBSERVABILITY_OBSERVATORIUM_GATEWAY="https://observatorium-mst.api.stage.openshift.com"
     OBSERVABILITY_OPERATOR_VERSION="v4.2.1"
@@ -86,7 +86,7 @@ case $ENVIRONMENT in
     ;;
 
   prod)
-    FM_ENDPOINT="https://api.openshift.com"
+    FM_ENDPOINT="https://ixi6srehbv5uxsa.api.openshift.com"
     OBSERVABILITY_GITHUB_TAG="production"
     OBSERVABILITY_OBSERVATORIUM_GATEWAY="https://observatorium-mst.api.openshift.com"
     OBSERVABILITY_OPERATOR_VERSION="v4.2.1"


### PR DESCRIPTION
New routes have been added to target only the "active" fleet-manager instance. 
- romndkjdq62p7sr.api.integration.openshift.com for integration
- gbrh0yv9ebhqegl.api.stage.openshift.com for stage
- ixi6srehbv5uxsa.api.openshift.com for prod

This will change the stage and prod FM_ENDPOINT urls to point to the active fleet-manager instance

Note that these endpoints are returning errors right now, that's because the envoy gateway config that listens on port 9002 has not been deployed to stage and production yet. When we deploy FM, the endpoints should be working 🤞 
