### PR TITLE
ROX-21884: remove commented out tenant name change test

### DIFF
--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -143,19 +143,6 @@ func isDNSEnabled(routesEnabled bool) (bool, string, string) {
 	return dnsEnabled, accessKey, secretKey
 }
 
-func assertCentralRequestName(ctx context.Context, client *fleetmanager.Client, id string, name string) func() error {
-	return func() error {
-		centralRequest, _, err := client.PublicAPI().GetCentralById(ctx, id)
-		if err != nil {
-			return err
-		}
-		if centralRequest.Name != name {
-			return fmt.Errorf("expected centralRequest name %q, got %q", name, centralRequest.Name)
-		}
-		return nil
-	}
-}
-
 func assertCentralRequestStatus(ctx context.Context, client *fleetmanager.Client, id string, status string) func() error {
 	return func() error {
 		centralRequest, _, err := client.PublicAPI().GetCentralById(ctx, id)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -424,25 +424,6 @@ var _ = Describe("Central", Ordered, func() {
 				Should(Succeed())
 		})
 
-		//TODO: Tenant name change breaks deletion, uncomment when fixed
-		// It("should patch the Central name", func() {
-		//	centralRequestName = newCentralName()
-		//	_, _, err := adminAPI.UpdateCentralNameById(ctx,
-		//		centralRequestID,
-		//		private.CentralUpdateNameRequest{
-		//			Name: centralRequestName, Reason: "e2e test",
-		//		},
-		//	)
-		//	Expect(err).To(BeNil())
-		// })
-		//
-		// It("should transition to central's new name", func() {
-		//	Eventually(assertCentralRequestName(ctx, client, centralRequestID, centralRequestName)).
-		//		WithTimeout(waitTimeout).
-		//		WithPolling(defaultPolling).
-		//		Should(Succeed())
-		// })
-
 		It("should transition central to deprovisioning state when deleting", func() {
 			Expect(deleteCentralByID(ctx, client, centralRequestID)).
 				To(Succeed())


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

I'd remove the tenant name change tests, because they give the false impression that the feature works out of the box, and they were also hiding incorrect behavior:
- the test was hiding the fact that a name change triggers the creation of a second Central in the namespace, because the name change and the deletion were performed at the same time, 
- `ensureCentralCRDeleted` was not deleting the central, instead it was deleted by `ensureNamespaceDeleted` which is why the tests were passing

Now because of https://github.com/stackrox/acs-fleet-manager/pull/1842 `ensureCentralCRDeleted` is timing out, so I'd remove them altogether for now, unless we want to fix the renaming logic soon.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
