### PR TITLE
ROX-23249: multiple emailsender issues discovered by debugging

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -76,6 +76,7 @@ emailsender:
   clusterId: ""
   clusterName: ""
   environment: ""
+  senderAddress: "noreply@mail.rhacs-dev.com"
   authConfigFromKubernetes: true
   resources:
     requests:

--- a/emailsender/cmd/app/main.go
+++ b/emailsender/cmd/app/main.go
@@ -44,8 +44,8 @@ func main() {
 		glog.Errorf("Failed to initialise SES Client: %v", err)
 		os.Exit(1)
 	}
-	temporarySenderName := "noreply@mail.acs.rhcloud.com"
-	emailSender := email.NewEmailSender(temporarySenderName, sesClient)
+
+	emailSender := email.NewEmailSender(cfg.SenderAddress, sesClient)
 	emailHandler := api.NewEmailHandler(emailSender)
 
 	router, err := api.SetupRoutes(cfg.AuthConfig, emailHandler)

--- a/emailsender/config/config.go
+++ b/emailsender/config/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	MetricsAddress           string `env:"METRICS_ADDRESS" envDefault:":9090"`
 	AuthConfigFile           string `env:"AUTH_CONFIG_FILE" envDefault:"config/emailsender-authz.yaml"`
 	AuthConfigFromKubernetes bool   `env:"AUTH_CONFIG_FROM_KUBERNETES" envDefault:"false"`
+	SenderAddress            string `env:"SENDER_ADDRESS" envDefault:"noreply@mail.rhacs-dev.com"`
 	AuthConfig               AuthConfig
 }
 

--- a/emailsender/pkg/api/emailhandler.go
+++ b/emailsender/pkg/api/emailhandler.go
@@ -18,8 +18,8 @@ type EmailHandler struct {
 
 // SendEmailRequest represents API requests for sending email
 type SendEmailRequest struct {
-	To         []string
-	RawMessage []byte
+	To         []string `json:"to"`
+	RawMessage []byte   `json:"rawMessage"`
 }
 
 type Envelope map[string]interface{}

--- a/emailsender/pkg/email/sender.go
+++ b/emailsender/pkg/email/sender.go
@@ -1,20 +1,27 @@
 package email
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+
 	"github.com/golang/glog"
 )
 
+const fromTemplate = "From: RHACS Cloud Service <%s>\r\n"
+
+// Sender defines the interface to send emails
 type Sender interface {
 	Send(ctx context.Context, to []string, rawMessage []byte) error
 }
 
+// MailSender is the default implementation for the Sender interface
 type MailSender struct {
 	from string
 	ses  *SES
 }
 
+// NewEmailSender returns a new MailSender instance
 func NewEmailSender(from string, ses *SES) *MailSender {
 	return &MailSender{
 		from: from,
@@ -22,8 +29,13 @@ func NewEmailSender(from string, ses *SES) *MailSender {
 	}
 }
 
+// Send sends an email to the given AWS SES
 func (s *MailSender) Send(ctx context.Context, to []string, rawMessage []byte) error {
-	_, err := s.ses.SendRawEmail(ctx, s.from, to, rawMessage)
+	// Even though AWS adds the from handler we need to set it the the message to show
+	// an alias in email inboxes that is more human friendly (noreply@rhacs-dev.com vs. RHACS Cloud Service)
+	fromBytes := []byte(fmt.Sprintf(fromTemplate, s.from))
+	raw := bytes.Join([][]byte{fromBytes, rawMessage}, nil)
+	_, err := s.ses.SendRawEmail(ctx, s.from, to, raw)
 	if err != nil {
 		glog.Errorf("Failed sending email: %v", err)
 		return fmt.Errorf("failed to send email: %v", err)


### PR DESCRIPTION
## Description
I tested sending emails via emailservice locally and discovered some problem that I needed to be fixed to be able to send a first email.

- Add a from header that looks more human friendly than the only the email address
- Have the sender address configurable (addon part t.b.d but it is now a helm value)
- Adding json tags to the SendEmailRequest so that it fits to the object send by central
- Adding some comments to satisfy Go linter



## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

- Run the emailsender locally
- Open stackrox repo
- add a temporary test:
```
func TestEmailSending(t *testing.T) {
	t.Setenv("ROX_ACSCS_EMAIL_URL", "http://localhost:8080")
	acscsEmail := acscsEmail{
		client: &clientImpl{
			loadToken: func() (string, error) {
				return "<your-ocm-token-here>", nil
			},
			url:        fmt.Sprintf("http://localhost:8080%s", sendMsgPath),
			httpClient: http.DefaultClient,
		},
		notifier: &storage.Notifier{
			LabelDefault: "jmalsam@redhat.com",
		},
	}

	err := acscsEmail.Test(context.Background())
	require.Nil(t, err, "failed to send test email")
}
```
- Login to AWS dev account for local AWS authentication
- Verify my email for aws ses sandbox in dev account
- Run the test, verify I got a test email

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
