### PR TITLE
ROX-16615: Add probe metrics endpoint

### DIFF
--- a/templates/probe-template.yml
+++ b/templates/probe-template.yml
@@ -86,3 +86,19 @@ objects:
                   cpu: ${CPU_LIMITS}
                   memory: ${MEMORY_LIMITS}
           terminationGracePeriodSeconds: 300
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      name: probe-metrics
+      labels:
+        app: probe
+        port: monitoring
+      annotations:
+        description: Exposes and load balances the probe pods metrics endpoint
+    spec:
+      selector:
+        app: probe
+      ports:
+        - port: 7070
+          targetPort: 7070
+          name: monitoring


### PR DESCRIPTION
## Description
Add a probe metric endpoint (Service) so that metrics can be scraped by Prometheus

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
