### PR TITLE
ROX-22361: Log ACSCS instance state change

### DIFF
--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -694,7 +694,7 @@ func (k *dinosaurService) Update(dinosaurRequest *dbapi.CentralRequest) *errors.
 		Model(dinosaurRequest).
 		Where("status not IN (?)", dinosaurDeletionStatuses) // ignore updates of dinosaur under deletion
 
-	logStateChange("delete request", dinosaurRequest.ID, dinosaurRequest)
+	logStateChange("updates", dinosaurRequest.ID, dinosaurRequest)
 
 	if err := dbConn.Updates(dinosaurRequest).Error; err != nil {
 		return errors.NewWithCause(errors.ErrorGeneral, err, "Failed to update central")

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -709,7 +709,7 @@ func (k *dinosaurService) Updates(dinosaurRequest *dbapi.CentralRequest, fields 
 		Model(dinosaurRequest).
 		Where("status not IN (?)", dinosaurDeletionStatuses) // ignore updates of dinosaur under deletion
 
-	glog.Infof("instance %q state change: %+v", dinosaurRequest.ID, fields)
+	glog.Infof("instance state change: id=%q: fields=%+v", dinosaurRequest.ID, fields)
 
 	if err := dbConn.Updates(fields).Error; err != nil {
 		return errors.NewWithCause(errors.ErrorGeneral, err, "Failed to update central")

--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -181,6 +181,8 @@ func (k *dinosaurService) RotateCentralRHSSOClient(ctx context.Context, centralR
 func (k *dinosaurService) ResetCentralSecretBackup(ctx context.Context, centralRequest *dbapi.CentralRequest) *errors.ServiceError {
 	centralRequest.Secrets = nil // pragma: allowlist secret
 
+	glog.Infof("instance %q state change: reset secrets", centralRequest.ID)
+
 	dbConn := k.connectionFactory.New()
 	if err := dbConn.Model(centralRequest).Select("secrets").Updates(centralRequest).Error; err != nil {
 		return errors.NewWithCause(errors.ErrorGeneral, err, "Unable to reset secrets for central request")
@@ -302,6 +304,9 @@ func (k *dinosaurService) RegisterDinosaurJob(ctx context.Context, dinosaurReque
 	// the API is restarted this time changing the --quota-type flag to quota-management-list, when dinosaur A is deleted at this point,
 	// we want to use the correct quota to perform the deletion.
 	dinosaurRequest.QuotaType = k.dinosaurConfig.Quota.Type
+
+	glog.Infof("instance %q state change: %+v", dinosaurRequest.ID, convertCentralRequestToString(dinosaurRequest))
+
 	if err := dbConn.Create(dinosaurRequest).Error; err != nil {
 		return errors.NewWithCause(errors.ErrorGeneral, err, "failed to create central request") // hide the db error to http caller
 	}
@@ -599,12 +604,12 @@ func (k *dinosaurService) Delete(centralRequest *dbapi.CentralRequest, force boo
 		}
 	}
 
+	glog.Infof("instance %q state change: delete request", centralRequest.ID)
 	// soft delete the dinosaur request
 	if err := dbConn.Delete(centralRequest).Error; err != nil {
 		return errors.NewWithCause(errors.ErrorGeneral, err, "unable to delete central request with id %s", centralRequest.ID)
 	}
 
-	glog.Infof("Successfully deleted Central tenant %q in the database.", centralRequest.ID)
 	if force {
 		glog.Infof("Make sure any other resources belonging to the Central tenant %q are manually deleted.", centralRequest.ID)
 	}
@@ -689,6 +694,8 @@ func (k *dinosaurService) Update(dinosaurRequest *dbapi.CentralRequest) *errors.
 		Model(dinosaurRequest).
 		Where("status not IN (?)", dinosaurDeletionStatuses) // ignore updates of dinosaur under deletion
 
+	glog.Infof("instance %q state change: %+v", dinosaurRequest.ID, convertCentralRequestToString(dinosaurRequest))
+
 	if err := dbConn.Updates(dinosaurRequest).Error; err != nil {
 		return errors.NewWithCause(errors.ErrorGeneral, err, "Failed to update central")
 	}
@@ -701,6 +708,8 @@ func (k *dinosaurService) Updates(dinosaurRequest *dbapi.CentralRequest, fields 
 	dbConn := k.connectionFactory.New().
 		Model(dinosaurRequest).
 		Where("status not IN (?)", dinosaurDeletionStatuses) // ignore updates of dinosaur under deletion
+
+	glog.Infof("instance %q state change: %+v", dinosaurRequest.ID, fields)
 
 	if err := dbConn.Updates(fields).Error; err != nil {
 		return errors.NewWithCause(errors.ErrorGeneral, err, "Failed to update central")
@@ -752,6 +761,8 @@ func (k *dinosaurService) UpdateStatus(id string, status dinosaurConstants.Centr
 		now := time.Now()
 		update.DeletionTimestamp = &now
 	}
+
+	glog.Infof("instance %q state change: change status to %q", id, status.String())
 
 	if err := dbConn.Model(&dbapi.CentralRequest{Meta: api.Meta{ID: id}}).Updates(update).Error; err != nil {
 		return true, errors.NewWithCause(errors.ErrorGeneral, err, "Failed to update central status")
@@ -849,6 +860,8 @@ func (k *dinosaurService) Restore(ctx context.Context, id string) *errors.Servic
 	resetRequest.ID = centralRequest.ID
 	resetRequest.Status = dinosaurConstants.CentralRequestStatusPreparing.String()
 	resetRequest.CreatedAt = time.Now()
+
+	glog.Infof("instance %q state change: %+v", resetRequest.ID, convertCentralRequestToString(resetRequest))
 
 	if err := dbConn.Unscoped().Model(resetRequest).Select(columnsToReset).Updates(resetRequest).Error; err != nil {
 		return errors.NewWithCause(errors.ErrorGeneral, err, "Unable to reset CentralRequest status")
@@ -976,4 +989,43 @@ func buildResourceRecordChange(recordName string, clusterIngress string, action 
 	}
 
 	return resourceRecordChange
+}
+
+func convertCentralRequestToString(req *dbapi.CentralRequest) string {
+	traits, _ := req.Traits.Value()
+	requestAsMap := map[string]interface{}{
+		"id":                      req.ID,
+		"created_at":              req.CreatedAt,
+		"updated_at":              req.UpdatedAt,
+		"deleted_at":              req.DeletedAt,
+		"region":                  req.Region,
+		"cluster_id":              req.ClusterID,
+		"cloud_provider":          req.CloudProvider,
+		"cloud_account_id":        req.CloudAccountID,
+		"multi_az":                req.MultiAZ,
+		"name":                    req.Name,
+		"status":                  req.Status,
+		"subscription_id":         req.SubscriptionID,
+		"owner":                   req.Owner,
+		"owner_account_id":        req.OwnerAccountID,
+		"owner_user_id":           req.OwnerUserID,
+		"owner_alternate_user_id": req.OwnerAlternateUserID,
+		"host":                    req.Host,
+		"organisation_id":         req.OrganisationID,
+		"organisation_name":       req.OrganisationName,
+		"failed_reason":           req.FailedReason,
+		"placement_id":            req.PlacementID,
+		"instance_type":           req.InstanceType,
+		"qouta_type":              req.QuotaType,
+		"routes_created":          req.RoutesCreated,
+		"namespace":               req.Namespace,
+		"routes_creation_id":      req.RoutesCreationID,
+		"deletion_timestamp":      req.DeletionTimestamp,
+		"internal":                req.Internal,
+		"expired_at":              req.ExpiredAt,
+		"traits":                  traits,
+		"issuer":                  req.Issuer,
+		"client_origin":           req.ClientOrigin,
+	}
+	return fmt.Sprintf("%+v", requestAsMap)
 }


### PR DESCRIPTION
## Description

This PR does its best to keep track of central request state change. 
Conversion to string is done so that secrets, routes and auth config are not logged.

`DeprovisionExpiredDinosaurs` is not covered here since query does not return affected rows.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

1. TBD
