### PR TITLE
ROX-21946: FS set central-tls OwnerReference if not already set

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -333,7 +333,7 @@
         "filename": "e2e/e2e_test.go",
         "hashed_secret": "7f38822bc2b03e97325ff310099f457f6f788daf",
         "is_verified": false,
-        "line_number": 268
+        "line_number": 290
       }
     ],
     "fleetshard/pkg/central/cloudprovider/dbclient_moq.go": [
@@ -586,5 +586,5 @@
       }
     ]
   },
-  "generated_at": "2024-01-25T17:36:32Z"
+  "generated_at": "2024-02-05T19:02:34Z"
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -258,6 +258,28 @@ var _ = Describe("Central", Ordered, func() {
 			assertEqualSecrets(actualSecrets, expectedSecrets)
 		})
 
+		It("should set central-tls OwnerReference after restore", func() {
+			centralTLSSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      k8s.CentralTLSSecretName,
+					Namespace: namespaceName,
+				},
+			}
+
+			Eventually(func() (err error) {
+				if err := k8sClient.Get(ctx, ctrlClient.ObjectKeyFromObject(centralTLSSecret), centralTLSSecret); err != nil {
+					return err
+				}
+
+				if len(centralTLSSecret.GetObjectMeta().GetOwnerReferences()) == 0 {
+					return fmt.Errorf("OwnerReference for %s is empty", k8s.CentralTLSSecretName)
+				}
+
+				return nil
+			}).WithPolling(time.Second * 10).WithTimeout(defaultTimeout).Should(Succeed())
+
+		})
+
 		It("should delete and recreate secret backup for admin reset API", func() {
 			secretBackup := k8s.NewSecretBackup(k8sClient, false)
 			oldSecrets, err := secretBackup.CollectSecrets(ctx, namespaceName)

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -922,8 +922,13 @@ func (r *CentralReconciler) ensureCentralTLSSecretHasOwnerReference(ctx context.
 		return nil
 	}
 
+	centralCR := &v1alpha1.Central{}
+	if err := r.client.Get(ctx, ctrlClient.ObjectKeyFromObject(central), centralCR); err != nil {
+		return fmt.Errorf("getting current central CR from k8s: %w", err)
+	}
+
 	secret.OwnerReferences = []metav1.OwnerReference{
-		*metav1.NewControllerRef(central, central.GroupVersionKind()),
+		*metav1.NewControllerRef(centralCR, centralCR.GroupVersionKind()),
 	}
 
 	if err := r.client.Update(ctx, secret); err != nil {

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -916,6 +916,10 @@ func (r *CentralReconciler) encryptSecrets(secrets map[string]*corev1.Secret) (m
 func (r *CentralReconciler) ensureCentralTLSSecretHasOwnerReference(ctx context.Context, remoteCentral *private.ManagedCentral, central *v1alpha1.Central) error {
 	secret, err := r.getSecret(remoteCentral.Metadata.Namespace, k8s.CentralTLSSecretName)
 	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			// no need to ensure correct owner reference if the secret doesn't exist
+			return nil
+		}
 		return err
 	}
 

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -639,7 +639,8 @@ func (r *CentralReconciler) reconcileCentral(ctx context.Context, remoteCentral 
 
 	centralExists := true
 	existingCentral := v1alpha1.Central{}
-	centralKey := ctrlClient.ObjectKey{Namespace: remoteCentralNamespace, Name: remoteCentralName}
+	centralKey := ctrlClient.
+		ObjectKey{Namespace: remoteCentralNamespace, Name: remoteCentralName}
 	err := r.client.Get(ctx, centralKey, &existingCentral)
 	if err != nil {
 		if !apiErrors.IsNotFound(err) {
@@ -928,7 +929,7 @@ func (r *CentralReconciler) ensureCentralTLSSecretHasOwnerReference(ctx context.
 	}
 
 	secret.OwnerReferences = []metav1.OwnerReference{
-		*metav1.NewControllerRef(centralCR, centralCR.GroupVersionKind()),
+		*metav1.NewControllerRef(centralCR, v1alpha1.CentralGVK),
 	}
 
 	if err := r.client.Update(ctx, secret); err != nil {

--- a/fleetshard/pkg/k8s/route.go
+++ b/fleetshard/pkg/k8s/route.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+
 	"github.com/stackrox/acs-fleet-manager/fleetshard/config"
 	"github.com/stackrox/rox/pkg/errox"
 
@@ -152,7 +153,7 @@ func (s *RouteService) configureReencryptRoute(ctx context.Context, route *opens
 	annotatedRoute.Spec.Host = remoteCentral.Spec.UiEndpoint.Host
 
 	namespace := remoteCentral.Metadata.Namespace
-	centralTLSSecret, retrievalErr := getSecret(ctx, s.client, centralTLSSecretName, namespace)
+	centralTLSSecret, retrievalErr := getSecret(ctx, s.client, CentralTLSSecretName, namespace)
 	if retrievalErr != nil {
 		wrappedErr := fmt.Errorf(
 			"getting central-tls secret for tenant %s: %w",
@@ -163,7 +164,7 @@ func (s *RouteService) configureReencryptRoute(ctx context.Context, route *opens
 	}
 	centralCA, ok := centralTLSSecret.Data["ca.pem"]
 	if !ok {
-		return nil, fmt.Errorf("could not find centrals ca certificate 'ca.pem' in secret/%s", centralTLSSecretName)
+		return nil, fmt.Errorf("could not find centrals ca certificate 'ca.pem' in secret/%s", CentralTLSSecretName)
 	}
 
 	if annotatedRoute.Spec.TLS == nil {

--- a/fleetshard/pkg/k8s/route_test.go
+++ b/fleetshard/pkg/k8s/route_test.go
@@ -203,7 +203,7 @@ func TestPassThroughRouteLifecycle(t *testing.T) {
 var (
 	centralTLSSecret = &coreV1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      centralTLSSecretName,
+			Name:      CentralTLSSecretName,
 			Namespace: testNamespace,
 		},
 		Data: map[string][]byte{

--- a/fleetshard/pkg/k8s/secret.go
+++ b/fleetshard/pkg/k8s/secret.go
@@ -11,13 +11,13 @@ import (
 )
 
 const (
-	centralTLSSecretName           = "central-tls"            // pragma: allowlist secret
+	CentralTLSSecretName           = "central-tls"            // pragma: allowlist secret
 	centralDBPasswordSecretName    = "central-db-password"    // pragma: allowlist secret
 	centralEncryptionKeySecretName = "central-encryption-key" // pragma: allowlist secret
 )
 
 var defaultSecretsToWatch = []string{
-	centralTLSSecretName,
+	CentralTLSSecretName,
 	centralEncryptionKeySecretName,
 }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

After restore of central-tls secret the owner reference is not set to the central CR again. This blocks the operator from automatically rotating leaf certificates for central, since it won't touch secrets not owned by it.

With this PR fleetshard-sync, will set the owner reference of the secret to the CR it creates, which should fix the issue.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [x] Add secret to app-interface Vault or Secrets Manager if necessary
- [x] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [x] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

CI and added e2e tests should be sufficient

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
