### PR TITLE
ROX-20474: Add TENANT_IMAGE_PULL_SECRET to the dp-terraform helm chart

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -134,6 +134,13 @@ spec:
         - name: FLEET_MANAGER_TOKEN_FILE
           value: "/var/run/secrets/tokens/fleet-manager-token"
         {{- end }}
+        {{- if .Values.fleetshardSync.tenantImagePullSecret.ref }}
+        - name: TENANT_IMAGE_PULL_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.fleetshardSync.tenantImagePullSecret.ref | quote }}
+              key: {{ .Values.fleetshardSync.tenantImagePullSecret.key | quote }}
+        {{- end }}
         volumeMounts:
           - mountPath: /var/run/secrets/tokens
             name: aws-token

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -134,11 +134,11 @@ spec:
         - name: FLEET_MANAGER_TOKEN_FILE
           value: "/var/run/secrets/tokens/fleet-manager-token"
         {{- end }}
-        {{- if .Values.fleetshardSync.tenantImagePullSecret.ref }}
+        {{- if .Values.fleetshardSync.tenantImagePullSecret.name }}
         - name: TENANT_IMAGE_PULL_SECRET
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.fleetshardSync.tenantImagePullSecret.ref | quote }}
+              name: {{ .Values.fleetshardSync.tenantImagePullSecret.name | quote }}
               key: {{ .Values.fleetshardSync.tenantImagePullSecret.key | quote }}
         {{- end }}
         volumeMounts:

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -64,6 +64,9 @@ fleetshardSync:
       effect: NoSchedule
   addonAutoUpgradeEnabled: true
   addonName: acs-fleetshard
+  tenantImagePullSecret:
+    ref: ""
+    key: .dockerconfigjson
 
 # Email sender service parameters
 # - enabled flag is used to completely enable/disable email sender service

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -65,7 +65,7 @@ fleetshardSync:
   addonAutoUpgradeEnabled: true
   addonName: acs-fleetshard
   tenantImagePullSecret:
-    ref: ""
+    name: ""
     key: .dockerconfigjson
 
 # Email sender service parameters

