### PR TITLE
fix: Remove eu-west-1 regions for cloudwatch exporter

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/templates/01-operator-03-config-map.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/templates/01-operator-03-config-map.yaml
@@ -55,7 +55,6 @@ data:
       - name: selinux_avc_denials
         namespace: "{{ .Values.clusterName }}"
         regions:
-          - eu-west-1
           - us-east-1
         metrics:
           - name: SELinuxDenials
@@ -67,7 +66,6 @@ data:
       - name: network_policy_acl_denials
         namespace: "{{ .Values.clusterName }}"
         regions:
-          - eu-west-1
           - us-east-1
         metrics:
           - name: NetworkPolicyDenials


### PR DESCRIPTION
## Description

Part of [ROX-22148](https://issues.redhat.com/browse/ROX-22148).
Since the cloudwatch resources are only located in us-east-1, we don't need to scrape for other regions within the cloudwatch exporter.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
