### PR TITLE
Disable ESO webhook

### DIFF
--- a/dp-terraform/helm/Dockerfile
+++ b/dp-terraform/helm/Dockerfile
@@ -21,7 +21,7 @@ RUN microdnf install gzip tar && \
         chmod +x /usr/local/bin/yq && \
         rm /tmp/yq_linux_amd64.tar.gz && \
     cd rhacs-terraform/charts && for filename in *.tgz; do tar -xf "$filename" && rm -f "$filename"; done && \
-    yq -i 'del(.securityContext.runAsUser) | del(.webhook.securityContext.runAsUser) | del(.certController.securityContext.runAsUser)' external-secrets/values.yaml
+    yq -i 'del(.securityContext.runAsUser)' external-secrets/values.yaml
 
 ARG FLEETSHARD_SYNC_IMAGE_TAG=main
 RUN yq -i ".fleetshardSync.image.tag = strenv(FLEETSHARD_SYNC_IMAGE_TAG)" rhacs-terraform/values.yaml

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -225,17 +225,9 @@ external-secrets:
   securityContext:
     runAsUser: null
   webhook:
-    securityContext:
-      runAsUser: null
-    image:
-      repository: quay.io/app-sre/external-secrets
-      tag: v0.9.5
+    create: false
   certController:
-    securityContext:
-      runAsUser: null
-    image:
-      repository: quay.io/app-sre/external-secrets
-      tag: v0.9.5
+    create: false
   tolerations:
     - key: node-role.kubernetes.io/acscs-infra
       operator: Exists


### PR DESCRIPTION
## Description
If the helm release fails, this puts the webhook in a broken state:

1. Cert-controller updates the CA cert every 5 minutes:
  ```
  {"level":"info","ts":1710156288.9732099,"logger":"controllers.webhook-certs-updater","msg":"injecting ca certificate and service names","cacrt":"...
  ```
2. The Fleetshard operator rolls back the secret due to a failed release and thus clears the secret data. The secret is empty in the chart: https://github.com/external-secrets/external-secrets/blob/main/deploy/charts/external-secrets/templates/webhook-secret.yaml

In other words, webhook can't start, because the operator reconciles it again and again.
This becomes an endless loop, spawning a service account every time a reconciliation is attempted. 
 
## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual
Test on integration 😅 
