### PR TITLE
ROX-22887: Use go 1.20 to build images in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -145,6 +145,10 @@ jobs:
           fetch-depth: 0 # Critical for correct image detection in Makefile
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Set up Go 1.20
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.20"
       - name: Build and push fleet-manager-tools image to quay.io
         if: github.event_name == 'push'
         env:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -493,70 +493,70 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "13032f402fed753c2248419ea4f69f99931f6dbc",
         "is_verified": false,
-        "line_number": 524
+        "line_number": 540
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "30025f80f6e22cdafb85db387d50f90ea884576a",
         "is_verified": false,
-        "line_number": 524
+        "line_number": 540
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "355f24fd038bcaf85617abdcaa64af51ed19bbcf",
         "is_verified": false,
-        "line_number": 524
+        "line_number": 540
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "3d8a1dcd2c3c765ce35c9a9552d23273cc4ddace",
         "is_verified": false,
-        "line_number": 524
+        "line_number": 540
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "4ac7b0522761eba972467942cd5cd7499dd2c361",
         "is_verified": false,
-        "line_number": 524
+        "line_number": 540
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "7639ab2a6bcf2ea30a055a99468c9cd844d4c22a",
         "is_verified": false,
-        "line_number": 524
+        "line_number": 540
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "b56360daf4793d2a74991a972b34d95bc00fb2da",
         "is_verified": false,
-        "line_number": 524
+        "line_number": 540
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "c9a73ef9ee8ce9f38437227801c70bcc6740d1a1",
         "is_verified": false,
-        "line_number": 524
+        "line_number": 540
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "14736999d9940728c5294277831a702f7882dece",
         "is_verified": false,
-        "line_number": 561
+        "line_number": 577
       },
       {
         "type": "Secret Keyword",
         "filename": "templates/service-template.yml",
         "hashed_secret": "4e199b4a1c40b497a95fcd1cd896351733849949",
         "is_verified": false,
-        "line_number": 708,
+        "line_number": 724,
         "is_secret": false
       }
     ],
@@ -586,5 +586,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-05T19:02:34Z"
+  "generated_at": "2024-03-06T08:30:04Z"
 }


### PR DESCRIPTION
Context is in https://issues.redhat.com/browse/ROX-22887

If we don't pin the version to 1.20 in the build step it will break when the runner tries to use 1.21, because our go.mod file is missing the new toolchain directive (see https://tip.golang.org/doc/toolchain).

When we upgrade to using go 1.21 we'll just need to run `go mod tidy` once, commit the changes, and update our CI runners to use go 1.21.