### PR TITLE
ROX-23255: add auth implementation for emailsender API

### DIFF
--- a/config/emailsender-authz.yaml
+++ b/config/emailsender-authz.yaml
@@ -1,0 +1,14 @@
+# For development we use ocm tokens issued by RH SSO to authenticate to emailsender API
+# for prod we use serviceaccount issued by the OSD cluster for centrals
+# this file should be replaced by a secret/configmap mounted to emailsender
+# with the fitting values per cluster through the fleetshard addon
+---
+jwks_urls:
+  - "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs"
+allowed_issuers:
+  - "https://sso.redhat.com/auth/realms/redhat-external"
+allowed_org_ids:
+  # RH ACS Organization (returned for personal tokens obtained by ocm token).
+  - "11009103"
+allowed_audiences:
+  - "cloud-services"

--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
@@ -32,6 +32,10 @@ spec:
               value: {{ .Values.emailsender.clusterName }}
             - name: ENVIRONMENT
               value: {{ .Values.emailsender.environment }}
+          {{- if .Values.emailsender.authConfigFromKubernetes }}
+            - name: AUTH_CONFIG_FROM_KUBERNETES
+              value: "true"
+          {{- end }}
           ports:
             - name: monitoring
               containerPort: 9090

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -76,6 +76,7 @@ emailsender:
   clusterId: ""
   clusterName: ""
   environment: ""
+  authConfigFromKubernetes: true
   resources:
     requests:
       cpu: "100m"

--- a/emailsender/cmd/app/main.go
+++ b/emailsender/cmd/app/main.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/gorilla/mux"
-
 	"golang.org/x/sys/unix"
 
 	"github.com/golang/glog"
@@ -50,9 +48,11 @@ func main() {
 	emailSender := email.NewEmailSender(temporarySenderName, sesClient)
 	emailHandler := api.NewEmailHandler(emailSender)
 
-	// base router
-	router := mux.NewRouter()
-	api.SetupRoutes(router, emailHandler)
+	router, err := api.SetupRoutes(cfg.AuthConfig, emailHandler)
+	if err != nil {
+		glog.Errorf("Failed to set up router: %v", err)
+		os.Exit(1)
+	}
 
 	server := http.Server{Addr: cfg.ServerAddress, Handler: router}
 

--- a/emailsender/config/config.go
+++ b/emailsender/config/config.go
@@ -2,7 +2,13 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"strings"
 
 	"github.com/caarlos0/env/v6"
 	"gopkg.in/yaml.v2"
@@ -10,18 +16,27 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/acs-fleet-manager/pkg/shared"
 	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+const (
+	defaultSATokenFile      = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	defaultKubernetesCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	k8sAPISvc               = "https://kubernetes.default.svc"
+	wellKnownPath           = ".well-known/openid-configuration"
 )
 
 // Config contains this application's runtime configuration.
 type Config struct {
-	ClusterID      string `env:"CLUSTER_ID"`
-	ServerAddress  string `env:"SERVER_ADDRESS" envDefault:":8080"`
-	EnableHTTPS    bool   `env:"ENABLE_HTTPS" envDefault:"false"`
-	HTTPSCertFile  string `env:"HTTPS_CERT_FILE" envDefault:""`
-	HTTPSKeyFile   string `env:"HTTPS_KEY_FILE" envDefault:""`
-	MetricsAddress string `env:"METRICS_ADDRESS" envDefault:":9090"`
-	AuthConfigFile string `env:"AUTH_CONFIG_FILE" envDefault:"config/emailsender-authz.yaml"`
-	AuthConfig     AuthConfig
+	ClusterID                string `env:"CLUSTER_ID"`
+	ServerAddress            string `env:"SERVER_ADDRESS" envDefault:":8080"`
+	EnableHTTPS              bool   `env:"ENABLE_HTTPS" envDefault:"false"`
+	HTTPSCertFile            string `env:"HTTPS_CERT_FILE" envDefault:""`
+	HTTPSKeyFile             string `env:"HTTPS_KEY_FILE" envDefault:""`
+	MetricsAddress           string `env:"METRICS_ADDRESS" envDefault:":9090"`
+	AuthConfigFile           string `env:"AUTH_CONFIG_FILE" envDefault:"config/emailsender-authz.yaml"`
+	AuthConfigFromKubernetes bool   `env:"AUTH_CONFIG_FROM_KUBERNETES" envDefault:"false"`
+	AuthConfig               AuthConfig
 }
 
 // GetConfig retrieves the current runtime configuration from the environment and returns it.
@@ -43,9 +58,28 @@ func GetConfig() (*Config, error) {
 		}
 	}
 
