### PR TITLE
ROX-24120: Add overlay for collector DaemonSet

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-cr.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-cr.yaml
@@ -105,3 +105,12 @@ spec:
       {{- if .Values.scannerV4.db.nodeSelector }}
       nodeSelector: {{ toYaml .Values.scannerV4.db.nodeSelector | nindent 8 }}
       {{- end }}
+  # TODO(ROX-24119): Once the issue is fixed within the Helm chart we can remove this:
+  overlays:
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      name: collector
+      patches:
+        - path: .spec.template.spec.containers[name:node-inventory].securityContext
+          value: |
+            privileged: true

--- a/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-cr.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-cr.yaml
@@ -111,6 +111,5 @@ spec:
       kind: DaemonSet
       name: collector
       patches:
-        - path: .spec.template.spec.containers[name:node-inventory].securityContext
-          value: |
-            privileged: true
+        - path: spec.template.spec.containers[name:node-inventory].securityContext.privileged
+          value: "true"


### PR DESCRIPTION
## Description

Adds an overlay to the dogfooding CR to prevent scanner SELinux violations for now.

A proper fix in the upstream Helm chart will be done as part of [ROX-24119](https://issues.redhat.com/browse/ROX-24119).

FYI @Maddosaurus 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
