### PR TITLE
ROX-23251: Add local deployment for email sender service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,15 @@ PROBE_NAMESPACE = rhacs-probe
 IMAGE_NAME = fleet-manager
 PROBE_IMAGE_NAME = probe
 IMAGE_TARGET = standard
+EMAIL_SENDER_IMAGE = email-sender
 
 SHORT_IMAGE_REF = "$(IMAGE_NAME):$(image_tag)"
 PROBE_SHORT_IMAGE_REF = "$(PROBE_IMAGE_NAME):$(image_tag)"
+EMAIL_SENDER_SHORT_IMAGE_REF = "$(EMAIL_SENDER_IMAGE):$(image_tag)"
 
 image_repository:=$(IMAGE_NAME)
 probe_image_repository:=$(PROBE_IMAGE_NAME)
+email_sender_image_repository:=$(EMAIL_SENDER_IMAGE)
 
 # In the development environment we are pushing the image directly to the image
 # registry inside the development cluster. That registry has a different name
@@ -256,7 +259,8 @@ verify: check-gopath openapi/validate
 		./internal/... \
 		./test/... \
 		./fleetshard/... \
-		./probe/...
+		./probe/... \
+		./emailsender/...
 .PHONY: verify
 
 # Runs linter against go files and .y(a)ml files in the templates directory
@@ -290,11 +294,15 @@ acsfleetctl:
 	GOOS="$(GOOS)" GOARCH="$(GOARCH)" CGO_ENABLED=0  $(GO) build $(GOARGS) -o acsfleetctl ./cmd/acsfleetctl
 .PHONY: acsfleetctl
 
-binary: fleet-manager fleetshard-sync probe acsfleetctl
+email-sender:
+	GOOS="$(GOOS)" GOARCH="$(GOARCH)" CGO_ENABLED=0  $(GO) build $(GOARGS) -o emailsender/bin/email-sender ./emailsender/cmd/app
+.PHONY: email-sender
+
+binary: fleet-manager fleetshard-sync probe acsfleetctl email-sender
 .PHONY: binary
 
 clean:
-	rm -f fleet-manager fleetshard-sync probe/bin/probe
+	rm -f fleet-manager fleetshard-sync probe/bin/probe emailsender/bin/email-sender
 .PHONY: clean
 
 # Runs the unit tests.
@@ -534,6 +542,20 @@ image/push/fleet-manager-tools: image/build/fleet-manager-tools
 	@echo
 	@echo "Image fleet-manager-tools was pushed as $(IMAGE_REF)."
 .PHONY: image/push/fleet-manager-tools
+
+image/build/email-sender: GOOS=linux
+image/build/email-sender: IMAGE_REF="$(external_image_registry)/$(email_sender_image_repository):$(image_tag)"
+image/build/email-sender:
+	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) build -t $(IMAGE_REF) -f emailsender/Dockerfile .
+	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) tag $(IMAGE_REF) $(EMAIL_SENDER_SHORT_IMAGE_REF)
+.PHONY: image/build/email-sender
+
+image/push/email-sender: IMAGE_REF="$(external_image_registry)/$(email_sender_image_repository):$(image_tag)"
+image/push/email-sender: image/build/email-sender
+	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) push $(IMAGE_REF)
+	@echo
+	@echo "Email sender image was pushed as $(IMAGE_REF)."
+.PHONY: image/push/email-sender
 
 # Build and push the image
 image/push: image/push/fleet-manager image/push/probe

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ PROBE_NAMESPACE = rhacs-probe
 IMAGE_NAME = fleet-manager
 PROBE_IMAGE_NAME = probe
 IMAGE_TARGET = standard
-EMAIL_SENDER_IMAGE = email-sender
+EMAIL_SENDER_IMAGE = emailsender
 
 SHORT_IMAGE_REF = "$(IMAGE_NAME):$(image_tag)"
 PROBE_SHORT_IMAGE_REF = "$(PROBE_IMAGE_NAME):$(image_tag)"
@@ -294,9 +294,9 @@ acsfleetctl:
 	GOOS="$(GOOS)" GOARCH="$(GOARCH)" CGO_ENABLED=0  $(GO) build $(GOARGS) -o acsfleetctl ./cmd/acsfleetctl
 .PHONY: acsfleetctl
 
-email-sender:
-	GOOS="$(GOOS)" GOARCH="$(GOARCH)" CGO_ENABLED=0  $(GO) build $(GOARGS) -o emailsender/bin/email-sender ./emailsender/cmd/app
-.PHONY: email-sender
+emailsender:
+	GOOS="$(GOOS)" GOARCH="$(GOARCH)" CGO_ENABLED=0  $(GO) build $(GOARGS) -o emailsender/bin/emailsender ./emailsender/cmd/app
+.PHONY: emailsender
 
 binary: fleet-manager fleetshard-sync probe acsfleetctl email-sender
 .PHONY: binary

