### PR TITLE
ROX-21682: Add support for central-encryption-key-chain

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -123,8 +123,8 @@ var _ = Describe("Central", Ordered, func() {
 			Expect(tenantLabelFound).To(BeTrue())
 		})
 
-		It("should generate a central-encryption-key secret", func() {
-			Eventually(assertSecretExists(ctx, &corev1.Secret{}, namespaceName, "central-encryption-key")).
+		It("should generate a central-encryption-key-chain secret", func() {
+			Eventually(assertSecretExists(ctx, &corev1.Secret{}, namespaceName, "central-encryption-key-chain")).
 				WithTimeout(waitTimeout).
 				WithPolling(defaultPolling).
 				Should(Succeed())

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -1249,7 +1249,7 @@ func (r *CentralReconciler) ensureEncryptionKeySecretExists(ctx context.Context,
 func (r *CentralReconciler) populateEncryptionKeySecret(secret *corev1.Secret) error {
 	const encryptionKeyChainFile = "key-chain.yaml"
 
-	if secret.StringData != nil {
+	if secret.Data != nil {
 		if _, ok := secret.Data[encryptionKeyChainFile]; ok {
 			// secret already populated with encryption key skip operation
 			return nil
@@ -1266,7 +1266,8 @@ func (r *CentralReconciler) populateEncryptionKeySecret(secret *corev1.Secret) e
 	if err != nil {
 		return err
 	}
-	secret.StringData = map[string]string{encryptionKeyChainFile: keyChainFile}
+	b64KeyChainFile := base64.StdEncoding.EncodeToString([]byte(keyChainFile))
+	secret.Data = map[string][]byte{encryptionKeyChainFile: []byte(b64KeyChainFile)}
 	return nil
 }
 

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -1266,12 +1266,12 @@ func (r *CentralReconciler) populateEncryptionKeySecret(secret *corev1.Secret) e
 	if err != nil {
 		return err
 	}
-	b64KeyChainFile := base64.StdEncoding.EncodeToString([]byte(keyChainFile))
+	b64KeyChainFile := base64.StdEncoding.EncodeToString(keyChainFile)
 	secret.Data = map[string][]byte{encryptionKeyChainFile: []byte(b64KeyChainFile)}
 	return nil
 }
 
-func generateNewKeyChainFile(b64Key string) (string, error) {
+func generateNewKeyChainFile(b64Key string) ([]byte, error) {
 	keyMap := make(map[int]string)
 	keyMap[0] = b64Key
 
@@ -1282,10 +1282,10 @@ func generateNewKeyChainFile(b64Key string) (string, error) {
 
 	yamlBytes, err := yaml.Marshal(keyChain)
 	if err != nil {
-		return "", fmt.Errorf("generating key-chain file: %w", err)
+		return []byte{}, fmt.Errorf("generating key-chain file: %w", err)
 	}
 
-	return string(yamlBytes), nil
+	return yamlBytes, nil
 }
 
 func (r *CentralReconciler) getCentralDBConnectionString(ctx context.Context, remoteCentral *private.ManagedCentral) (string, error) {

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
 	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
 	"github.com/stackrox/acs-fleet-manager/pkg/features"
+	centralNotifierUtils "github.com/stackrox/rox/central/notifiers/utils"
 	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"github.com/stackrox/rox/pkg/random"
@@ -78,7 +79,7 @@ const (
 	centralDbOverrideConfigMap = "central-db-override"
 	centralDeletePollInterval  = 5 * time.Second
 
-	centralEncryptionKeySecretName = "central-encryption-key" // pragma: allowlist secret
+	centralEncryptionKeySecretName = "central-encryption-key-chain" // pragma: allowlist secret
 
 	sensibleDeclarativeConfigSecretName = "cloud-service-sensible-declarative-configs" // pragma: allowlist secret
 	manualDeclarativeConfigSecretName   = "cloud-service-manual-declarative-configs"   // pragma: allowlist secret
@@ -1246,8 +1247,10 @@ func (r *CentralReconciler) ensureEncryptionKeySecretExists(ctx context.Context,
 }
 
 func (r *CentralReconciler) populateEncryptionKeySecret(secret *corev1.Secret) error {
-	if secret.Data != nil {
-		if _, ok := secret.Data["encryption-key"]; ok {
+	const encryptionKeyChainFile = "key-chain.yaml"
+
+	if secret.StringData != nil {
+		if _, ok := secret.Data[encryptionKeyChainFile]; ok {
 			// secret already populated with encryption key skip operation
 			return nil
 		}
@@ -1259,8 +1262,29 @@ func (r *CentralReconciler) populateEncryptionKeySecret(secret *corev1.Secret) e
 	}
 
 	b64Key := base64.StdEncoding.EncodeToString(encryptionKey)
-	secret.Data = map[string][]byte{"encryption-key": []byte(b64Key)}
+	keyChainFile, err := generateNewKeyChainFile(b64Key)
+	if err != nil {
+		return err
+	}
+	secret.StringData = map[string]string{encryptionKeyChainFile: keyChainFile}
 	return nil
+}
+
+func generateNewKeyChainFile(b64Key string) (string, error) {
+	keyMap := make(map[int]string)
+	keyMap[0] = b64Key
+
+	keyChain := centralNotifierUtils.KeyChain{
+		KeyMap:         keyMap,
+		ActiveKeyIndex: 0,
+	}
+
+	yamlBytes, err := yaml.Marshal(keyChain)
+	if err != nil {
+		return "", fmt.Errorf("generating key-chain file: %w", err)
+	}
+
+	return string(yamlBytes), nil
 }
 
 func (r *CentralReconciler) getCentralDBConnectionString(ctx context.Context, remoteCentral *private.ManagedCentral) (string, error) {

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -877,10 +877,13 @@ func TestCentralEncryptionKeyIsGenerated(t *testing.T) {
 	key := client.ObjectKey{Namespace: simpleManagedCentral.Metadata.Namespace, Name: centralEncryptionKeySecretName}
 	err = fakeClient.Get(context.TODO(), key, &centralEncryptionSecret)
 	require.NoError(t, err)
-	require.Contains(t, centralEncryptionSecret.StringData, "key-chain.yaml")
+	require.Contains(t, centralEncryptionSecret.Data, "key-chain.yaml")
+
+	keyChainFileContents, err := base64.StdEncoding.DecodeString(string(centralEncryptionSecret.Data["key-chain.yaml"]))
+	require.NoError(t, err)
 
 	var keyChain centralNotifierUtils.KeyChain
-	err = yaml.Unmarshal([]byte(centralEncryptionSecret.StringData["key-chain.yaml"]), &keyChain)
+	err = yaml.Unmarshal(keyChainFileContents, &keyChain)
 	require.NoError(t, err)
 	require.Equal(t, 0, keyChain.ActiveKeyIndex)
 	require.Equal(t, 1, len(keyChain.KeyMap))

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
 	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
 	fmMocks "github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager/mocks"
+	centralNotifierUtils "github.com/stackrox/rox/central/notifiers/utils"
 	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"github.com/stackrox/rox/pkg/utils"
@@ -876,11 +877,17 @@ func TestCentralEncryptionKeyIsGenerated(t *testing.T) {
 	key := client.ObjectKey{Namespace: simpleManagedCentral.Metadata.Namespace, Name: centralEncryptionKeySecretName}
 	err = fakeClient.Get(context.TODO(), key, &centralEncryptionSecret)
 	require.NoError(t, err)
-	require.Contains(t, centralEncryptionSecret.Data, "encryption-key")
+	require.Contains(t, centralEncryptionSecret.StringData, "key-chain.yaml")
 
-	encKey, err := base64.StdEncoding.DecodeString(string(centralEncryptionSecret.Data["encryption-key"]))
+	var keyChain centralNotifierUtils.KeyChain
+	err = yaml.Unmarshal([]byte(centralEncryptionSecret.StringData["key-chain.yaml"]), &keyChain)
 	require.NoError(t, err)
-	expectedKeyLen := len(encKey)
+	require.Equal(t, 0, keyChain.ActiveKeyIndex)
+	require.Equal(t, 1, len(keyChain.KeyMap))
+
+	encKey, err := base64.StdEncoding.DecodeString(keyChain.KeyMap[keyChain.ActiveKeyIndex])
+	require.NoError(t, err)
+	expectedKeyLen := 32 // 256 bits key
 	require.Equal(t, expectedKeyLen, len(encKey))
 }
 

--- a/fleetshard/pkg/k8s/secret.go
+++ b/fleetshard/pkg/k8s/secret.go
@@ -11,9 +11,10 @@ import (
 )
 
 const (
-	CentralTLSSecretName           = "central-tls"            // pragma: allowlist secret
-	centralDBPasswordSecretName    = "central-db-password"    // pragma: allowlist secret
-	centralEncryptionKeySecretName = "central-encryption-key" // pragma: allowlist secret
+	// CentralTLSSecretName is the secret that stores the Central TLS certificate data
+	CentralTLSSecretName           = "central-tls"                  // pragma: allowlist secret
+	centralDBPasswordSecretName    = "central-db-password"          // pragma: allowlist secret
+	centralEncryptionKeySecretName = "central-encryption-key-chain" // pragma: allowlist secret
 )
 
 var defaultSecretsToWatch = []string{


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This PR updates the name and format of the notifier encryption key secret. See the [ROX-21682](https://issues.redhat.com/browse/ROX-21682) for more details.

Note that the old secret is not preserved, because backwards compatibility is not needed. For existing tenants, the old secret will continue to exist in the namespace (but not in the fleet-manager backup), but this shouldn't cause any issues.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

```bash
make deploy/dev
./scripts/create-central.sh

❯ kubectl -n rhacs-cnu4bn0ed75c738999k0 get secret central-encryption-key-chain -o yaml
apiVersion: v1
data:
  key-chain.yaml: a2V5TWFwOgogIDA6IFB3WTVVVXdWYzlsN0tLc1VlVzhoM2pWRERyakdaTWJUdXUyWVVwVUdvU1k9CmFjdGl2ZUtleUluZGV4OiAwCg==
kind: Secret
metadata:
  annotations:
    platform.stackrox.io/managed-services: "true"
  creationTimestamp: "2024-03-21T14:37:19Z"
  labels:
    app.kubernetes.io/managed-by: rhacs-fleetshard
  name: central-encryption-key-chain
  namespace: rhacs-cnu4bn0ed75c738999k0
  resourceVersion: "275715"
  uid: 831a3085-0423-4bcc-a3bd-547f6993812f
type: Opaque

❯ echo a2V5TWFwOgogIDA6IFB3WTVVVXdWYzlsN0tLc1VlVzhoM2pWRERyakdaTWJUdXUyWVVwVUdvU1k9CmFjdGl2ZUtleUluZGV4OiAwCg== | base64 --decode
keyMap:
  0: PwY5UUwVc9l7KKsUeW8h3jVDDrjGZMbTuu2YUpUGoSY=
activeKeyIndex: 0
```

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
Additional tests will be run in the `integration` environment after this PR is merged.