### PR TITLE
ROX-15091: Add deprecated_sub claim mapping

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -405,6 +405,10 @@ func getAuthProviderConfig(remoteCentral private.ManagedCentral) *declarativecon
 				Path: "is_org_admin",
 				Name: "rh_is_org_admin",
 			},
+			{
+				Path: "deprecated_sub",
+				Name: "userid",
+			},
 		},
 		OIDCConfig: &declarativeconfig.OIDCConfig{
 			Issuer:                    remoteCentral.Spec.Auth.Issuer,


### PR DESCRIPTION
## Description
Once RHSSO dynamic clients will return both `sub` and `deprecated_sub`, it will allow for seamless transition to the new format.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