--- a/dp-terraform/test/helm_template_test.go
+++ b/dp-terraform/test/helm_template_test.go
@@ -71,30 +71,30 @@ func TestHelmTemplate_FleetshardSyncDeployment_Tenant(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		ref          string
-		wantNoEnvVar bool
-		expectedRef  string
-		key          string
-		expectedKey  string
+		name               string
+		secretName         string
+		wantNoEnvVar       bool
+		expectedSecretName string
+		key                string
+		expectedKey        string
 	}{
 		{
-			name:         "should not add env var if ref value is not set",
+			name:         "should not add env var if secret name value is not set",
 			wantNoEnvVar: true,
 		},
 		{
-			name:        "should add env var if ref value is set",
-			ref:         "stackrox",
-			expectedRef: "stackrox",
+			name:               "should add env var if secret name value is set",
+			secretName:         "stackrox", // pragma: allowlist secret
+			expectedSecretName: "stackrox", // pragma: allowlist secret
 		},
 		{
-			name:        "should set default key if ref value is set",
-			ref:         "stackrox",
+			name:        "should set default key if secret name value is set",
+			secretName:  "stackrox", // pragma: allowlist secret
 			expectedKey: ".dockerconfigjson",
 		},
 		{
-			name:        "should set key if ref and key is set",
-			ref:         "stackrox",
+			name:        "should set key if secret name and key is set",
+			secretName:  "stackrox", // pragma: allowlist secret
 			key:         "customkey",
 			expectedKey: "customkey",
 		},
@@ -107,8 +107,8 @@ func TestHelmTemplate_FleetshardSyncDeployment_Tenant(t *testing.T) {
 				"fleetshardSync.managedDB.enabled": "false",
 			}
 
-			if tt.ref != "" {
-				values["fleetshardSync.tenantImagePullSecret.ref"] = tt.ref
+			if tt.secretName != "" {
+				values["fleetshardSync.tenantImagePullSecret.name"] = tt.secretName
 			}
 			if tt.key != "" {
 				values["fleetshardSync.tenantImagePullSecret.key"] = tt.key
@@ -130,8 +130,8 @@ func TestHelmTemplate_FleetshardSyncDeployment_Tenant(t *testing.T) {
 				return
 			}
 			require.NotEmpty(t, tenantImagePullSecret)
-			if tt.expectedRef != "" {
-				require.Equal(t, tt.expectedRef, tenantImagePullSecret.ValueFrom.SecretKeyRef.Name)
+			if tt.expectedSecretName != "" {
+				require.Equal(t, tt.expectedSecretName, tenantImagePullSecret.ValueFrom.SecretKeyRef.Name)
 			}
 			if tt.expectedKey != "" {
 				require.Equal(t, tt.expectedKey, tenantImagePullSecret.ValueFrom.SecretKeyRef.Key)

--- a/dp-terraform/test/helm_template_test.go
+++ b/dp-terraform/test/helm_template_test.go
@@ -14,22 +14,11 @@ import (
 func TestHelmTemplate_FleetshardSyncDeployment_ServiceAccountTokenAuthType(t *testing.T) {
 	t.Parallel()
 
-	helmChartPath, err := filepath.Abs("../helm/rhacs-terraform")
-	releaseName := "rhacs-terraform"
-	require.NoError(t, err)
-
-	namespaceName := "rhacs"
-
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"secured-cluster.enabled":          "false",
-			"fleetshardSync.managedDB.enabled": "false",
-			"fleetshardSync.authType":          "SERVICE_ACCOUNT_TOKEN",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
-	}
-
-	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/fleetshard-sync.yaml"})
+	output := renderTemplate(t, map[string]string{
+		"secured-cluster.enabled":          "false",
+		"fleetshardSync.managedDB.enabled": "false",
+		"fleetshardSync.authType":          "SERVICE_ACCOUNT_TOKEN",
+	})
 
 	var deployment appsv1.Deployment
 	helm.UnmarshalK8SYaml(t, output, &deployment)
@@ -43,21 +32,110 @@ func TestHelmTemplate_FleetshardSyncDeployment_ServiceAccountTokenAuthType(t *te
 	require.Equal(t, "fleet-manager-token", volume.Name)
 
 	envVars := container.Env
-	require.Equal(t, "SERVICE_ACCOUNT_TOKEN", findEnvVar("AUTH_TYPE", envVars))
+	require.Equal(t, "SERVICE_ACCOUNT_TOKEN", findEnvVar("AUTH_TYPE", envVars).Value)
 	require.Empty(t, findEnvVar("RHSSO_SERVICE_ACCOUNT_CLIENT_ID", envVars))
 	require.Empty(t, findEnvVar("RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET", envVars))
 	require.Empty(t, findEnvVar("RHSSO_REALM", envVars))
 	require.Empty(t, findEnvVar("RHSSO_ENDPOINT", envVars))
 
 	tokenFile := findEnvVar("FLEET_MANAGER_TOKEN_FILE", envVars)
-	require.NotEmpty(t, tokenFile)
+	require.NotEmpty(t, tokenFile.Value)
 }
 
-func findEnvVar(name string, envVars []corev1.EnvVar) string {
+func renderTemplate(t *testing.T, values map[string]string) string {
+	helmChartPath, err := filepath.Abs("../helm/rhacs-terraform")
+	releaseName := "rhacs-terraform"
+	require.NoError(t, err)
+
+	namespaceName := "rhacs"
+
+	options := &helm.Options{
+		SetValues:      values,
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/fleetshard-sync.yaml"})
+	return output
+}
+
+func findEnvVar(name string, envVars []corev1.EnvVar) *corev1.EnvVar {
 	for _, envVar := range envVars {
 		if envVar.Name == name {
-			return envVar.Value
+			return &envVar
 		}
 	}
-	return ""
+	return nil
+}
+
+func TestHelmTemplate_FleetshardSyncDeployment_Tenant(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		ref          string
+		wantNoEnvVar bool
+		expectedRef  string
+		key          string
+		expectedKey  string
+	}{
+		{
+			name:         "should not add env var if ref value is not set",
+			wantNoEnvVar: true,
+		},
+		{
+			name:        "should add env var if ref value is set",
+			ref:         "stackrox",
+			expectedRef: "stackrox",
+		},
+		{
+			name:        "should set default key if ref value is set",
+			ref:         "stackrox",
+			expectedKey: ".dockerconfigjson",
+		},
+		{
+			name:        "should set key if ref and key is set",
+			ref:         "stackrox",
+			key:         "customkey",
+			expectedKey: "customkey",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values := map[string]string{
+				"secured-cluster.enabled":          "false",
+				"fleetshardSync.managedDB.enabled": "false",
+			}
+
+			if tt.ref != "" {
+				values["fleetshardSync.tenantImagePullSecret.ref"] = tt.ref
+			}
+			if tt.key != "" {
+				values["fleetshardSync.tenantImagePullSecret.key"] = tt.key
+			}
+
+			output := renderTemplate(t, values)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(t, output, &deployment)
+
+			container := deployment.Spec.Template.Spec.Containers[0]
+			require.Equal(t, "fleetshard-sync", container.Name)
+
+			envVars := container.Env
+
+			tenantImagePullSecret := findEnvVar("TENANT_IMAGE_PULL_SECRET", envVars)
+			if tt.wantNoEnvVar {
+				require.Empty(t, tenantImagePullSecret)
+				return
+			}
+			require.NotEmpty(t, tenantImagePullSecret)
+			if tt.expectedRef != "" {
+				require.Equal(t, tt.expectedRef, tenantImagePullSecret.ValueFrom.SecretKeyRef.Name)
+			}
+			if tt.expectedKey != "" {
+				require.Equal(t, tt.expectedKey, tenantImagePullSecret.ValueFrom.SecretKeyRef.Key)
+			}
+		})
+	}
 }

--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	DefaultBaseCRDURL    string        `env:"DEFAULT_BASE_CRD_URL" envDefault:"https://raw.githubusercontent.com/stackrox/stackrox/%s/operator/bundle/manifests/"`
 	// TenantImagePullSecret can be used to inject a Kubernetes image pull secret into tenant namespaces.
 	// If it is empty, nothing is injected (for example, it is not required when running on OpenShift).
-	// It is however required in some situations (such as remote GKE clusters) when central images need to fetched from a private Quay registry.
+	// It is required when central images need to fetched from a private Quay registry.
 	// It needs to given as Docker Config JSON object.
 	TenantImagePullSecret string `env:"TENANT_IMAGE_PULL_SECRET"`
 	ManagedDB             ManagedDB


### PR DESCRIPTION
## Description
Add TENANT_IMAGE_PULL_SECRET to the dp-terraform helm chart in order to derive an imagepullsecret from fleetshard-sync namespace

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