-	auth := &AuthConfig{file: c.AuthConfigFile}
-	if err := auth.ReadFile(); err != nil {
-		configErrors.AddError(err)
+	auth := &AuthConfig{
+		configFile:  c.AuthConfigFile,
+		saTokenFile: defaultSATokenFile,
+		k8sSvcURL:   k8sAPISvc,
+		jwksDir:     os.TempDir(),
+	}
+
+	var authError error
+	if c.AuthConfigFromKubernetes {
+		client, err := k8sSvcClient()
+		if err != nil {
+			authError = err
+		} else {
+			auth.httpClient = client
+			authError = auth.readFromKubernetes()
+		}
+	} else {
+		authError = auth.readFile()
+	}
+
+	if authError != nil {
+		configErrors.AddError(authError)
 	}
 
 	c.AuthConfig = *auth
@@ -56,18 +90,28 @@ func GetConfig() (*Config, error) {
 	return &c, nil
 }
 
+type oidcConfig struct {
+	JwksURI string `json:"jwks_uri"`
+	Issuer  string `json:"issuer"`
+}
+
 // AuthConfig is the configuration for authn/authz for the emailsender
 type AuthConfig struct {
-	file             string
+	configFile       string
+	saTokenFile      string
+	k8sSvcURL        string
+	httpClient       *http.Client
+	jwksDir          string
 	JwksURLs         []string `yaml:"jwks_urls"`
+	JwksFiles        []string `yaml:"jwks_files"`
 	AllowedIssuer    []string `yaml:"allowed_issuers"`
 	AllowedOrgIDs    []string `yaml:"allowed_org_ids"`
 	AllowedAudiences []string `yaml:"allowed_audiences"`
 }
 
-// ReadFile reads the config
-func (c *AuthConfig) ReadFile() error {
-	fileContents, err := shared.ReadFile(c.file)
+// readFile reads the config
+func (c *AuthConfig) readFile() error {
+	fileContents, err := shared.ReadFile(c.configFile)
 	if err != nil {
 		return fmt.Errorf("failed to read emailsender authz config: %w", err)
 	}
@@ -78,4 +122,119 @@ func (c *AuthConfig) ReadFile() error {
 	}
 
 	return nil
+}
+
+// readFromKubernetes uses the service account token and the Kubernetes api
+// to derive an AuthConfig from the Kubernetes openid-configuration
+func (c *AuthConfig) readFromKubernetes() error {
+	// we need the own SA token to be able to authenticate to the jwks key endpoint
+	// since we're not allowed to call it with an anonymous user
+	tokenBytes, err := shared.ReadFile(c.saTokenFile)
+	if err != nil {
+		return fmt.Errorf("failed to read service account token from file %w", err)
+	}
+
+	token := string(tokenBytes)
+	oidcCfg, err := c.getOIDCConfig(token)
+	if err != nil {
+		return err
+	}
+
+	jwksBytes, err := c.getJWKS(oidcCfg, token)
+	if err != nil {
+		return err
+	}
+
+	jwksFilePath := path.Join(c.jwksDir, "jwks.json")
+	// We store this in a file because the OCM SDK middleware we use for auth
+	// isn't able to call a jwks URL that requires authentication.
+	// As a workaround we can pre-load the jwks to a file and use the JwksFile option of that SDK.
+	if err := os.WriteFile(jwksFilePath, jwksBytes, 0644); err != nil {
+		return fmt.Errorf("failed to store jwks file in temp dir: %w", err)
+	}
+
+	// for default svc account token issuer == audience
+	c.AllowedAudiences = []string{oidcCfg.Issuer}
+	c.AllowedIssuer = []string{oidcCfg.Issuer}
+	c.JwksFiles = []string{jwksFilePath}
+
+	return nil
+}
+
+func (c *AuthConfig) getOIDCConfig(token string) (oidcConfig, error) {
+	var oidcCfg oidcConfig
+
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", c.k8sSvcURL, wellKnownPath), nil)
+	if err != nil {
+		return oidcCfg, fmt.Errorf("failed to create HTTP request for openid configuration: %w", err)
+	}
+	addAuthHeader(req, token)
+
+	oidcCfgRes, err := c.httpClient.Do(req)
+	if err != nil {
+		return oidcCfg, fmt.Errorf("failed to send HTTP requests for openid configuration: %w", err)
+	}
+	defer utils.IgnoreError(oidcCfgRes.Body.Close)
+
+	if oidcCfgRes.StatusCode != 200 {
+		return oidcCfg, fmt.Errorf("HTTP request for openid configuration failed with status: %d", oidcCfgRes.StatusCode)
+	}
+
+	if err := json.NewDecoder(oidcCfgRes.Body).Decode(&oidcCfg); err != nil {
+		return oidcCfg, fmt.Errorf("failed to decoded openid configuration response body: %w", err)
+	}
+
+	return oidcCfg, nil
+}
+
+func (c *AuthConfig) getJWKS(oidcCfg oidcConfig, token string) ([]byte, error) {
+	// replacing the potentially public facing JWKS url with the cluster internal k8sSvcURL
+	// since we don't want to call the endpoint via ingress but within the cluster
+	jwksPath := jwksPathFromURL(oidcCfg.JwksURI)
+	jwksRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", c.k8sSvcURL, jwksPath), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request for jwks: %w", err)
+	}
+	addAuthHeader(jwksRequest, token)
+
+	jwksRes, err := c.httpClient.Do(jwksRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send HTTP request for jwks: %w", err)
+	}
+	defer utils.IgnoreError(jwksRes.Body.Close)
+
+	if jwksRes.StatusCode != 200 {
+		return nil, fmt.Errorf("jwks key request failed with status code: %d", jwksRes.StatusCode)
+	}
+
+	jwksBytes, err := io.ReadAll(jwksRes.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body for jwks: %w", err)
+	}
+
+	return jwksBytes, nil
+}
+
+func jwksPathFromURL(url string) string {
+	jwksPath, _ := strings.CutPrefix(url, "https://")
+	jwksPath, _ = strings.CutPrefix(jwksPath, "http://")
+	_, jwksPath, _ = strings.Cut(jwksPath, "/")
+	return jwksPath
+}
+
+func addAuthHeader(req *http.Request, token string) {
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+}
+
+func k8sSvcClient() (*http.Client, error) {
+	tlsConf, err := shared.TLSWithAdditionalCAs(defaultKubernetesCAFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tls conf: %w", err)
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConf,
+		},
+	}, nil
 }

