### PR TITLE
ROX-22549: Add an addon metric to track version mismatch

### DIFF
--- a/internal/dinosaur/pkg/services/addon.go
+++ b/internal/dinosaur/pkg/services/addon.go
@@ -116,11 +116,11 @@ func (p *AddonProvisioner) Provision(cluster api.Cluster, expectedConfigs []gito
 			continue
 		}
 		if clusterInstallationDifferent(installedOnCluster, versionInstalledInOCM) {
-			updateClusterAddonMismatchDurationMetric(clusterID, installedOnCluster, versionInstalledInOCM, time.Since(installedInOCM.UpdatedTimestamp()))
+			updateClusterAddonMismatchDurationMetric(clusterID, installedOnCluster, versionInstalledInOCM, installedInOCM.UpdatedTimestamp())
 			multiErr = multierror.Append(multiErr, p.updateAddon(clusterID, expectedConfig))
 		} else {
 			glog.V(10).Infof("Addon %s is already up-to-date", installedOnCluster.ID)
-			updateClusterAddonMismatchDurationMetric(clusterID, installedOnCluster, versionInstalledInOCM, 0)
+			updateClusterAddonMismatchDurationMetric(clusterID, installedOnCluster, versionInstalledInOCM, time.Unix(0, 0))
 			multiErr = validateUpToDateAddon(multiErr, installedInOCM, installedOnCluster)
 		}
 	}
@@ -133,8 +133,8 @@ func (p *AddonProvisioner) Provision(cluster api.Cluster, expectedConfigs []gito
 	return errorOrNil(multiErr)
 }
 
