### PR TITLE
ROX 23550: Fix fleetshard sync to central

### DIFF
--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/network-policy-central.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/network-policy-central.yaml
@@ -31,6 +31,16 @@ spec:
       ports:
         - port: 8443
           protocol: TCP
+    - from: # Allow ingress from fleetshard-sync for "readiness" check on Central - ensuring auth provider exists
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: rhacs
+        - podSelector:
+            matchLabels:
+              app: fleetshard-sync
+      ports:
+        - port: 8443
+          protocol: TCP
     - from:  # Allow ingress from observability to scrape metrics
         - namespaceSelector:
             matchExpressions:


### PR DESCRIPTION
CloudWatch logs show repeated NetworkPolicy denial from 10.128.2.21 to four IPs each running Central pods on port 8443 - we were missing a NetworkPolicy for Fleetshard Sync's "readiness" check on Central's auth provider existing.

Whether this auth provider configuration should exist or not now that it's declarative is debatable. If we remove it, we should remove this NetworkPolicy as well.