### PR TITLE
ROX-16615: Probe template

### DIFF
--- a/probe/README.md
+++ b/probe/README.md
@@ -38,3 +38,37 @@ make probe
 # or run an endless loop of probes
 ./probe/bin/probe start
 ```
+
+
+## Run probe on a dev cluster
+##### Prerequisites
+1. Switch kubectl context to the local cluster, e.g.
+```
+kubectl config use-context colima
+```
+2. Deploy fleet-manager
+```
+make deploy/bootstrap deploy/dev
+```
+For more details, see the root [README.md](../README.md) file
+##### Steps
+
+1. Build the probe image
+```
+make image/build/probe
+```
+2. Deploy on the cluster
+```
+make deploy/probe
+```
+To deploy the probe service with a custom tag:
+```
+# For example: Mark the image built for the previous commit as latest
+docker tag quay.io/rhacs-eng/probe:$(git rev-parse --short=7 HEAD^) quay.io/rhacs-eng/probe:latest
+# Deploy probe with latest tag
+make deploy/probe IMAGE_TAG=latest
+```
+##### Cleanup
+```
+make undeploy/probe
+```

--- a/probe/README.md
+++ b/probe/README.md
@@ -63,10 +63,8 @@ make deploy/probe
 ```
 To deploy the probe service with a custom tag:
 ```
-# For example: Mark the image built for the previous commit as latest
-docker tag quay.io/rhacs-eng/probe:$(git rev-parse --short=7 HEAD^) quay.io/rhacs-eng/probe:latest
-# Deploy probe with latest tag
-make deploy/probe IMAGE_TAG=latest
+# Deploy probe with the label created from the previous commit
+make deploy/probe IMAGE_TAG=$(git rev-parse --short=7 HEAD^)
 ```
 ##### Cleanup
 ```

--- a/probe/config/config.go
+++ b/probe/config/config.go
@@ -15,7 +15,7 @@ import (
 // Config contains this application's runtime configuration.
 type Config struct {
 	AuthType                string        `env:"AUTH_TYPE" envDefault:"RHSSO"`
-	CentralSpecs            CentralSpecs  `env:"CENTRAL_SPECS" envDefault:"[{ \"cloudProvider\": \"aws\", \"region\": \"us-east-1\" }]"`
+	CentralSpecs            CentralSpecs  `env:"CENTRAL_SPECS" envDefault:"[{ \"cloudProvider\": \"standalone\", \"region\": \"standalone\" }]"`
 	FleetManagerEndpoint    string        `env:"FLEET_MANAGER_ENDPOINT" envDefault:"http://127.0.0.1:8000"`
 	MetricsAddress          string        `env:"METRICS_ADDRESS" envDefault:":7070"`
 	RHSSOClientID           string        `env:"RHSSO_SERVICE_ACCOUNT_CLIENT_ID"`

--- a/probe/config/config_test.go
+++ b/probe/config/config_test.go
@@ -65,8 +65,8 @@ func TestGetConfig_CentralSpecDefault(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, CentralSpecs{
 		{
-			CloudProvider: "aws",
-			Region:        "us-east-1",
+			CloudProvider: "standalone",
+			Region:        "standalone",
 		},
 	}, cfg.CentralSpecs)
 }

--- a/templates/probe-template.yml
+++ b/templates/probe-template.yml
@@ -1,0 +1,93 @@
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: fleet-manager-probe
+  annotations:
+    openshift.io/display-name: Fleet Manager Probe
+    description: ACS Services Fleet Manager Probe
+    tags: golang
+    iconClass: icon-shadowman
+    template.openshift.io/provider-display-name: Red Hat, Inc.
+    template.openshift.io/documentation-url: https://gitlab.cee.redhat.com/service/
+labels:
+  template: fleet-manager-probe
+parameters:
+  - name: IMAGE_REGISTRY
+    displayName: Image Registry
+    required: true
+  - name: IMAGE_REPOSITORY
+    displayName: Image Repository
+    required: true
+  - name: IMAGE_TAG
+    displayName: Image tag
+    value: latest
+  - name: FLEET_MANAGER_ENDPOINT
+    displayName: Fleet Manager Endpoint
+    value: http://fleet-manager.rhacs:8000
+  - name: CENTRAL_SPECS
+    display: Central Specifications
+    value: '[{ "cloudProvider": "standalone", "region": "standalone" }]'
+  - name: CPU_REQUESTS
+    displayName: CPU Requests
+    value: 100m
+  - name: CPU_LIMITS
+    displayName: CPU Limits
+    value: 100m
+  - name: MEMORY_REQUESTS
+    displayName: Memory Requests
+    value: 128Mi
+  - name: MEMORY_LIMITS
+    displayName: Memory Limits
+    value: 128Mi
+objects:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: probe
+      labels:
+        app: probe
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: probe
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            app: probe
+        spec:
+          containers:
+            - name: probe
+              image: ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: FLEET_MANAGER_ENDPOINT
+                  value: ${FLEET_MANAGER_ENDPOINT}
+                - name: AUTH_TYPE
+                  value: OCM
+                - name: OCM_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: probe-credentials
+                      key: OCM_USERNAME
+                - name: OCM_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: probe-credentials
+                      key: OCM_TOKEN
+                - name: CENTRAL_SPECS
+                  value: ${CENTRAL_SPECS}
+              ports:
+                - name: monitoring
+                  containerPort: 7070
+              resources:
+                requests:
+                  cpu: ${CPU_REQUESTS}
+                  memory: ${MEMORY_REQUESTS}
+                limits:
+                  cpu: ${CPU_LIMITS}
+                  memory: ${MEMORY_LIMITS}
+          terminationGracePeriodSeconds: 300

--- a/templates/probe-template.yml
+++ b/templates/probe-template.yml
@@ -59,7 +59,7 @@ objects:
         spec:
           containers:
             - name: probe
-              image: ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}
+              image: "${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}"
               imagePullPolicy: IfNotPresent
               env:
                 - name: FLEET_MANAGER_ENDPOINT

--- a/templates/probe-template.yml
+++ b/templates/probe-template.yml
@@ -8,8 +8,6 @@ metadata:
     description: ACS Services Fleet Manager Probe
     tags: golang
     iconClass: icon-shadowman
-    template.openshift.io/provider-display-name: Red Hat, Inc.
-    template.openshift.io/documentation-url: https://gitlab.cee.redhat.com/service/
 labels:
   template: fleet-manager-probe
 parameters:


### PR DESCRIPTION
## Description
This change introduces the probe template as an alternative installation method to the helm chart. Templates are used to deploy services on app-interface.

#### Scope
- Template yaml
- dev makefile targets
- Instructions to run on dev clusters

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~Unit and integration tests added~~
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual
```
make deploy/probe
```
