### PR TITLE
feat: enable scanner-v4 monitoring

### DIFF
--- a/internal/dinosaur/pkg/gitops/default_central.yaml
+++ b/internal/dinosaur/pkg/gitops/default_central.yaml
@@ -55,6 +55,9 @@ spec:
           memory: 2Gi
     monitoring:
       exposeEndpoint: Enabled
+  scannerV4:
+    monitoring:
+      exposeEndpoint: Enabled
   monitoring:
     openshift:
       enabled:  {{ not .IsInternal }}

--- a/internal/dinosaur/pkg/gitops/default_central_test.go
+++ b/internal/dinosaur/pkg/gitops/default_central_test.go
@@ -98,6 +98,11 @@ func wantCentralForDummyParams(p *CentralParams) *v1alpha1.Central {
 					ExposeEndpoint: &exposeEndpointEnabled,
 				},
 			},
+			ScannerV4: &v1alpha1.ScannerV4Spec{
+				Monitoring: &v1alpha1.Monitoring{
+					ExposeEndpoint: &exposeEndpointEnabled,
+				},
+			},
 			Monitoring: &v1alpha1.GlobalMonitoring{
 				OpenShiftMonitoring: &v1alpha1.OpenShiftMonitoring{
 					Enabled: true,


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Expose scanner http monitoring port for Prometheus metrics. This will allow us to scrape scannerV4 pods.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
