### PR TITLE
ROX-23749: fix scanner-v4-matcher network policy

### DIFF
--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/network-policy-scanner-v4.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/network-policy-scanner-v4.yaml
@@ -89,10 +89,10 @@ spec:
       ports:
         - port: 5432
           protocol: TCP
-    - to:  # Allow egress to Central for periodic file updates
+    - to:  # Allow egress to indexer for normal function, and Central for periodic file updates
         - podSelector:
-            matchLabels:
-              app: central
+            matchExpressions:
+              - { key: app, operator: In, values: [central, scanner-v4-indexer] }
       ports:
         - port: 8443
           protocol: TCP


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This PR fixes an omission from the scanner-v4 network policies: matcher should allow egress to indexer.

Indexer is already allowing ingress from matcher.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
