### PR TITLE
ROX-21682: remove double base64 encoding

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -1266,8 +1266,7 @@ func (r *CentralReconciler) populateEncryptionKeySecret(secret *corev1.Secret) e
 	if err != nil {
 		return err
 	}
-	b64KeyChainFile := base64.StdEncoding.EncodeToString(keyChainFile)
-	secret.Data = map[string][]byte{encryptionKeyChainFile: []byte(b64KeyChainFile)}
+	secret.Data = map[string][]byte{encryptionKeyChainFile: keyChainFile}
 	return nil
 }
 

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -879,11 +879,8 @@ func TestCentralEncryptionKeyIsGenerated(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, centralEncryptionSecret.Data, "key-chain.yaml")
 
-	keyChainFileContents, err := base64.StdEncoding.DecodeString(string(centralEncryptionSecret.Data["key-chain.yaml"]))
-	require.NoError(t, err)
-
 	var keyChain centralNotifierUtils.KeyChain
-	err = yaml.Unmarshal(keyChainFileContents, &keyChain)
+	err = yaml.Unmarshal(centralEncryptionSecret.Data["key-chain.yaml"], &keyChain)
 	require.NoError(t, err)
 	require.Equal(t, 0, keyChain.ActiveKeyIndex)
 	require.Equal(t, 1, len(keyChain.KeyMap))


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

`populateEncryptionKeySecret` was base64-encoding the `key-chain.yaml` file twice. 

`k8s` is already base64-encoding Data fields of secrets, so by doing a base64 encode I was effectively encoding the contents of the file twice. Then Central cannot parse the secret. This PR fixes this.


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

```bash
make deploy/dev
./scripts/create-central.sh

❯ kubectl -n rhacs-co1bmsl75klc73alldc0 get secret central-encryption-key-chain -o yaml
apiVersion: v1
data:
  key-chain.yaml: a2V5TWFwOgogIDA6IGVPcUFRSXNrWVBwQndoWS9hN3FxRytyRDdXQ2lYV1pJZmZ6VFJJcWRITjg9CmFjdGl2ZUtleUluZGV4OiAwCg==
kind: Secret
metadata:
  annotations:
    platform.stackrox.io/managed-services: "true"
  creationTimestamp: "2024-03-26T12:13:04Z"
  labels:
    app.kubernetes.io/managed-by: rhacs-fleetshard
  name: central-encryption-key-chain
  namespace: rhacs-co1bmsl75klc73alldc0
  resourceVersion: "306002"
  uid: 08806669-b8c7-4e0c-b5ff-0ff775a2412a
type: Opaque

❯ echo a2V5TWFwOgogIDA6IGVPcUFRSXNrWVBwQndoWS9hN3FxRytyRDdXQ2lYV1pJZmZ6VFJJcWRITjg9CmFjdGl2ZUtleUluZGV4OiAwCg== | base64 --decode
keyMap:
  0: eOqAQIskYPpBwhY/a7qqG+rD7WCiXWZIffzTRIqdHN8=
activeKeyIndex: 0
```

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
