### PR TITLE
ROX-22289: Remove kube-rbac-proxy sidecar

### DIFF
--- a/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-deployment.yaml
+++ b/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-deployment.yaml
@@ -38,35 +38,6 @@ spec:
       {{- end }}
       containers:
         - args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --http2-disable
-            - --upstream=http://127.0.0.1:8080/
-            - --logtostderr=true
-            - --v=0
-          env:
-            - name: ROX_OPERATOR_MAIN_REGISTRY
-              value: quay.io/rhacs-eng
-            - name: ROX_OPERATOR_COLLECTOR_REGISTRY
-              value: quay.io/rhacs-eng
-            - name: OPERATOR_CONDITION_NAME
-              value: rhacs-operator.v3.74.0
-          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13
-          imagePullPolicy: IfNotPresent
-          name: kube-rbac-proxy
-          ports:
-            - containerPort: 8443
-              name: https
-              protocol: TCP
-          resources:
-            limits:
-              cpu: {{ ((((.rbac).resources).limits).cpu) | default $.Values.operator.default.rbac.resources.limits.cpu }}
-              memory: {{ ((((.rbac).resources).limits).memory) | default $.Values.operator.default.rbac.resources.limits.memory }}
-            requests:
-              cpu: {{ ((((.rbac).resources).requests).cpu) | default $.Values.operator.default.rbac.resources.requests.cpu }}
-              memory: {{ ((((.rbac).resources).requests).memory) | default $.Values.operator.default.rbac.resources.requests.memory }}
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
-        - args:
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=127.0.0.1:8080
           env:

--- a/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-deployment.yaml
+++ b/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-deployment.yaml
@@ -39,7 +39,7 @@ spec:
       containers:
         - args:
             - --health-probe-bind-address=:8081
-            - --metrics-bind-address=127.0.0.1:8080
+            - --metrics-bind-address=0.0.0.0:8443
           env:
             - name: ENABLE_PROFILING
               value: 'true'
@@ -103,6 +103,9 @@ spec:
           ports:
             - containerPort: 9443
               name: webhook-server
+              protocol: TCP
+            - containerPort: 8443
+              name: https
               protocol: TCP
           readinessProbe:
             failureThreshold: 3

--- a/fleetshard/pkg/central/charts/data/rhacs-operator/values.yaml
+++ b/fleetshard/pkg/central/charts/data/rhacs-operator/values.yaml
@@ -55,4 +55,3 @@ operator:
   #     securedClusterReconcilerEnabled: true
   #
   images: []
-  # TODO: add value for kube-rbac-proxy image

--- a/fleetshard/pkg/central/operator/upgrade_test.go
+++ b/fleetshard/pkg/central/operator/upgrade_test.go
@@ -151,8 +151,8 @@ func TestOperatorUpgradeFreshInstall(t *testing.T) {
 	err = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: ACSOperatorNamespace, Name: operatorDeployment1.Name}, operatorDeployment1)
 	require.NoError(t, err)
 	containers := operatorDeployment1.Spec.Template.Spec.Containers
-	assert.Len(t, containers, 2)
-	managerContainer := containers[1]
+	assert.Len(t, containers, 1)
+	managerContainer := containers[0]
 	assert.Equal(t, managerContainer.Image, operatorImage1)
 }
 
@@ -165,12 +165,12 @@ func TestOperatorUpgradeMultipleVersions(t *testing.T) {
 
 	err = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: ACSOperatorNamespace, Name: operatorDeployment1.Name}, operatorDeployment1)
 	require.NoError(t, err)
-	managerContainer := operatorDeployment1.Spec.Template.Spec.Containers[1]
+	managerContainer := operatorDeployment1.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, managerContainer.Image, operatorImage1)
 
 	err = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: ACSOperatorNamespace, Name: operatorDeployment2.Name}, operatorDeployment2)
 	require.NoError(t, err)
-	managerContainer = operatorDeployment2.Spec.Template.Spec.Containers[1]
+	managerContainer = operatorDeployment2.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, managerContainer.Image, operatorImage2)
 }
 
@@ -187,7 +187,7 @@ func TestOperatorUpgradeImageWithDigest(t *testing.T) {
 
 	err = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: ACSOperatorNamespace, Name: operatorDeployment1.Name}, operatorDeployment1)
 	require.NoError(t, err)
-	managerContainer := operatorDeployment1.Spec.Template.Spec.Containers[1]
+	managerContainer := operatorDeployment1.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, managerContainer.Image, digestedImage)
 }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

The `ose-kube-rbac-proxy` sidecar is no longer used by the ACS operator (as of 4.4.0, see https://github.com/stackrox/stackrox/pull/9808), so ACS CS should also no longer deploy it.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
