### PR TITLE
ROX-23551: Add EgressFirewall to Tenant Helm chart

### DIFF
--- a/fleetshard/pkg/central/charts/data/tenant-resources/config/local-network-cidr-ranges.yaml.tpl
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/config/local-network-cidr-ranges.yaml.tpl
@@ -1,0 +1,8 @@
+- 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
+- 10.0.0.0/8		    # RFC 1918 local private network (LAN)
+- 100.64.0.0/10		    # RFC 6598 shared address space (CGN)
+- 169.254.0.0/16 	    # RFC 3927 link-local (directly plugged) machines
+- 172.16.0.0/12		    # RFC 1918 local private network (LAN)
+- 192.168.0.0/16		# RFC 1918 local private network (LAN)
+- fc00::/7       	    # RFC 4193 local private network range
+- fe80::/10      	    # RFC 4291 link-local (directly plugged) machines

--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/_helpers.tpl
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/_helpers.tpl
@@ -9,3 +9,7 @@
 {{- $annotations = merge (deepCopy .Values.annotations) $annotations -}}
 {{- $annotations | toYaml | nindent 0 }}
 {{- end -}}
+
+{{- define "localNetworkCidrRanges" -}}
+{{- tpl (.Files.Get "config/local-network-cidr-ranges.yaml.tpl") . -}}
+{{- end -}}

--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/network-policy.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/network-policy.yaml
@@ -1,0 +1,154 @@
+# If zero NetworkPolicy's exist for Ingress or Egress, then all traffic is by
+# default *allowed*. By explicitly creating an *empty* policy for Ingress and
+# Egress targeting all pods in the namespace, we are saying "deny all traffic
+# unless another NetworkPolicy allows it".
+# Following https://docs.openshift.com/container-platform/4.14/networking/network_policy/about-network-policy.html#nw-networkpolicy-optimize-ovn_about-network-policy
+# also combine the deny-all with allow-dns policies.
+# Note that OpenShift has two: (internal) DNS and ExternalDNS.
+# TODO: Double check this allows KubeDNS, OpenShift Internal DNS, OpenShift External DNS
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all-except-dns
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    {{- include "annotations" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress: []
+  egress:
+  - to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - port: 53
+      protocol: UDP
+---
+# Source: https://docs.openshift.com/container-platform/4.13/networking/network_policy/about-network-policy.html#nw-networkpolicy-allow-from-router_about-network-policy
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tenant-central
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    {{- include "annotations" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: central
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:  # Allow ingress from external Internet to use Central
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+    ports:
+    - port: 8443
+      protocol: TCP
+  - from:  # Allow ingress from observability to scrape metrics
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: rhacs-observability
+    ports:
+    - port: 9090
+      protocol: TCP
+    - port: 9091
+      protocol: TCP
+  egress:
+  - to:  # Allow egress to RDS subnet, EgressFirewall will limit to its specific instance because the IP address is not static and EgressFirewall can do DNS resolution
+    - ipBlock:
+        cidr: 10.1.0.0/16
+    ports:
+      - port: 5432
+        protocol: TCP
+  - to:  # Allow egress to Scanner
+    - podSelector:
+        matchLabels:
+          app: scanner
+    ports:
+    - port: 8080
+      protocol: TCP
+    - port: 8443
+      protocol: TCP
+  - to:  # Allow egress to external Internet
+    - ipBlock:
+        cidr: 0.0.0.0/0
+      except:
+        {{- include "localNetworkCidrRanges" . | nindent 8 }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tenant-scanner
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    {{- include "annotations" . | nindent 4 }}
+spec:
+  podSelector: 
+    matchLabels:
+      app: scanner
+  ingress:
+  - from:  # Allow ingress from Central to use Scanner
+    - podSelector:
+        matchLabels:
+          app: central
+    ports:
+    - port: 8080
+      protocol: TCP
+    - port: 8443
+      protocol: TCP
+  - from:  # Allow ingress from observability to scrape metrics
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: rhacs-observability
+    ports:
+    - port: 9090
+      protocol: TCP
+    - port: 9091
+      protocol: TCP
+  egress:
+  - to:  # Allow egress to Scanner-db
+    - podSelector:
+        matchLabels:
+          app: scanner-db
+    ports:
+    - port: 5432
+      protocol: TCP
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tenant-scanner-db
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    {{- include "annotations" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: scanner-db
+  ingress:
+  - from:  # Allow ingress from scanner to use scanner-db
+    - podSelector:
+        matchLabels:
+          app: scanner
+    ports:
+    - port: 5432
+      protocol: TCP
+  policyTypes:
+  - Ingress


### PR DESCRIPTION
## Description
Add EgressFirewall to the Fleetshard Sync Tenant Helm chart.

This restricts the Central's RDS access to only its instance.

Document discussing the changes: https://docs.google.com/document/d/15-rlsU_wDsv6TX_2hKHNFir82W1T9Ov1SOnRSha1VUY/edit

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
