### PR TITLE
ROX-23260: Add backoff to send raw email

### DIFF
--- a/emailsender/cmd/app/main.go
+++ b/emailsender/cmd/app/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"time"
 
 	"golang.org/x/sys/unix"
 
@@ -39,7 +40,8 @@ func main() {
 	ctx := context.Background()
 
 	// initialize components
-	sesClient, err := email.NewSES(ctx)
+	backoffMaxDuration := time.Duration(cfg.SendEmailBackoffMaxMinutes) * time.Minute
+	sesClient, err := email.NewSES(ctx, backoffMaxDuration)
 	if err != nil {
 		glog.Errorf("Failed to initialise SES Client: %v", err)
 		os.Exit(1)

--- a/emailsender/config/config.go
+++ b/emailsender/config/config.go
@@ -28,15 +28,16 @@ const (
 
 // Config contains this application's runtime configuration.
 type Config struct {
-	ClusterID                string `env:"CLUSTER_ID"`
-	ServerAddress            string `env:"SERVER_ADDRESS" envDefault:":8080"`
-	EnableHTTPS              bool   `env:"ENABLE_HTTPS" envDefault:"false"`
-	HTTPSCertFile            string `env:"HTTPS_CERT_FILE" envDefault:""`
-	HTTPSKeyFile             string `env:"HTTPS_KEY_FILE" envDefault:""`
-	MetricsAddress           string `env:"METRICS_ADDRESS" envDefault:":9090"`
-	AuthConfigFile           string `env:"AUTH_CONFIG_FILE" envDefault:"config/emailsender-authz.yaml"`
-	AuthConfigFromKubernetes bool   `env:"AUTH_CONFIG_FROM_KUBERNETES" envDefault:"false"`
-	AuthConfig               AuthConfig
+	ClusterID                  string `env:"CLUSTER_ID"`
+	ServerAddress              string `env:"SERVER_ADDRESS" envDefault:":8080"`
+	EnableHTTPS                bool   `env:"ENABLE_HTTPS" envDefault:"false"`
+	HTTPSCertFile              string `env:"HTTPS_CERT_FILE" envDefault:""`
+	HTTPSKeyFile               string `env:"HTTPS_KEY_FILE" envDefault:""`
+	MetricsAddress             string `env:"METRICS_ADDRESS" envDefault:":9090"`
+	AuthConfigFile             string `env:"AUTH_CONFIG_FILE" envDefault:"config/emailsender-authz.yaml"`
+	AuthConfigFromKubernetes   bool   `env:"AUTH_CONFIG_FROM_KUBERNETES" envDefault:"false"`
+	SendEmailBackoffMaxMinutes int    `env:"SEND_EMAIL_BACKOFF_MAX_MINUTES" envDefault:"30"`
+	AuthConfig                 AuthConfig
 }
 
 // GetConfig retrieves the current runtime configuration from the environment and returns it.

--- a/emailsender/pkg/email/ses_test.go
+++ b/emailsender/pkg/email/ses_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ses"
@@ -78,7 +79,7 @@ func TestSendEmail_Failure(t *testing.T) {
 			return nil, errors.New(errorText)
 		},
 	}
-	mockedSES := SES{sesClient: mockClient}
+	mockedSES := SES{sesClient: mockClient, backoffMaxDuration: 1 * time.Second}
 
 	messageID, err := mockedSES.SendEmail(
 		context.Background(),
@@ -130,7 +131,7 @@ func TestSendRawEmail_Failure(t *testing.T) {
 			return nil, errors.New(errorText)
 		},
 	}
-	mockedSES := SES{sesClient: mockClient}
+	mockedSES := SES{sesClient: mockClient, backoffMaxDuration: 1 * time.Second}
 
 	buf := bytes.NewBuffer(nil)
 	buf.WriteString(fmt.Sprintf("Subject: %s\r\n", "Test Subject"))


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Add an exponential backoff to SES send raw email method

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
