### PR TITLE
ROX-22358: reset grace period on restore

### DIFF
--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -837,21 +837,17 @@ func (k *dinosaurService) Restore(ctx context.Context, id string) *errors.Servic
 		"ClientOrigin",
 		"ClientSecret",
 		"CreatedAt",
+		// reset expired_at to null: it may later be updated by the next run
+		// of the expiration manager.
 		"ExpiredAt",
 	}
-
-	now := time.Now()
 
 	// use a new central request, so that unset field for columnsToReset will automatically be set to the zero value
 	// this Update only changes columns listed in columnsToReset
 	resetRequest := &dbapi.CentralRequest{}
 	resetRequest.ID = centralRequest.ID
 	resetRequest.Status = dinosaurConstants.CentralRequestStatusPreparing.String()
-	resetRequest.CreatedAt = now
-
-	if centralRequest.ExpiredAt != nil && centralRequest.ExpiredAt.Before(now) {
-		resetRequest.ExpiredAt = &now // starts the grace period.
-	}
+	resetRequest.CreatedAt = time.Now()
 
 	if err := dbConn.Unscoped().Model(resetRequest).Select(columnsToReset).Updates(resetRequest).Error; err != nil {
 		return errors.NewWithCause(errors.ErrorGeneral, err, "Unable to reset CentralRequest status")

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -838,7 +838,8 @@ func (k *dinosaurService) Restore(ctx context.Context, id string) *errors.Servic
 		"ClientSecret",
 		"CreatedAt",
 		// reset expired_at to null: it may later be updated by the next run
-		// of the expiration manager.
+		// of the expiration manager. If there is still no quota, the grace
+		// period will start over.
 		"ExpiredAt",
 	}
 

--- a/internal/dinosaur/pkg/services/dinosaur_test.go
+++ b/internal/dinosaur/pkg/services/dinosaur_test.go
@@ -2,8 +2,10 @@ package services
 
 import (
 	"context"
+	"database/sql/driver"
 	"reflect"
 	"testing"
+	"time"
 
 	mocket "github.com/selvatico/go-mocket"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
@@ -202,4 +204,40 @@ func Test_dinosaurService_DeprovisionExpiredDinosaursQuery(t *testing.T) {
 	svcErr = k.DeprovisionExpiredDinosaurs()
 	assert.Nil(t, svcErr)
 	assert.True(t, m.Triggered)
+}
+
+func Test_dinosaurService_RestoreExpiredDinosaurs(t *testing.T) {
+	dbcf := db.NewMockConnectionFactory(nil)
+
+	k := &dinosaurService{
+		connectionFactory: dbcf,
+		dinosaurConfig: &config.CentralConfig{
+			CentralLifespan:            config.NewCentralLifespanConfig(),
+			CentralRetentionPeriodDays: 2,
+		},
+	}
+
+	now := time.Now()
+	yesterday := now.Add(-24 * time.Hour)
+
+	m := mocket.Catcher.Reset().NewMock()
+	selectQuery := m.WithQuery(`SELECT`).
+		WithReply([]map[string]interface{}{{
+			"id":         "test-id",
+			"deleted_at": gorm.DeletedAt{Time: yesterday, Valid: true}.Time,
+			"expired_at": yesterday,
+		}}).OneTime()
+
+	m1 := mocket.Catcher.NewMock()
+	updateQuery := m1.WithQuery(`UPDATE`).WithCallback(
+		func(s string, nv []driver.NamedValue) {
+			expiredAt, _ := (nv[11].Value).(time.Time)
+			assert.False(t, expiredAt.Before(now))   // expired_at >= now
+			assert.Equal(t, "test-id", nv[12].Value) // id
+		})
+
+	svcErr := k.Restore(context.Background(), "test-id")
+	assert.Nil(t, svcErr)
+	assert.True(t, selectQuery.Triggered)
+	assert.True(t, updateQuery.Triggered)
 }

--- a/internal/dinosaur/pkg/services/dinosaur_test.go
+++ b/internal/dinosaur/pkg/services/dinosaur_test.go
@@ -231,8 +231,8 @@ func Test_dinosaurService_RestoreExpiredDinosaurs(t *testing.T) {
 	m1 := mocket.Catcher.NewMock()
 	updateQuery := m1.WithQuery(`UPDATE`).WithCallback(
 		func(s string, nv []driver.NamedValue) {
-			expiredAt, _ := (nv[11].Value).(time.Time)
-			assert.False(t, expiredAt.Before(now))   // expired_at >= now
+			expiredAt, _ := (nv[11].Value).(*time.Time)
+			assert.Nil(t, expiredAt)
 			assert.Equal(t, "test-id", nv[12].Value) // id
 		})
 


### PR DESCRIPTION
## Description

When restoring an expired instance, reset the expiration timestamp to `null`, so that the grace period restarts, which allows for 2 more weeks for postponing or giving quota.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