--- a/Makefile
+++ b/Makefile
@@ -298,11 +298,11 @@ emailsender:
 	GOOS="$(GOOS)" GOARCH="$(GOARCH)" CGO_ENABLED=0  $(GO) build $(GOARGS) -o emailsender/bin/emailsender ./emailsender/cmd/app
 .PHONY: emailsender
 
-binary: fleet-manager fleetshard-sync probe acsfleetctl email-sender
+binary: fleet-manager fleetshard-sync probe acsfleetctl emailsender
 .PHONY: binary
 
 clean:
-	rm -f fleet-manager fleetshard-sync probe/bin/probe emailsender/bin/email-sender
+	rm -f fleet-manager fleetshard-sync probe/bin/probe emailsender/bin/emailsender
 .PHONY: clean
 
 # Runs the unit tests.
@@ -543,19 +543,19 @@ image/push/fleet-manager-tools: image/build/fleet-manager-tools
 	@echo "Image fleet-manager-tools was pushed as $(IMAGE_REF)."
 .PHONY: image/push/fleet-manager-tools
 
-image/build/email-sender: GOOS=linux
-image/build/email-sender: IMAGE_REF="$(external_image_registry)/$(email_sender_image_repository):$(image_tag)"
-image/build/email-sender:
+image/build/emailsender: GOOS=linux
+image/build/emailsender: IMAGE_REF="$(external_image_registry)/$(email_sender_image_repository):$(image_tag)"
+image/build/emailsender:
 	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) build -t $(IMAGE_REF) -f emailsender/Dockerfile .
 	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) tag $(IMAGE_REF) $(EMAIL_SENDER_SHORT_IMAGE_REF)
-.PHONY: image/build/email-sender
+.PHONY: image/build/emailsender
 
-image/push/email-sender: IMAGE_REF="$(external_image_registry)/$(email_sender_image_repository):$(image_tag)"
-image/push/email-sender: image/build/email-sender
+image/push/emailsender: IMAGE_REF="$(external_image_registry)/$(email_sender_image_repository):$(image_tag)"
+image/push/emailsender: image/build/emailsender
 	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) push $(IMAGE_REF)
 	@echo
 	@echo "Email sender image was pushed as $(IMAGE_REF)."
-.PHONY: image/push/email-sender
+.PHONY: image/push/emailsender
 
 # Build and push the image
 image/push: image/push/fleet-manager image/push/probe

--- a/Makefile
+++ b/Makefile
@@ -28,15 +28,15 @@ PROBE_NAMESPACE = rhacs-probe
 IMAGE_NAME = fleet-manager
 PROBE_IMAGE_NAME = probe
 IMAGE_TARGET = standard
-EMAIL_SENDER_IMAGE = emailsender
+EMAILSENDER_IMAGE = emailsender
 
 SHORT_IMAGE_REF = "$(IMAGE_NAME):$(image_tag)"
 PROBE_SHORT_IMAGE_REF = "$(PROBE_IMAGE_NAME):$(image_tag)"
-EMAIL_SENDER_SHORT_IMAGE_REF = "$(EMAIL_SENDER_IMAGE):$(image_tag)"
+EMAILSENDER_SHORT_IMAGE_REF = "$(EMAILSENDER_IMAGE):$(image_tag)"
 
 image_repository:=$(IMAGE_NAME)
 probe_image_repository:=$(PROBE_IMAGE_NAME)
-email_sender_image_repository:=$(EMAIL_SENDER_IMAGE)
+emailsender_image_repository:=$(EMAILSENDER_IMAGE)
 
 # In the development environment we are pushing the image directly to the image
 # registry inside the development cluster. That registry has a different name
@@ -547,14 +547,14 @@ image/build/emailsender: GOOS=linux
 image/build/emailsender: IMAGE_REF="$(external_image_registry)/$(email_sender_image_repository):$(image_tag)"
 image/build/emailsender:
 	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) build -t $(IMAGE_REF) -f emailsender/Dockerfile .
-	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) tag $(IMAGE_REF) $(EMAIL_SENDER_SHORT_IMAGE_REF)
+	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) tag $(IMAGE_REF) $(EMAILSENDER_SHORT_IMAGE_REF)
 .PHONY: image/build/emailsender
 
-image/push/emailsender: IMAGE_REF="$(external_image_registry)/$(email_sender_image_repository):$(image_tag)"
+image/push/emailsender: IMAGE_REF="$(external_image_registry)/$(emailsender_image_repository):$(image_tag)"
 image/push/emailsender: image/build/emailsender
 	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) push $(IMAGE_REF)
 	@echo
-	@echo "Email sender image was pushed as $(IMAGE_REF)."
+	@echo "emailsender image was pushed as $(IMAGE_REF)."
 .PHONY: image/push/emailsender
 
 # Build and push the image

