### PR TITLE
ROX-23555: Disable egress proxy creation when securing tenant network

### DIFF
--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/egress-proxy.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.secureTenantNetwork }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -118,3 +119,4 @@ spec:
     ports:
     - port: 3128
       protocol: TCP
+{{ end }}


### PR DESCRIPTION
## Description
We are seeing network policy violations in Probe namespaces sporadically - ~4 spread over a few minutes each time a Probe cycle runs. We have a theory that it's due to the NetworkPolicy's being updated, potentially due to updates to the egress-proxy deployment. Since we'd like to remove it anyways, this PR disables the egress-proxy deployment creation; we can then see if it has the desired effect on the network policy reloading.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- ~~[ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- ~~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- ~~[ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
- ~~[ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
- ~~[ ] Check AWS limits are reasonable for changes provisioning new resources~~
- ~~[ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment~~

## Test manual

Ongoing testing in Integration environment.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
