### PR TITLE
ROX-23967: Tenant network policies tests

### DIFF
--- a/.openshift-ci/e2e-runtime/Dockerfile
+++ b/.openshift-ci/e2e-runtime/Dockerfile
@@ -35,6 +35,11 @@ RUN curl -L --retry 10 --silent --show-error --fail -o "/usr/local/bin/ocm" \
     "https://github.com/openshift-online/ocm-cli/releases/download/v${OCM_VERSION}/ocm-linux-amd64" && \
     chmod +x /usr/local/bin/ocm
 
+RUN curl -L --retry 10 --silent --show-error --fail -o /usr/local/bin/helm \
+    "https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest/helm-linux-amd64" && \
+    chmod +x /usr/local/bin/helm && \
+    helm version
+
 RUN mkdir /src $GOPATH
 WORKDIR /src
 

--- a/.openshift-ci/tests/e2e.sh
+++ b/.openshift-ci/tests/e2e.sh
@@ -115,6 +115,10 @@ if [[ "$SPAWN_LOGGER" == "true" ]]; then
 fi
 
 FAIL=0
+if ! "${GITROOT}/.openshift-ci/tests/netpol-test.sh"; then
+    FAIL=1
+fi
+
 if ! "${GITROOT}/.openshift-ci/tests/e2e-test.sh"; then
     FAIL=1
 fi

--- a/.openshift-ci/tests/netpol-test.sh
+++ b/.openshift-ci/tests/netpol-test.sh
@@ -6,23 +6,65 @@ export GITROOT
 # shellcheck source=/dev/null
 source "${GITROOT}/dev/env/scripts/lib.sh"
 
-CENTRAL_NS="rhacs-fake-service"
-SCANNER_NS="rhacs-fake-client"
+# Tests that a connection is allowed without network policies, and that it's disallowed after applying the policies (in either namespaces)
+test_central_connectivity_from_different_namespace() {
+    local CENTRAL_NS="$1"
+    local CLIENT_NS="$2"
+    local CLIENT_NAME="$3"
 
-helm install fake-central "${GITROOT}/test/network-policy/fake-service" --namespace "${CENTRAL_NS}" --create-namespace
-$KUBECTL -n "${CENTRAL_NS}" wait --for=condition=Available deployment/central
+    helm install fake-client "${GITROOT}/test/network-policy/fake-client" --set name="${CLIENT_NAME}" --namespace "${CLIENT_NS}" --create-namespace
+    $KUBECTL -n "${CLIENT_NS}" wait --for=condition=Available deployment/"${CLIENT_NAME}"
 
-helm install fake-scanner "${GITROOT}/test/network-policy/fake-client" --namespace "${SCANNER_NS}" --create-namespace
-$KUBECTL -n "${SCANNER_NS}" wait --for=condition=Available deployment/scanner
+    helm install client-netpol "${GITROOT}/fleetshard/pkg/central/charts/data/tenant-resources" --namespace "${CLIENT_NS}" --set secureTenantNetwork=true
+    $KUBECTL -n "${CLIENT_NS}" wait --for=condition=Available=false deployment/"${CLIENT_NAME}"
 
-helm install scanner-netpol "${GITROOT}/fleetshard/pkg/central/charts/data/tenant-resources" --namespace "${SCANNER_NS}" --set secureTenantNetwork=true
-$KUBECTL -n "${SCANNER_NS}" wait --for=condition=Available=false deployment/scanner
+    helm uninstall client-netpol --namespace "${CLIENT_NS}"
+    $KUBECTL -n "${CLIENT_NS}" wait --for=condition=Available deployment/"${CLIENT_NAME}"
 
-helm uninstall scanner-netpol --namespace "${SCANNER_NS}"
-$KUBECTL -n "${SCANNER_NS}" wait --for=condition=Available deployment/scanner
+    helm install central-netpol "${GITROOT}/fleetshard/pkg/central/charts/data/tenant-resources" --namespace "${CENTRAL_NS}" --set secureTenantNetwork=true
+    $KUBECTL -n "${CLIENT_NS}" wait --for=condition=Available=false deployment/"${CLIENT_NAME}"
 
-helm install central-netpol "${GITROOT}/fleetshard/pkg/central/charts/data/tenant-resources" --namespace "${CENTRAL_NS}" --set secureTenantNetwork=true
-$KUBECTL -n "${SCANNER_NS}" wait --for=condition=Available=false deployment/scanner
+    helm uninstall central-netpol --namespace "${CENTRAL_NS}"
+    helm uninstall fake-client --namespace "${CLIENT_NS}"
+}
 
