### PR TITLE
Revert "ROX-24158: Wait for central-service pods to terminate before netpol deletion"

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -424,24 +424,23 @@ var _ = Describe("Central", Ordered, func() {
 				Should(Succeed())
 		})
 
-		//TODO: Tenant name change breaks deletion, uncomment when fixed
-		// It("should patch the Central name", func() {
-		//	centralRequestName = newCentralName()
-		//	_, _, err := adminAPI.UpdateCentralNameById(ctx,
-		//		centralRequestID,
-		//		private.CentralUpdateNameRequest{
-		//			Name: centralRequestName, Reason: "e2e test",
-		//		},
-		//	)
-		//	Expect(err).To(BeNil())
-		// })
-		//
-		// It("should transition to central's new name", func() {
-		//	Eventually(assertCentralRequestName(ctx, client, centralRequestID, centralRequestName)).
-		//		WithTimeout(waitTimeout).
-		//		WithPolling(defaultPolling).
-		//		Should(Succeed())
-		// })
+		It("should patch the Central name", func() {
+			centralRequestName = newCentralName()
+			_, _, err := adminAPI.UpdateCentralNameById(ctx,
+				centralRequestID,
+				private.CentralUpdateNameRequest{
+					Name: centralRequestName, Reason: "e2e test",
+				},
+			)
+			Expect(err).To(BeNil())
+		})
+
+		It("should transition to central's new name", func() {
+			Eventually(assertCentralRequestName(ctx, client, centralRequestID, centralRequestName)).
+				WithTimeout(waitTimeout).
+				WithPolling(defaultPolling).
+				Should(Succeed())
+		})
 
 		It("should transition central to deprovisioning state when deleting", func() {
 			Expect(deleteCentralByID(ctx, client, centralRequestID)).


### PR DESCRIPTION
Reverts stackrox/acs-fleet-manager#1842

Not sure if it should be reverted or not (maybe the new behavior is better?) - but waiting for pods to terminate doesn't reduce the number of network policy violations, which was the intention behind the original PR. It's still theoretically possible that the original PR prevents some violations from taking place, but then they are very few and it doesn't visibly affect the average.

The old code is also (unintentionally) more resilient (e.g. it can delete a tenant even if it's not deleting its CR first).