### PR TITLE
ROX-20872: fix fleetshard reconciler race condition

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -187,7 +187,9 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	remoteCentralNamespace := remoteCentral.Metadata.Namespace
 
 	if remoteCentral.Metadata.DeletionTimestamp != "" {
-		return r.reconcileInstanceDeletion(ctx, &remoteCentral, central)
+		status, err := r.reconcileInstanceDeletion(ctx, &remoteCentral, central)
+		shouldUpdateCentralHash = err == nil
+		return status, err
 	}
 
 	namespaceLabels := map[string]string{

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -86,8 +86,10 @@ const (
 	tenantImagePullSecretName = "stackrox" // pragma: allowlist secret
 )
 
-type verifyAuthProviderExistsFunc func(ctx context.Context, central private.ManagedCentral,
-	client ctrlClient.Client) (bool, error)
+type verifyAuthProviderExistsFunc func(ctx context.Context, central private.ManagedCentral, client ctrlClient.Client) (bool, error)
+type needsReconcileFunc func(changed bool, central *v1alpha1.Central, storedSecrets []string) bool
+type restoreCentralSecretsFunc func(ctx context.Context, remoteCentral private.ManagedCentral) error
+type areSecretsStoredFunc func(secretsStored []string) bool
 
 // CentralReconcilerOptions are the static options for creating a reconciler.
 type CentralReconcilerOptions struct {
@@ -111,6 +113,7 @@ type CentralReconciler struct {
 	central                private.ManagedCentral
 	status                 *int32
 	lastCentralHash        [16]byte
+	lastCentralHashTime    time.Time
 	useRoutes              bool
 	Resources              bool
 	routeService           *k8s.RouteService
@@ -133,6 +136,11 @@ type CentralReconciler struct {
 	hasAuthProvider        bool
 	verifyAuthProviderFunc verifyAuthProviderExistsFunc
 	tenantImagePullSecret  []byte
+	clock                  clock
+
+	areSecretsStoredFunc      areSecretsStoredFunc
+	needsReconcileFunc        needsReconcileFunc
+	restoreCentralSecretsFunc restoreCentralSecretsFunc
 }
 
 // Reconcile takes a private.ManagedCentral and tries to install it into the cluster managed by the fleet-shard.
@@ -146,16 +154,29 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	}
 	defer atomic.StoreInt32(r.status, FreeStatus)
 
+	centralHash, err := r.computeCentralHash(remoteCentral)
+	if err != nil {
+		return nil, errors.Wrap(err, "computing central hash")
+	}
+
 	central, err := r.getInstanceConfig(&remoteCentral)
 	if err != nil {
 		return nil, err
 	}
 
-	changed, err := r.centralChanged(remoteCentral)
-	if err != nil {
-		return nil, errors.Wrap(err, "checking if central changed")
-	}
-	needsReconcile := r.needsReconcile(changed, central, remoteCentral.Metadata.SecretsStored)
+	shouldUpdateCentralHash := false
+	defer func() {
+		if shouldUpdateCentralHash {
+			r.lastCentralHash = centralHash
+			r.lastCentralHashTime = time.Now()
+		} else {
+			r.lastCentralHash = [16]byte{}
+		}
+	}()
+
+	changed := r.centralChanged(centralHash)
+
+	needsReconcile := r.needsReconcileFunc(changed, central, remoteCentral.Metadata.SecretsStored)
 
 	if !needsReconcile && r.shouldSkipReadyCentral(remoteCentral) {
 		return nil, ErrCentralNotChanged
@@ -187,7 +208,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		}
 	}
 
-	err = r.restoreCentralSecrets(ctx, remoteCentral)
+	err = r.restoreCentralSecretsFunc(ctx, remoteCentral)
 	if err != nil {
 		return nil, err
 	}
@@ -256,11 +277,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		return nil, err
 	}
 
-	// Setting the last central hash must always be executed as the last step.
-	// defer can't be used for this call because it is also executed after the reconcile failed.
-	if err := r.setLastCentralHash(remoteCentral); err != nil {
-		return nil, errors.Wrap(err, "setting central reconcilation cache")
-	}
+	shouldUpdateCentralHash = true
 
 	logStatus := *status
 	logStatus.Secrets = obscureSecrets(status.Secrets)
@@ -681,9 +698,10 @@ func (r *CentralReconciler) reconcileCentral(ctx context.Context, remoteCentral 
 			return errors.Wrapf(err, "incrementing Central %v revision", centralKey)
 		}
 
-		if err := r.client.Update(ctx, desiredCentral); err != nil {
+		if err := r.client.Update(context.Background(), desiredCentral); err != nil {
 			return errors.Wrapf(err, "updating Central %v", centralKey)
 		}
+
 	}
 
 	return nil
