### PR TITLE
ROX-22557: Count `expired-at` non-null changes

### DIFF
--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/expiration_date_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/expiration_date_mgr.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/services"
 	"github.com/stackrox/acs-fleet-manager/pkg/api"
 	serviceErr "github.com/stackrox/acs-fleet-manager/pkg/errors"
+	"github.com/stackrox/acs-fleet-manager/pkg/metrics"
 	"github.com/stackrox/acs-fleet-manager/pkg/workers"
 )
 
@@ -118,6 +119,9 @@ func (k *ExpirationDateManager) reconcileCentralExpiredAt(centrals dbapi.Central
 
 func (k *ExpirationDateManager) updateExpiredAtInDB(central *dbapi.CentralRequest) *serviceErr.ServiceError {
 	glog.Infof("updating expired_at of central %q to %q", central.ID, central.ExpiredAt)
+	if central.ExpiredAt != nil {
+		metrics.CentralExpirationSet(central.ID)
+	}
 	return k.centralService.Updates(&dbapi.CentralRequest{Meta: api.Meta{ID: central.ID}},
 		map[string]interface{}{"expired_at": central.ExpiredAt})
 }

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/expiration_date_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/expiration_date_mgr.go
@@ -120,7 +120,7 @@ func (k *ExpirationDateManager) reconcileCentralExpiredAt(centrals dbapi.Central
 func (k *ExpirationDateManager) updateExpiredAtInDB(central *dbapi.CentralRequest) *serviceErr.ServiceError {
 	glog.Infof("updating expired_at of central %q to %q", central.ID, central.ExpiredAt)
 	if central.ExpiredAt != nil {
-		metrics.CentralExpirationSet(central.ID)
+		metrics.CentralExpirationSet(central.OrganisationID, central.ID)
 	}
 	return k.centralService.Updates(&dbapi.CentralRequest{Meta: api.Meta{ID: central.ID}},
 		map[string]interface{}{"expired_at": central.ExpiredAt})

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/expiration_date_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/expiration_date_mgr.go
@@ -113,15 +113,18 @@ func (k *ExpirationDateManager) reconcileCentralExpiredAt(centrals dbapi.Central
 			}
 		}
 	}
-
+	expiredInstances := 0
+	for _, central := range centrals {
+		if central.ExpiredAt != nil {
+			expiredInstances++
+		}
+	}
+	metrics.UpdateCentralsExpiredMetric(float64(expiredInstances))
 	return svcErrors
 }
 
 func (k *ExpirationDateManager) updateExpiredAtInDB(central *dbapi.CentralRequest) *serviceErr.ServiceError {
 	glog.Infof("updating expired_at of central %q to %q", central.ID, central.ExpiredAt)
-	if central.ExpiredAt != nil {
-		metrics.CentralExpirationSet(central.OrganisationID, central.ID)
-	}
 	return k.centralService.Updates(&dbapi.CentralRequest{Meta: api.Meta{ID: central.ID}},
 		map[string]interface{}{"expired_at": central.ExpiredAt})
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -740,6 +740,7 @@ func init() {
 	prometheus.MustRegister(centralOperationsTotalCountMetric)
 	prometheus.MustRegister(centralStatusSinceCreatedMetric)
 	prometheus.MustRegister(CentralStatusCountMetric)
+	prometheus.MustRegister(centralExpirationSetCountMetric)
 
 	// metrics for reconcilers
 	prometheus.MustRegister(reconcilerDurationMetric)
@@ -808,6 +809,7 @@ func Reset() {
 	centralOperationsTotalCountMetric.Reset()
 	centralStatusSinceCreatedMetric.Reset()
 	CentralStatusCountMetric.Reset()
+	centralExpirationSetCountMetric.Reset()
 
 	reconcilerDurationMetric.Reset()
 	reconcilerSuccessCountMetric.Reset()

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -27,6 +27,7 @@ const (
 	LabelStatus            = "status"
 	LabelClusterID         = "cluster_id"
 	LabelClusterExternalID = "external_id"
+	LabelOrganisationID    = "organisation_id"
 
 	// CentralOperationsSuccessCount - name of the metric for Central-related successful operations
 	CentralOperationsSuccessCount = "central_operations_success_count"
@@ -336,11 +337,11 @@ var centralExpirationSetCountMetric = prometheus.NewCounterVec(
 		Name:      CentralExpirationSetCount,
 		Help:      "number of expiration timestamps set",
 	},
-	[]string{"id"},
+	[]string{LabelOrganisationID, LabelID},
 )
 
-func CentralExpirationSet(centralID string) {
-	centralExpirationSetCountMetric.WithLabelValues(centralID).Inc()
+func CentralExpirationSet(organisationID string, centralID string) {
+	centralExpirationSetCountMetric.WithLabelValues(organisationID, centralID).Inc()
 }
 
 // #### Metrics for Dataplane clusters - End ####

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -43,6 +43,9 @@ const (
 	ClusterOperationsTotalCount = "cluster_operations_total_count"
 	labelOperation              = "operation"
 
+	// CentralExpirationSetCount - name of the metric for the count of central expiration timestamp non-null updates
+	CentralExpirationSetCount = "central_expiration_set_count"
+
 	ReconcilerDuration     = "reconciler_duration_in_seconds"
 	ReconcilerSuccessCount = "reconciler_success_count"
 	ReconcilerFailureCount = "reconciler_failure_count"
@@ -324,6 +327,20 @@ func UpdateCentralPerClusterCountMetric(clusterID string, clusterExternalID stri
 		LabelClusterExternalID: clusterExternalID,
 	}
 	centralPerClusterCountMetric.With(labels).Set(float64(count))
+}
+
+// create a new counterVec for when expiration timestamp is set to a central
+var centralExpirationSetCountMetric = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Subsystem: FleetManager,
+		Name:      CentralExpirationSetCount,
+		Help:      "number of expiration timestamps set",
+	},
+	[]string{"id"},
+)
+
+func CentralExpirationSet(centralID string) {
+	centralExpirationSetCountMetric.WithLabelValues(centralID).Inc()
 }
 
 // #### Metrics for Dataplane clusters - End ####


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

A new Fleet-manager Prometheus metric, showing the total number of expired centrals.
The idea is to create an alert on a spike of such events.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

Initial run:

```console
$ curl -s http://localhost:8080/metrics | grep expired
# HELP acs_fleet_manager_expired_centrals_count total number of expired centrals
# TYPE acs_fleet_manager_expired_centrals_count gauge
acs_fleet_manager_expired_centrals_count 0
```

1. Created locally an eval central, managed by quota-management-list;
2. Patched quota-management-list config to allow 0 instances;
3. Restarted fleet-manager to trigger expiration worker;
4. Checked the fleet-manager metrics:

    ```console
    curl -s http://localhost:8080/metrics | grep expired
    # HELP acs_fleet_manager_expired_centrals_count total number of expired centrals
    # TYPE acs_fleet_manager_expired_centrals_count gauge
    acs_fleet_manager_expired_centrals_count 1
    ```