--- a/emailsender/config/config_test.go
+++ b/emailsender/config/config_test.go
@@ -1,6 +1,12 @@
 package config
 
 import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,4 +69,97 @@ func TestGetConfigFailureEnabledHTTPSOnly(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
+}
+
+func TestJWKSPathFromURL(t *testing.T) {
+
+	tests := map[string]struct {
+		url      string
+		expected string
+	}{
+		"crc url": {
+			url:      "https://api-int.crc.testing:6443/openid/v1/jwks",
+			expected: "openid/v1/jwks",
+		},
+		"dataplane internal url": {
+			url:      "https://10.0.145.59:6443/openid/v1/jwks",
+			expected: "openid/v1/jwks",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := jwksPathFromURL(tc.url)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+// copied from a CRC openid-configuration response
+const exampleOidcCfgContent = `{"issuer":"https://kubernetes.default.svc","jwks_uri":"https://api-int.crc.testing:6443/openid/v1/jwks","response_types_supported":["id_token"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"]}`
+
+// copied from a CRC jwks response
+const exampleJwksContent = `{"keys":[{"use":"sig","kty":"RSA","kid":"fopPsQkHnyVQN7buPdX_dZprJGWLS9yUB3snAklSwrU","alg":"RS256","n":"0xQ7zns3GOmClc5MLs4auWGrxndZnZ_UbzUC7gfhG2aIoUoJ7E8M5OVwl403nHo4mL8-7Q-U7xj59SFgLOfCCSbppW1VlaIec848RknnACSB-BArOKpoNliiSV5825P1ASgb2m5OJPdDTB6fe-7dSEXk_YjOVzuQUDB12b7oV6gjpKDspCAuK7jPiGyW_HrdavCPJu8zmHFmJUK8nhAE2eJy54BK4u7Iy6B8-al6Ah2ljxKrp_u6YQDyV_uXg4DjGM0iyZNOONmUdBrVKbnlUxtUYD-FIZgQxJad7qNX19dPt4yJE3DLZt4uA8A4GP6W-ZeI87AuvAVc0JXF_UJQiQ","e":"AQAB"},{"use":"sig","kty":"RSA","kid":"_xRpmmptK7pO0biiahy7FfW9msL0bOWSiUYHGfMBSjo","alg":"RS256","n":"wYWZZSARuDz1XCgaJ_MEG9znRz_9261tbZqsYpML2rioc41_8oRZE1QYKRUmHQnF51xkM6TuJr8lr10bP8mi17L_Y5UutQtCWuTKhwDwBfy3Bb-_dXwo9DCuK8gMryVcwViMWlOhFJ_573dpSfoQ3eyP3JkKMSFcn_aO5VVhJPvphDOj8cD8eJOilWCjjObpfNqHlcQUZ-rT15B6KzsVD_62SiecO6aEFU8jOYJGZOdCc4mp4ava7EW3jxbOAr3izTK781VS-PcuAQ1CxQA_H_Iwx1FMos70o0dxtFhZv0CNXQ9afATYha9vybksUaTkCStRI0hxnQaRoFzhsodiT0WH_JxsWBLrn38YWphAzTqMC8PtZYoaJnTzyme5Pq30xfr6Z_T-zk0TEB2PZ4jlw-2S2s3rxOPykaBf7tUOcrKzA0YZfn5LC_1DIt7B_IxGxjw5JMhz4-V15D-zOr0Mb0HWFnfhA1pNqNSGt9MdQMAVFGFP7PceKnthz0AqNI2u_J1f4KtuF_NCkmtyqlidevZD__QcKmobEpC81Zq05jNOLdDODpwQ9jdEMQKmlRZbVYdK8j0HcVhPZSMmWFMop94mwh9zuLkTr1xbv1Acnt9uUBaD6YYtC4TOSPAbKQUQfvZlwaeMp2RDclriafrEcbIq5P10oJFCs5mmjJH3KuM","e":"AQAB"},{"use":"sig","kty":"RSA","kid":"IXZasI0jKhRyIDobBVzn9WK28OFK0nf3csqvVacUYRw","alg":"RS256","n":"qZoqs8fW9RGNms1cTbTCRp9K1FNJDRPA16YcyyEBxMyA52g3lEtD7Qt59enBO4ecTj6E4_2qMQIvOSiq1scG5aROhgdG1ikXzFJP1oZiYBYUZ11tWtvH340mYNmucGQBjDOFtFZw8g-5JTir7PL2zdt1JtM2fyT9PIwXfsWtS9pedcMAJ0qFcv63JdTef3yxIbbpKPGjnOGZALSSP_GRpcXyUPGzByRZOcNcjYzcdU2bBed9x7pLz0ryv_E75mXnDN5FXi3oUI_WfMb_7s4ctV-RAe_KcFQVQ1O5CwUj7u6diRXZSZF_XiN09JPgOh1x8B_roviWr_ZrxA4uz9OcmxpzjTCJvO5V3L6S_WBwM4KhAdo2Cln1_oFdf_0FVx42iu9WPplNoBYDrHLxIXJXgykPQKsCBTiD9x6jHnDE60MENiVAg7MqaXvZ2JqtA7QDO8tUqhsPQTwNfJoowfofugKUhUpKl3KH8U5B-UY8Any3yvjtSv9uLxEUHMX-px-pPQGbtzcTgpyp2NNoxI_36HfFDX54HsEJRCUk4-E7S5XPu_e27iC4CFlvOIn7J6OZsnDIsLQFS2ff_uUx3ONIPiE3rDtFRo4ayE1iswCbJRHGIvYCBI3St5PbF9KCtKkBUsqoMEqqtgE06D5IsRCMZs6cgmAp9Reh93B9flTrh-8","e":"AQAB"}]}` // pragma: allowlist secret
+
+func TestAuthConfigFromKubernetes(t *testing.T) {
+	t.Setenv("AUTH_CONFIG_FROM_KUBERNETES", "true")
+	testDir := t.TempDir()
+	tokenFile := path.Join(testDir, "token")
+	expectedToken := "faketoken"
+
+	err := os.WriteFile(tokenFile, []byte(expectedToken), 0644)
+	require.NoError(t, err, "failed to write test token to file")
+
+	rt := fakeK8sRoundTripper{
+		expectedToken: expectedToken,
+		returnOidcCfg: exampleOidcCfgContent,
+		returnJwks:    exampleJwksContent,
+		t:             t,
+	}
+	fakeK8sClient := &http.Client{Transport: rt}
+
+	authCfg := &AuthConfig{
+		saTokenFile: tokenFile,
+		httpClient:  fakeK8sClient,
+		k8sSvcURL:   "localhost.testservice",
+		jwksDir:     testDir,
+	}
+
+	err = authCfg.readFromKubernetes()
+	require.NoError(t, err)
+	require.Equal(t, []string{"https://kubernetes.default.svc"}, authCfg.AllowedIssuer, "issuers do not match")
+	require.Equal(t, []string{"https://kubernetes.default.svc"}, authCfg.AllowedAudiences, "audiences do not match")
+	require.Equal(t, []string{path.Join(testDir, "jwks.json")}, authCfg.JwksFiles, "jwks files do not match")
+}
+
+type fakeK8sRoundTripper struct {
+	expectedToken string
+	returnOidcCfg string
+	returnJwks    string
+	t             *testing.T
+}
+
+func (f fakeK8sRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	token := req.Header.Get("Authorization")
+	require.Equal(f.t, fmt.Sprintf("Bearer %s", f.expectedToken), token, "request token did not match expected token")
+
+	res := &http.Response{}
+
+	switch url := req.URL.String(); {
+	case strings.Contains(url, wellKnownPath):
+		res.StatusCode = 200
+		res.Body = readCloserFromString(exampleOidcCfgContent)
+	case strings.Contains(url, "jwks"):
+		res.StatusCode = 200
+		res.Body = readCloserFromString(exampleJwksContent)
+	default:
+		res.StatusCode = 404
+		res.Body = readCloserFromString("")
+	}
+
+	return res, nil
+}
+
+func readCloserFromString(s string) io.ReadCloser {
+	return io.NopCloser(strings.NewReader(s))
 }

--- a/emailsender/pkg/api/middleware.go
+++ b/emailsender/pkg/api/middleware.go
@@ -13,7 +13,7 @@ import (
 )
 
 const ocmIssuer = "https://sso.redhat.com/auth/realms/redhat-external"
-const centralServiceAccountRegEx = "system:serviceaccount:rhacs-[a-z]*:central"
+const centralServiceAccountRegEx = "system:serviceaccount:rhacs-[a-z0-9]*:central"
 
 // EnsureJSONContentType enforces Content-Type: application/json header
 func EnsureJSONContentType(next http.Handler) http.Handler {

--- a/emailsender/pkg/api/middleware.go
+++ b/emailsender/pkg/api/middleware.go
@@ -3,7 +3,17 @@ package api
 import (
 	"mime"
 	"net/http"
+	"regexp"
+
+	"github.com/gorilla/mux"
+	"github.com/stackrox/acs-fleet-manager/emailsender/config"
+	"github.com/stackrox/acs-fleet-manager/pkg/auth"
+	"github.com/stackrox/acs-fleet-manager/pkg/errors"
+	"github.com/stackrox/acs-fleet-manager/pkg/shared"
 )
+
+const ocmIssuer = "https://sso.redhat.com/auth/realms/redhat-external"
+const centralServiceAccountRegEx = "system:serviceaccount:rhacs-[a-z]*:central"
 
 // EnsureJSONContentType enforces Content-Type: application/json header
 func EnsureJSONContentType(next http.Handler) http.Handler {
@@ -29,4 +39,59 @@ func EnsureJSONContentType(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+func emailsenderAuthorizationMiddleware(authConfig config.AuthConfig) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := req.Context()
+			claims, err := auth.GetClaimsFromContext(ctx)
+			if err != nil {
+				shared.HandleError(req, w, errors.Unauthorized("invalid token claims"))
+				return
+			}
+
+			if claims.VerifyIssuer(ocmIssuer, true) {
+				// only check for org ID if we're using OCM tokens
+				next = auth.CheckAllowedOrgIDs(authConfig.AllowedOrgIDs)(next)
+				next = auth.NewRequireOrgIDMiddleware().RequireOrgID(errors.ErrorUnauthorized)(next)
+			} else {
+				// in this case we expect a k8s service account token
+				// so we need to check for the sub
+				next = checkCentralServiceAccountSubject()(next)
+			}
+
+			next = auth.CheckAudience(authConfig.AllowedAudiences)(next)
+			next = auth.NewRequireIssuerMiddleware().RequireIssuer(authConfig.AllowedIssuer, errors.ErrorUnauthorized)(next)
+
+			next.ServeHTTP(w, req)
+		})
+	}
+}
+
+func checkCentralServiceAccountSubject() mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := req.Context()
+			claims, err := auth.GetClaimsFromContext(ctx)
+			if err != nil {
+				shared.HandleError(req, w, errors.Unauthorized("invalid token claims"))
+				return
+			}
+
+			sub, err := claims.GetSubject()
+			if err != nil {
+				shared.HandleError(req, w, errors.Unauthorized("failed to get subject from token claims"))
+				return
+			}
+
+			match, err := regexp.MatchString(centralServiceAccountRegEx, sub)
+			if err != nil || !match {
+				shared.HandleError(req, w, errors.Unauthorized("failed to match subject"))
+				return
+			}
+
+			next.ServeHTTP(w, req)
+		})
+	}
 }

