### PR TITLE
ROX-23559: Export Violation Denial Metrics

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/templates/01-operator-03-config-map.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/templates/01-operator-03-config-map.yaml
@@ -51,3 +51,16 @@ data:
             - name: Bounce
             - name: Reputation.BounceRate
             - name: Reputation.ComplaintRate
+    static:
+      - name: selinux_avc_denials
+        namespace: SELinux
+        regions:
+          - eu-west-1
+          - us-east-1
+        metrics:
+          - name: AVCDenial
+            nilToZero: true
+            statistics:
+              - SampleCount
+            period: 300
+            length: 300

--- a/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/templates/01-operator-03-config-map.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/templates/01-operator-03-config-map.yaml
@@ -58,7 +58,19 @@ data:
           - eu-west-1
           - us-east-1
         metrics:
-          - name: AVCDenial
+          - name: AVCDenials
+            nilToZero: true
+            statistics:
+              - SampleCount
+            period: 300
+            length: 300
+      - name: network_policy_acl_denials
+        namespace: NetworkPolicy
+        regions:
+          - eu-west-1
+          - us-east-1
+        metrics:
+          - name: ACLDenials
             nilToZero: true
             statistics:
               - SampleCount

--- a/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/templates/01-operator-03-config-map.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/templates/01-operator-03-config-map.yaml
@@ -53,24 +53,24 @@ data:
             - name: Reputation.ComplaintRate
     static:
       - name: selinux_avc_denials
-        namespace: SELinux
+        namespace: "{{ .Values.clusterName }}"
         regions:
           - eu-west-1
           - us-east-1
         metrics:
-          - name: AVCDenials
+          - name: SELinuxDenials
             nilToZero: true
             statistics:
               - SampleCount
             period: 300
             length: 300
       - name: network_policy_acl_denials
-        namespace: NetworkPolicy
+        namespace: "{{ .Values.clusterName }}"
         regions:
           - eu-west-1
           - us-east-1
         metrics:
-          - name: ACLDenials
+          - name: NetworkPolicyDenials
             nilToZero: true
             statistics:
               - SampleCount


### PR DESCRIPTION
## Description

This PR adds settings for the cloudwatch exporter to also export our custom violation denials metrics. This includes the metric for SELinux AVC denials and the metric for NetworkPolicy ACL denials.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
