### PR TITLE
ROX-22926: Enable dogfood local scanner

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-cr.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-cr.yaml
@@ -76,3 +76,32 @@ spec:
       {{- if .Values.scanner.db.nodeSelector }}
       nodeSelector: {{ toYaml .Values.scanner.db.nodeSelector | nindent 8 }}
       {{- end }}
+
+  scannerV4:
+    {{- if .Values.scannerV4.scannerComponent }}
+    scannerComponent: {{ .Values.scannerV4.scannerComponent }}
+    {{- end }}
+    indexer:
+      {{- if .Values.scannerV4.indexer.resources }}
+      resources: {{ toYaml .Values.scannerV4.indexer.resources | nindent 8 }}
+      {{- end }}
+      {{- if .Values.scannerV4.indexer.tolerations }}
+      tolerations: {{ toYaml .Values.scannerV4.indexer.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.scannerV4.indexer.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.scannerV4.indexer.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.scannerV4.indexer.scaling }}
+      scaling: {{ toYaml .Values.scannerV4.indexer.scaling | nindent 8 }}
+      {{- end }}
+
+    db:
+      {{- if .Values.scannerV4.db.resources }}
+      resources: {{ toYaml .Values.scannerV4.db.resources | nindent 8 }}
+      {{- end }}
+      {{- if .Values.scannerV4.db.tolerations }}
+      tolerations: {{ toYaml .Values.scannerV4.db.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.scannerV4.db.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.scannerV4.db.nodeSelector | nindent 8 }}
+      {{- end }}

--- a/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/values.yaml
@@ -51,6 +51,15 @@ scanner:
       requests:
         memory: 100Mi
         cpu: 100m
+scannerV4:
+  scannerComponent: null
+  indexer:
+    tolerations: []
+    nodeSelector: {}
+    scaling: null
+  db:
+    tolerations: []
+    nodeSelector: {}
 sensor:
   resources:
     requests:

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -184,7 +184,37 @@ secured-cluster:
     nodeSelector:
       node-role.kubernetes.io/acscs-infra: ""
   scanner:
-    scannerComponent: Disabled
+    scannerComponent: Enabled
+    db:
+      tolerations:
+        - key: node-role.kubernetes.io/acscs-infra
+          operator: Exists
+          effect: NoSchedule
+      nodeSelector:
+        node-role.kubernetes.io/acscs-infra: ""
+    analyzer:
+      tolerations:
+        - key: node-role.kubernetes.io/acscs-infra
+          operator: Exists
+          effect: NoSchedule
+      nodeSelector:
+        node-role.kubernetes.io/acscs-infra: ""
+  scannerV4:
+    scannerComponent: Enabled
+    db:
+      tolerations:
+        - key: node-role.kubernetes.io/acscs-infra
+          operator: Exists
+          effect: NoSchedule
+      nodeSelector:
+        node-role.kubernetes.io/acscs-infra: ""
+    indexer:
+      tolerations:
+        - key: node-role.kubernetes.io/acscs-infra
+          operator: Exists
+          effect: NoSchedule
+      nodeSelector:
+        node-role.kubernetes.io/acscs-infra: ""
 
 external-secrets:
   fullnameOverride: rhacs-external-secrets


### PR DESCRIPTION
## Description
- Adding template & default values for secured cluster ScannerV4
- Enabling local scanning on SecuredClusters

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~Unit and integration tests added~~
- [ ] ~~Added test description under `Test manual`~~
- [ ] ~~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- [ ] ~~Add secret to app-interface Vault or Secrets Manager if necessary~~
- [ ] ~~RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
- [ ] ~~Check AWS limits are reasonable for changes provisioning new resources~~
- [ ] ~~(If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment~~

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