--- a/emailsender/pkg/api/middleware_test.go
+++ b/emailsender/pkg/api/middleware_test.go
@@ -5,7 +5,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/openshift-online/ocm-sdk-go/authentication"
+	"github.com/stackrox/acs-fleet-manager/emailsender/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var called bool
@@ -36,4 +40,136 @@ func TestEnsureJSONContentTypeInvalid(t *testing.T) {
 	testHandler.ServeHTTP(httptest.NewRecorder(), req)
 
 	assert.False(t, called)
+}
+
+func TestAuthorizationMiddleware(t *testing.T) {
+
+	tests := map[string]struct {
+		cfg          config.AuthConfig
+		token        *jwt.Token
+		expectedCode int
+	}{
+		"unauthorized if issuer does not match": {
+			cfg: config.AuthConfig{AllowedIssuer: []string{"test-issuer"}},
+			token: &jwt.Token{
+				Claims: jwt.MapClaims{
+					"iss": "invalid-issuer",
+				},
+			},
+			expectedCode: 403,
+		},
+		"unauthorized if audience does not match": {
+			cfg: config.AuthConfig{
+				AllowedIssuer:    []string{"test-issuer"},
+				AllowedAudiences: []string{"test-audience"},
+			},
+			token: &jwt.Token{
+				Claims: jwt.MapClaims{
+					"iss": "my-test-issuer",
+					"aud": "invalid-audience",
+				},
+			},
+			expectedCode: 403,
+		},
+		"unauthorized if subject does not match": {
+			cfg: config.AuthConfig{
+				AllowedIssuer:    []string{"test-issuer"},
+				AllowedAudiences: []string{"test-audience"},
+			},
+			token: &jwt.Token{
+				Claims: jwt.MapClaims{
+					"iss": "test-issuer",
+					"aud": "test-audience",
+					"sub": "does not match central SA regexp",
+				},
+			},
+			expectedCode: 403,
+		},
+		"authorized if not ocm and expected claims match": {
+			cfg: config.AuthConfig{
+				AllowedIssuer:    []string{"test-issuer"},
+				AllowedAudiences: []string{"test-audience"},
+			},
+			token: &jwt.Token{
+				Claims: jwt.MapClaims{
+					"iss": "test-issuer",
+					"aud": "test-audience",
+					"sub": "system:serviceaccount:rhacs-abc:central",
+				},
+			},
+			expectedCode: 200,
+		},
+		"authorized if not ocm and org_id does not not match": {
+			cfg: config.AuthConfig{
+				AllowedIssuer:    []string{"test-issuer"},
+				AllowedAudiences: []string{"test-audience"},
+				AllowedOrgIDs:    []string{"test-org"},
+			},
+			token: &jwt.Token{
+				Claims: jwt.MapClaims{
+					"iss":    "test-issuer",
+					"aud":    "test-audience",
+					"sub":    "system:serviceaccount:rhacs-abc:central",
+					"org_id": "invalid-org",
+				},
+			},
+			expectedCode: 200,
+		},
+		"not found if ocm and org ID does not match": {
+			// this returns 404 since the given org_id authorization method from fleet-manager return 404 in
+			// cases where the org is not authorized
+			cfg: config.AuthConfig{
+				AllowedIssuer:    []string{"https://sso.redhat.com/auth/realms/redhat-external"},
+				AllowedAudiences: []string{"test-audience"},
+				AllowedOrgIDs:    []string{"test-org"},
+			},
+			token: &jwt.Token{
+				Claims: jwt.MapClaims{
+					"iss":    "https://sso.redhat.com/auth/realms/redhat-external",
+					"aud":    "test-audience",
+					"sub":    "system:serviceaccount:rhacs-abc:central",
+					"org_id": "invalid-org",
+				},
+			},
+			expectedCode: 404,
+		},
+		"authorized if ocm and expected claims match": {
+			cfg: config.AuthConfig{
+				AllowedIssuer:    []string{"https://sso.redhat.com/auth/realms/redhat-external"},
+				AllowedAudiences: []string{"test-audience"},
+				AllowedOrgIDs:    []string{"test-org"},
+			},
+			token: &jwt.Token{
+				Claims: jwt.MapClaims{
+					"iss":    "https://sso.redhat.com/auth/realms/redhat-external",
+					"aud":    "test-audience",
+					"sub":    "arbitrary-sub",
+					"org_id": "test-org",
+				},
+			},
+			expectedCode: 200,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			req, err := http.NewRequest(http.MethodGet, "/api/v1/test", nil)
+			require.NoError(t, err, "failed to create HTTP req")
+			ctx := authentication.ContextWithToken(req.Context(), tc.token)
+			req = req.WithContext(ctx)
+
+			rec := httptest.NewRecorder()
+			authzHandler := emailsenderAuthorizationMiddleware(tc.cfg)
+			authzHandler.Middleware(successHandler()).ServeHTTP(rec, req)
+
+			require.Equal(t, tc.expectedCode, rec.Result().StatusCode)
+		})
+	}
+}
+
+func successHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
 }

