### PR TITLE
ROX-24127: tenant resources via gitops

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -304,14 +304,14 @@
         "filename": "internal/dinosaur/pkg/presenters/managedcentral.go",
         "hashed_secret": "f4ac636d63edfd5477df8f25e4f4794c73e91d51",
         "is_verified": false,
-        "line_number": 207
+        "line_number": 208
       },
       {
         "type": "Secret Keyword",
         "filename": "internal/dinosaur/pkg/presenters/managedcentral.go",
         "hashed_secret": "e26735ec1cbf8ad15cb7d1eea4893035f61297aa",
         "is_verified": false,
-        "line_number": 213
+        "line_number": 214
       }
     ],
     "internal/dinosaur/pkg/services/dinosaurservice_moq.go": [
@@ -463,5 +463,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-12T16:55:50Z"
+  "generated_at": "2024-05-08T19:37:20Z"
 }

--- a/dev/config/gitops-config.yaml
+++ b/dev/config/gitops-config.yaml
@@ -11,12 +11,12 @@ tenantResources:
   default: |
     labels:
       app.kubernetes.io/managed-by: rhacs-fleetshard
-      app.kubernetes.io/instance: {{ .Name }}
-      rhacs.redhat.com/org-id: {{ .OrganizationID }}
-      rhacs.redhat.com/tenant: {{ .ID }}
-      rhacs.redhat.com/instance-type: {{ .InstanceType }}
+      app.kubernetes.io/instance: "{{ .Name }}"
+      rhacs.redhat.com/org-id: "{{ .OrganizationID }}"
+      rhacs.redhat.com/tenant: "{{ .ID }}"
+      rhacs.redhat.com/instance-type: "{{ .InstanceType }}"
     annotations:
-      rhacs.redhat.com/org-name: {{ .OrganizationName }}
+      rhacs.redhat.com/org-name: "{{ .OrganizationName }}"
     secureTenantNetwork: false
     centralRdsCidrBlock: "10.1.0.0/16"
     egressProxy:

--- a/dev/config/gitops-config.yaml
+++ b/dev/config/gitops-config.yaml
@@ -11,23 +11,23 @@ tenantResources:
   default: |
     labels:
       app.kubernetes.io/managed-by: rhacs-fleetshard
-      app.kubernetes.io/instance: { { .Name } }
-      rhacs.redhat.com/org-id: { { .OrganizationID } }
-      rhacs.redhat.com/tenant: { { .ID } }
-      rhacs.redhat.com/instance-type: { { .InstanceType } }
+      app.kubernetes.io/instance: {{ .Name }}
+      rhacs.redhat.com/org-id: {{ .OrganizationID }}
+      rhacs.redhat.com/tenant: {{ .ID }}
+      rhacs.redhat.com/instance-type: {{ .InstanceType }}
     annotations:
-      rhacs.redhat.com/org-name: { { .OrganizationName } }
+      rhacs.redhat.com/org-name: {{ .OrganizationName }}
     secureTenantNetwork: false
     centralRdsCidrBlock: "10.1.0.0/16"
     egressProxy:
       image: "registry.redhat.io/openshift4/ose-egress-http-proxy:v4.14"
       replicas: 2
       resources:
-      requests:
-        cpu: 100m
-        memory: 275Mi
-      limits:
-        memory: 275Mi
+        requests:
+          cpu: 100m
+          memory: 275Mi
+        limits:
+          memory: 275Mi
 centrals:
   overrides:
     - instanceIds:

--- a/dev/config/gitops-config.yaml
+++ b/dev/config/gitops-config.yaml
@@ -7,7 +7,27 @@ rhacsOperators:
       image: "quay.io/rhacs-eng/stackrox-operator:4.3.4"
       centralLabelSelector: "rhacs.redhat.com/version-selector=4.3.4"
       securedClusterReconcilerEnabled: false
