### PR TITLE
Build on microshift preset for crc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -513,7 +513,7 @@ docker/login/internal:
 
 # Build the image
 image/build:
-	DOCKER_CONFIG=${DOCKER_CONFIG} DOCKER_BUILDKIT=1 $(DOCKER) build -t $(SHORT_IMAGE_REF) .
+	DOCKER_CONFIG=${DOCKER_CONFIG} $(DOCKER) buildx build -t $(SHORT_IMAGE_REF) . --load
 	@echo "New image tag: $(SHORT_IMAGE_REF). You might want to"
 	@echo "export FLEET_MANAGER_IMAGE=$(SHORT_IMAGE_REF)"
 ifeq ("$(CLUSTER_TYPE)","kind")

--- a/dev/env/defaults/04-crc.env
+++ b/dev/env/defaults/04-crc.env
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
 
-if [[ "$CLUSTER_NAME" == "api-crc-testing:6443" ]]; then
+if [[ "$CLUSTER_NAME" == "api-crc-testing:6443" || "$CLUSTER_NAME" == "microshift" ]]; then
     export CLUSTER_TYPE_DEFAULT="crc"
 fi

--- a/dev/env/defaults/cluster-type-crc/env
+++ b/dev/env/defaults/cluster-type-crc/env
@@ -1,2 +1,4 @@
 export ENABLE_CENTRAL_EXTERNAL_CERTIFICATE="true"
+export ENABLE_EXTERNAL_CONFIG_DEFAULT="true"
 export AWS_AUTH_HELPER_DEFAULT="aws-saml"
+export INHERIT_IMAGEPULLSECRETS_DEFAULT="true" # pragma: allowlist secret

--- a/dev/env/scripts/docker.sh
+++ b/dev/env/scripts/docker.sh
@@ -60,8 +60,8 @@ ensure_fleet_manager_image_exists() {
             if [[ "$image_available" != "true" || "$FLEET_MANAGER_IMAGE" =~ dirty$ ]]; then
                 # Attempt to build this image.
                 if [[ "$FLEET_MANAGER_IMAGE" == "$(make -s -C "${GITROOT}" full-image-tag)" ]]; then
-                        log "Building local image..."
-                        make -C "${GITROOT}" image/build
+                    log "Building local image..."
+                    make -C "${GITROOT}" image/build
                 else
                     die "Cannot find image '${FLEET_MANAGER_IMAGE}' and don't know how to build it"
                 fi
@@ -75,6 +75,9 @@ ensure_fleet_manager_image_exists() {
 
         if [[ "${CLUSTER_TYPE}" == "kind" ]]; then
             kind load docker-image "$FLEET_MANAGER_IMAGE"
+        fi
+        if [[ "${CLUSTER_TYPE}" == "crc" ]]; then
+            docker tag "$FLEET_MANAGER_IMAGE" "${ACSCS_NAMESPACE}/$FLEET_MANAGER_IMAGE"
         fi
 
         # Verify that the image is there.

--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -138,6 +138,9 @@ init() {
     if [[ "$CLUSTER_TYPE" == "minikube" ]]; then
         eval "$(minikube docker-env)"
     fi
+    if [[ "$CLUSTER_TYPE" == "crc" ]]; then
+        eval "$(crc podman-env)"
+    fi
 
     if [[ "$EMAIL_SENDER_IMAGE" == "" ]]; then
         EMAIL_SENDER_IMAGE=$(make -s -C "$GITROOT" image-tag/emailsender)


### PR DESCRIPTION
## Description
Adjust crc settings for dev scripts in order to run microshift preset. 

More info: https://crc.dev/blog/posts/2023-04-05-microshift-on-crc/

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual
Setup
```
$crc version
CRC version: 2.35.0+3956e8
OpenShift version: 4.15.10
Podman version: 4.4.4
```
```
$crc config view  
- consent-telemetry                     : yes
- cpus                                  : 8
- memory                                : 16384
- preset                                : microshift
```

Steps
```
crc setup
crc start
eval $(crc oc-env)
make deploy/bootstrap
make deploy/dev
```