--- a/emailsender/pkg/api/routes.go
+++ b/emailsender/pkg/api/routes.go
@@ -1,15 +1,65 @@
 package api
 
 import (
+	"fmt"
+	"net/http"
+
 	"github.com/gorilla/mux"
+
+	"github.com/golang/glog"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/openshift-online/ocm-sdk-go/authentication"
+	"github.com/pkg/errors"
+
+	"github.com/stackrox/acs-fleet-manager/emailsender/config"
+	acscsErrors "github.com/stackrox/acs-fleet-manager/pkg/errors"
 	loggingMiddleware "github.com/stackrox/acs-fleet-manager/pkg/server/logging"
 )
 
 // SetupRoutes configures API route mapping
-func SetupRoutes(router *mux.Router, emailHandler *EmailHandler) {
+func SetupRoutes(authConfig config.AuthConfig, emailHandler *EmailHandler) (http.Handler, error) {
+
+	router := mux.NewRouter()
+
+	// using a path prefix here to seperate endpoints that should use
+	// middleware vs. endpoints that shouldn't for instance /health
+	apiRouter := router.PathPrefix("/api").Subrouter()
+
 	// add middlewares
-	router.Use(loggingMiddleware.RequestLoggingMiddleware, EnsureJSONContentType)
+	apiRouter.Use(
+		loggingMiddleware.RequestLoggingMiddleware,
+		EnsureJSONContentType,
+		emailsenderAuthorizationMiddleware(authConfig),
+	)
 
 	router.HandleFunc("/health", HealthCheckHandler).Methods("GET")
-	router.HandleFunc("/api/v1/acscsemail", emailHandler.SendEmail).Methods("POST")
+	apiRouter.HandleFunc("/v1/acscsemail", emailHandler.SendEmail).Methods("POST")
+
+	authLogger, err := sdk.NewGlogLoggerBuilder().
+		InfoV(glog.Level(1)).
+		DebugV(glog.Level(5)).
+		Build()
+
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create auth logger")
+	}
+
+	authHandlerBuilder := authentication.NewHandler().
+		Logger(authLogger).
+		Error(fmt.Sprint(acscsErrors.ErrorUnauthenticated)).
+		Service("ACSCS-EMAIL").
+		Next(router).
+		Public("/health")
+
+	for _, keyURL := range authConfig.JwksURLs {
+		authHandlerBuilder.KeysURL(keyURL)
+	}
+
+	authHandler, err := authHandlerBuilder.Build()
+
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create authentication handler")
+	}
+
+	return authHandler, nil
 }

