### PR TITLE
Rollback helm-operator to v1.33.0

### DIFF
--- a/dp-terraform/helm/Dockerfile
+++ b/dp-terraform/helm/Dockerfile
@@ -26,7 +26,7 @@ RUN microdnf install gzip tar && \
 ARG FLEETSHARD_SYNC_IMAGE_TAG=main
 RUN yq -i ".fleetshardSync.image.tag = strenv(FLEETSHARD_SYNC_IMAGE_TAG)" rhacs-terraform/values.yaml
 
-FROM quay.io/operator-framework/helm-operator:v1.34.0
+FROM quay.io/operator-framework/helm-operator:v1.33.0
 
 ENV HOME=/opt/helm
 ENV ADDON_NAME=acs-fleetshard


### PR DESCRIPTION
## Description
It looks like v1.34.0 is broken. The reconciliation stopped working after merging #1687

Related issues: 
- https://github.com/operator-framework/operator-sdk/issues/6690
- https://github.com/operator-framework/operator-sdk/issues/6692

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual
No testing performed
