### PR TITLE
ROX-16615: Add probe image build on app-interface

### DIFF
--- a/build_push_app_interface.sh
+++ b/build_push_app_interface.sh
@@ -1,0 +1,82 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2024 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# =====================================================================================================================
+# This script builds and pushes the ACS Fleet Manager service docker image on AppSRE JenkinsCI.
+# You can find CI configuration in app-interface repository:
+# https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/acs-fleet-manager/cicd/jobs.yaml
+# In order to work, it needs the following variables defined in the CI/CD configuration of the project:
+#
+# QUAY_USER - The name of the robot account used to push images to
+# 'quay.io', for example 'openshift-unified-hybrid-cloud+jenkins'.
+#
+# QUAY_TOKEN - The token of the robot account used to push images to
+# 'quay.io'.
+#
+# The machines that run this script need to have access to internet, so that
+# the built images can be pushed to quay.io.
+# =====================================================================================================================
+
+# Set image repository to default value if it is not passed via env
+IMAGE_REPOSITORY="${QUAY_IMAGE_REPOSITORY:-app-sre/acs-fleet-manager}"
+PROBE_IMAGE_REPOSITORY="${PROBE_QUAY_IMAGE_REPOSITORY:-app-sre/acscs-probe}"
+
+source ./scripts/build_setup.sh
+
+# Push the image:
+echo "Quay.io user and token is set, will push images to $IMAGE_REPOSITORY"
+make \
+  DOCKER_CONFIG="${DOCKER_CONFIG}" \
+  QUAY_USER="${QUAY_USER}" \
+  QUAY_TOKEN="${QUAY_TOKEN}" \
+  external_image_registry="quay.io" \
+  internal_image_registry="quay.io" \
+  image_repository="${IMAGE_REPOSITORY}" \
+  docker/login/fleet-manager \
+  image/push/fleet-manager
+
+make \
+  DOCKER_CONFIG="${DOCKER_CONFIG}" \
+  QUAY_USER="${QUAY_USER}" \
+  QUAY_TOKEN="${QUAY_TOKEN}" \
+  TAG="${BRANCH}" \
+  external_image_registry="quay.io" \
+  internal_image_registry="quay.io" \
+  image_repository="${IMAGE_REPOSITORY}" \
+  docker/login/fleet-manager \
+  image/push/fleet-manager
+
+make \
+  DOCKER_CONFIG="${DOCKER_CONFIG}" \
+  QUAY_PROBE_USER="${QUAY_USER}" \
+  QUAY_PROBE_TOKEN="${QUAY_TOKEN}" \
+  external_image_registry="quay.io" \
+  internal_image_registry="quay.io" \
+  probe_image_repository="${PROBE_IMAGE_REPOSITORY}" \
+  docker/login/probe \
+  image/push/probe
+
+make \
+  DOCKER_CONFIG="${DOCKER_CONFIG}" \
+  QUAY_PROBE_USER="${QUAY_USER}" \
+  QUAY_PROBE_TOKEN="${QUAY_TOKEN}" \
+  TAG="main" \
+  external_image_registry="quay.io" \
+  internal_image_registry="quay.io" \
+  probe_image_repository="${PROBE_IMAGE_REPOSITORY}" \
+  docker/login/probe \
+  image/push/probe


### PR DESCRIPTION
## Description
Add probe image build on app-interface.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
