### PR TITLE
ROX-23550: Add scanner egress to Internet for image registry access

### DIFF
--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/README.md
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/README.md
@@ -1,0 +1,3 @@
+# Network Policies
+
+Regarding the Tenant's Network Policies, we must respect the ACS Architecture (see https://docs.openshift.com/acs/4.4/architecture/acs-architecture.html#acs-architecture-interaction-between-services_acs-architecture).

--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/network-policy-scanner-v4.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/network-policy-scanner-v4.yaml
@@ -41,7 +41,7 @@ spec:
       ports:
         - port: 8443
           protocol: TCP
-    - to:  # Allow egress to external Internet
+    - to:  # Allow egress to external Internet for Image Registries
         - ipBlock:
             cidr: 0.0.0.0/0
             except:

--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/network-policy-scanner.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/network-policy-scanner.yaml
@@ -45,6 +45,15 @@ spec:
       ports:
         - port: 5432
           protocol: TCP
+    - to: # Allow egress to external Internet for Image Registries
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+                  {{- include "localNetworkCidrRanges" . | nindent 14 }}
+        - ipBlock:
+            cidr: ::/0
+            except:
+                  {{- include "localNetworkCidrRangesIPv6" . | nindent 14 }}
   policyTypes:
     - Ingress
     - Egress


### PR DESCRIPTION
## Description
Added Scanner v2 Internet access per https://docs.openshift.com/acs/4.4/architecture/acs-architecture.html#acs-architecture-interaction-between-services_acs-architecture

## Checklist (Definition of Done)
- ~~[ ] Unit and integration tests added~~
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- ~~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- ~~[ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
- ~~[ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
- ~~[ ] Check AWS limits are reasonable for changes provisioning new resources~~
- ~~[ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment~~

## Test manual

Ongoing testing of Network Policies in ACSCS Integration.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