--- a/emailsender/pkg/api/routes.go
+++ b/emailsender/pkg/api/routes.go
@@ -77,6 +77,10 @@ func buildAuthnHandler(router http.Handler, cfg config.AuthConfig) (http.Handler
 		authnHandlerBuilder.KeysURL(keyURL)
 	}
 
+	for _, keyFile := range cfg.JwksFiles {
+		authnHandlerBuilder.KeysFile(keyFile)
+	}
+
 	authHandler, err := authnHandlerBuilder.Build()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create authentication handler")

--- a/emailsender/pkg/api/routes_test.go
+++ b/emailsender/pkg/api/routes_test.go
@@ -12,7 +12,7 @@ import (
 func TestHealthSuccessWithNoAuth(t *testing.T) {
 	handler, err := SetupRoutes(config.AuthConfig{
 		JwksURLs: []string{"test-key-url.test"},
-	})
+	}, nil)
 	require.NoError(t, err, "failed to setup router")
 
 	rec := httptest.NewRecorder()
@@ -25,7 +25,7 @@ func TestHealthSuccessWithNoAuth(t *testing.T) {
 }
 
 func TestAuthnHandlerIsUsed(t *testing.T) {
-	handler, err := setupRoutes(buildAlwaysDenyAuthnHandler, config.AuthConfig{})
+	handler, err := setupRoutes(buildAlwaysDenyAuthnHandler, config.AuthConfig{}, nil)
 	require.NoError(t, err, "failed to setup router")
 
 	rec := httptest.NewRecorder()

--- a/emailsender/pkg/api/routes_test.go
+++ b/emailsender/pkg/api/routes_test.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stackrox/acs-fleet-manager/emailsender/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthSuccessWithNoAuth(t *testing.T) {
+	handler, err := SetupRoutes(config.AuthConfig{
+		JwksURLs: []string{"test-key-url.test"},
+	})
+	require.NoError(t, err, "failed to setup router")
+
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodGet, "/health", nil)
+	require.NoError(t, err, "failed to create request")
+
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, 200, rec.Code)
+}
+
+func TestAuthnHandlerIsUsed(t *testing.T) {
+	handler, err := setupRoutes(buildAlwaysDenyAuthnHandler, config.AuthConfig{})
+	require.NoError(t, err, "failed to setup router")
+
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodGet, "/api/test", nil)
+	require.NoError(t, err, "failed to create request")
+
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, 401, rec.Code)
+}
+
+func buildAlwaysDenyAuthnHandler(router http.Handler, cfg config.AuthConfig) (http.Handler, error) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+	}), nil
+}

