### PR TITLE
fix: check if telemetry is enabled

### DIFF
--- a/internal/dinosaur/pkg/services/telemetry.go
+++ b/internal/dinosaur/pkg/services/telemetry.go
@@ -117,6 +117,9 @@ func (t *Telemetry) trackCreationRequested(ctx context.Context, tenantID string,
 // RegisterTenant initializes the tenant group with the associated properties
 // and issues a following event tracking the central creation request.
 func (t *Telemetry) RegisterTenant(ctx context.Context, convCentral *dbapi.CentralRequest, isAdmin bool, err error) {
+	if !t.enabled() {
+		return
+	}
 	user, err := t.auth.getUserFromContext(ctx)
 	if err != nil {
 		glog.Error(errors.Wrap(err, "cannot get telemetry user from context claims"))
@@ -142,6 +145,9 @@ func (t *Telemetry) RegisterTenant(ctx context.Context, convCentral *dbapi.Centr
 
 // UpdateTenant updates tenant group properties.
 func (t *Telemetry) UpdateTenantProperties(convCentral *dbapi.CentralRequest) {
+	if !t.enabled() {
+		return
+	}
 	props := t.getTenantProperties(convCentral)
 	// Update tenant group properties from the name of fleet-manager backend.
 	t.config.Telemeter().Group(props,


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This change fixes panic in case telemetry collection is disabled.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

Existing tests are good enough.
