### PR TITLE
ROX-23370: add requests and limits to FM initContainer

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -862,6 +862,13 @@ objects:
             - --enable-db-debug=${ENABLE_DB_DEBUG}
             - --alsologtostderr
             - -v=${GLOG_V}
+            resources:
+              requests:
+                cpu: ${CPU_REQUEST}
+                memory: ${MEMORY_REQUEST}
+              limits:
+                cpu: ${CPU_LIMIT}
+                memory: ${MEMORY_LIMIT}
           containers:
           - name: service
             image: ${REPO_DIGEST}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This PR adds requests and limits to the initContainer of fleet-manager.

The initContainer executes `fleet-manager migrate`, which is why I decided to re-use the same requests and limits that we use for the `fleet-manager` container itself (which executes `fleet-manager serve`).

It's not possible to see on Prometheus the actual memory & CPU usage of the init container in production, probably because the process is too short lived and it's not getting scraped. To get an estimation of its usage, I ran this locally:
```bash
❯ /usr/bin/time -l -h -p ./fleet-manager migrate
I0408 15:37:43.709514   26957 cmd.go:20] Migration starting
I0408 15:37:43.873693   26957 202212150000_add_organisation_name.go:67] added column "OrganisationName" in schema migration "202212150000"
I0408 15:37:43.879213   26957 202301301200_add_internal_to_central_request.go:69] Successfully added the Internal column
I0408 15:37:43.892965   26957 202303220000_drop_skip_scheduling_from_clusters.go:32] Successfully removed the SkipScheduling column
I0408 15:37:43.899766   26957 202303230000_add_schedulable_to_clusters.go:32] Successfully added the Schedulable column
I0408 15:37:43.906613   26957 202304200000_add_force_reconcile_to_central_request.go:27] Successfully added the ForceReconcile column
I0408 15:37:43.992760   26957 cmd.go:23] Database has 27 migrations applied
real 0.35
user 0.08
sys 0.03
            70582272  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
                5100  page reclaims
                   0  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                 547  messages sent
                 546  messages received
                 102  signals received
                  66  voluntary context switches
                6305  involuntary context switches
           636463809  instructions retired
           316147130  cycles elapsed
            35587776  peak memory footprint
```

The maximum resident set was ~70MiB. This should work well with the current memory requests / limits of 512Mi / 1024Mi.

I also looked at the CPU usage, which peaked at 80%. This should also work well with the current CPU requests / limits of 200m / 1.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
