### PR TITLE
ROX-22360: `expired_at` is not nullified

### DIFF
--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/expiration_date_mgr_test.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/expiration_date_mgr_test.go
@@ -34,7 +34,10 @@ func TestExpirationDateManager(t *testing.T) {
 			ListByStatusFunc: func(status ...constants.CentralStatus) ([]*dbapi.CentralRequest, *errors.ServiceError) {
 				return centrals, nil
 			},
-			UpdateFunc: func(centralRequest *dbapi.CentralRequest) *errors.ServiceError {
+			UpdatesFunc: func(centralRequest *dbapi.CentralRequest, fields map[string]any) *errors.ServiceError {
+				if _, ok := fields["expired_at"]; !ok {
+					return errors.GeneralError("bad fields")
+				}
 				return nil
 			},
 		}
@@ -50,7 +53,7 @@ func TestExpirationDateManager(t *testing.T) {
 		errs := mgr.Reconcile()
 		require.Empty(t, errs)
 		assert.Len(t, centralService.ListByStatusCalls(), 1)
-		assert.Empty(t, centralService.UpdateCalls())
+		assert.Empty(t, centralService.UpdatesCalls())
 		assert.Empty(t, quotaSvc.HasQuotaAllowanceCalls())
 		assert.Len(t, quotaFactory.GetQuotaServiceCalls(), 1)
 	})
@@ -66,7 +69,7 @@ func TestExpirationDateManager(t *testing.T) {
 		assert.Nil(t, central.ExpiredAt)
 		assert.Len(t, centralService.ListByStatusCalls(), 1)
 		assert.Len(t, quotaSvc.HasQuotaAllowanceCalls(), 1)
-		assert.Len(t, centralService.UpdateCalls(), 1)
+		assert.Len(t, centralService.UpdatesCalls(), 1)
 		assert.Len(t, quotaFactory.GetQuotaServiceCalls(), 1)
 	})
 
@@ -82,7 +85,7 @@ func TestExpirationDateManager(t *testing.T) {
 		assert.Less(t, now, *central.ExpiredAt)
 		assert.Len(t, centralService.ListByStatusCalls(), 1)
 		assert.Len(t, quotaSvc.HasQuotaAllowanceCalls(), 1)
-		assert.Len(t, centralService.UpdateCalls(), 1)
+		assert.Len(t, centralService.UpdatesCalls(), 1)
 		assert.Len(t, quotaFactory.GetQuotaServiceCalls(), 1)
 	})
 
@@ -105,7 +108,7 @@ func TestExpirationDateManager(t *testing.T) {
 		assert.Nil(t, centralE.ExpiredAt)
 		assert.Len(t, centralService.ListByStatusCalls(), 1)
 		assert.Len(t, quotaSvc.HasQuotaAllowanceCalls(), 3)
-		assert.Len(t, centralService.UpdateCalls(), 5)
+		assert.Len(t, centralService.UpdatesCalls(), 5)
 		assert.Len(t, quotaFactory.GetQuotaServiceCalls(), 1)
 	})
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

Tested with patching via `centrals/{id}/expired-at` and restarting the pod to trigger expiration manager, which nullifies the field.
