### PR TITLE
Allow for both "sub" claim formats to be used in login

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -546,10 +546,10 @@ func getAuthProviderConfig(remoteCentral private.ManagedCentral) *declarativecon
 			RoleName:       "Admin",
 		},
 	}
-	if remoteCentral.Spec.Auth.OwnerAlternativeUserId != "" {
+	if remoteCentral.Spec.Auth.OwnerAlternateUserId != "" {
 		groups = append(groups, declarativeconfig.Group{
 			AttributeKey:   "userid",
-			AttributeValue: remoteCentral.Spec.Auth.OwnerAlternativeUserId,
+			AttributeValue: remoteCentral.Spec.Auth.OwnerAlternateUserId,
 			RoleName:       "Admin",
 		})
 	}

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -529,27 +529,35 @@ func (r *CentralReconciler) configureAuditLogNotifier(secret *corev1.Secret, nam
 }
 
 func getAuthProviderConfig(remoteCentral private.ManagedCentral) *declarativeconfig.AuthProvider {
+	groups := []declarativeconfig.Group{
+		{
+			AttributeKey:   "userid",
+			AttributeValue: remoteCentral.Spec.Auth.OwnerUserId,
+			RoleName:       "Admin",
+		},
+		{
+			AttributeKey:   "groups",
+			AttributeValue: "admin:org:all",
+			RoleName:       "Admin",
+		},
+		{
+			AttributeKey:   "rh_is_org_admin",
+			AttributeValue: "true",
+			RoleName:       "Admin",
+		},
+	}
+	if remoteCentral.Spec.Auth.OwnerAlternativeUserId != "" {
+		groups = append(groups, declarativeconfig.Group{
+			AttributeKey:   "userid",
+			AttributeValue: remoteCentral.Spec.Auth.OwnerAlternativeUserId,
+			RoleName:       "Admin",
+		})
+	}
 	return &declarativeconfig.AuthProvider{
 		Name:             authProviderName(remoteCentral),
 		UIEndpoint:       remoteCentral.Spec.UiEndpoint.Host,
 		ExtraUIEndpoints: []string{"localhost:8443"},
-		Groups: []declarativeconfig.Group{
-			{
-				AttributeKey:   "userid",
-				AttributeValue: remoteCentral.Spec.Auth.OwnerUserId,
-				RoleName:       "Admin",
-			},
-			{
-				AttributeKey:   "groups",
-				AttributeValue: "admin:org:all",
-				RoleName:       "Admin",
-			},
-			{
-				AttributeKey:   "rh_is_org_admin",
-				AttributeValue: "true",
-				RoleName:       "Admin",
-			},
-		},
+		Groups:           groups,
 		RequiredAttributes: []declarativeconfig.RequiredAttribute{
 			{
 				AttributeKey:   "rh_org_id",

--- a/internal/dinosaur/pkg/api/dbapi/central_request_types.go
+++ b/internal/dinosaur/pkg/api/dbapi/central_request_types.go
@@ -44,6 +44,9 @@ type CentralRequest struct {
 	OwnerAccountID string `json:"owner_account_id"`
 	// OwnerUserID is the subject claim (confusingly it is NOT the user_id claim) of the Red Hat SSO token.
 	OwnerUserID string `json:"owner_user_id"`
+	// OwnerAlternativeUserID is the user_id claim of the Red Hat SSO token.
+	// It is introduced to allow for a seamless migration of the subject claim format.
+	OwnerAlternativeUserID string `json:"owner_alternative_user_id"`
 
 	// Instance-independent part of the Central's hostname. For example, this
 	// can be `rhacs-dev.com`, `acs-stage.rhcloud.com`, etc.

--- a/internal/dinosaur/pkg/api/dbapi/central_request_types.go
+++ b/internal/dinosaur/pkg/api/dbapi/central_request_types.go
@@ -46,7 +46,7 @@ type CentralRequest struct {
 	OwnerUserID string `json:"owner_user_id"`
 	// OwnerAlternateUserID is the user_id claim of the Red Hat SSO token.
 	// It is introduced to allow for a seamless migration of the subject claim format.
-	OwnerAlternateUserID string `json:"owner_alternative_user_id"`
+	OwnerAlternateUserID string `json:"owner_alternate_user_id"`
 
 	// Instance-independent part of the Central's hostname. For example, this
 	// can be `rhacs-dev.com`, `acs-stage.rhcloud.com`, etc.

--- a/internal/dinosaur/pkg/api/dbapi/central_request_types.go
+++ b/internal/dinosaur/pkg/api/dbapi/central_request_types.go
@@ -44,9 +44,9 @@ type CentralRequest struct {
 	OwnerAccountID string `json:"owner_account_id"`
 	// OwnerUserID is the subject claim (confusingly it is NOT the user_id claim) of the Red Hat SSO token.
 	OwnerUserID string `json:"owner_user_id"`
-	// OwnerAlternativeUserID is the user_id claim of the Red Hat SSO token.
+	// OwnerAlternateUserID is the user_id claim of the Red Hat SSO token.
 	// It is introduced to allow for a seamless migration of the subject claim format.
-	OwnerAlternativeUserID string `json:"owner_alternative_user_id"`
+	OwnerAlternateUserID string `json:"owner_alternative_user_id"`
 
 	// Instance-independent part of the Central's hostname. For example, this
 	// can be `rhacs-dev.com`, `acs-stage.rhcloud.com`, etc.

--- a/internal/dinosaur/pkg/api/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/private/api/openapi.yaml
@@ -454,6 +454,8 @@ components:
           type: string
         ownerUserId:
           type: string
+        ownerAlternativeUserId:
+          type: string
         ownerOrgId:
           type: string
         ownerOrgName:

--- a/internal/dinosaur/pkg/api/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/private/api/openapi.yaml
@@ -454,7 +454,7 @@ components:
           type: string
         ownerUserId:
           type: string
-        ownerAlternativeUserId:
+        ownerAlternateUserId:
           type: string
         ownerOrgId:
           type: string

--- a/internal/dinosaur/pkg/api/private/model_managed_central_all_of_spec_auth.go
+++ b/internal/dinosaur/pkg/api/private/model_managed_central_all_of_spec_auth.go
@@ -12,11 +12,12 @@ package private
 
 // ManagedCentralAllOfSpecAuth struct for ManagedCentralAllOfSpecAuth
 type ManagedCentralAllOfSpecAuth struct {
-	ClientSecret string `json:"clientSecret,omitempty"`
-	ClientId     string `json:"clientId,omitempty"`
-	ClientOrigin string `json:"clientOrigin,omitempty"`
-	OwnerUserId  string `json:"ownerUserId,omitempty"`
-	OwnerOrgId   string `json:"ownerOrgId,omitempty"`
-	OwnerOrgName string `json:"ownerOrgName,omitempty"`
-	Issuer       string `json:"issuer,omitempty"`
+	ClientSecret           string `json:"clientSecret,omitempty"`
+	ClientId               string `json:"clientId,omitempty"`
+	ClientOrigin           string `json:"clientOrigin,omitempty"`
+	OwnerUserId            string `json:"ownerUserId,omitempty"`
+	OwnerAlternativeUserId string `json:"ownerAlternativeUserId,omitempty"`
+	OwnerOrgId             string `json:"ownerOrgId,omitempty"`
+	OwnerOrgName           string `json:"ownerOrgName,omitempty"`
+	Issuer                 string `json:"issuer,omitempty"`
 }

--- a/internal/dinosaur/pkg/api/private/model_managed_central_all_of_spec_auth.go
+++ b/internal/dinosaur/pkg/api/private/model_managed_central_all_of_spec_auth.go
@@ -12,12 +12,12 @@ package private
 
 // ManagedCentralAllOfSpecAuth struct for ManagedCentralAllOfSpecAuth
 type ManagedCentralAllOfSpecAuth struct {
-	ClientSecret           string `json:"clientSecret,omitempty"`
-	ClientId               string `json:"clientId,omitempty"`
-	ClientOrigin           string `json:"clientOrigin,omitempty"`
-	OwnerUserId            string `json:"ownerUserId,omitempty"`
-	OwnerAlternativeUserId string `json:"ownerAlternativeUserId,omitempty"`
-	OwnerOrgId             string `json:"ownerOrgId,omitempty"`
-	OwnerOrgName           string `json:"ownerOrgName,omitempty"`
-	Issuer                 string `json:"issuer,omitempty"`
+	ClientSecret         string `json:"clientSecret,omitempty"`
+	ClientId             string `json:"clientId,omitempty"`
+	ClientOrigin         string `json:"clientOrigin,omitempty"`
+	OwnerUserId          string `json:"ownerUserId,omitempty"`
+	OwnerAlternateUserId string `json:"ownerAlternateUserId,omitempty"`
+	OwnerOrgId           string `json:"ownerOrgId,omitempty"`
+	OwnerOrgName         string `json:"ownerOrgName,omitempty"`
+	Issuer               string `json:"issuer,omitempty"`
 }

--- a/internal/dinosaur/pkg/handlers/validation.go
+++ b/internal/dinosaur/pkg/handlers/validation.go
@@ -110,6 +110,7 @@ func ValidateDinosaurClaims(ctx context.Context, dinosaurRequestPayload *public.
 		dinosaurRequest.OrganisationID, _ = claims.GetOrgID()
 		dinosaurRequest.OwnerAccountID, _ = claims.GetAccountID()
 		dinosaurRequest.OwnerUserID, _ = claims.GetSubject()
+		dinosaurRequest.OwnerAlternativeUserID, _ = claims.GetUserID()
 
 		return nil
 	}

--- a/internal/dinosaur/pkg/handlers/validation.go
+++ b/internal/dinosaur/pkg/handlers/validation.go
@@ -110,7 +110,7 @@ func ValidateDinosaurClaims(ctx context.Context, dinosaurRequestPayload *public.
 		dinosaurRequest.OrganisationID, _ = claims.GetOrgID()
 		dinosaurRequest.OwnerAccountID, _ = claims.GetAccountID()
 		dinosaurRequest.OwnerUserID, _ = claims.GetSubject()
-		dinosaurRequest.OwnerAlternativeUserID, _ = claims.GetUserID()
+		dinosaurRequest.OwnerAlternateUserID, _ = claims.GetAlternateUserID()
 
 		return nil
 	}

--- a/internal/dinosaur/pkg/migrations/20240122180000_add_alternate_user_id.go
+++ b/internal/dinosaur/pkg/migrations/20240122180000_add_alternate_user_id.go
@@ -12,10 +12,10 @@ import (
 	"gorm.io/gorm"
 )
 
-func addAlternativeUserIDFieldToCentralRequests() *gormigrate.Migration {
+func addAlternateUserIDFieldToCentralRequests() *gormigrate.Migration {
 	type CentralRequest struct {
 		db.Model
-		OwnerAlternativeUserID string `json:"owner_alternative_user_id"`
+		OwnerAlternateUserID string `json:"owner_alternate_user_id"`
 	}
 	migrationID := "20240122180000"
 

--- a/internal/dinosaur/pkg/migrations/20240122180000_add_alternate_user_id.go
+++ b/internal/dinosaur/pkg/migrations/20240122180000_add_alternate_user_id.go
@@ -22,12 +22,12 @@ func addAlternateUserIDFieldToCentralRequests() *gormigrate.Migration {
 	return &gormigrate.Migration{
 		ID: migrationID,
 		Migrate: func(tx *gorm.DB) error {
-			return addColumnIfNotExists(tx, &CentralRequest{}, "owner_alternative_user_id")
+			return addColumnIfNotExists(tx, &CentralRequest{}, "owner_alternate_user_id")
 		},
 		Rollback: func(tx *gorm.DB) error {
 			return errors.Wrap(
-				tx.Migrator().DropColumn(&CentralRequest{}, "owner_alternative_user_id"),
-				"failed to drop owner_alternative_user_id column",
+				tx.Migrator().DropColumn(&CentralRequest{}, "owner_alternate_user_id"),
+				"failed to drop owner_alternate_user_id column",
 			)
 		},
 	}

--- a/internal/dinosaur/pkg/migrations/20240122180000_add_alternative_user_id.go
+++ b/internal/dinosaur/pkg/migrations/20240122180000_add_alternative_user_id.go
@@ -1,0 +1,34 @@
+package migrations
+
+// Migrations should NEVER use types from other packages. Types can change
+// and then migrations run on a _new_ database will fail or behave unexpectedly.
+// Instead of importing types, always re-create the type in the migration, as
+// is done here, even though the same type is defined in pkg/api
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/pkg/errors"
+	"github.com/stackrox/acs-fleet-manager/pkg/db"
+	"gorm.io/gorm"
+)
+
+func addAlternativeUserIDFieldToCentralRequests() *gormigrate.Migration {
+	type CentralRequest struct {
+		db.Model
+		OwnerAlternativeUserID string `json:"owner_alternative_user_id"`
+	}
+	migrationID := "20240122180000"
+
+	return &gormigrate.Migration{
+		ID: migrationID,
+		Migrate: func(tx *gorm.DB) error {
+			return addColumnIfNotExists(tx, &CentralRequest{}, "owner_alternative_user_id")
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return errors.Wrap(
+				tx.Migrator().DropColumn(&CentralRequest{}, "owner_alternative_user_id"),
+				"failed to drop owner_alternative_user_id column",
+			)
+		},
+	}
+}

--- a/internal/dinosaur/pkg/migrations/migrations.go
+++ b/internal/dinosaur/pkg/migrations/migrations.go
@@ -52,6 +52,7 @@ func getMigrations() []*gormigrate.Migration {
 		addExpiredAtFieldToCentralRequests(),
 		addExpirationLeaseType(),
 		addClusterAddons(),
+		addAlternativeUserIDFieldToCentralRequests(),
 	}
 }
 

--- a/internal/dinosaur/pkg/migrations/migrations.go
+++ b/internal/dinosaur/pkg/migrations/migrations.go
@@ -52,7 +52,7 @@ func getMigrations() []*gormigrate.Migration {
 		addExpiredAtFieldToCentralRequests(),
 		addExpirationLeaseType(),
 		addClusterAddons(),
-		addAlternativeUserIDFieldToCentralRequests(),
+		addAlternateUserIDFieldToCentralRequests(),
 	}
 }
 

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -125,14 +125,14 @@ func (c *ManagedCentralPresenter) presentManagedCentral(gitopsConfig gitops.Conf
 				from.Owner,
 			},
 			Auth: private.ManagedCentralAllOfSpecAuth{
-				ClientId:               from.AuthConfig.ClientID,
-				ClientSecret:           from.AuthConfig.ClientSecret, // pragma: allowlist secret
-				ClientOrigin:           from.AuthConfig.ClientOrigin,
-				OwnerOrgId:             from.OrganisationID,
-				OwnerOrgName:           from.OrganisationName,
-				OwnerUserId:            from.OwnerUserID,
-				OwnerAlternativeUserId: from.OwnerAlternativeUserID,
-				Issuer:                 from.AuthConfig.Issuer,
+				ClientId:             from.AuthConfig.ClientID,
+				ClientSecret:         from.AuthConfig.ClientSecret, // pragma: allowlist secret
+				ClientOrigin:         from.AuthConfig.ClientOrigin,
+				OwnerOrgId:           from.OrganisationID,
+				OwnerOrgName:         from.OrganisationName,
+				OwnerUserId:          from.OwnerUserID,
+				OwnerAlternateUserId: from.OwnerAlternateUserID,
+				Issuer:               from.AuthConfig.Issuer,
 			},
 			UiEndpoint: private.ManagedCentralAllOfSpecUiEndpoint{
 				Host: from.GetUIHost(),

--- a/internal/dinosaur/pkg/presenters/managedcentral.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral.go
@@ -125,13 +125,14 @@ func (c *ManagedCentralPresenter) presentManagedCentral(gitopsConfig gitops.Conf
 				from.Owner,
 			},
 			Auth: private.ManagedCentralAllOfSpecAuth{
-				ClientId:     from.AuthConfig.ClientID,
-				ClientSecret: from.AuthConfig.ClientSecret, // pragma: allowlist secret
-				ClientOrigin: from.AuthConfig.ClientOrigin,
-				OwnerOrgId:   from.OrganisationID,
-				OwnerOrgName: from.OrganisationName,
-				OwnerUserId:  from.OwnerUserID,
-				Issuer:       from.AuthConfig.Issuer,
+				ClientId:               from.AuthConfig.ClientID,
+				ClientSecret:           from.AuthConfig.ClientSecret, // pragma: allowlist secret
+				ClientOrigin:           from.AuthConfig.ClientOrigin,
+				OwnerOrgId:             from.OrganisationID,
+				OwnerOrgName:           from.OrganisationName,
+				OwnerUserId:            from.OwnerUserID,
+				OwnerAlternativeUserId: from.OwnerAlternativeUserID,
+				Issuer:                 from.AuthConfig.Issuer,
 			},
 			UiEndpoint: private.ManagedCentralAllOfSpecUiEndpoint{
 				Host: from.GetUIHost(),

--- a/openapi/fleet-manager-private.yaml
+++ b/openapi/fleet-manager-private.yaml
@@ -292,7 +292,7 @@ components:
                       type: string
                     ownerUserId:
                       type: string
-                    ownerAlternativeUserId:
+                    ownerAlternateUserId:
                       type: string
                     ownerOrgId:
                       type: string

--- a/openapi/fleet-manager-private.yaml
+++ b/openapi/fleet-manager-private.yaml
@@ -292,6 +292,8 @@ components:
                       type: string
                     ownerUserId:
                       type: string
+                    ownerAlternativeUserId:
+                      type: string
                     ownerOrgId:
                       type: string
                     ownerOrgName:

--- a/pkg/auth/acs_claims.go
+++ b/pkg/auth/acs_claims.go
@@ -49,6 +49,14 @@ func (c *ACSClaims) GetUserID() (string, error) {
 		tenantUserIDClaim, alternateTenantUserIDClaim)
 }
 
+// GetAlternateUserID ...
+func (c *ACSClaims) GetAlternateUserID() (string, error) {
+	if alternateSub, ok := (*c)[alternateSubClaim].(string); ok {
+		return alternateSub, nil
+	}
+	return "", fmt.Errorf("can't find %q attribute in claims", alternateSubClaim)
+}
+
 // GetOrgID ...
 func (c *ACSClaims) GetOrgID() (string, error) {
 	if idx, val := arrays.FindFirst(func(x interface{}) bool { return x != nil },

--- a/pkg/auth/context_config.go
+++ b/pkg/auth/context_config.go
@@ -22,6 +22,7 @@ var (
 	alternateTenantIDClaim     = "rh-org-id"
 	alternateTenantUserIDClaim = "rh-user-id"
 
+	// Sub claim in old format.
 	alternateSubClaim = "deprecated_sub"
 )
 

--- a/pkg/auth/context_config.go
+++ b/pkg/auth/context_config.go
@@ -21,6 +21,8 @@ var (
 	// The claims relate to the Red Hat organisation and user that created the service account.
 	alternateTenantIDClaim     = "rh-org-id"
 	alternateTenantUserIDClaim = "rh-user-id"
+
+	alternateSubClaim = "deprecated_sub"
 )
 
 // ContextConfig ...


### PR DESCRIPTION
## Description
This PR is based on next assumptions:
* There's ongoing process of switching from old `sub` claim format to new one
* Console dot is returning `sub` in new format under `sub` claim name; it will return `sub` in old format under `deprecated_sub` claim name
*  When using dynamic client, `sso.r.c` returns `sub` in old format; at some point switch will be made to return `sub` in new format

This PR adds auth provider groups for both old and new format so that the owner of an instance can login whatever format is returned from `sso.r.c`.

**Note**: this PR only solves the problem for new instances. Already existing instances will continue to work until a switch in dynamic clients happens. This case should be handled in a separate PR.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
