### PR TITLE
ROX-22428: Rename dinosaurService#Update

### DIFF
--- a/internal/dinosaur/pkg/services/data_plane_dinosaur.go
+++ b/internal/dinosaur/pkg/services/data_plane_dinosaur.go
@@ -159,7 +159,7 @@ func (s *dataPlaneCentralService) setCentralClusterFailed(centralRequest *dbapi.
 
 	centralRequest.Status = string(constants.CentralRequestStatusFailed)
 	centralRequest.FailedReason = fmt.Sprintf("Central reported as failed: '%s'", errMessage)
-	err = s.dinosaurService.Update(centralRequest)
+	err = s.dinosaurService.UpdateIgnoreNils(centralRequest)
 	if err != nil {
 		return serviceError.NewWithCause(err.Code, err, "failed to update central cluster to %s status for central cluster %s", constants.CentralRequestStatusFailed, centralRequest.ID)
 	}
@@ -189,7 +189,7 @@ func (s *dataPlaneCentralService) reassignCentralCluster(centralRequest *dbapi.C
 		// But now we only have one OSD cluster, so we need to change the placementId field so that the fleetshard-operator will try it again
 		// In the future, we may consider adding a new table to track the placement history for dinosaur clusters if there are multiple OSD clusters and the value here can be the key of that table
 		centralRequest.PlacementID = api.NewID()
-		if err := s.dinosaurService.Update(centralRequest); err != nil {
+		if err := s.dinosaurService.UpdateIgnoreNils(centralRequest); err != nil {
 			return err
 		}
 		metrics.UpdateCentralRequestsStatusSinceCreatedMetric(constants.CentralRequestStatusProvisioning, centralRequest.ID, centralRequest.ClusterID, time.Since(centralRequest.CreatedAt))
@@ -244,7 +244,7 @@ func (s *dataPlaneCentralService) persistCentralValues(centralRequest *dbapi.Cen
 		return err
 	}
 
-	if err := s.dinosaurService.Update(centralRequest); err != nil {
+	if err := s.dinosaurService.UpdateIgnoreNils(centralRequest); err != nil {
 		return serviceError.NewWithCause(err.Code, err, "failed to update routes for central cluster %s", centralRequest.ID)
 	}
 

--- a/internal/dinosaur/pkg/services/dinosaurservice_moq.go
+++ b/internal/dinosaur/pkg/services/dinosaurservice_moq.go
@@ -91,8 +91,8 @@ var _ DinosaurService = &DinosaurServiceMock{}
 //			RotateCentralRHSSOClientFunc: func(ctx context.Context, centralRequest *dbapi.CentralRequest) *serviceError.ServiceError {
 //				panic("mock out the RotateCentralRHSSOClient method")
 //			},
-//			UpdateFunc: func(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError {
-//				panic("mock out the Update method")
+//			UpdateIgnoreNilsFunc: func(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError {
+//				panic("mock out the UpdateIgnoreNils method")
 //			},
 //			UpdateStatusFunc: func(id string, status dinosaurConstants.CentralStatus) (bool, *serviceError.ServiceError) {
 //				panic("mock out the UpdateStatus method")
@@ -176,8 +176,8 @@ type DinosaurServiceMock struct {
 	// RotateCentralRHSSOClientFunc mocks the RotateCentralRHSSOClient method.
 	RotateCentralRHSSOClientFunc func(ctx context.Context, centralRequest *dbapi.CentralRequest) *serviceError.ServiceError
 
-	// UpdateFunc mocks the Update method.
-	UpdateFunc func(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError
+	// UpdateIgnoreNilsFunc mocks the UpdateIgnoreNils method.
+	UpdateIgnoreNilsFunc func(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError
 
 	// UpdateStatusFunc mocks the UpdateStatus method.
 	UpdateStatusFunc func(id string, status dinosaurConstants.CentralStatus) (bool, *serviceError.ServiceError)
@@ -310,8 +310,8 @@ type DinosaurServiceMock struct {
 			// CentralRequest is the centralRequest argument value.
 			CentralRequest *dbapi.CentralRequest
 		}
-		// Update holds details about calls to the Update method.
-		Update []struct {
+		// UpdateIgnoreNils holds details about calls to the UpdateIgnoreNils method.
+		UpdateIgnoreNils []struct {
 			// DinosaurRequest is the dinosaurRequest argument value.
 			DinosaurRequest *dbapi.CentralRequest
 		}
@@ -359,7 +359,7 @@ type DinosaurServiceMock struct {
 	lockResetCentralSecretBackup          sync.RWMutex
 	lockRestore                           sync.RWMutex
 	lockRotateCentralRHSSOClient          sync.RWMutex
-	lockUpdate                            sync.RWMutex
+	lockUpdateIgnoreNils                  sync.RWMutex
 	lockUpdateStatus                      sync.RWMutex
 	lockUpdates                           sync.RWMutex
 	lockVerifyAndUpdateDinosaurAdmin      sync.RWMutex
@@ -1085,35 +1085,35 @@ func (mock *DinosaurServiceMock) RotateCentralRHSSOClientCalls() []struct {
 	return calls
 }
 
-// Update calls UpdateFunc.
-func (mock *DinosaurServiceMock) Update(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError {
-	if mock.UpdateFunc == nil {
-		panic("DinosaurServiceMock.UpdateFunc: method is nil but DinosaurService.Update was just called")
+// UpdateIgnoreNils calls UpdateIgnoreNilsFunc.
+func (mock *DinosaurServiceMock) UpdateIgnoreNils(dinosaurRequest *dbapi.CentralRequest) *serviceError.ServiceError {
+	if mock.UpdateIgnoreNilsFunc == nil {
+		panic("DinosaurServiceMock.UpdateIgnoreNilsFunc: method is nil but DinosaurService.UpdateIgnoreNils was just called")
 	}
 	callInfo := struct {
 		DinosaurRequest *dbapi.CentralRequest
 	}{
 		DinosaurRequest: dinosaurRequest,
 	}
-	mock.lockUpdate.Lock()
-	mock.calls.Update = append(mock.calls.Update, callInfo)
-	mock.lockUpdate.Unlock()
-	return mock.UpdateFunc(dinosaurRequest)
+	mock.lockUpdateIgnoreNils.Lock()
+	mock.calls.UpdateIgnoreNils = append(mock.calls.UpdateIgnoreNils, callInfo)
+	mock.lockUpdateIgnoreNils.Unlock()
+	return mock.UpdateIgnoreNilsFunc(dinosaurRequest)
 }
 
-// UpdateCalls gets all the calls that were made to Update.
+// UpdateIgnoreNilsCalls gets all the calls that were made to UpdateIgnoreNils.
 // Check the length with:
 //
-//	len(mockedDinosaurService.UpdateCalls())
-func (mock *DinosaurServiceMock) UpdateCalls() []struct {
+//	len(mockedDinosaurService.UpdateIgnoreNilsCalls())
+func (mock *DinosaurServiceMock) UpdateIgnoreNilsCalls() []struct {
 	DinosaurRequest *dbapi.CentralRequest
 } {
 	var calls []struct {
 		DinosaurRequest *dbapi.CentralRequest
 	}
-	mock.lockUpdate.RLock()
-	calls = mock.calls.Update
-	mock.lockUpdate.RUnlock()
+	mock.lockUpdateIgnoreNils.RLock()
+	calls = mock.calls.UpdateIgnoreNils
+	mock.lockUpdateIgnoreNils.RUnlock()
 	return calls
 }
 

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_auth_config_mgr.go
@@ -113,7 +113,7 @@ func (k *CentralAuthConfigManager) reconcileCentralRequest(cr *dbapi.CentralRequ
 	cr.AuthConfig.ClientOrigin = ternary.String(k.centralConfig.HasStaticAuth(),
 		dbapi.AuthConfigStaticClientOrigin, dbapi.AuthConfigDynamicClientOrigin)
 
-	if err := k.centralService.Update(cr); err != nil {
+	if err := k.centralService.UpdateIgnoreNils(cr); err != nil {
 		return errors.Wrapf(err, "failed to update central request %s", cr.ID)
 	}
 

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_routes_cname_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/dinosaurs_routes_cname_mgr.go
@@ -93,7 +93,7 @@ func (k *DinosaurRoutesCNAMEManager) Reconcile() []error {
 			dinosaur.RoutesCreated = true
 		}
 
-		if err := k.dinosaurService.Update(dinosaur); err != nil {
+		if err := k.dinosaurService.UpdateIgnoreNils(dinosaur); err != nil {
 			errs = append(errs, err)
 			continue
 		}

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/preparing_dinosaurs_mgr.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/preparing_dinosaurs_mgr.go
@@ -100,7 +100,7 @@ func (k *PreparingDinosaurManager) handleDinosaurRequestCreationError(dinosaurRe
 			metrics.IncreaseCentralTotalOperationsCountMetric(constants2.CentralOperationCreate)
 			dinosaurRequest.Status = string(constants2.CentralRequestStatusFailed)
 			dinosaurRequest.FailedReason = err.Reason
-			updateErr := k.dinosaurService.Update(dinosaurRequest)
+			updateErr := k.dinosaurService.UpdateIgnoreNils(dinosaurRequest)
 			if updateErr != nil {
 				return errors.Wrapf(updateErr, "Failed to update central %s in failed state. Central failed reason %s", dinosaurRequest.ID, dinosaurRequest.FailedReason)
 			}
@@ -111,7 +111,7 @@ func (k *PreparingDinosaurManager) handleDinosaurRequestCreationError(dinosaurRe
 		metrics.IncreaseCentralTotalOperationsCountMetric(constants2.CentralOperationCreate)
 		dinosaurRequest.Status = string(constants2.CentralRequestStatusFailed)
 		dinosaurRequest.FailedReason = err.Reason
-		updateErr := k.dinosaurService.Update(dinosaurRequest)
+		updateErr := k.dinosaurService.UpdateIgnoreNils(dinosaurRequest)
 		if updateErr != nil {
 			return errors.Wrapf(err, "Failed to update central %s in failed state", dinosaurRequest.ID)
 		}

--- a/internal/dinosaur/pkg/workers/dinosaurmgrs/timeout.go
+++ b/internal/dinosaur/pkg/workers/dinosaurmgrs/timeout.go
@@ -17,7 +17,7 @@ func FailIfTimeoutExceeded(centralService services.DinosaurService, timeout time
 		centralRequest.Status = constants2.CentralRequestStatusFailed.String()
 		centralRequest.FailedReason = "Creation time went over the timeout. Interrupting central initialization."
 
-		if err := centralService.Update(centralRequest); err != nil {
+		if err := centralService.UpdateIgnoreNils(centralRequest); err != nil {
 			return errors.Wrapf(err, "failed to update timed out central %s", centralRequest.ID)
 		}
 		metrics.UpdateCentralRequestsStatusSinceCreatedMetric(constants2.CentralRequestStatusFailed, centralRequest.ID, centralRequest.ClusterID, time.Since(centralRequest.CreatedAt))


### PR DESCRIPTION
## Description
Rename dinosaurService `Update` to `UpdateIgnoreNils` to better highlight that it doesn't support nil values update. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual
CI
