### PR TITLE
fix(tests): Update ACS to 4.4.2 in e2e tests and dev env

### DIFF
--- a/dev/config/gitops-config.yaml
+++ b/dev/config/gitops-config.yaml
@@ -1,11 +1,11 @@
 rhacsOperators:
   crdUrls:
-    - https://raw.githubusercontent.com/stackrox/stackrox/4.3.4/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
-    - https://raw.githubusercontent.com/stackrox/stackrox/4.3.4/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+    - https://raw.githubusercontent.com/stackrox/stackrox/4.4.2/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+    - https://raw.githubusercontent.com/stackrox/stackrox/4.4.2/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
   operators:
-    - deploymentName: "rhacs-operator-4.3.4"
-      image: "quay.io/rhacs-eng/stackrox-operator:4.3.4"
-      centralLabelSelector: "rhacs.redhat.com/version-selector=4.3.4"
+    - deploymentName: "rhacs-operator-4.4.2"
+      image: "quay.io/rhacs-eng/stackrox-operator:4.4.2"
+      centralLabelSelector: "rhacs.redhat.com/version-selector=4.4.2"
       securedClusterReconcilerEnabled: false
 tenantResources:
   default: |
@@ -36,10 +36,10 @@ centrals:
     - instanceIds:
         - "*"
       patch: |
-        # Set label for all centrals to 4.3.4
+        # Set label for all centrals to 4.4.2
         metadata:
           labels:
-            rhacs.redhat.com/version-selector: "4.3.4"
+            rhacs.redhat.com/version-selector: "4.4.2"
         # Adjust centrals for development environment
         spec:
           monitoring:

--- a/e2e/e2e_canary_upgrade_test.go
+++ b/e2e/e2e_canary_upgrade_test.go
@@ -31,14 +31,14 @@ const (
 	namespace              = "rhacs"
 	gitopsConfigmapName    = "gitops-config"
 	gitopsConfigmapDataKey = "config.yaml"
-	operatorVersion1       = "4.3.3"
-	operatorVersion2       = "4.3.4"
+	operatorVersion1       = "4.4.1"
+	operatorVersion2       = "4.4.2"
 )
 
 var (
 	defaultCRDUrls = []string{
-		"https://raw.githubusercontent.com/stackrox/stackrox/4.3.4/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml",
-		"https://raw.githubusercontent.com/stackrox/stackrox/4.3.4/operator/bundle/manifests/platform.stackrox.io_centrals.yaml",
+		"https://raw.githubusercontent.com/stackrox/stackrox/4.4.2/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml",
+		"https://raw.githubusercontent.com/stackrox/stackrox/4.4.2/operator/bundle/manifests/platform.stackrox.io_centrals.yaml",
 	}
 	operatorConfig1         = operatorConfigForVersion(operatorVersion1)
 	operatorConfig2         = operatorConfigForVersion(operatorVersion2)
@@ -688,9 +688,9 @@ func defaultGitopsConfig() gitops.Config {
 			CRDURLs: defaultCRDUrls,
 			Configs: []operator.OperatorConfig{
 				{
-					"deploymentName":                  "rhacs-operator-4.3.4",
-					"image":                           "quay.io/rhacs-eng/stackrox-operator:4.3.4",
-					"centralLabelSelector":            "rhacs.redhat.com/version-selector=4.3.4",
+					"deploymentName":                  "rhacs-operator-4.4.2",
+					"image":                           "quay.io/rhacs-eng/stackrox-operator:4.4.2",
+					"centralLabelSelector":            "rhacs.redhat.com/version-selector=4.4.2",
 					"securedClusterReconcilerEnabled": false,
 				},
 			},
@@ -702,7 +702,7 @@ func defaultGitopsConfig() gitops.Config {
 					Patch: `
 metadata:
   labels:
-    rhacs.redhat.com/version-selector: "4.3.4"`,
+    rhacs.redhat.com/version-selector: "4.4.2"`,
 				}, {
 					InstanceIDs: []string{"*"},
 					Patch: `


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Use ACS 4.4.z in the tests and dev env, to prevent error logs about scanner-v4 (unknown field in 4.3).

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