-
+tenantResources:
+  default: |
+    labels:
+      app.kubernetes.io/managed-by: rhacs-fleetshard
+      app.kubernetes.io/instance: { { .Name } }
+      rhacs.redhat.com/org-id: { { .OrganizationID } }
+      rhacs.redhat.com/tenant: { { .ID } }
+      rhacs.redhat.com/instance-type: { { .InstanceType } }
+    annotations:
+      rhacs.redhat.com/org-name: { { .OrganizationName } }
+    secureTenantNetwork: false
+    centralRdsCidrBlock: "10.1.0.0/16"
+    egressProxy:
+      image: "registry.redhat.io/openshift4/ose-egress-http-proxy:v4.14"
+      replicas: 2
+      resources:
+      requests:
+        cpu: 100m
+        memory: 275Mi
+      limits:
+        memory: 275Mi
 centrals:
   overrides:
     - instanceIds:

--- a/e2e/e2e_canary_upgrade_test.go
+++ b/e2e/e2e_canary_upgrade_test.go
@@ -217,13 +217,13 @@ var _ = Describe("Fleetshard-sync Targeted Upgrade", Ordered, func() {
 			Expect(updateGitopsConfig(ctx, func(config gitops.Config) gitops.Config {
 				config.TenantResources.Default = `
 labels:
-  app.kubernetes.io/managed-by: rhacs-fleetshard
-  app.kubernetes.io/instance: {{ .Name }}
-  rhacs.redhat.com/org-id: {{ .OrganizationID }}
-  rhacs.redhat.com/tenant: {{ .ID }}
-  rhacs.redhat.com/instance-type: {{ .InstanceType }}
+  app.kubernetes.io/managed-by: "rhacs-fleetshard"
+  app.kubernetes.io/instance: "{{ .Name }}"
+  rhacs.redhat.com/org-id: "{{ .OrganizationID }}"
+  rhacs.redhat.com/tenant: "{{ .ID }}"
+  rhacs.redhat.com/instance-type: "{{ .InstanceType }}"
 annotations:
-  rhacs.redhat.com/org-name: {{ .OrganizationName }}
+  rhacs.redhat.com/org-name: "{{ .OrganizationName }}"
 secureTenantNetwork: false
 centralRdsCidrBlock: "10.1.0.0/16"
 egressProxy:
@@ -585,13 +585,13 @@ metadata:
 func defaultTenantResourceValues() string {
 	return `
 labels:
-  app.kubernetes.io/managed-by: rhacs-fleetshard
-  app.kubernetes.io/instance: {{ .Name }}
-  rhacs.redhat.com/org-id: {{ .OrganizationID }}
-  rhacs.redhat.com/tenant: {{ .ID }}
-  rhacs.redhat.com/instance-type: {{ .InstanceType }}
+  app.kubernetes.io/managed-by: "rhacs-fleetshard"
+  app.kubernetes.io/instance: "{{ .Name }}"
+  rhacs.redhat.com/org-id: "{{ .OrganizationID }}"
+  rhacs.redhat.com/tenant: "{{ .ID }}"
+  rhacs.redhat.com/instance-type: "{{ .InstanceType }}"
 annotations:
-  rhacs.redhat.com/org-name: {{ .OrganizationName }}
+  rhacs.redhat.com/org-name: "{{ .OrganizationName }}"
 secureTenantNetwork: false
 centralRdsCidrBlock: "10.1.0.0/16"
 egressProxy:

--- a/e2e/e2e_canary_upgrade_test.go
+++ b/e2e/e2e_canary_upgrade_test.go
@@ -215,7 +215,8 @@ var _ = Describe("Fleetshard-sync Targeted Upgrade", Ordered, func() {
 			Expect(egressProxy.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("275Mi"))
 			Expect(egressProxy.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("275Mi"))
 			Expect(updateGitopsConfig(ctx, func(config gitops.Config) gitops.Config {
-				config.TenantResources.Default = `
+				tenantResources := config.TenantResources
+				tenantResources.Default = `
 labels:
   app.kubernetes.io/managed-by: "rhacs-fleetshard"
   app.kubernetes.io/instance: "{{ .Name }}"
@@ -236,6 +237,7 @@ egressProxy:
   limits:
     memory: 200Mi
 `
+				config.TenantResources = tenantResources
 				return config
 			})).To(Succeed())
 			debugGitopsConfig(ctx)

--- a/e2e/e2e_canary_upgrade_test.go
+++ b/e2e/e2e_canary_upgrade_test.go
@@ -230,11 +230,11 @@ egressProxy:
   image: "registry.redhat.io/openshift4/ose-egress-http-proxy:v4.14"
   replicas: 2
   resources:
-	requests:
-	  cpu: 100m
-	  memory: 200Mi
-	limits:
-	  memory: 200Mi
+  requests:
+    cpu: 100m
+    memory: 200Mi
+  limits:
+    memory: 200Mi
 `
 				return config
 			})).To(Succeed())
@@ -598,11 +598,11 @@ egressProxy:
   image: "registry.redhat.io/openshift4/ose-egress-http-proxy:v4.14"
   replicas: 2
   resources:
-	requests:
-	  cpu: 100m
-	  memory: 275Mi
-	limits:
-	  memory: 275Mi`
+    requests:
+      cpu: 100m
+      memory: 275Mi
+    limits:
+      memory: 275Mi`
 }
 
 func defaultGitopsConfig() gitops.Config {

--- a/e2e/e2e_canary_upgrade_test.go
+++ b/e2e/e2e_canary_upgrade_test.go
@@ -231,11 +231,11 @@ egressProxy:
   image: "registry.redhat.io/openshift4/ose-egress-http-proxy:v4.14"
   replicas: 2
   resources:
-  requests:
-    cpu: 100m
-    memory: 200Mi
-  limits:
-    memory: 200Mi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+    limits:
+      memory: 200Mi
 `
 				config.TenantResources = tenantResources
 				return config

--- a/e2e/e2e_canary_upgrade_test.go
+++ b/e2e/e2e_canary_upgrade_test.go
@@ -153,19 +153,15 @@ var _ = Describe("Fleetshard-sync Targeted Upgrade", Ordered, func() {
 		var centralNamespace string
 
 		It("run only one operator with version: "+operatorVersion1, func() {
-			config := gitops.Config{
-				RHACSOperators: operator.OperatorConfigs{
-					CRDURLs: defaultCRDUrls,
-					Configs: []operator.OperatorConfig{operatorConfig1},
-				},
-				Centrals: gitops.CentralsConfig{
-					Overrides: []gitops.CentralOverride{
-						overrideAllCentralsToBeReconciledByOperator(operatorConfig1),
-						overrideAllCentralsToUseMinimalResources(),
-					},
-				},
-			}
-			Expect(putGitopsConfig(ctx, config)).To(Succeed())
+			Expect(updateGitopsConfig(ctx, func(config gitops.Config) gitops.Config {
+				config = defaultGitopsConfig()
+				config.RHACSOperators.Configs = []operator.OperatorConfig{operatorConfig1}
+				config.Centrals.Overrides = []gitops.CentralOverride{
+					overrideAllCentralsToBeReconciledByOperator(operatorConfig1),
+					overrideAllCentralsToUseMinimalResources(),
+				}
+				return config
+			})).To(Succeed())
 			Eventually(assertDeployedOperators(ctx, operator1DeploymentName)).
 				WithTimeout(waitTimeout).
 				WithPolling(defaultPolling).
@@ -194,20 +190,69 @@ var _ = Describe("Fleetshard-sync Targeted Upgrade", Ordered, func() {
 		})
 
 		It("upgrade central", func() {
-			config := gitops.Config{
-				RHACSOperators: operator.OperatorConfigs{
-					CRDURLs: defaultCRDUrls,
-					Configs: []operator.OperatorConfig{operatorConfig1, operatorConfig2},
-				},
-				Centrals: gitops.CentralsConfig{
-					Overrides: []gitops.CentralOverride{
-						overrideAllCentralsToBeReconciledByOperator(operatorConfig2),
-						overrideAllCentralsToUseMinimalResources(),
-					},
-				},
-			}
-			Expect(putGitopsConfig(ctx, config)).To(Succeed())
+			Expect(updateGitopsConfig(ctx, func(config gitops.Config) gitops.Config {
+				config = defaultGitopsConfig()
+				config.RHACSOperators.Configs = []operator.OperatorConfig{operatorConfig1, operatorConfig2}
+				config.Centrals.Overrides = []gitops.CentralOverride{
+					overrideAllCentralsToBeReconciledByOperator(operatorConfig2),
+					overrideAllCentralsToUseMinimalResources(),
+				}
+				return config
+			})).To(Succeed())
 			Eventually(assertCentralLabelSelectorPresent(ctx, createdCentral, centralNamespace, operatorVersion2)).
+				WithTimeout(waitTimeout).
+				WithPolling(defaultPolling).
+				Should(Succeed())
+		})
+
+		It("changes tenant resources", func() {
+			egressProxy, err := getDeployment(ctx, centralNamespace, "egress-proxy")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(egressProxy.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(egressProxy.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("100m"))
+			Expect(egressProxy.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("275Mi"))
+			Expect(egressProxy.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("275Mi"))
+			Expect(updateGitopsConfig(ctx, func(config gitops.Config) gitops.Config {
+				config.TenantResources.Default = `
+labels:
+  app.kubernetes.io/managed-by: rhacs-fleetshard
+  app.kubernetes.io/instance: {{ .Name }}
+  rhacs.redhat.com/org-id: {{ .OrganizationID }}
+  rhacs.redhat.com/tenant: {{ .ID }}
+  rhacs.redhat.com/instance-type: {{ .InstanceType }}
+annotations:
+  rhacs.redhat.com/org-name: {{ .OrganizationName }}
+secureTenantNetwork: false
+centralRdsCidrBlock: "10.1.0.0/16"
+egressProxy:
+  image: "registry.redhat.io/openshift4/ose-egress-http-proxy:v4.14"
+  replicas: 2
+  resources:
+	requests:
+	  cpu: 100m
+	  memory: 200Mi
+	limits:
+	  memory: 200Mi
+`
+				return config
+			})).To(Succeed())
+
+			Eventually(func() error {
+				egressProxy, err := getDeployment(ctx, centralNamespace, "egress-proxy")
+				if err != nil {
+					return err
+				}
+				if egressProxy.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String() != "200Mi" {
+					return fmt.Errorf("egress proxy memory request not updated")
+				}
+				if egressProxy.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String() != "200Mi" {
+					return fmt.Errorf("egress proxy memory limit not updated")
+				}
+				if egressProxy.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String() != "100m" {
+					return fmt.Errorf("egress proxy cpu request not updated")
+				}
+				return nil
+			}).
 				WithTimeout(waitTimeout).
 				WithPolling(defaultPolling).
 				Should(Succeed())
@@ -287,6 +332,24 @@ func putGitopsConfig(ctx context.Context, config gitops.Config) error {
 		return nil
 	}
 	return k8sClient.Create(ctx, configMap)
+}
+
+func updateGitopsConfig(ctx context.Context, updateFn func(config gitops.Config) gitops.Config) error {
+	var configMap v1.ConfigMap
+	if err := k8sClient.Get(ctx, ctrlClient.ObjectKey{Namespace: namespace, Name: gitopsConfigmapName}, &configMap); err != nil {
+		return err
+	}
+	var config gitops.Config
+	if err := yaml.Unmarshal([]byte(configMap.Data[gitopsConfigmapDataKey]), &config); err != nil {
+		return err
+	}
+	updated := updateFn(config)
+	configYAML, err := yaml.Marshal(updated)
+	if err != nil {
+		return err
+	}
+	configMap.Data[gitopsConfigmapDataKey] = string(configYAML)
+	return k8sClient.Update(ctx, &configMap)
 }
 
 func operatorConfigForVersion(version string) operator.OperatorConfig {
@@ -481,8 +544,34 @@ metadata:
     ` + key + `: "` + value + `"`)
 }
 
+func defaultTenantResourceValues() string {
+	return `
+labels:
+  app.kubernetes.io/managed-by: rhacs-fleetshard
+  app.kubernetes.io/instance: {{ .Name }}
+  rhacs.redhat.com/org-id: {{ .OrganizationID }}
+  rhacs.redhat.com/tenant: {{ .ID }}
+  rhacs.redhat.com/instance-type: {{ .InstanceType }}
+annotations:
+  rhacs.redhat.com/org-name: {{ .OrganizationName }}
+secureTenantNetwork: false
+centralRdsCidrBlock: "10.1.0.0/16"
+egressProxy:
+  image: "registry.redhat.io/openshift4/ose-egress-http-proxy:v4.14"
+  replicas: 2
+  resources:
+	requests:
+	  cpu: 100m
+	  memory: 275Mi
+	limits:
+	  memory: 275Mi`
+}
+
 func defaultGitopsConfig() gitops.Config {
 	return gitops.Config{
+		TenantResources: gitops.TenantResourceConfig{
+			Default: defaultTenantResourceValues(),
+		},
 		RHACSOperators: operator.OperatorConfigs{
 			CRDURLs: defaultCRDUrls,
 			Configs: []operator.OperatorConfig{

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -1732,6 +1732,14 @@ func (r *CentralReconciler) chartValues(c private.ManagedCentral) (chartutil.Val
 		return nil, errors.New("resources chart is not set")
 	}
 	src := r.resourcesChart.Values
+
+	// We are introducing the passing of helm values from fleetManager (and gitops). If the managed central
+	// includes the tenant resource values, we will use them. Otherwise, defaults to the previous
+	// implementation.
+	if len(c.Spec.TenantResourcesValues) > 0 {
+		return chartutil.CoalesceTables(c.Spec.TenantResourcesValues, src), nil
+	}
+
 	dst := map[string]interface{}{
 		"labels":      stringMapToMapInterface(getTenantLabels(c)),
 		"annotations": stringMapToMapInterface(getTenantAnnotations(c)),

--- a/internal/dinosaur/pkg/api/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/private/api/openapi.yaml
@@ -537,6 +537,8 @@ components:
           - eval
           - standard
           type: string
+        tenantResourcesValues:
+          type: object
         centralCRYAML:
           type: string
         owners:

--- a/internal/dinosaur/pkg/api/private/model_managed_central_all_of_spec.go
+++ b/internal/dinosaur/pkg/api/private/model_managed_central_all_of_spec.go
@@ -13,6 +13,7 @@ package private
 // ManagedCentralAllOfSpec struct for ManagedCentralAllOfSpec
 type ManagedCentralAllOfSpec struct {
 	InstanceType           string                                        `json:"instanceType,omitempty"`
+	TenantResourcesValues  map[string]interface{}                        `json:"tenantResourcesValues,omitempty"`
 	CentralCRYAML          string                                        `json:"centralCRYAML,omitempty"`
 	Owners                 []string                                      `json:"owners,omitempty"`
 	Auth                   ManagedCentralAllOfSpecAuth                   `json:"auth,omitempty"`

--- a/internal/dinosaur/pkg/gitops/config.go
+++ b/internal/dinosaur/pkg/gitops/config.go
@@ -131,7 +131,7 @@ func validateTenantResourcesConfig(path *field.Path, config TenantResourceConfig
 
 func validateTenantResourcesDefault(path *field.Path, defaultValues string) field.ErrorList {
 	var errs field.ErrorList
-	if err := tryRenderDummyValuesWithPatch(defaultValues); err != nil {
+	if err := renderDummyValuesWithPatchForValidation(defaultValues); err != nil {
 		errs = append(errs, field.Invalid(path, defaultValues, "invalid default values: "+err.Error()))
 	}
 	return errs
@@ -148,7 +148,7 @@ func validateTenantResourceOverrides(path *field.Path, overrides []TenantResourc
 func validateTenantResourceOverride(path *field.Path, override TenantResourceOverride) field.ErrorList {
 	var errs field.ErrorList
 	errs = append(errs, validateInstanceIDs(path.Child("instanceIds"), override.InstanceIDs)...)
-	if err := tryRenderDummyValuesWithPatch(override.Values); err != nil {
+	if err := renderDummyValuesWithPatchForValidation(override.Values); err != nil {
 		errs = append(errs, field.Invalid(path.Child("values"), override.Values, "invalid values: "+err.Error()))
 	}
 	return errs
@@ -301,15 +301,15 @@ func validatePatch(path *field.Path, patch string) field.ErrorList {
 		errs = append(errs, field.Required(path, "patch is required"))
 		return errs
 	}
-	if err := tryRenderDummyCentralWithPatch(patch); err != nil {
+	if err := renderDummyCentralWithPatchForValidation(patch); err != nil {
 		errs = append(errs, field.Invalid(path, patch, "invalid patch: "+err.Error()))
 	}
 	return errs
 }
 
-// tryRenderDummyCentralWithPatch renders a dummy Central instance with the given patch.
-// useful to test that a patch is valid.
-func tryRenderDummyCentralWithPatch(patch string) error {
+// renderDummyCentralWithPatchForValidation renders a dummy Central instance with the given patch.
+// useful to test that a Central patch is valid.
+func renderDummyCentralWithPatchForValidation(patch string) error {
 	var dummyParams = getDummyCentralParams()
 	dummyConfig := Config{
 		Centrals: CentralsConfig{
@@ -327,7 +327,9 @@ func tryRenderDummyCentralWithPatch(patch string) error {
 	return nil
 }
 
-func tryRenderDummyValuesWithPatch(patch string) error {
+// renderDummyValuesWithPatchForValidation renders a dummy tenant resource values with the given patch.
+// useful to test that a values patch is valid.
+func renderDummyValuesWithPatchForValidation(patch string) error {
 	var dummyParams = getDummyCentralParams()
 	dummyConfig := Config{
 		TenantResources: TenantResourceConfig{

--- a/internal/dinosaur/pkg/gitops/config.go
+++ b/internal/dinosaur/pkg/gitops/config.go
@@ -100,6 +100,7 @@ type TenantResourceConfig struct {
 }
 
 // TenantResourceOverride represents the configuration for a tenant resource override. The override
+// will be applied on top of the default tenant resource values configuration.
 type TenantResourceOverride struct {
 	InstanceIDs []string `json:"instanceIds"`
 	Values      string   `json:"values"`

--- a/internal/dinosaur/pkg/gitops/service.go
+++ b/internal/dinosaur/pkg/gitops/service.go
@@ -179,16 +179,3 @@ func renderPatchTemplate(patchTemplate string, ctx CentralParams) (string, error
 
 // defaultTemplate is the default template for Central instances.
 var defaultTemplate = template.Must(template.New("default").Parse(string(defaultCentralTemplate)))
-
-func copyMap(m map[string]interface{}) map[string]interface{} {
-	result := make(map[string]interface{})
-	for k, v := range m {
-		switch v := v.(type) {
-		case map[string]interface{}:
-			result[k] = copyMap(v)
-		default:
-			result[k] = v
-		}
-	}
-	return result
-}

--- a/internal/dinosaur/pkg/gitops/service_test.go
+++ b/internal/dinosaur/pkg/gitops/service_test.go
@@ -123,6 +123,146 @@ func TestRenderCentral(t *testing.T) {
 	}
 }
 
+func TestRenderTenantResourceValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		config Config
+		params CentralParams
+		assert func(t *testing.T, got map[string]interface{}, err error)
+	}{
+		{
+			name: "no overrides",
+			params: CentralParams{
+				ID: "central-1",
+			},
+			config: Config{},
+			assert: func(t *testing.T, got map[string]interface{}, err error) {
+				assert.NoError(t, err)
+				assert.Empty(t, got)
+			},
+		}, {
+			name: "default without overrides",
+			params: CentralParams{
+				ID: "central-1",
+			},
+			config: Config{
+				TenantResources: TenantResourceConfig{
+					Default: `{"foo": "bar"}`,
+				},
+			},
+			assert: func(t *testing.T, got map[string]interface{}, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, map[string]interface{}{"foo": "bar"}, got)
+			},
+		}, {
+			name: "default with override",
+			params: CentralParams{
+				ID: "central-1",
+			},
+			config: Config{
+				TenantResources: TenantResourceConfig{
+					Default: `{"foo": "bar"}`,
+					Overrides: []TenantResourceOverride{
+						{
+							InstanceIDs: []string{"central-1"},
+							Values:      `{"foo": "baz"}`,
+						},
+					},
+				},
+			},
+			assert: func(t *testing.T, got map[string]interface{}, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, map[string]interface{}{"foo": "baz"}, got)
+			},
+		},
+		{
+			name: "default with multiple overrides",
+			params: CentralParams{
+				ID: "central-1",
+			},
+			config: Config{
+				TenantResources: TenantResourceConfig{
+					Default: `{"foo": "bar"}`,
+					Overrides: []TenantResourceOverride{
+						{
+							InstanceIDs: []string{"central-1"},
+							Values:      `{"foo": "baz"}`,
+						},
+						{
+							InstanceIDs: []string{"central-1"},
+							Values:      `{"foo": "qux"}`,
+						},
+					},
+				},
+			},
+			assert: func(t *testing.T, got map[string]interface{}, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, map[string]interface{}{"foo": "qux"}, got)
+			},
+		}, {
+			name: "complex valued patch",
+			params: CentralParams{
+				ID: "central-1",
+			},
+			config: Config{
+				TenantResources: TenantResourceConfig{
+					Default: `{"buzz":"snap", "foo": "snafu"}`,
+					Overrides: []TenantResourceOverride{
+						{
+							InstanceIDs: []string{"central-1"},
+							Values:      `{"foo":{ "bar": "qux" }}`,
+						},
+					},
+				},
+			},
+			assert: func(t *testing.T, got map[string]interface{}, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, map[string]interface{}{"buzz": "snap", "foo": map[string]interface{}{"bar": "qux"}}, got)
+			},
+		}, {
+			name: "default with templating",
+			params: CentralParams{
+				ID: "central-1",
+			},
+			config: Config{
+				TenantResources: TenantResourceConfig{
+					Default: `{"foo": "{{ .ID }}"}`,
+				},
+			},
+			assert: func(t *testing.T, got map[string]interface{}, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, map[string]interface{}{"foo": "central-1"}, got)
+			},
+		}, {
+			name: "overrides with templating",
+			params: CentralParams{
+				ID: "central-1",
+			},
+			config: Config{
+				TenantResources: TenantResourceConfig{
+					Default: `{"foo": "bar"}`,
+					Overrides: []TenantResourceOverride{
+						{
+							InstanceIDs: []string{"central-1"},
+							Values:      `{"foo": "{{ .ID }}"}`,
+						},
+					},
+				},
+			},
+			assert: func(t *testing.T, got map[string]interface{}, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, map[string]interface{}{"foo": "central-1"}, got)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := RenderTenantResourceValues(tt.params, tt.config)
+			tt.assert(t, got, err)
+		})
+	}
+}
+
 // TestDefaultTemplateIsValid tests that the default template is valid and
 // can be unmarshaled to a functional v1alpha1.Central object.
 func Test_defaultTemplate_isValid(t *testing.T) {

--- a/internal/dinosaur/pkg/presenters/managedcentral_test.go
+++ b/internal/dinosaur/pkg/presenters/managedcentral_test.go
@@ -13,7 +13,7 @@ func TestShouldNotRenderTwiceForSameParams(t *testing.T) {
 	var params = gitops.CentralParams{}
 	var renderCount = 0
 	r := newCachedCentralRenderer()
-	r.renderFn = func(params gitops.CentralParams, config gitops.Config) (v1alpha1.Central, error) {
+	r.renderCentralFn = func(params gitops.CentralParams, config gitops.Config) (v1alpha1.Central, error) {
 		renderCount++
 		return v1alpha1.Central{}, nil
 	}
@@ -21,29 +21,29 @@ func TestShouldNotRenderTwiceForSameParams(t *testing.T) {
 	assert.Equal(t, 0, renderCount)
 
 	// first call should render once
-	r.getCentralYaml(gitopsConfig, params)
+	r.render(gitopsConfig, params)
 	assert.Equal(t, 1, renderCount)
 
 	// second call should not render again
-	r.getCentralYaml(gitopsConfig, params)
+	r.render(gitopsConfig, params)
 	assert.Equal(t, 1, renderCount)
 
 	// third call with different params should render again
 	params = gitops.CentralParams{ID: "foo"}
-	r.getCentralYaml(gitopsConfig, params)
+	r.render(gitopsConfig, params)
 	assert.Equal(t, 2, renderCount)
 
 	// fourth call with same params should not render again
-	r.getCentralYaml(gitopsConfig, params)
+	r.render(gitopsConfig, params)
 	assert.Equal(t, 2, renderCount)
 
 	// fifth call with different params should render again
 	gitopsConfig = gitops.Config{Centrals: gitops.CentralsConfig{Overrides: []gitops.CentralOverride{{InstanceIDs: []string{"foo"}}}}}
-	r.getCentralYaml(gitopsConfig, params)
+	r.render(gitopsConfig, params)
 	assert.Equal(t, 3, renderCount)
 
 	// sixth call with same params should not render again
-	r.getCentralYaml(gitopsConfig, params)
+	r.render(gitopsConfig, params)
 	assert.Equal(t, 3, renderCount)
 }
 
@@ -54,7 +54,7 @@ func TestShouldNotCacheOnError(t *testing.T) {
 	var shouldThrow = false
 
 	r := newCachedCentralRenderer()
-	r.renderFn = func(params gitops.CentralParams, config gitops.Config) (v1alpha1.Central, error) {
+	r.renderCentralFn = func(params gitops.CentralParams, config gitops.Config) (v1alpha1.Central, error) {
 		renderCount++
 		if shouldThrow {
 			return v1alpha1.Central{}, assert.AnError
@@ -65,17 +65,17 @@ func TestShouldNotCacheOnError(t *testing.T) {
 	assert.Equal(t, 0, renderCount)
 
 	shouldThrow = true
-	r.getCentralYaml(gitopsConfig, params)
+	r.render(gitopsConfig, params)
 	assert.Equal(t, 1, renderCount)
 
-	r.getCentralYaml(gitopsConfig, params)
+	r.render(gitopsConfig, params)
 	assert.Equal(t, 2, renderCount)
 
 	shouldThrow = false
-	r.getCentralYaml(gitopsConfig, params)
+	r.render(gitopsConfig, params)
 	assert.Equal(t, 3, renderCount)
 
-	r.getCentralYaml(gitopsConfig, params)
+	r.render(gitopsConfig, params)
 	assert.Equal(t, 3, renderCount)
 }
 

--- a/openapi/fleet-manager-private.yaml
+++ b/openapi/fleet-manager-private.yaml
@@ -279,6 +279,8 @@ components:
                 instanceType:
                   type: string
                   enum: [ eval, standard ]
+                tenantResourcesValues:
+                  type: object
                 centralCRYAML:
                   type: string
                 owners:
@@ -392,7 +394,7 @@ components:
                 allOf:
                   - $ref: "#/components/schemas/ManagedCentral"
             rhacs_operators:
-              $ref: RHACSOperatorConfigs
+              $ref: "#/components/schemas/RHACSOperatorConfigs"
 
     RHACSOperatorConfigs:
       properties:


### PR DESCRIPTION
## Description
Currently, only tweaking central CRs via gitops is possible. 
I want to enable the VPA only for select tenants. But the VPA will be defined in the "tenant-resources" helm chart. 

This PR adds the following features
- Defining the default tenant-resources chart values within the gitops config
- Overriding per-tenant tenant-resources chart values with gitops config
- "Graceful" fallback to previous implementation if the values are not provided via the gitops config

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