-$KUBECTL delete ns "${CENTRAL_NS}"
-$KUBECTL delete ns "${SCANNER_NS}"
+# Tests that a connection is allowed without network policies, and that it's disallowed after applying the policies
+test_central_connectivity_from_same_namespace()
+{
+    local CLIENT_NS="$1"
+    local CLIENT_NAME="$2"
+
+    helm install fake-client "${GITROOT}/test/network-policy/fake-client" --set name="${CLIENT_NAME}" --namespace "${CLIENT_NS}"
+    $KUBECTL -n "${CLIENT_NS}" wait --for=condition=Available deployment/"${CLIENT_NAME}"
+
+    helm install client-netpol "${GITROOT}/fleetshard/pkg/central/charts/data/tenant-resources" --namespace "${CLIENT_NS}" --set secureTenantNetwork=true
+    $KUBECTL -n "${CLIENT_NS}" wait --for=condition=Available=false deployment/"${CLIENT_NAME}"
+
+    helm uninstall client-netpol --namespace "${CLIENT_NS}"
+    helm uninstall fake-client --namespace "${CLIENT_NS}"
+}
+
+test_central_connectivity() {
+    local CENTRAL_NS="rhacs-fake-service"
+    local CLIENT_NS="rhacs-fake-client"
+
+    helm install fake-central "${GITROOT}/test/network-policy/fake-service" --namespace "${CENTRAL_NS}" --create-namespace
+    $KUBECTL -n "${CENTRAL_NS}" wait --for=condition=Available deployment/central
+
+    test_central_connectivity_from_different_namespace "${CENTRAL_NS}" "${CLIENT_NS}" central
+    test_central_connectivity_from_different_namespace "${CENTRAL_NS}" "${CLIENT_NS}" scanner
+    test_central_connectivity_from_different_namespace "${CENTRAL_NS}" "${CLIENT_NS}" scanner-db
+    test_central_connectivity_from_different_namespace "${CENTRAL_NS}" "${CLIENT_NS}" scanner-v4-indexer
+    test_central_connectivity_from_different_namespace "${CENTRAL_NS}" "${CLIENT_NS}" scanner-v4-matcher
+    test_central_connectivity_from_different_namespace "${CENTRAL_NS}" "${CLIENT_NS}" scanner-v4-db
+    test_central_connectivity_from_different_namespace "${CENTRAL_NS}" "${CLIENT_NS}" other-app
+
+    test_central_connectivity_from_same_namespace "${CENTRAL_NS}" scanner-db
+    test_central_connectivity_from_same_namespace "${CENTRAL_NS}" scanner-v4-db
+    test_central_connectivity_from_same_namespace "${CENTRAL_NS}" other-app
+
+    $KUBECTL delete ns "${CENTRAL_NS}"
+    $KUBECTL delete ns "${CLIENT_NS}"
+}
+
+test_central_connectivity

--- a/.openshift-ci/tests/netpol-test.sh
+++ b/.openshift-ci/tests/netpol-test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+GITROOT="$(git rev-parse --show-toplevel)"
+export GITROOT
+# shellcheck source=/dev/null
+source "${GITROOT}/dev/env/scripts/lib.sh"
+
+CENTRAL_NS="rhacs-fake-service"
+SCANNER_NS="rhacs-fake-client"
+
+helm install fake-central "${GITROOT}/test/network-policy/fake-service" --namespace "${CENTRAL_NS}" --create-namespace
+$KUBECTL -n "${CENTRAL_NS}" wait --for=condition=Available deployment/central
+
+helm install fake-scanner "${GITROOT}/test/network-policy/fake-client" --namespace "${SCANNER_NS}" --create-namespace
+$KUBECTL -n "${SCANNER_NS}" wait --for=condition=Available deployment/scanner
+
+helm install scanner-netpol "${GITROOT}/fleetshard/pkg/central/charts/data/tenant-resources" --namespace "${SCANNER_NS}" --set secureTenantNetwork=true
+$KUBECTL -n "${SCANNER_NS}" wait --for=condition=Available=false deployment/scanner
+
+helm uninstall scanner-netpol --namespace "${SCANNER_NS}"
+$KUBECTL -n "${SCANNER_NS}" wait --for=condition=Available deployment/scanner
+
+helm install central-netpol "${GITROOT}/fleetshard/pkg/central/charts/data/tenant-resources" --namespace "${CENTRAL_NS}" --set secureTenantNetwork=true
+$KUBECTL -n "${SCANNER_NS}" wait --for=condition=Available=false deployment/scanner
+
+$KUBECTL delete ns "${CENTRAL_NS}"
+$KUBECTL delete ns "${SCANNER_NS}"

