### PR TITLE
fix: consider zero-cost resources allowed

### DIFF
--- a/internal/dinosaur/pkg/services/quota/ams_quota_service.go
+++ b/internal/dinosaur/pkg/services/quota/ams_quota_service.go
@@ -246,11 +246,12 @@ func mapAllowedQuotaCosts(quotaCosts []*amsv1.QuotaCost) (map[amsv1.BillingModel
 	costsMap := make(map[amsv1.BillingModel][]*amsv1.QuotaCost)
 	var foundUnsupportedBillingModels []string
 	for _, qc := range quotaCosts {
-		// When an SKU entitlement expires in AMS, the allowed value for that quota cost is set back to 0.
-		if qc.Allowed() == 0 {
-			continue
-		}
 		for _, rr := range qc.RelatedResources() {
+			// When an SKU entitlement expires in AMS, the allowed value for that quota cost is set back to 0.
+			// Ignore allowance for zero-cost resources.
+			if qc.Allowed() == 0 && rr.Cost() != 0 {
+				continue
+			}
 			bm := amsv1.BillingModel(rr.BillingModel())
 			if _, isCompatibleBillingModel := supportedAMSBillingModels[rr.BillingModel()]; isCompatibleBillingModel {
 				costsMap[bm] = append(costsMap[bm], qc)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

RHACSTrial quota_cost may have zero allowance, but we still allow provisioning due to zero-cost. This PR makes the `HasQuotaAllowance` method consistent with the `ReserveQuota` logic.

The tests are also corrected for related resources not having `marketplace-aws`, but `marketplace` billing model _type_.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

Not manual. Unit tests.
