### PR TITLE
ROX 23550: Fix deployment, quote parameter

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -56,7 +56,7 @@ spec:
         - name: EGRESS_PROXY_IMAGE
           value: {{ .Values.fleetshardSync.egressProxy.image | quote }}
         - name: SECURE_TENANT_NETWORK
-          value: {{ .Values.fleetshardSync.secureTenantNetwork }}
+          value: {{ .Values.fleetshardSync.secureTenantNetwork | quote }}
         - name: RHSSO_SERVICE_ACCOUNT_CLIENT_ID
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
The Deployment's `env` schema expects values as strings, even for boolean values. The Go code in the fleetshard-sync will do the conversion from string to bool internally. This quotes the boolean value.

Error:
> release upgrade failed; cannot patch "fleetshard-sync" with kind Deployment:  "" is invalid: patch: Invalid value: "": json: cannot unmarshal bool into Go struct field EnvVar.spec.template.spec.containers.env.value of type string