### PR TITLE
Keep central hash when central is ready

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -179,6 +179,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	needsReconcile := r.needsReconcileFunc(changed, central, remoteCentral.Metadata.SecretsStored)
 
 	if !needsReconcile && r.shouldSkipReadyCentral(remoteCentral) {
+		shouldUpdateCentralHash = true
 		return nil, ErrCentralNotChanged
 	}
 


### PR DESCRIPTION
When central is ready, we should keep the hash so that next reconciles will be skipped