### PR TITLE
ROX-23254: Add SendRawEmail method

### DIFF
--- a/emailsender/pkg/email/ses_test.go
+++ b/emailsender/pkg/email/ses_test.go
@@ -1,7 +1,9 @@
 package email
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -11,13 +13,15 @@ import (
 )
 
 type MockSESClient struct {
-	sender   string
-	to       []string
-	subject  string
-	htmlBody string
-	textBody string
+	sender     string
+	to         []string
+	subject    string
+	htmlBody   string
+	textBody   string
+	rawMessage []byte
 
-	SendEmailFunc func(ctx context.Context, params *ses.SendEmailInput, optFns ...func(*ses.Options)) (*ses.SendEmailOutput, error)
+	SendEmailFunc    func(ctx context.Context, params *ses.SendEmailInput, optFns ...func(*ses.Options)) (*ses.SendEmailOutput, error)
+	SendRawEmailFunc func(ctx context.Context, params *ses.SendRawEmailInput, optFns ...func(*ses.Options)) (*ses.SendRawEmailOutput, error)
 }
 
 func (m *MockSESClient) SendEmail(ctx context.Context, params *ses.SendEmailInput, optFns ...func(*ses.Options)) (*ses.SendEmailOutput, error) {
@@ -28,6 +32,14 @@ func (m *MockSESClient) SendEmail(ctx context.Context, params *ses.SendEmailInpu
 	m.textBody = *params.Message.Body.Text.Data
 
 	return m.SendEmailFunc(ctx, params, optFns...)
+}
+
+func (m *MockSESClient) SendRawEmail(ctx context.Context, params *ses.SendRawEmailInput, optFns ...func(*ses.Options)) (*ses.SendRawEmailOutput, error) {
+	m.sender = *params.Source
+	m.to = params.Destinations
+	m.rawMessage = params.RawMessage.Data
+
+	return m.SendRawEmailFunc(ctx, params, optFns...)
 }
 
 func TestSendEmail_Success(t *testing.T) {
@@ -75,6 +87,61 @@ func TestSendEmail_Failure(t *testing.T) {
 		"Test Subject",
 		"<h1>HTML body</h1>",
 		"Text body",
+	)
+	assert.Error(t, err)
+	assert.Equal(t, "", messageID)
+	assert.Contains(t, err.Error(), errorText)
+}
+
+func TestSendRawEmail_Success(t *testing.T) {
+	sender := "sender@example.com"
+	to := []string{"to1@example.com", "to2@example.com"}
+	subject := "Test subject"
+	textBody := "text body"
+	var messageBuf bytes.Buffer
+	messageBuf.WriteString(fmt.Sprintf("Subject: %s\r\n", subject))
+	messageBuf.WriteString(textBody)
+	rawMessage := messageBuf.Bytes()
+
+	testMessageID := "test-message-id"
+
+	mockClient := &MockSESClient{
+		SendRawEmailFunc: func(ctx context.Context, params *ses.SendRawEmailInput, optFns ...func(*ses.Options)) (*ses.SendRawEmailOutput, error) {
+			return &ses.SendRawEmailOutput{
+				MessageId: aws.String(testMessageID),
+			}, nil
+		},
+	}
+	mockedSES := SES{sesClient: mockClient}
+
+	messageID, err := mockedSES.SendRawEmail(context.Background(), sender, to, rawMessage)
+	assert.NoError(t, err)
+	assert.Equal(t, testMessageID, messageID)
+	assert.Equal(t, sender, mockClient.sender)
+	assert.Equal(t, to, mockClient.to)
+	assert.Equal(t, rawMessage, mockClient.rawMessage)
+}
+
+func TestSendRawEmail_Failure(t *testing.T) {
+	errorText := "failed to send email"
+
+	mockClient := &MockSESClient{
+		SendRawEmailFunc: func(ctx context.Context, params *ses.SendRawEmailInput, optFns ...func(*ses.Options)) (*ses.SendRawEmailOutput, error) {
+			return nil, errors.New(errorText)
+		},
+	}
+	mockedSES := SES{sesClient: mockClient}
+
+	buf := bytes.NewBuffer(nil)
+	buf.WriteString(fmt.Sprintf("Subject: %s\r\n", "Test Subject"))
+	buf.WriteString("test body")
+	rawMessage := buf.Bytes()
+
+	messageID, err := mockedSES.SendRawEmail(
+		context.Background(),
+		"sender@example.com",
+		[]string{"to@example.com"},
+		rawMessage,
 	)
 	assert.Error(t, err)
 	assert.Equal(t, "", messageID)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Central sends raw email message bodies. It should be more convenient to use SES `SendRawEmail` API instead `SendEmail` because there is no need to parse Central's raw message in this case. Also, Central might send attachments and only `SendRawEmail` supports sending attachments.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
~- [ ] Added test description under `Test manual`~
~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~
~- [ ] Add secret to app-interface Vault or Secrets Manager if necessary~
~- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~
~- [ ] Check AWS limits are reasonable for changes provisioning new resources~
~- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment~

## Test manual

N/A