-func updateClusterAddonMismatchDurationMetric(clusterID string, installedOnCluster dbapi.AddonInstallation, versionInstalledInOCM *clustersmgmtv1.AddOnVersion, duration time.Duration) {
-	metrics.UpdateClusterAddonMismatchDurationMetric(
+func updateClusterAddonMismatchDurationMetric(clusterID string, installedOnCluster dbapi.AddonInstallation, versionInstalledInOCM *clustersmgmtv1.AddOnVersion, updatedTimestamp time.Time) {
+	metrics.UpdateClusterAddonUpgradeStartedTimestampMetric(
 		installedOnCluster.ID,
 		clusterID,
 		versionInstalledInOCM.ID(),
@@ -143,7 +143,7 @@ func updateClusterAddonMismatchDurationMetric(clusterID string, installedOnClust
 		installedOnCluster.Version,
 		installedOnCluster.SourceImage,
 		installedOnCluster.PackageImage,
-		duration,
+		updatedTimestamp,
 	)
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -73,8 +73,8 @@ const (
 	// ClusterStatusCapacityUsed - metric name for the current number of instances
 	ClusterStatusCapacityUsed = "cluster_status_capacity_used"
 
-	// ClusterAddonMismatchDuration - metric name for the time period after the addon is upgraded in OCM but not yet installed on a cluster in seconds
-	ClusterAddonMismatchDuration = "cluster_addon_version_mismatch_duration"
+	// ClusterAddonUpgradeStartedTimestamp - metric name for the timestamp when the addon is upgraded in OCM but not yet installed on a cluster in seconds
+	ClusterAddonUpgradeStartedTimestamp = "cluster_addon_upgrade_started_timestamp_seconds"
 
 	// GitopsConfigProviderErrorCount - metric name for the number of errors encountered while fetching GitOps config
 	GitopsConfigProviderErrorCount = "gitops_config_provider_error_count"
@@ -180,7 +180,7 @@ var clusterStatusCapacityLabels = []string{
 	LabelClusterID,
 }
 
-var clusterAddonMismatchDurationLabels = []string{
+var clusterAddonUpgradeStartedTimestampLabels = []string{
 	LabelID,
 	LabelClusterID,
 	labelAddonOCMVersion,
@@ -727,19 +727,19 @@ func init() {
 	GitopsConfigProviderErrorCounter.WithLabelValues().Add(0)
 }
 
-// clusterAddonMismatchDurationMetric create a new GaugeVec for cluster addon mismatch duration
-var clusterAddonMismatchDurationMetric = prometheus.NewGaugeVec(
+// clusterAddonUpgradeStartedTimestampMetric create a new GaugeVec for cluster addon upgrade started timestamp
+var clusterAddonUpgradeStartedTimestampMetric = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Subsystem: FleetManager,
-		Name:      ClusterAddonMismatchDuration,
+		Name:      ClusterAddonUpgradeStartedTimestamp,
 		Help:      "metric name for the time period after the addon is upgraded in OCM but not yet installed on a cluster in seconds",
 	},
-	clusterAddonMismatchDurationLabels,
+	clusterAddonUpgradeStartedTimestampLabels,
 )
 
-// UpdateClusterAddonMismatchDurationMetric updates ClusterAddonMismatchDuration Metric
-func UpdateClusterAddonMismatchDurationMetric(addonID, clusterID, ocmVersion, ocmSourceImage, ocmPackageImage,
-	clusterVersion, clusterSourceImage, clusterPackageImage string, duration time.Duration) {
+// UpdateClusterAddonUpgradeStartedTimestampMetric updates ClusterAddonUpgradeStartedTimestamp Metric
+func UpdateClusterAddonUpgradeStartedTimestampMetric(addonID, clusterID, ocmVersion, ocmSourceImage, ocmPackageImage,
+	clusterVersion, clusterSourceImage, clusterPackageImage string, updatedTimestamp time.Time) {
 	labels := prometheus.Labels{
 		LabelID:                       addonID,
 		LabelClusterID:                clusterID,
@@ -750,7 +750,7 @@ func UpdateClusterAddonMismatchDurationMetric(addonID, clusterID, ocmVersion, oc
 		labelAddonClusterSourceImage:  clusterSourceImage,
 		labelAddonClusterPackageImage: clusterPackageImage,
 	}
-	clusterAddonMismatchDurationMetric.With(labels).Set(duration.Seconds())
+	clusterAddonUpgradeStartedTimestampMetric.With(labels).Set(float64(updatedTimestamp.Unix()))
 }
 
 // UpdateDatabaseQueryDurationMetric Update the observatorium request duration metric with the following labels:
@@ -777,7 +777,7 @@ func init() {
 	prometheus.MustRegister(centralPerClusterCountMetric)
 	prometheus.MustRegister(clusterStatusCapacityMaxMetric)
 	prometheus.MustRegister(clusterStatusCapacityUsedMetric)
-	prometheus.MustRegister(clusterAddonMismatchDurationMetric)
+	prometheus.MustRegister(clusterAddonUpgradeStartedTimestampMetric)
 	prometheus.MustRegister(GitopsConfigProviderErrorCounter)
 
 	// metrics for Centrals
@@ -848,7 +848,7 @@ func Reset() {
 	centralPerClusterCountMetric.Reset()
 	clusterStatusCapacityMaxMetric.Reset()
 	clusterStatusCapacityUsedMetric.Reset()
-	clusterAddonMismatchDurationMetric.Reset()
+	clusterAddonUpgradeStartedTimestampMetric.Reset()
 	GitopsConfigProviderErrorCounter.Reset()
 
 	requestCentralCreationDurationMetric.Reset()

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -5,10 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	constants2 "github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
-	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/dbapi"
-
 	"github.com/stackrox/acs-fleet-manager/pkg/api"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -741,16 +738,17 @@ var clusterAddonMismatchDurationMetric = prometheus.NewGaugeVec(
 )
 
 // UpdateClusterAddonMismatchDurationMetric updates ClusterAddonMismatchDuration Metric
-func UpdateClusterAddonMismatchDurationMetric(clusterID string, installedOnCluster dbapi.AddonInstallation, versionInstalledInOCM *clustersmgmtv1.AddOnVersion, duration time.Duration) {
+func UpdateClusterAddonMismatchDurationMetric(addonID, clusterID, ocmVersion, ocmSourceImage, ocmPackageImage,
+	clusterVersion, clusterSourceImage, clusterPackageImage string, duration time.Duration) {
 	labels := prometheus.Labels{
-		LabelID:                       installedOnCluster.ID,
+		LabelID:                       addonID,
 		LabelClusterID:                clusterID,
-		labelAddonOCMVersion:          versionInstalledInOCM.ID(),
-		labelAddonOCMSourceImage:      versionInstalledInOCM.SourceImage(),
-		labelAddonOCMPackageImage:     versionInstalledInOCM.PackageImage(),
-		labelAddonClusterVersion:      installedOnCluster.Version,
-		labelAddonClusterSourceImage:  installedOnCluster.SourceImage,
-		labelAddonClusterPackageImage: installedOnCluster.PackageImage,
+		labelAddonOCMVersion:          ocmVersion,
+		labelAddonOCMSourceImage:      ocmSourceImage,
+		labelAddonOCMPackageImage:     ocmPackageImage,
+		labelAddonClusterVersion:      clusterVersion,
+		labelAddonClusterSourceImage:  clusterSourceImage,
+		labelAddonClusterPackageImage: clusterPackageImage,
 	}
 	clusterAddonMismatchDurationMetric.With(labels).Set(duration.Seconds())
 }


### PR DESCRIPTION
## Description
The metric is needed when the OCM api returns success after an update, but something is wrong on the cluster and the components cannot be updated. This leads to a situation where all components of the data plane are running but are not up to date.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
