### PR TITLE
Backup manual declarative config

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -345,6 +345,29 @@
         "line_number": 143
       }
     ],
+    "fleetshard/pkg/k8s/secret.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "fleetshard/pkg/k8s/secret.go",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "is_verified": false,
+        "line_number": 21
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "fleetshard/pkg/k8s/secret.go",
+        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
+        "is_verified": false,
+        "line_number": 23
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "fleetshard/pkg/k8s/secret.go",
+        "hashed_secret": "3fd643ebfac50d22955b62b6529bfe40feb881ae",
+        "is_verified": false,
+        "line_number": 45
+      }
+    ],
     "internal/dinosaur/pkg/api/public/api/openapi.yaml": [
       {
         "type": "Base64 High Entropy String",
@@ -519,5 +542,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-07T13:45:14Z"
+  "generated_at": "2024-03-12T14:14:45Z"
 }

--- a/fleetshard/pkg/k8s/secret.go
+++ b/fleetshard/pkg/k8s/secret.go
@@ -11,27 +11,29 @@ import (
 )
 
 const (
-	CentralTLSSecretName           = "central-tls"            // pragma: allowlist secret
-	centralDBPasswordSecretName    = "central-db-password"    // pragma: allowlist secret
-	centralEncryptionKeySecretName = "central-encryption-key" // pragma: allowlist secret
+	CentralTLSSecretName              = "central-tls"                              // pragma: allowlist secret
+	centralDBPasswordSecretName       = "central-db-password"                      // pragma: allowlist secret
+	centralEncryptionKeySecretName    = "central-encryption-key"                   // pragma: allowlist secret
+	manualDeclarativeConfigSecretName = "cloud-service-manual-declarative-configs" // pragma: allowlist secret
 )
 
-var defaultSecretsToWatch = []string{
-	CentralTLSSecretName,
-	centralEncryptionKeySecretName,
+var defaultSecretsToWatch = map[string]bool{
+	CentralTLSSecretName:              true,
+	centralEncryptionKeySecretName:    true,
+	manualDeclarativeConfigSecretName: false,
 }
 
 // SecretBackup is responsible for reading secrets to Backup for a tenant.
 type SecretBackup struct {
 	client         ctrlClient.Client
-	secretsToWatch []string
+	secretsToWatch map[string]bool
 }
 
 // NewSecretBackup creates a new instance of SecretService.
 func NewSecretBackup(client ctrlClient.Client, managedDB bool) *SecretBackup {
 	secretsToWatch := defaultSecretsToWatch // pragma: allowlist secret
 	if managedDB {
-		secretsToWatch = append(secretsToWatch, centralDBPasswordSecretName)
+		secretsToWatch[centralDBPasswordSecretName] = true
 	}
 
 	return &SecretBackup{client: client, secretsToWatch: secretsToWatch} // pragma: allowlist secret
@@ -39,8 +41,10 @@ func NewSecretBackup(client ctrlClient.Client, managedDB bool) *SecretBackup {
 
 // GetWatchedSecrets return a sorted list of secrets watched by this package
 func (s *SecretBackup) GetWatchedSecrets() []string {
-	secrets := make([]string, len(s.secretsToWatch))
-	copy(secrets, s.secretsToWatch)
+	secrets := make([]string, 0, len(s.secretsToWatch))
+	for secretName := range s.secretsToWatch {
+		secrets = append(secrets, secretName)
+	}
 	sort.Strings(secrets)
 	return secrets
 }
@@ -49,26 +53,31 @@ func (s *SecretBackup) GetWatchedSecrets() []string {
 // watched by SecretServices
 func (s *SecretBackup) CollectSecrets(ctx context.Context, namespace string) (map[string]*corev1.Secret, error) {
 	secrets := map[string]*corev1.Secret{}
-	for _, secretname := range s.secretsToWatch { // pragma: allowlist secret
-		secret, err := getSecret(ctx, s.client, secretname, namespace)
+	for secretName, required := range s.secretsToWatch { // pragma: allowlist secret
+		secret, found, err := getSecret(ctx, s.client, required, secretName, namespace)
 		if err != nil {
 			return nil, err
 		}
-		secrets[secretname] = secret // pragma: allowlist secret
+		if found {
+			secrets[secretName] = secret // pragma: allowlist secret
+		}
 	}
 
 	return secrets, nil
 }
 
-func getSecret(ctx context.Context, client ctrlClient.Client, secretname, namespace string) (*corev1.Secret, error) {
+func getSecret(ctx context.Context, client ctrlClient.Client, required bool, secretname, namespace string) (*corev1.Secret, bool, error) {
 	centralSecret := &corev1.Secret{}
 	err := client.Get(ctx, ctrlClient.ObjectKey{Namespace: namespace, Name: secretname}, centralSecret)
 	if err != nil {
 		if apiErrors.IsNotFound(err) {
-			return centralSecret, fmt.Errorf("%s secret not found", secretname)
+			if required {
+				return centralSecret, false, fmt.Errorf("%s secret not found", secretname)
+			}
+			return centralSecret, false, nil
 		}
-		return centralSecret, fmt.Errorf("getting secret %s/%s: %w", namespace, secretname, err)
+		return centralSecret, false, fmt.Errorf("getting secret %s/%s: %w", namespace, secretname, err)
 	}
 
-	return centralSecret, nil
+	return centralSecret, true, nil
 }


### PR DESCRIPTION
## Description
This PR adds manual declarative config to a list of watched secrets for backup. In case manual declarative config is missing, `fleetshard-sync` skips backing it up.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

1. TBD
