### PR TITLE
ROX-21702: fix error matching logic for central-tls secret not found

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -249,7 +249,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	centralTLSSecretFound := true // pragma: allowlist secret
 	if r.useRoutes {
 		if err := r.ensureRoutesExist(ctx, remoteCentral); err != nil {
-			if errors.Is(err, k8s.ErrCentralTLSSecretNotFound) {
+			if k8s.IsCentralTLSNotFound(err) {
 				centralTLSSecretFound = false // pragma: allowlist secret
 			} else {
 				return nil, errors.Wrap(err, "updating routes")

--- a/fleetshard/pkg/k8s/route.go
+++ b/fleetshard/pkg/k8s/route.go
@@ -35,9 +35,6 @@ const (
 	rateTCPAnnotationKey              = rateLimitConnectionAnnotationKeyRoot + ".rate-tcp"
 )
 
-// ErrCentralTLSSecretNotFound returned when central-tls secret is not found
-var ErrCentralTLSSecretNotFound = errors.New("central-tls secret not found")
-
 // RouteService is responsible for performing read and write operations on the OpenShift Route objects in the cluster.
 // This service is specific to ACS Managed Services and provides methods to work on specific routes.
 type RouteService struct {

--- a/fleetshard/pkg/k8s/secret_test.go
+++ b/fleetshard/pkg/k8s/secret_test.go
@@ -1,0 +1,44 @@
+package k8s
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsCentralTLSNotFound(t *testing.T) {
+
+	tests := map[string]struct {
+		inputErr    error
+		shouldMatch bool
+	}{
+		"match": {
+			inputErr:    &SecretNotFound{SecretName: CentralTLSSecretName}, // pragma: allowlist secret
+			shouldMatch: true,
+		},
+		"wrapped match": {
+			inputErr:    fmt.Errorf("wrapped error: %w", &SecretNotFound{SecretName: CentralTLSSecretName}),
+			shouldMatch: true,
+		},
+		"type does not match": {
+			inputErr:    errors.New("some error"),
+			shouldMatch: false,
+		},
+		"secret name does not match": {
+			inputErr:    &SecretNotFound{SecretName: "test-name"}, // pragma: allowlist secret
+			shouldMatch: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := IsCentralTLSNotFound(tc.inputErr)
+			assert.Equal(t, tc.shouldMatch, actual, "unexpected return value want: %s, got: %s", tc.shouldMatch, actual)
+			if tc.shouldMatch != actual {
+				t.Fail()
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

The check on the expected error when central-tls secret was not yet created before routes get created was broken because the error we checked for was no longer returned. Leading to error logs like:
```
E0111 15:09:47.955154 1 runtime.go:246] Unexpected error occurred rhacs-cmg021tu6lpgt9015g6g/probe-7687b89ff9-kd2jv-4fb9: updating routes: creating reencrypt route for central cmg021tu6lpgt9015g6g: getting central-tls secret for tenant probe-7687b89ff9-kd2jv-4fb9: central-tls secret not found 
```

I've implemented a solution that should now properly check for this error again:

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- ~~[ ] Added test description under `Test manual`~~ -> CI is sufficient
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- ~~[] Add secret to app-interface Vault or Secrets Manager if necessary~~
- ~~[ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
- ~~[ ] Check AWS limits are reasonable for changes provisioning new resources~~
- ~~[ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment~~

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
