### PR TITLE
fix: update for secret backup for tenants

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -786,7 +786,7 @@ func (r *CentralReconciler) collectReconciliationStatus(ctx context.Context, rem
 	}
 
 	// Only report secrets if Central is ready, to ensure we're not trying to get secrets before they are created.
-	// Only report secrets once. Ensures we don't overwrite initial secrets with corrupted secrets
+	// Only report secrets if not all secrets are already stored to ensures we don't overwrite initial secrets with corrupted secrets
 	// from the cluster state.
 	if isRemoteCentralReady(remoteCentral) && !r.areSecretsStored(remoteCentral.Metadata.SecretsStored) {
 		secrets, err := r.collectSecretsEncrypted(ctx, remoteCentral)

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -786,7 +786,7 @@ func (r *CentralReconciler) collectReconciliationStatus(ctx context.Context, rem
 	}
 
 	// Only report secrets if Central is ready, to ensure we're not trying to get secrets before they are created.
-	// Only report secrets if not all secrets are already stored to ensures we don't overwrite initial secrets with corrupted secrets
+	// Only report secrets if not all secrets are already stored to ensure we don't overwrite initial secrets with corrupted secrets
 	// from the cluster state.
 	if isRemoteCentralReady(remoteCentral) && !r.areSecretsStored(remoteCentral.Metadata.SecretsStored) {
 		secrets, err := r.collectSecretsEncrypted(ctx, remoteCentral)

--- a/internal/dinosaur/pkg/services/data_plane_dinosaur.go
+++ b/internal/dinosaur/pkg/services/data_plane_dinosaur.go
@@ -276,8 +276,8 @@ func (s *dataPlaneCentralService) addRoutesToRequest(centralRequest *dbapi.Centr
 }
 
 func (d *dataPlaneCentralService) addSecretsToRequest(centralRequest *dbapi.CentralRequest, centralStatus *dbapi.DataPlaneCentralStatus, cluster *api.Cluster) *serviceError.ServiceError {
-	if centralRequest.Secrets != nil { // pragma: allowlist secret
-		logger.Logger.V(10).Infof("skip persisting secrets for Central %s as they are already stored", centralRequest.ID)
+	if centralStatus.Secrets == nil || len(centralStatus.Secrets) == 0 { // pragma: allowlist secret
+		logger.Logger.V(10).Infof("skip persisting secrets for Central %s, report is empty or nil", centralRequest.ID)
 		return nil
 	}
 	logger.Logger.Infof("store secret information for central %s", centralRequest.ID)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
The check intended to prevent fleet-manager from overwriting secrets if they are already stored broke the update logic in case new secrets were added.

The check was still useful because it protected FM from overwriting secrets with an empty map if no secrets are reported by FS, so I only changed the logic to validate the incoming request instead of the database state. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Unit and integration tests added~~
~~- [ ] Added test description under `Test manual`~~
~~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [x] CI and all relevant tests are passing
~~- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~~
~~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
~~- [ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
~~- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
~~- [ ] Check AWS limits are reasonable for changes provisioning new resources~~

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