@@ -1042,22 +1060,20 @@ func (r *CentralReconciler) getDatabaseID(ctx context.Context, remoteCentralName
 }
 
 // centralChanged compares the given central to the last central reconciled using a hash
-func (r *CentralReconciler) centralChanged(central private.ManagedCentral) (bool, error) {
-	currentHash, err := util.MD5SumFromJSONStruct(&central)
-	if err != nil {
-		return true, errors.Wrap(err, "hashing central")
-	}
-	return !bytes.Equal(r.lastCentralHash[:], currentHash[:]), nil
+func (r *CentralReconciler) centralChanged(currentHash [16]byte) bool {
+	return !bytes.Equal(r.lastCentralHash[:], currentHash[:])
 }
 
-func (r *CentralReconciler) setLastCentralHash(central private.ManagedCentral) error {
+func (r *CentralReconciler) setLastCentralHash(currentHash [16]byte) {
+	r.lastCentralHash = currentHash
+}
+
+func (r *CentralReconciler) computeCentralHash(central private.ManagedCentral) ([16]byte, error) {
 	hash, err := util.MD5SumFromJSONStruct(&central)
 	if err != nil {
-		return fmt.Errorf("calculating MD5 from JSON: %w", err)
+		return [16]byte{}, fmt.Errorf("calculating MD5 from JSON: %w", err)
 	}
-
-	r.lastCentralHash = hash
-	return nil
+	return hash, nil
 }
 
 func (r *CentralReconciler) getNamespace(name string) (*corev1.Namespace, error) {
@@ -1602,11 +1618,15 @@ func (r *CentralReconciler) shouldSkipReadyCentral(remoteCentral private.Managed
 }
 
 func (r *CentralReconciler) needsReconcile(changed bool, central *v1alpha1.Central, storedSecrets []string) bool {
-	if !r.areSecretsStored(storedSecrets) {
+	if !r.areSecretsStoredFunc(storedSecrets) {
 		return true
 	}
 
 	if changed {
+		return true
+	}
+
+	if r.clock.Now().Sub(r.lastCentralHashTime) > time.Minute*15 {
 		return true
 	}
 
@@ -1686,7 +1706,7 @@ func NewCentralReconciler(k8sClient ctrlClient.Client, fleetmanagerClient *fleet
 	secretCipher cipher.Cipher, encryptionKeyGenerator cipher.KeyGenerator,
 	opts CentralReconcilerOptions,
 ) *CentralReconciler {
-	return &CentralReconciler{
+	r := &CentralReconciler{
 		client:                 k8sClient,
 		fleetmanagerClient:     fleetmanagerClient,
 		central:                central,
@@ -1711,7 +1731,13 @@ func NewCentralReconciler(k8sClient ctrlClient.Client, fleetmanagerClient *fleet
 		tenantImagePullSecret:  []byte(opts.TenantImagePullSecret),
 
 		resourcesChart: resourcesChart,
+		clock:          realClock{},
 	}
+	r.needsReconcileFunc = r.needsReconcile
+
+	r.restoreCentralSecretsFunc = r.restoreCentralSecrets //pragma: allowlist secret
+	r.areSecretsStoredFunc = r.areSecretsStored           //pragma: allowlist secret
+	return r
 }
 
 func obscureSecrets(secrets map[string]string) map[string]string {
@@ -1722,4 +1748,22 @@ func obscureSecrets(secrets map[string]string) map[string]string {
 	}
 
 	return obscuredSecrets
+}
+
+type clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time {
+	return time.Now()
+}
+
+type fakeClock struct {
+	NowTime time.Time
+}
+
+func (f fakeClock) Now() time.Time {
+	return f.NowTime
 }

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -359,6 +359,9 @@ func TestReconcileLastHashNotUpdatedOnError(t *testing.T) {
 		encryptionKeyGenerator: cipher.AES256KeyGenerator{},
 		secretBackup:           k8s.NewSecretBackup(fakeClient, false),
 	}
+	r.areSecretsStoredFunc = r.areSecretsStored //pragma: allowlist secret
+	r.needsReconcileFunc = r.needsReconcile
+	r.restoreCentralSecretsFunc = r.restoreCentralSecrets //pragma: allowlist secret
 
 	_, err := r.Reconcile(context.TODO(), simpleManagedCentral)
 	require.Error(t, err)

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	yaml2 "sigs.k8s.io/yaml"
 )
 
 const (
@@ -764,12 +765,14 @@ func TestCentralChanged(t *testing.T) {
 			)
 
 			if test.lastCentral != nil {
-				err := reconciler.setLastCentralHash(*test.lastCentral)
+				centralHash, err := reconciler.computeCentralHash(*test.lastCentral)
 				require.NoError(t, err)
+				reconciler.setLastCentralHash(centralHash)
 			}
 
-			got, err := reconciler.centralChanged(test.currentCentral)
+			centralHash, err := reconciler.computeCentralHash(test.currentCentral)
 			require.NoError(t, err)
+			got := reconciler.centralChanged(centralHash)
 			assert.Equal(t, test.want, got)
 		})
 	}
@@ -2265,4 +2268,208 @@ metadata:
 		})
 	}
 
+}
+
+func TestReconciler_needsReconcile(t *testing.T) {
+	tests := []struct {
+		name string
+		// central (hash) has changed
+		changed bool
+		// the central to reconcile
+		central *v1alpha1.Central
+		// mocking the areSecretsStoredFunc
+		secretsStoredFunc areSecretsStoredFunc
+		// how long since the last hash was stored
+		timePassed time.Duration
+		// desired output
+		want bool
+	}{
+		{
+			name:              "no change",
+			changed:           false,
+			central:           &v1alpha1.Central{},
+			secretsStoredFunc: func([]string) bool { return true },
+			timePassed:        0,
+			want:              false,
+		}, {
+			name:              "central changed",
+			changed:           true,
+			central:           &v1alpha1.Central{},
+			secretsStoredFunc: func([]string) bool { return true },
+			timePassed:        0,
+			want:              true,
+		}, {
+			name:              "secrets not stored",
+			changed:           false,
+			central:           &v1alpha1.Central{},
+			secretsStoredFunc: func([]string) bool { return false },
+			timePassed:        0,
+			want:              true,
+		}, {
+			name:              "time passed",
+			changed:           false,
+			central:           &v1alpha1.Central{},
+			secretsStoredFunc: func([]string) bool { return true },
+			timePassed:        1 * time.Hour,
+			want:              true,
+		}, {
+			name:    "force reconcile",
+			changed: false,
+			central: &v1alpha1.Central{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"rhacs.redhat.com/force-reconcile": "true",
+					},
+				},
+			},
+			secretsStoredFunc: func([]string) bool { return true },
+			timePassed:        0,
+			want:              true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, r := getClientTrackerAndReconciler(t, simpleManagedCentral, nil, defaultReconcilerOptions)
+			r.areSecretsStoredFunc = tt.secretsStoredFunc //pragma: allowlist secret
+			r.clock = fakeClock{
+				NowTime: time.Now(),
+			}
+			r.lastCentralHashTime = r.clock.Now().Add(-tt.timePassed)
+			got := r.needsReconcile(tt.changed, tt.central, []string{})
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestReconcilerRaceCondition tests that reconciling a central that changes in quick
+// succession will still be able to accurately reconcile the central.
+// The reason for this test is that the reconciler will exit early if the deployment
+// is not ready.
+func TestReconcilerRaceCondition(t *testing.T) {
+	var managedCentral = simpleManagedCentral
+	managedCentral.RequestStatus = centralConstants.CentralRequestStatusReady.String()
+	// Creating 2 "ready" centrals, with 2 different cpu limit values
+	var central1 = withCpuLimit(t, managedCentral, "100m")
+	var central2 = withCpuLimit(t, managedCentral, "200m")
+
+	cli, _, r := getClientTrackerAndReconciler(t, central1, nil, defaultReconcilerOptions)
+	ctx := context.Background()
+	namespace := central1.Metadata.Namespace
+	name := central1.Metadata.Name
+
+	// we mock the "needsReconcileFunc" to only return true when the hash changes
+	r.needsReconcileFunc = func(changed bool, central *v1alpha1.Central, storedSecrets []string) bool {
+		return changed
+	}
+	// we mock the "restoreCentralSecrets" to always succeed
+	r.restoreCentralSecretsFunc = func(ctx context.Context, remoteCentral private.ManagedCentral) error {
+		return nil
+	}
+
+	// Perform first reconciliation
+	_, err := r.Reconcile(ctx, central1)
+	require.NoError(t, err)
+	printCentralHash(t, r)
+	assertCentralCpuLimit(t, ctx, cli, namespace, name, "100m")
+
+	// Perform second reconciliation
+	_, err = r.Reconcile(ctx, central2)
+	require.NoError(t, err)
+	printCentralHash(t, r)
+	assertCentralCpuLimit(t, ctx, cli, namespace, name, "200m")
+
+	makeDeploymentNotReady(t, ctx, cli, namespace)
+
+	// Reconcile with first central again
+	_, err = r.Reconcile(ctx, central1)
+	require.NoError(t, err)
+	printCentralHash(t, r)
+	assertCentralCpuLimit(t, ctx, cli, namespace, name, "100m")
+
+	// Then reconcile with second central
+	_, err = r.Reconcile(ctx, central2)
+	require.NoError(t, err)
+	printCentralHash(t, r)
+	assertCentralCpuLimit(t, ctx, cli, namespace, name, "200m")
+
+	makeDeploymentReady(t, ctx, cli, namespace)
+
+	// Reconcile with first central again
+	_, err = r.Reconcile(ctx, central1)
+	require.NoError(t, err)
+	printCentralHash(t, r)
+	assertCentralCpuLimit(t, ctx, cli, namespace, name, "100m")
+
+	// Then reconcile with second central
+	_, err = r.Reconcile(ctx, central2)
+	require.NoError(t, err)
+	printCentralHash(t, r)
+	assertCentralCpuLimit(t, ctx, cli, namespace, name, "200m")
+}
+
+func printCentralHash(t *testing.T, reconciler *CentralReconciler) {
+	t.Logf("Last central hash: %x", reconciler.lastCentralHash[:])
+}
+
+func makeDeploymentNotReady(t *testing.T, ctx context.Context, cli client.WithWatch, namespace string) {
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: centralDeploymentName}, deployment))
+	deployment.Status.AvailableReplicas = 0
+	require.NoError(t, cli.Status().Update(ctx, deployment))
+	// ensure deployment is not ready
+	assertDeploymentNotReady(t, ctx, cli, namespace)
+}
+
+func makeDeploymentReady(t *testing.T, ctx context.Context, cli client.WithWatch, namespace string) {
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: centralDeploymentName}, deployment))
+	deployment.Status.AvailableReplicas = 1
+	require.NoError(t, cli.Status().Update(ctx, deployment))
+	// ensure deployment is not ready
+	assertDeploymentReady(t, ctx, cli, namespace)
+}
+
+func assertDeploymentReady(t *testing.T, ctx context.Context, cli client.WithWatch, namespace string) {
+	isReady, err := isCentralDeploymentReady(ctx, cli, namespace)
+	require.NoError(t, err)
+	require.True(t, isReady)
+}
+
+func assertDeploymentNotReady(t *testing.T, ctx context.Context, cli client.WithWatch, namespace string) {
+	isReady, err := isCentralDeploymentReady(ctx, cli, namespace)
+	require.NoError(t, err)
+	require.False(t, isReady)
+}
+
+func assertCentralCpuLimit(t *testing.T, ctx context.Context, cli client.WithWatch, namespace, name string, cpuLimit string) {
+	var central v1alpha1.Central
+	require.NoError(t, cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &central))
+	require.NotNil(t, central.Spec.Central)
+	require.NotNil(t, central.Spec.Central.Resources)
+	require.NotNil(t, central.Spec.Central.Resources.Requests)
+	require.NotNil(t, central.Spec.Central.Resources.Requests.Cpu())
+	assert.Equal(t, cpuLimit, central.Spec.Central.Resources.Requests.Cpu().String())
+}
+
+func withCpuLimit(t *testing.T, central private.ManagedCentral, cpuLimit string) private.ManagedCentral {
+	var cr v1alpha1.Central
+	err := yaml2.Unmarshal([]byte(central.Spec.CentralCRYAML), &cr)
+	require.NoError(t, err)
+
+	if cr.Spec.Central == nil {
+		cr.Spec.Central = &v1alpha1.CentralComponentSpec{}
+	}
+	if cr.Spec.Central.Resources == nil {
+		cr.Spec.Central.Resources = &v1.ResourceRequirements{}
+	}
+	if cr.Spec.Central.Resources.Requests == nil {
+		cr.Spec.Central.Resources.Requests = make(v1.ResourceList)
+	}
+	cr.Spec.Central.Resources.Requests["cpu"] = resource.MustParse(cpuLimit)
+	central2Yaml, err := yaml2.Marshal(cr)
+	require.NoError(t, err)
+	var clone private.ManagedCentral = central
+	clone.Spec.CentralCRYAML = string(central2Yaml)
+	return clone
 }


### PR DESCRIPTION
## Description

Fixing of the fleetshard cache bug. 

How to reproduce: 
1. Reconcile central v1
2. Reconcile centra v2
3. Deployment is unhealthy (restarting)
4. Reconcile central v1
5. Reconcile central v2 (ignored/skipped)

The reason that the reconcile loop at step 5 is ignored is that the hash is not stored at step 4, even if the central CR was updated. At step 5, the reconciler will be skipped because the hash (v2) matches the last stored hash (step 2). 

The effect is that v1 is deployed, but the reconciler thinks it reconciled v2.

The fix is to unset the hash if the reconciler exited early. 

As an added precaution, trigger the reconcile loop if central was reconciled more than 15 minutes ago.
