### PR TITLE
 ROX-23557: Add annotation for ACL Logging to tenant namespaces

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -61,6 +61,9 @@ const (
 	clusterNameAnnotationKey  = "rhacs.redhat.com/cluster-name"
 	orgNameAnnotationKey      = "rhacs.redhat.com/org-name"
 
+	ovnACLLoggingAnnotationKey     = "k8s.ovn.org/acl-logging"
+	ovnACLLoggingAnnotationDefault = "{\"deny\": \"warning\"}"
+
 	labelManagedByFleetshardValue = "rhacs-fleetshard"
 	instanceLabelKey              = "app.kubernetes.io/instance"
 	instanceTypeLabelKey          = "rhacs.redhat.com/instance-type"
@@ -1716,6 +1719,7 @@ func getNamespaceAnnotations(c private.ManagedCentral) map[string]string {
 	if c.Metadata.ExpiredAt != nil {
 		namespaceAnnotations[centralExpiredAtKey] = c.Metadata.ExpiredAt.Format(time.RFC3339)
 	}
+	namespaceAnnotations[ovnACLLoggingAnnotationKey] = ovnACLLoggingAnnotationDefault
 	return namespaceAnnotations
 }
 

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -801,6 +801,23 @@ func TestNamespaceLabelsAreSet(t *testing.T) {
 	assert.Equal(t, simpleManagedCentral.Spec.Auth.OwnerOrgId, namespace.GetLabels()[orgIDLabelKey])
 }
 
+func TestNamespaceAnnotationsAreSet(t *testing.T) {
+	fakeClient, _, r := getClientTrackerAndReconciler(
+		t,
+		defaultCentralConfig,
+		nil,
+		useRoutesReconcilerOptions,
+	)
+
+	_, err := r.Reconcile(context.TODO(), simpleManagedCentral)
+	require.NoError(t, err)
+
+	namespace := &v1.Namespace{}
+	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralNamespace}, namespace)
+	require.NoError(t, err)
+	assert.Equal(t, ovnACLLoggingAnnotationDefault, namespace.GetAnnotations()[ovnACLLoggingAnnotationKey])
+}
+
 func TestReportRoutesStatuses(t *testing.T) {
 	_, _, r := getClientTrackerAndReconciler(
 		t,
@@ -2312,6 +2329,7 @@ func TestReconciler_reconcileNamespace(t *testing.T) {
 					},
 					Annotations: map[string]string{
 						"rhacs.redhat.com/org-name": "org-name",
+						ovnACLLoggingAnnotationKey:  ovnACLLoggingAnnotationDefault,
 					},
 				},
 			},
@@ -2331,6 +2349,7 @@ func TestReconciler_reconcileNamespace(t *testing.T) {
 					},
 					Annotations: map[string]string{
 						"rhacs.redhat.com/org-name": "wrong",
+						ovnACLLoggingAnnotationKey:  "{\"allow\": \"wrong\"}",
 					},
 				},
 			},
@@ -2346,6 +2365,7 @@ func TestReconciler_reconcileNamespace(t *testing.T) {
 					},
 					Annotations: map[string]string{
 						"rhacs.redhat.com/org-name": "org-name",
+						ovnACLLoggingAnnotationKey:  ovnACLLoggingAnnotationDefault,
 					},
 				},
 			},
@@ -2365,6 +2385,7 @@ func TestReconciler_reconcileNamespace(t *testing.T) {
 					},
 					Annotations: map[string]string{
 						"rhacs.redhat.com/org-name": "org-name",
+						ovnACLLoggingAnnotationKey:  ovnACLLoggingAnnotationDefault,
 						"extra":                     "extra",
 					},
 				},
@@ -2382,6 +2403,7 @@ func TestReconciler_reconcileNamespace(t *testing.T) {
 					},
 					Annotations: map[string]string{
 						"rhacs.redhat.com/org-name": "org-name",
+						ovnACLLoggingAnnotationKey:  ovnACLLoggingAnnotationDefault,
 						"extra":                     "extra",
 					},
 				},
@@ -2401,6 +2423,7 @@ func TestReconciler_reconcileNamespace(t *testing.T) {
 					},
 					Annotations: map[string]string{
 						"rhacs.redhat.com/org-name": "org-name",
+						ovnACLLoggingAnnotationKey:  ovnACLLoggingAnnotationDefault,
 					},
 				},
 			},
@@ -2416,6 +2439,7 @@ func TestReconciler_reconcileNamespace(t *testing.T) {
 					},
 					Annotations: map[string]string{
 						"rhacs.redhat.com/org-name": "org-name",
+						ovnACLLoggingAnnotationKey:  ovnACLLoggingAnnotationDefault,
 					},
 				},
 			},


### PR DESCRIPTION
## Description

For [ROX-23557](https://issues.redhat.com/browse/ROX-23557) we need to make sure that all namespaces for which NetworkPolicy denial logging is desired carry a certain annotation. This PR introduces this annotation for tenant namespaces.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [x] ~~Documentation added if necessary~~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [x] ~~Add secret to app-interface Vault or Secrets Manager if necessary~~
- [x] ~~RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
- [x] ~~Check AWS limits are reasonable for changes provisioning new resources~~
- [x] ~~(If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment~~

## Test manual

I haven't conducted manual tests. CI e2e tests + unit tests should be good.
