### PR TITLE
Fix missing PackageImage field in clusters_mgmt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -150,6 +150,7 @@ require (
 	github.com/segmentio/ksuid v1.0.4 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/stackrox/scanner v0.0.0-20230411230651-f2265de65ce4 // indirect
 	github.com/stretchr/objx v0.5.1 // indirect
@@ -191,6 +192,7 @@ replace (
 	github.com/fullsailor/pkcs7 => github.com/stackrox/pkcs7 v0.0.0-20220914154527-cfdb0aa47179
 	github.com/gogo/protobuf => github.com/connorgorman/protobuf v1.2.2-0.20210115205927-b892c1b298f7
 	github.com/heroku/docker-registry-client => github.com/stackrox/docker-registry-client v0.0.0-20230411213734-d75b95d65d28
+	github.com/openshift-online/ocm-sdk-go => github.com/kovayur/ocm-sdk-go v0.0.0-20240205105723-c1851636f634 // TODO(ROX-22237): Contribute upstream - PackageImage is missing in clusters_mgmt
 	github.com/operator-framework/helm-operator-plugins => github.com/stackrox/helm-operator v0.0.12-0.20221003092512-fbf71229411f
 	github.com/stackrox/rox => github.com/stackrox/stackrox v0.0.0-20231019141000-eccb839f2abb
 	go.uber.org/zap => github.com/stackrox/zap v1.15.1-0.20230918235618-2bd149903d0e

--- a/go.sum
+++ b/go.sum
@@ -405,6 +405,8 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kovayur/ocm-sdk-go v0.0.0-20240205105723-c1851636f634 h1:388051OxCtSDS9IbrZ1WCHkCUZmm1pvrgvu24CMBE7M=
+github.com/kovayur/ocm-sdk-go v0.0.0-20240205105723-c1851636f634/go.mod h1:tke8vKcE7eHKyRbkJv6qo4ljo919zhx04uyQTcgF5cQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -460,8 +462,6 @@ github.com/onsi/gomega v1.29.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8P
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/openshift-online/ocm-sdk-go v0.1.391 h1:BCC/sM1gVooxCL76MiPux2kng8MUbwM1IQr62hMPXeU=
-github.com/openshift-online/ocm-sdk-go v0.1.391/go.mod h1:/+VFIw1iW2H0jEkFH4GnbL/liWareyzsL0w7mDIudB4=
 github.com/openshift/addon-operator/apis v0.0.0-20231110045543-dd01f2f5c184 h1:P93o33VcHaOTjOTm6/UojtJdr1qLc2U7vPMBno39rdc=
 github.com/openshift/addon-operator/apis v0.0.0-20231110045543-dd01f2f5c184/go.mod h1:JS2tbakhIZRgBiULsIUSHGsdz7G/Vylvg1mqI1TlXzs=
 github.com/openshift/api v0.0.0-20230502160752-c71432710382 h1:oIlUAGCdktBKMjCMtP7AedtAc00T/GFaSosoqBa2gkU=
@@ -530,6 +530,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.5.1 h1:R+kOtfhWQE6TVQzY+4D7wJLBgkdVasCEFxSUBYBYIlA=

--- a/internal/dinosaur/pkg/services/addon.go
+++ b/internal/dinosaur/pkg/services/addon.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/hashicorp/go-multierror"
-	addonsmgmtv1 "github.com/openshift-online/ocm-sdk-go/addonsmgmt/v1"
 	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/gitops"
@@ -235,7 +234,7 @@ func gitOpsConfigDifferent(expectedConfig gitops.AddonConfig, installedInOCM *cl
 	return installedInOCM.AddonVersion().ID() != expectedConfig.Version || !maps.Equal(convertParametersFromOCMAPI(installedInOCM.Parameters()), expectedConfig.Parameters)
 }
 
-func clusterInstallationDifferent(current dbapi.AddonInstallation, addonVersion *addonsmgmtv1.AddonVersion) bool {
+func clusterInstallationDifferent(current dbapi.AddonInstallation, addonVersion *clustersmgmtv1.AddOnVersion) bool {
 	return current.SourceImage != addonVersion.SourceImage() || current.PackageImage != addonVersion.PackageImage()
 }
 

--- a/internal/dinosaur/pkg/services/addon_test.go
+++ b/internal/dinosaur/pkg/services/addon_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	addonsmgmtv1 "github.com/openshift-online/ocm-sdk-go/addonsmgmt/v1"
 	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/gitops"
@@ -201,8 +200,8 @@ func TestAddonProvisioner_Provision(t *testing.T) {
 						Expect(err).To(Not(HaveOccurred()))
 						return object, nil
 					},
-					GetAddonVersionFunc: func(addonID string, version string) (*addonsmgmtv1.AddonVersion, error) {
-						return addonsmgmtv1.NewAddonVersion().
+					GetAddonVersionFunc: func(addonID string, version string) (*clustersmgmtv1.AddOnVersion, error) {
+						return clustersmgmtv1.NewAddOnVersion().
 							ID("0.2.0").
 							SourceImage("quay.io/osd-addons/acs-fleetshard-index@sha256:71eaaccb4d3962043eac953fb3c19a6cc6a88b18c472dd264efc5eb3da4960ac").
 							PackageImage("quay.io/osd-addons/acs-fleetshard-package@sha256:3e4fc039662b876c83dd4b48a9608d6867a12ab4932c5b7297bfbe50ba8ee61c").
@@ -251,8 +250,8 @@ func TestAddonProvisioner_Provision(t *testing.T) {
 						Expect(err).To(Not(HaveOccurred()))
 						return object, nil
 					},
-					GetAddonVersionFunc: func(addonID string, version string) (*addonsmgmtv1.AddonVersion, error) {
-						return addonsmgmtv1.NewAddonVersion().
+					GetAddonVersionFunc: func(addonID string, version string) (*clustersmgmtv1.AddOnVersion, error) {
+						return clustersmgmtv1.NewAddOnVersion().
 							ID("0.2.0").
 							SourceImage("quay.io/osd-addons/acs-fleetshard-index@sha256:71eaaccb4d3962043eac953fb3c19a6cc6a88b18c472dd264efc5eb3da4960ac").
 							PackageImage("quay.io/osd-addons/acs-fleetshard-package@sha256:3e4fc039662b876c83dd4b48a9608d6867a12ab4932c5b7297bfbe50ba8ee61c").
@@ -299,8 +298,8 @@ func TestAddonProvisioner_Provision(t *testing.T) {
 						Expect(err).To(Not(HaveOccurred()))
 						return object, nil
 					},
-					GetAddonVersionFunc: func(addonID string, version string) (*addonsmgmtv1.AddonVersion, error) {
-						return addonsmgmtv1.NewAddonVersion().
+					GetAddonVersionFunc: func(addonID string, version string) (*clustersmgmtv1.AddOnVersion, error) {
+						return clustersmgmtv1.NewAddOnVersion().
 							ID("0.2.0").
 							SourceImage("quay.io/osd-addons/acs-fleetshard-index@sha256:71eaaccb4d3962043eac953fb3c19a6cc6a88b18c472dd264efc5eb3da4960ac").
 							PackageImage("quay.io/osd-addons/acs-fleetshard-package@sha256:3e4fc039662b876c83dd4b48a9608d6867a12ab4932c5b7297bfbe50ba8ee61c").
@@ -352,8 +351,8 @@ func TestAddonProvisioner_Provision(t *testing.T) {
 						Expect(err).To(Not(HaveOccurred()))
 						return object, nil
 					},
-					GetAddonVersionFunc: func(addonID string, version string) (*addonsmgmtv1.AddonVersion, error) {
-						return addonsmgmtv1.NewAddonVersion().
+					GetAddonVersionFunc: func(addonID string, version string) (*clustersmgmtv1.AddOnVersion, error) {
+						return clustersmgmtv1.NewAddOnVersion().
 							ID("0.2.0").
 							SourceImage("quay.io/osd-addons/acs-fleetshard-index@sha256:71eaaccb4d3962043eac953fb3c19a6cc6a88b18c472dd264efc5eb3da4960ac").
 							PackageImage("quay.io/osd-addons/acs-fleetshard-package@sha256:3e4fc039662b876c83dd4b48a9608d6867a12ab4932c5b7297bfbe50ba8ee61c").
@@ -405,8 +404,8 @@ func TestAddonProvisioner_Provision(t *testing.T) {
 						Expect(err).To(Not(HaveOccurred()))
 						return object, nil
 					},
-					GetAddonVersionFunc: func(addonID string, version string) (*addonsmgmtv1.AddonVersion, error) {
-						return addonsmgmtv1.NewAddonVersion().
+					GetAddonVersionFunc: func(addonID string, version string) (*clustersmgmtv1.AddOnVersion, error) {
+						return clustersmgmtv1.NewAddOnVersion().
 							ID("0.2.0").
 							SourceImage("quay.io/osd-addons/acs-fleetshard-index@sha256:71eaaccb4d3962043eac953fb3c19a6cc6a88b18c472dd264efc5eb3da4960ac").
 							PackageImage("quay.io/osd-addons/acs-fleetshard-package@sha256:3e4fc039662b876c83dd4b48a9608d6867a12ab4932c5b7297bfbe50ba8ee61c").
@@ -458,8 +457,8 @@ func TestAddonProvisioner_Provision(t *testing.T) {
 						Expect(err).To(Not(HaveOccurred()))
 						return object, nil
 					},
-					GetAddonVersionFunc: func(addonID string, version string) (*addonsmgmtv1.AddonVersion, error) {
-						return addonsmgmtv1.NewAddonVersion().
+					GetAddonVersionFunc: func(addonID string, version string) (*clustersmgmtv1.AddOnVersion, error) {
+						return clustersmgmtv1.NewAddOnVersion().
 							ID("0.2.0").
 							SourceImage("quay.io/osd-addons/acs-fleetshard-index@sha256:71eaaccb4d3962043eac953fb3c19a6cc6a88b18c472dd264efc5eb3da4960ac").
 							PackageImage("quay.io/osd-addons/acs-fleetshard-package@sha256:4e4fc039662b876c83dd4b48a9608d6867a12ab4932c5b7297bfbe50ba8ee61c").
@@ -511,8 +510,8 @@ func TestAddonProvisioner_Provision(t *testing.T) {
 						Expect(err).To(Not(HaveOccurred()))
 						return object, nil
 					},
-					GetAddonVersionFunc: func(addonID string, version string) (*addonsmgmtv1.AddonVersion, error) {
-						return addonsmgmtv1.NewAddonVersion().
+					GetAddonVersionFunc: func(addonID string, version string) (*clustersmgmtv1.AddOnVersion, error) {
+						return clustersmgmtv1.NewAddOnVersion().
 							ID("0.2.0").
 							SourceImage("quay.io/osd-addons/acs-fleetshard-index@sha256:71eaaccb4d3962043eac953fb3c19a6cc6a88b18c472dd264efc5eb3da4960ac").
 							PackageImage("quay.io/osd-addons/acs-fleetshard-package@sha256:3e4fc039662b876c83dd4b48a9608d6867a12ab4932c5b7297bfbe50ba8ee61c").
@@ -702,8 +701,8 @@ func TestAddonProvisioner_Provision_InheritFleetshardImageTag_Upgrade(t *testing
 			Expect(err).To(Not(HaveOccurred()))
 			return object, nil
 		},
-		GetAddonVersionFunc: func(addonID string, version string) (*addonsmgmtv1.AddonVersion, error) {
-			return addonsmgmtv1.NewAddonVersion().
+		GetAddonVersionFunc: func(addonID string, version string) (*clustersmgmtv1.AddOnVersion, error) {
+			return clustersmgmtv1.NewAddOnVersion().
 				ID("0.2.0").
 				SourceImage("quay.io/osd-addons/acs-fleetshard-index@sha256:71eaaccb4d3962043eac953fb3c19a6cc6a88b18c472dd264efc5eb3da4960ac").
 				PackageImage("quay.io/osd-addons/acs-fleetshard-package@sha256:3e4fc039662b876c83dd4b48a9608d6867a12ab4932c5b7297bfbe50ba8ee61c").

--- a/pkg/client/ocm/client.go
+++ b/pkg/client/ocm/client.go
@@ -3,7 +3,6 @@ package ocm
 import (
 	sdkClient "github.com/openshift-online/ocm-sdk-go"
 	amsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
-	addonsmgmtv1 "github.com/openshift-online/ocm-sdk-go/addonsmgmt/v1"
 	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	serviceErrors "github.com/stackrox/acs-fleet-manager/pkg/errors"
 )
@@ -22,8 +21,8 @@ type Client interface {
 	CreateAddonInstallation(clusterID string, addon *clustersmgmtv1.AddOnInstallation) error
 	UpdateAddonInstallation(clusterID string, addon *clustersmgmtv1.AddOnInstallation) error
 	DeleteAddonInstallation(clusterID string, addonID string) error
-	GetAddon(addonID string) (*addonsmgmtv1.Addon, error)
-	GetAddonVersion(addonID string, version string) (*addonsmgmtv1.AddonVersion, error)
+	GetAddon(addonID string) (*clustersmgmtv1.AddOn, error)
+	GetAddonVersion(addonID string, version string) (*clustersmgmtv1.AddOnVersion, error)
 	GetClusterDNS(clusterID string) (string, error)
 	CreateIdentityProvider(clusterID string, identityProvider *clustersmgmtv1.IdentityProvider) (*clustersmgmtv1.IdentityProvider, error)
 	DeleteCluster(clusterID string) (int, error)

--- a/pkg/client/ocm/impl/client_impl.go
+++ b/pkg/client/ocm/impl/client_impl.go
@@ -8,7 +8,6 @@ import (
 	"github.com/golang/glog"
 	sdkClient "github.com/openshift-online/ocm-sdk-go"
 	amsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
-	addonsmgmtv1 "github.com/openshift-online/ocm-sdk-go/addonsmgmt/v1"
 	v1 "github.com/openshift-online/ocm-sdk-go/authorizations/v1"
 	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift-online/ocm-sdk-go/logging"
@@ -283,12 +282,12 @@ func (c *client) GetRegions(provider *clustersmgmtv1.CloudProvider) (*clustersmg
 	return regionList, nil
 }
 
-func (c *client) GetAddon(addonID string) (*addonsmgmtv1.Addon, error) {
+func (c *client) GetAddon(addonID string) (*clustersmgmtv1.AddOn, error) {
 	if c.connection == nil {
 		return nil, serviceErrors.InvalidOCMConnection()
 	}
 
-	resp, err := c.connection.AddonsMgmt().V1().Addons().Addon(addonID).Get().Send()
+	resp, err := c.connection.ClustersMgmt().V1().Addons().Addon(addonID).Get().Send()
 	if err != nil {
 		if resp != nil && resp.Status() == http.StatusNotFound {
 			return nil, serviceErrors.NotFound("")
@@ -299,12 +298,12 @@ func (c *client) GetAddon(addonID string) (*addonsmgmtv1.Addon, error) {
 	return resp.Body(), nil
 }
 
-func (c *client) GetAddonVersion(addonID string, versionID string) (*addonsmgmtv1.AddonVersion, error) {
+func (c *client) GetAddonVersion(addonID string, versionID string) (*clustersmgmtv1.AddOnVersion, error) {
 	if c.connection == nil {
 		return nil, serviceErrors.InvalidOCMConnection()
 	}
 
-	resp, err := c.connection.AddonsMgmt().V1().Addons().Addon(addonID).Versions().Version(versionID).Get().Send()
+	resp, err := c.connection.ClustersMgmt().V1().Addons().Addon(addonID).Versions().Version(versionID).Get().Send()
 	if err != nil {
 		if resp != nil && resp.Status() == http.StatusNotFound {
 			return nil, serviceErrors.NotFound("")

--- a/pkg/client/ocm/mocks/client_moq.go
+++ b/pkg/client/ocm/mocks/client_moq.go
@@ -6,7 +6,6 @@ package mocks
 import (
 	sdkClient "github.com/openshift-online/ocm-sdk-go"
 	amsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
-	addonsmgmtv1 "github.com/openshift-online/ocm-sdk-go/addonsmgmt/v1"
 	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/stackrox/acs-fleet-manager/pkg/client/ocm"
 	serviceErrors "github.com/stackrox/acs-fleet-manager/pkg/errors"
@@ -50,13 +49,13 @@ var _ ocm.Client = &ClientMock{}
 //			FindSubscriptionsFunc: func(query string) (*amsv1.SubscriptionsListResponse, error) {
 //				panic("mock out the FindSubscriptions method")
 //			},
-//			GetAddonFunc: func(addonID string) (*addonsmgmtv1.Addon, error) {
+//			GetAddonFunc: func(addonID string) (*clustersmgmtv1.AddOn, error) {
 //				panic("mock out the GetAddon method")
 //			},
 //			GetAddonInstallationFunc: func(clusterID string, addonID string) (*clustersmgmtv1.AddOnInstallation, *serviceErrors.ServiceError) {
 //				panic("mock out the GetAddonInstallation method")
 //			},
-//			GetAddonVersionFunc: func(addonID string, version string) (*addonsmgmtv1.AddonVersion, error) {
+//			GetAddonVersionFunc: func(addonID string, version string) (*clustersmgmtv1.AddOnVersion, error) {
 //				panic("mock out the GetAddonVersion method")
 //			},
 //			GetCloudProvidersFunc: func() (*clustersmgmtv1.CloudProviderList, error) {
@@ -133,13 +132,13 @@ type ClientMock struct {
 	FindSubscriptionsFunc func(query string) (*amsv1.SubscriptionsListResponse, error)
 
 	// GetAddonFunc mocks the GetAddon method.
-	GetAddonFunc func(addonID string) (*addonsmgmtv1.Addon, error)
+	GetAddonFunc func(addonID string) (*clustersmgmtv1.AddOn, error)
 
 	// GetAddonInstallationFunc mocks the GetAddonInstallation method.
 	GetAddonInstallationFunc func(clusterID string, addonID string) (*clustersmgmtv1.AddOnInstallation, *serviceErrors.ServiceError)
 
 	// GetAddonVersionFunc mocks the GetAddonVersion method.
-	GetAddonVersionFunc func(addonID string, version string) (*addonsmgmtv1.AddonVersion, error)
+	GetAddonVersionFunc func(addonID string, version string) (*clustersmgmtv1.AddOnVersion, error)
 
 	// GetCloudProvidersFunc mocks the GetCloudProviders method.
 	GetCloudProvidersFunc func() (*clustersmgmtv1.CloudProviderList, error)
@@ -645,7 +644,7 @@ func (mock *ClientMock) FindSubscriptionsCalls() []struct {
 }
 
 // GetAddon calls GetAddonFunc.
-func (mock *ClientMock) GetAddon(addonID string) (*addonsmgmtv1.Addon, error) {
+func (mock *ClientMock) GetAddon(addonID string) (*clustersmgmtv1.AddOn, error) {
 	if mock.GetAddonFunc == nil {
 		panic("ClientMock.GetAddonFunc: method is nil but Client.GetAddon was just called")
 	}
@@ -713,7 +712,7 @@ func (mock *ClientMock) GetAddonInstallationCalls() []struct {
 }
 
 // GetAddonVersion calls GetAddonVersionFunc.
-func (mock *ClientMock) GetAddonVersion(addonID string, version string) (*addonsmgmtv1.AddonVersion, error) {
+func (mock *ClientMock) GetAddonVersion(addonID string, version string) (*clustersmgmtv1.AddOnVersion, error) {
 	if mock.GetAddonVersionFunc == nil {
 		panic("ClientMock.GetAddonVersionFunc: method is nil but Client.GetAddonVersion was just called")
 	}


### PR DESCRIPTION
## Description
1. Replace `addons_mgmt` to `clusters_mgmt` in OCM client facade.
1. Use forked version that contains PackageImage until it becomes available upstream.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
