### PR TITLE
ROX-23709: Unskip/Fix E2E tests that use private API

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -268,7 +268,7 @@
         "filename": "e2e/e2e_test.go",
         "hashed_secret": "7f38822bc2b03e97325ff310099f457f6f788daf",
         "is_verified": false,
-        "line_number": 291
+        "line_number": 297
       }
     ],
     "fleetshard/pkg/central/cloudprovider/dbclient_moq.go": [
@@ -463,5 +463,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-27T15:02:35Z"
+  "generated_at": "2024-05-27T17:14:26Z"
 }

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -198,9 +198,9 @@ func obtainCentralRequest(ctx context.Context, client *fleetmanager.Client, id s
 	return nil
 }
 
-func assertStoredSecrets(ctx context.Context, client *fleetmanager.Client, centralRequestID string, expected []string) func() error {
+func assertStoredSecrets(ctx context.Context, privateAPI fleetmanager.PrivateAPI, centralRequestID string, expected []string) func() error {
 	return func() error {
-		privateCentral, _, err := client.PrivateAPI().GetCentral(ctx, centralRequestID)
+		privateCentral, _, err := privateAPI.GetCentral(ctx, centralRequestID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description
Unskip/Fix E2E tests that use private API

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
