### PR TITLE
Drop default CPU limit for ACS operator

### DIFF
--- a/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-deployment.yaml
+++ b/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-deployment.yaml
@@ -119,7 +119,6 @@ spec:
             timeoutSeconds: 1
           resources:
             limits:
-              cpu: {{ (((.resources).limits).cpu) | default $.Values.operator.default.resources.limits.cpu }}
               memory: {{ (((.resources).limits).memory) | default $.Values.operator.default.resources.limits.memory }}
             requests:
               cpu: {{ (((.resources).requests).cpu) | default $.Values.operator.default.resources.requests.cpu }}

--- a/fleetshard/pkg/central/charts/data/rhacs-operator/values.yaml
+++ b/fleetshard/pkg/central/charts/data/rhacs-operator/values.yaml
@@ -3,7 +3,6 @@ operator:
   default:
     resources:
       limits:
-        cpu: "2"
         memory: "2Gi"
       requests:
         cpu: "1"


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
There was a decision to drop CPU limits for ACS operator. Even though it is removed from gitops it still applies this default CPU limit for each running ACS Operator

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

N/A