--- a/test/network-policy/fake-client/Chart.yaml
+++ b/test/network-policy/fake-client/Chart.yaml
@@ -1,0 +1,6 @@
+# Chart.yaml
+apiVersion: v2
+name: fake-client
+description: A Helm chart for deploying a configurable client deployment, for testing connectivity
+version: 0.1.0
+appVersion: "1.0"

--- a/test/network-policy/fake-client/templates/deployment.yaml
+++ b/test/network-policy/fake-client/templates/deployment.yaml
@@ -1,0 +1,41 @@
+# templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Release.namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.name }}
+    spec:
+      containers:
+        - name: {{ .Values.name }}
+          image: curlimages/curl
+          command: ["sh", "-c"]
+          args: [
+            "while true; do \
+            response=$(curl --connect-timeout 10 -sf -w '%{http_code}' {{ .Values.service.host }}:{{ .Values.service.port }} -o /dev/null); \
+            status=$?; \
+            if [ $status -ne 0 ]; then \
+              echo \"Connection failed with error $status, retrying in 1 second...\"; \
+              rm -rf /tmp/ready; \
+              sleep 1; \
+              continue; \
+            fi; \
+            echo 'Connection successful'; \
+            touch /tmp/ready; \
+            sleep 1; \
+          done"
+          ]
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /tmp/ready
+            periodSeconds: 1

--- a/test/network-policy/fake-client/values.yaml
+++ b/test/network-policy/fake-client/values.yaml
@@ -1,0 +1,5 @@
+# values.yaml
+name: scanner
+service:
+  host: central-service.rhacs-fake-service.svc.cluster.local
+  port: 8443

--- a/test/network-policy/fake-service/Chart.yaml
+++ b/test/network-policy/fake-service/Chart.yaml
@@ -1,0 +1,6 @@
+# Chart.yaml
+apiVersion: v2
+name: fake-service
+description: A Helm chart for deploying a fake service with nginx
+version: 0.1.0
+appVersion: "1.0"

--- a/test/network-policy/fake-service/templates/configmap.yaml
+++ b/test/network-policy/fake-service/templates/configmap.yaml
@@ -16,7 +16,7 @@ http {
     default_type  application/octet-stream;
 
     server {
-        listen       8443;
+        listen       {{ .Values.port }};
         server_name  localhost;
 
         location / {

--- a/test/network-policy/fake-service/templates/configmap.yaml
+++ b/test/network-policy/fake-service/templates/configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.name }}-nginx-config
+  namespace: {{ .Release.namespace }}
+data:
+  nginx.conf: '
+worker_processes auto;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    default_type  application/octet-stream;
+
+    server {
+        listen       8443;
+        server_name  localhost;
+
+        location / {
+            return 200 "rhacs-fake-service reply";
+        }
+    }
+}
+'

--- a/test/network-policy/fake-service/templates/deployment.yaml
+++ b/test/network-policy/fake-service/templates/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Release.namespace }}
+  labels:
+    app: {{ .Values.name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.name }}
+    spec:
+      containers:
+        - image: nginx:latest
+          name: nginx
+          ports:
+            - containerPort: {{ .Values.port }}
+              name: web
+          volumeMounts:
+            - name: config-vol
+              mountPath: /etc/nginx/
+            - name: cache-volume
+              mountPath: /var/cache/nginx
+      volumes:
+        - name: config-vol
+          configMap:
+            name: {{ .Values.name }}-nginx-config
+            items:
+              - key: nginx.conf
+                path: nginx.conf
+        - name: cache-volume
+          emptyDir: {}

--- a/test/network-policy/fake-service/templates/service.yaml
+++ b/test/network-policy/fake-service/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}-service
+  namespace: {{ .Release.namespace }}
+  labels:
+    app: {{ .Values.name }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.port }}
+      targetPort: {{ .Values.port }}
+      protocol: TCP
+  selector:
+    app: {{ .Values.name }}

--- a/test/network-policy/fake-service/values.yaml
+++ b/test/network-policy/fake-service/values.yaml
@@ -1,0 +1,5 @@
+# values.yaml
+name: central
+labels:
+  app: central
+port: 8443


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This PR introduces tests for the tenant network policies.

The `fake-service` service and `fake-client` deployment can then be used to mock ACS components, by applying the appropriate labels and setting the ports where they listen or connect to. They can easily be installed using Helm.

They can then be used to write tests, such as the following:
* create a fake Central in namespace A, and a fake Scanner in namespace B
* show that Scanner can connect to Central
* apply the network policies, in turn, in namespace A and then namespace B
* shows that in both cases, the communication is interrupted - proving that the network policies prevent lateral communication between tenants in this case

They will run on OpenShift CI, as part of the e2e test suite.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
