### PR TITLE
ROX-23253: add emailsender TLS service to helm template

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
@@ -39,6 +39,10 @@ spec:
           {{- if .Values.emailsender.authConfigFromKubernetes }}
             - name: AUTH_CONFIG_FROM_KUBERNETES
               value: "true"
+          {{- end }}    
+          {{- if .Values.emailsender.enableHTTPS }}
+            - name: ENABLE_HTTPS
+              value: "true"
           {{- end }}
           ports:
             - name: monitoring
@@ -51,14 +55,18 @@ spec:
             requests:
               cpu: {{ .Values.emailsender.resources.requests.cpu | quote }}
               memory: {{ .Values.emailsender.resources.requests.memory | quote }}
+        {{- if .Values.emailsender.enableHTTPS }}
           volumeMounts:
           - name: emailsender-tls
             mountPath: /var/run/certs
             readOnly: true
+        {{- end }}
+    {{- if .Values.emailsender.enableHTTPS }}
       volumes:
         - name: emailsender-tls
           secret:
             secretName: emailsender-tls # pragma: allowlist secret
+    {{- end-}}
 ---
 apiVersion: v1
 kind: Service

--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
@@ -39,7 +39,7 @@ spec:
           {{- if .Values.emailsender.authConfigFromKubernetes }}
             - name: AUTH_CONFIG_FROM_KUBERNETES
               value: "true"
-          {{- end }}    
+          {{- end }}
           {{- if .Values.emailsender.enableHTTPS }}
             - name: ENABLE_HTTPS
               value: "true"
@@ -66,7 +66,7 @@ spec:
         - name: emailsender-tls
           secret:
             secretName: emailsender-tls # pragma: allowlist secret
-    {{- end-}}
+    {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
@@ -32,6 +32,10 @@ spec:
               value: {{ .Values.emailsender.clusterName }}
             - name: ENVIRONMENT
               value: {{ .Values.emailsender.environment }}
+            - name: HTTPS_CERT_FILE
+              value: "/var/run/certs/tls.crt"
+            - name: HTTPS_KEY_FILE
+              value: "/var/run/certs/tls.key"
           {{- if .Values.emailsender.authConfigFromKubernetes }}
             - name: AUTH_CONFIG_FROM_KUBERNETES
               value: "true"
@@ -47,4 +51,31 @@ spec:
             requests:
               cpu: {{ .Values.emailsender.resources.requests.cpu | quote }}
               memory: {{ .Values.emailsender.resources.requests.memory | quote }}
+          volumeMounts:
+          - name: emailsender-tls
+            mountPath: /var/run/certs
+            readOnly: true
+      volumes:
+        - name: emailsender-tls
+          secret:
+            secretName: emailsender-tls # pragma: allowlist secret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: emailsender
+  name: emailsender
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: emailsender-tls
+spec:
+  ports:
+  - name: 443-8080
+    port: 443
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: emailsender
+  type: ClusterIP
 {{- end }}

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -69,6 +69,9 @@ fleetshardSync:
 # - enabled flag is used to completely enable/disable email sender service
 emailsender:
   enabled: false
+  # Use this in case you apply this manifest against a cluster without service-ca operator
+  # to turn of HTTPS and mounting the service-ca certs since they'll not be created
+  enableHTTPS: true
   replicas: 3
   image:
     repo: "quay.io/app-sre/acscs-emailsender"


### PR DESCRIPTION
## Description
This PR add a kubernetes svc resource for the emailsender template.
The service includes an annotation that will cause openshifts service-ca operator to create a secret called `emailsender-tls` that contains a cluster internal CA certfiicate.

The PR also changes the emailsender deployment to use this certificate.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [x] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

Tested by rendering and applying emailsender manifest locally on a crc:
```
helm template --namespace rhacs --set "secured-cluster.clusterName=test,secured-cluster.centralEndpoint=test,fleetshardSync.managedDB.enabled=false,emailsender.enabled=true,emailsender.clusterId=test,emailsender.clusterName=test,emailsender.environment=dev" . | yq e '. | select(.metadata.name == "emailsender")' > emailsender-manifests.yaml

k apply -f emailsender-manifests.yaml

# Verify it's running and using expected TLS cert
```
