### PR TITLE
fix(scannerv4): adjust proxy settings

### DIFF
--- a/fleetshard/pkg/central/reconciler/proxy.go
+++ b/fleetshard/pkg/central/reconciler/proxy.go
@@ -21,9 +21,12 @@ func getProxyEnvVars(namespace string, additionalNoProxyTargets ...url.URL) []co
 	}
 
 	directServicesAndPorts := map[string][]int{
-		"central":    {443},
-		"scanner":    {8080, 8443},
-		"scanner-db": {5432},
+		"central":            {443},
+		"scanner":            {8080, 8443},
+		"scanner-db":         {5432},
+		"scanner-v4-db":      {5432},
+		"scanner-v4-indexer": {8443},
+		"scanner-v4-matcher": {8443},
 	}
 	var noProxyTargets []string
 	for svcName, ports := range directServicesAndPorts {

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -2117,11 +2117,11 @@ func TestReconciler_applyProxyConfig(t *testing.T) {
 		},
 		{
 			Name:  "no_proxy",
-			Value: "central.namespace.svc:443,central.namespace:443,central:443,host:9000,kubernetes.default.svc.cluster.local.:443,scanner-db.namespace.svc:5432,scanner-db.namespace:5432,scanner-db:5432,scanner.namespace.svc:8080,scanner.namespace.svc:8443,scanner.namespace:8080,scanner.namespace:8443,scanner:8080,scanner:8443",
+			Value: "central.namespace.svc:443,central.namespace:443,central:443,host:9000,kubernetes.default.svc.cluster.local.:443,scanner-db.namespace.svc:5432,scanner-db.namespace:5432,scanner-db:5432,scanner-v4-db.namespace.svc:5432,scanner-v4-db.namespace:5432,scanner-v4-db:5432,scanner-v4-indexer.namespace.svc:8443,scanner-v4-indexer.namespace:8443,scanner-v4-indexer:8443,scanner-v4-matcher.namespace.svc:8443,scanner-v4-matcher.namespace:8443,scanner-v4-matcher:8443,scanner.namespace.svc:8080,scanner.namespace.svc:8443,scanner.namespace:8080,scanner.namespace:8443,scanner:8080,scanner:8443",
 		},
 		{
 			Name:  "NO_PROXY",
-			Value: "central.namespace.svc:443,central.namespace:443,central:443,host:9000,kubernetes.default.svc.cluster.local.:443,scanner-db.namespace.svc:5432,scanner-db.namespace:5432,scanner-db:5432,scanner.namespace.svc:8080,scanner.namespace.svc:8443,scanner.namespace:8080,scanner.namespace:8443,scanner:8080,scanner:8443",
+			Value: "central.namespace.svc:443,central.namespace:443,central:443,host:9000,kubernetes.default.svc.cluster.local.:443,scanner-db.namespace.svc:5432,scanner-db.namespace:5432,scanner-db:5432,scanner-v4-db.namespace.svc:5432,scanner-v4-db.namespace:5432,scanner-v4-db:5432,scanner-v4-indexer.namespace.svc:8443,scanner-v4-indexer.namespace:8443,scanner-v4-indexer:8443,scanner-v4-matcher.namespace.svc:8443,scanner-v4-matcher.namespace:8443,scanner-v4-matcher:8443,scanner.namespace.svc:8080,scanner.namespace.svc:8443,scanner.namespace:8080,scanner.namespace:8443,scanner:8080,scanner:8443",
 		},
 	})
 }
@@ -2248,10 +2248,10 @@ metadata:
 								Value: "http://egress-proxy.rhacs.svc:3128",
 							}, {
 								Name:  "no_proxy",
-								Value: ":0,central.rhacs.svc:443,central.rhacs:443,central:443,kubernetes.default.svc.cluster.local.:443,scanner-db.rhacs.svc:5432,scanner-db.rhacs:5432,scanner-db:5432,scanner.rhacs.svc:8080,scanner.rhacs.svc:8443,scanner.rhacs:8080,scanner.rhacs:8443,scanner:8080,scanner:8443",
+								Value: ":0,central.rhacs.svc:443,central.rhacs:443,central:443,kubernetes.default.svc.cluster.local.:443,scanner-db.rhacs.svc:5432,scanner-db.rhacs:5432,scanner-db:5432,scanner-v4-db.rhacs.svc:5432,scanner-v4-db.rhacs:5432,scanner-v4-db:5432,scanner-v4-indexer.rhacs.svc:8443,scanner-v4-indexer.rhacs:8443,scanner-v4-indexer:8443,scanner-v4-matcher.rhacs.svc:8443,scanner-v4-matcher.rhacs:8443,scanner-v4-matcher:8443,scanner.rhacs.svc:8080,scanner.rhacs.svc:8443,scanner.rhacs:8080,scanner.rhacs:8443,scanner:8080,scanner:8443",
 							}, {
 								Name:  "NO_PROXY",
-								Value: ":0,central.rhacs.svc:443,central.rhacs:443,central:443,kubernetes.default.svc.cluster.local.:443,scanner-db.rhacs.svc:5432,scanner-db.rhacs:5432,scanner-db:5432,scanner.rhacs.svc:8080,scanner.rhacs.svc:8443,scanner.rhacs:8080,scanner.rhacs:8443,scanner:8080,scanner:8443",
+								Value: ":0,central.rhacs.svc:443,central.rhacs:443,central:443,kubernetes.default.svc.cluster.local.:443,scanner-db.rhacs.svc:5432,scanner-db.rhacs:5432,scanner-db:5432,scanner-v4-db.rhacs.svc:5432,scanner-v4-db.rhacs:5432,scanner-v4-db:5432,scanner-v4-indexer.rhacs.svc:8443,scanner-v4-indexer.rhacs:8443,scanner-v4-indexer:8443,scanner-v4-matcher.rhacs.svc:8443,scanner-v4-matcher.rhacs:8443,scanner-v4-matcher:8443,scanner.rhacs.svc:8080,scanner.rhacs.svc:8443,scanner.rhacs:8080,scanner.rhacs:8443,scanner:8080,scanner:8443",
 							},
 						},
 					},


### PR DESCRIPTION
## Description

With the introduction of ScannerV4 to ACSCS, this required also changing up the proxy configuration (specifically the NO_PROXY one) for deployed components.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