--- a/pkg/auth/acs_claims.go
+++ b/pkg/auth/acs_claims.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/golang/glog"
+	"github.com/gorilla/mux"
 	"github.com/stackrox/acs-fleet-manager/pkg/shared/utils/arrays"
 )
 
@@ -13,8 +14,8 @@ import (
 type ACSClaims jwt.MapClaims
 
 // VerifyIssuer verifies the issuer claim of the access token
-func (c *ACSClaims) VerifyIssuer(cmp string, req bool) bool {
-	return jwt.MapClaims(*c).VerifyIssuer(cmp, req)
+func (c *ACSClaims) VerifyIssuer(cmp string, reqired bool) bool {
+	return jwt.MapClaims(*c).VerifyIssuer(cmp, reqired)
 }
 
 // VerifyAudience verifies the audience claim of the access token.
@@ -112,4 +113,10 @@ func (c *ACSClaims) GetAudience() ([]string, error) {
 func (c *ACSClaims) IsOrgAdmin() bool {
 	isOrgAdmin, _ := (*c)[tenantOrgAdminClaim].(bool)
 	return isOrgAdmin
+}
+
+// CheckAllowedOrgIDs is a middleware to check if org id claim in a
+// given request matches the allowedOrgIDs
+func CheckAllowedOrgIDs(allowedOrgIDs []string) mux.MiddlewareFunc {
+	return checkClaim(tenantIDClaim, (*ACSClaims).GetOrgID, allowedOrgIDs)
 }

--- a/pkg/auth/context_config.go
+++ b/pkg/auth/context_config.go
@@ -26,6 +26,7 @@ var (
 	alternateSubClaim = "deprecated_sub"
 
 	audienceClaim = "aud"
+	issuerClaim   = "iss"
 )
 
 // ContextConfig ...

--- a/pkg/auth/fleetshard_authz_middleware_test.go
+++ b/pkg/auth/fleetshard_authz_middleware_test.go
@@ -112,7 +112,7 @@ func TestUseFleetShardAuthorizationMiddleware_NoTokenSet(t *testing.T) {
 		return setContextToken(handler, nil)
 	})
 
-	route.Use(checkAllowedOrgIDs(allowedOrgIds))
+	route.Use(CheckAllowedOrgIDs(allowedOrgIds))
 
 	req := httptest.NewRequest("GET", "http://example.com/agent-clusters/1234", nil)
 	recorder := httptest.NewRecorder()

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -17,6 +17,14 @@ type stackTracer interface {
 	StackTrace() errors.StackTrace
 }
 
+// ErrorCodePrefixOverride is a variable to override the ErrorCodePrefix used in error messages for ServiceErrors
+// use this in case you are using the service errors defined in this package for other services
+var ErrorCodePrefixOverride = ""
+
+// ErrorHREFOverride is used to override the ErrorHREF used in error messages for ServiceErrors
+// use this in case you are using the service errors defined in this package for other services
+var ErrorHREFOverride = ""
+
 // ErrorCodePrefix ...
 const (
 	ErrorCodePrefix = "RHACS-MGMT"
@@ -486,12 +494,20 @@ func (e *ServiceError) AsOpenapiError(operationID string, basePath string) compa
 
 // CodeStr ...
 func CodeStr(code ServiceErrorCode) string {
-	return fmt.Sprintf("%s-%d", ErrorCodePrefix, code)
+	prefix := ErrorCodePrefix
+	if ErrorCodePrefixOverride != "" {
+		prefix = ErrorCodePrefixOverride
+	}
+	return fmt.Sprintf("%s-%d", prefix, code)
 }
 
 // Href ...
 func Href(code ServiceErrorCode) string {
-	return fmt.Sprintf("%s%d", ErrorHREF, code)
+	href := ErrorHREF
+	if ErrorHREFOverride != "" {
+		href = ErrorHREFOverride
+	}
+	return fmt.Sprintf("%s%d", href, code)
 }
 
 // NotFound ...

--- a/pkg/shared/tls.go
+++ b/pkg/shared/tls.go
@@ -1,0 +1,29 @@
+package shared
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+)
+
+// TLSWithAdditionalCAs returns a tls config with addiotional trusted ca certificates.
+// It uses the systems default certificates and appends the CA certificates in the given files.
+func TLSWithAdditionalCAs(caFiles ...string) (*tls.Config, error) {
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load system cert pool: %w", err)
+	}
+
+	for _, caFile := range caFiles {
+		ca, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read ca file '%s': %w", caFile, err)
+		}
+		rootCAs.AppendCertsFromPEM(ca)
+	}
+
+	return &tls.Config{
+		RootCAs: rootCAs,
+	}, nil
+}

