### PR TITLE
fix: checkAudience by returning if an audience matched

### DIFF
--- a/pkg/auth/fleetshard_authz_middleware.go
+++ b/pkg/auth/fleetshard_authz_middleware.go
@@ -68,7 +68,7 @@ func checkAudience(allowedAudiences []string) mux.MiddlewareFunc {
 			for _, audience := range allowedAudiences {
 				if claims.VerifyAudience(audience) {
 					next.ServeHTTP(writer, request)
-					break
+					return
 				}
 			}
 


### PR DESCRIPTION
## Description
I think the audience check is broken. I've reused it in one of my PRs (#1826) and tested it. It was always returning an error although I had a matching audience.

I think the issue is that when matching audiences we should return and not break the loop. At least that fixed it in my PR.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