--- a/emailsender/Dockerfile
+++ b/emailsender/Dockerfile
@@ -1,0 +1,29 @@
+FROM registry.access.redhat.com/ubi8/go-toolset:1.20 AS build
+USER root
+ENV GOFLAGS="-mod=mod"
+
+RUN mkdir /src
+WORKDIR /src
+RUN CGO_ENABLED=0 go install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@v1.20.1
+COPY go.*  ./
+RUN go mod download
+COPY . ./
+
+RUN make email-sender
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9 as standard
+
+RUN microdnf install shadow-utils
+
+RUN useradd -u 1001 unprivilegeduser
+# Switch to non-root user
+USER unprivilegeduser
+
+COPY --from=build /src/emailsender/bin /acscs/
+EXPOSE 8000
+ENTRYPOINT ["/acscs/email-sender"]
+LABEL name="ACSCS email sender" \
+	vendor="Red Hat" \
+	version="0.0.1" \
+	summary="Email sender service for ACSCS" \
+	description="Email sender service for the Red Hat Advanced Cluster Security Cloud Services"

--- a/emailsender/Dockerfile
+++ b/emailsender/Dockerfile
@@ -4,7 +4,6 @@ ENV GOFLAGS="-mod=mod"
 
 RUN mkdir /src
 WORKDIR /src
-RUN CGO_ENABLED=0 go install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@v1.20.1
 COPY go.*  ./
 RUN go mod download
 COPY . ./
@@ -21,7 +20,7 @@ USER unprivilegeduser
 
 COPY --from=build /src/emailsender/bin /acscs/
 EXPOSE 8080
-ENTRYPOINT ["/acscs/email-sender"]
+ENTRYPOINT ["/acscs/emailsender"]
 LABEL name="ACSCS email sender" \
 	vendor="Red Hat" \
 	version="0.0.1" \

--- a/emailsender/Dockerfile
+++ b/emailsender/Dockerfile
@@ -9,7 +9,7 @@ COPY go.*  ./
 RUN go mod download
 COPY . ./
 
-RUN make email-sender
+RUN make emailsender
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9 as standard
 
@@ -20,7 +20,7 @@ RUN useradd -u 1001 unprivilegeduser
 USER unprivilegeduser
 
 COPY --from=build /src/emailsender/bin /acscs/
-EXPOSE 8000
+EXPOSE 8080
 ENTRYPOINT ["/acscs/email-sender"]
 LABEL name="ACSCS email sender" \
 	vendor="Red Hat" \

--- a/emailsender/cmd/app/main.go
+++ b/emailsender/cmd/app/main.go
@@ -69,6 +69,14 @@ func main() {
 		}
 	}()
 
+	metricServer := metrics.NewMetricsServer(cfg)
+	go func() {
+		glog.Info("Creating metrics server...")
+		if err := metricServer.ListenAndServe(); err != nil {
+			glog.Errorf("serving metrics server error: %v", err)
+		}
+	}()
+
 	sigs := make(chan os.Signal, 1)
 	notifySignals := []os.Signal{os.Interrupt, unix.SIGTERM}
 	signal.Notify(sigs, notifySignals...)

--- a/emailsender/cmd/app/main.go
+++ b/emailsender/cmd/app/main.go
@@ -69,14 +69,6 @@ func main() {
 		}
 	}()
 
-	metricServer := metrics.NewMetricsServer(cfg)
-	go func() {
-		glog.Info("Creating metrics server...")
-		if err := metricServer.ListenAndServe(); err != nil {
-			glog.Errorf("serving metrics server error: %v", err)
-		}
-	}()
-
 	sigs := make(chan os.Signal, 1)
 	notifySignals := []os.Signal{os.Interrupt, unix.SIGTERM}
 	signal.Notify(sigs, notifySignals...)

--- a/emailsender/config/config_test.go
+++ b/emailsender/config/config_test.go
@@ -23,6 +23,7 @@ func TestGetConfigSuccess(t *testing.T) {
 	assert.Equal(t, cfg.EnableHTTPS, true)
 	assert.Equal(t, cfg.HTTPSCertFile, "/some/tls.crt")
 	assert.Equal(t, cfg.HTTPSKeyFile, "/some/tls.key")
+	assert.Equal(t, cfg.MetricsAddress, ":9999")
 }
 
 func TestGetConfigFailureMissingClusterID(t *testing.T) {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Add local building for Email service

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~- [ ] Unit and integration tests added~
- [x] Added test description under `Test manual`
~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~
~- [ ] Add secret to app-interface Vault or Secrets Manager if necessary~
~- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~
~- [ ] Check AWS limits are reasonable for changes provisioning new resources~
~- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment~

## Test manual

```
make email-sender
...
make image/build/email-sender
docker run --rm -it -e CLUSTER_ID=test quay.io/rhacs-eng/email-sender:9cdc064
....
```