--- a/pkg/shared/tls_test.go
+++ b/pkg/shared/tls_test.go
@@ -1,0 +1,103 @@
+package shared
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/pkg/certgen"
+	"github.com/stackrox/rox/pkg/mtls"
+	"github.com/stackrox/rox/pkg/retry"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTLSWithAdditonalCA(t *testing.T) {
+	ca, err := certgen.GenerateCA()
+	require.NoError(t, err, "failed to generate test CA")
+
+	caDir := t.TempDir()
+	filePath := path.Join(caDir, "cert.pem")
+	err = os.WriteFile(filePath, ca.CertPEM(), 0644)
+	require.NoError(t, err, "failed to write test CA to file")
+
+	testServerCalled := false
+	tlsServ := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testServerCalled = true
+		w.WriteHeader(200)
+	}))
+
+	tlsServ.TLS = &tls.Config{
+		Certificates: []tls.Certificate{generateTestServerCert(t, ca)},
+	}
+
+	tlsServ.StartTLS()
+	defer tlsServ.Close()
+
+	tlsConf, err := TLSWithAdditionalCAs(filePath)
+	require.NoError(t, err, "failed to create tls config")
+
+	httpClient := http.Client{Transport: &http.Transport{
+		TLSClientConfig: tlsConf,
+	}}
+
+	err = retry.WithRetry(
+		// there's a chance the first call fails on tests depending on
+		// server startup timing
+		func() error {
+			_, err := httpClient.Get(tlsServ.URL)
+			return err
+		},
+		retry.Tries(3),
+		retry.BetweenAttempts(func(_ int) {
+			time.Sleep(1 * time.Second)
+		}),
+	)
+
+	require.NoError(t, err, "expected HTTP call to test server to succeed")
+	require.True(t, testServerCalled, "expected test server to be called succesfully")
+}
+
+func generateTestServerCert(t *testing.T, ca mtls.CA) tls.Certificate {
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	certKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "failed to generate test server TLS key")
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, ca.Certificate(), certKey.Public(), ca.PrivateKey())
+	require.NoError(t, err, "failed to generate test server TLS cert")
+
+	certPem := &bytes.Buffer{}
+	err = pem.Encode(certPem, &pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	require.NoError(t, err, "failed to encode test server TLS cert to pem")
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(certKey)
+	require.NoError(t, err, "failed to marshal test server TLS key")
+	keyPem := &bytes.Buffer{}
+	err = pem.Encode(keyPem, &pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	require.NoError(t, err, "failed to encode test server TLS key to pem")
+
+	cert, err := tls.X509KeyPair(certPem.Bytes(), keyPem.Bytes())
+	require.NoError(t, err, "failed to create test server TLS key pair")
+	return cert
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...) -> will be added once emailsender is ready to be worked on by others
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

Additional to the added unit tests I tested the API as follows:

```
# Start emailservice
export CLUSTER_ID=test
go run emailsender/cmd/app/main.go

# By default the authentication configuration will allow calling the API with a OCM token of any
# engineer in the ACS organization, so make sure you're logged in to ocm.

# Run
curl localhost:8080/api/v1/acscsemail -H "Authorization: Bearer $(ocm token)" -H "Content-Type: application/json" -XPOST --data-raw '{"to":["test@test.acscs-email.test"],"rawMessage":"dGVzdCBtZXNzYWdlIGNvbnRlbnQ="}' -v
# Should yield a 200 status code

# Run the same without auth header
curl localhost:8080/api/v1/acscsemail -H "Content-Type: application/json" -XPOST --data-raw '{"to":["test@test.acscs-email.test"],"rawMessage":"dGVzdCBtZXNzYWdlIGNvbnRlbnQ="}'
# Should yield a 401 status code
```

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
