### PR TITLE
fix: log message argument

### DIFF
--- a/internal/dinosaur/pkg/services/quota/ams_quota_service.go
+++ b/internal/dinosaur/pkg/services/quota/ams_quota_service.go
@@ -67,7 +67,7 @@ func (q amsQuotaService) HasQuotaAllowance(central *dbapi.CentralRequest, instan
 	entitled := standardAccountIsActive || cloudAccountIsActive(quotaCostsByModel, central)
 
 	if !entitled {
-		glog.Infof("Quota no longer entitled for organisation %q", org.ID)
+		glog.Infof("Quota no longer entitled for organisation %q", org.ID())
 		return false, nil
 	}
 	return true, nil


### PR DESCRIPTION
`ID()` is a function returning `string`.

Before:
```
I0121 05:25:42.860591       1 ams_quota_service.go:70] Quota no longer entitled for organisation %!q(func() string=0x2ecf500)
```