### PR TITLE
ROX-23259: emailsender aws sts

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender-secret.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: emailsender-ext-parameters
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretStoreRef:
+    name: {{ .Values.global.secretStore.aws.parameterStoreSecretStoreName }}
+    kind: ClusterSecretStore
+  target:
+    name: emailsender-parameters
+    creationPolicy: Owner
+  data:
+    - secretKey: aws-role-arn # pragma: allowlist secret
+      remoteRef:
+        key: "/emailsender/aws_role_arn"

--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
@@ -53,6 +53,8 @@ spec:
                 secretKeyRef:
                   name: emailsender-parameters
                   key: "aws-role-arn"
+            - name: AWS_WEB_IDENTITY_TOKEN_FILE
+              value: "/var/run/secrets/tokens/aws-token"
           ports:
             - name: monitoring
               containerPort: 9090
@@ -69,12 +71,22 @@ spec:
           - name: emailsender-tls
             mountPath: /var/run/certs
             readOnly: true
+          - name: aws-token
+            mountPath: /var/run/secrets/tokens
+            readOnly: true
         {{- end }}
     {{- if .Values.emailsender.enableHTTPS }}
       volumes:
         - name: emailsender-tls
           secret:
             secretName: emailsender-tls # pragma: allowlist secret
+        - name: aws-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: aws-token
+                  audience: sts.amazonaws.com
+                  expirationSeconds: 3600
     {{- end }}
 ---
 apiVersion: v1

--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
@@ -66,20 +66,21 @@ spec:
             requests:
               cpu: {{ .Values.emailsender.resources.requests.cpu | quote }}
               memory: {{ .Values.emailsender.resources.requests.memory | quote }}
-        {{- if .Values.emailsender.enableHTTPS }}
           volumeMounts:
-          - name: emailsender-tls
-            mountPath: /var/run/certs
-            readOnly: true
           - name: aws-token
             mountPath: /var/run/secrets/tokens
             readOnly: true
-        {{- end }}
-    {{- if .Values.emailsender.enableHTTPS }}
+          {{- if .Values.emailsender.enableHTTPS }}
+          - name: emailsender-tls
+            mountPath: /var/run/certs
+            readOnly: true
+          {{- end }}
       volumes:
+        {{- if .Values.emailsender.enableHTTPS }}
         - name: emailsender-tls
           secret:
             secretName: emailsender-tls # pragma: allowlist secret
+        {{- end }}
         - name: aws-token
           projected:
             sources:
@@ -87,7 +88,6 @@ spec:
                   path: aws-token
                   audience: sts.amazonaws.com
                   expirationSeconds: 3600
-    {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
@@ -44,6 +44,15 @@ spec:
             - name: ENABLE_HTTPS
               value: "true"
           {{- end }}
+            # Reusing fleetshardSync.aws.region here since the Values file defines multiple
+            # aws region for different components and the emailsender should always use the same as FS
+            - name: AWS_REGION
+              value: {{ .Values.fleetshardSync.aws.region }}
+            - name: AWS_ROLE_ARN
+              valueFrom:
+                secretKeyRef:
+                  name: emailsender-parameters
+                  key: "aws-role-arn"
           ports:
             - name: monitoring
               containerPort: 9090

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-secret.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-secret.yaml
@@ -8,7 +8,7 @@ spec:
     name: {{ .Values.global.secretStore.aws.secretsManagerSecretStoreName }}
     kind: ClusterSecretStore
   target:
-    name: fleetshard-sync
+    name: cluster-{clustername}-db
     creationPolicy: Owner
   data:
     {{- if eq "RHSSO" .Values.fleetshardSync.authType }}

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-secret.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-secret.yaml
@@ -8,7 +8,7 @@ spec:
     name: {{ .Values.global.secretStore.aws.secretsManagerSecretStoreName }}
     kind: ClusterSecretStore
   target:
-    name: cluster-{clustername}-db
+    name: fleetshard-sync
     creationPolicy: Owner
   data:
     {{- if eq "RHSSO" .Values.fleetshardSync.authType }}


### PR DESCRIPTION
## Description
Adding the environment variables and volume mounts necessary to make emailsender deployment use the kubernetes service account token to get AWS IAM credentials for the emailsender role.

This requires https://github.com/stackrox/acs-fleet-manager-aws-config/pull/213 to be merged.
## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
