### PR TITLE
fix: always build images in github actions on main and stage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,18 +5,6 @@ on:
     branches:
       - main
       - stage
-    paths-ignore:
-      - '*.md'
-      - '*.sh'
-      - '.github/*.md'
-      - '.github/workflows/openapi_update.yaml'
-      - '.github/CODEOWNERS'
-      - 'templates/**'
-      - '.openapi-generator-ignore'
-      - 'openapi/**'
-      - 'docs/**'
-      - 'pkg/api/openapi/docs/**'
-      - 'pkg/api/openapi/.openapi-generator-ignore'
 
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

We don't build addon operator images, if PR merged to main/stage only contained changes in certain directory.

This leads to the addon operator CD to be broken on integration if the latest commit to main was not a change that triggers the image build job.

With this PR we remove those ignores to make sure addon operator images are always build.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
