### PR TITLE
ROX-22549: Remove excessive labels for the addon metric

### DIFF
--- a/internal/dinosaur/pkg/services/addon.go
+++ b/internal/dinosaur/pkg/services/addon.go
@@ -116,11 +116,11 @@ func (p *AddonProvisioner) Provision(cluster api.Cluster, dataplaneClusterConfig
 		}
 		if clusterInstallationDifferent(installedOnCluster, versionInstalledInOCM) {
 			multiErr = multierror.Append(multiErr, p.updateAddon(clusterID, expectedConfig))
-			p.updateAddonStatusMetric(dataplaneClusterConfig.ClusterName, installedOnCluster, versionInstalledInOCM, metrics.AddonUpgrade)
+			metrics.UpdateClusterAddonStatusMetric(installedOnCluster.ID, dataplaneClusterConfig.ClusterName, metrics.AddonUpgrade)
 		} else {
 			glog.V(10).Infof("Addon %s is already up-to-date", installedOnCluster.ID)
 			multiErr = validateUpToDateAddon(multiErr, installedInOCM, installedOnCluster)
-			p.updateAddonStatusMetric(dataplaneClusterConfig.ClusterName, installedOnCluster, versionInstalledInOCM, metrics.AddonUp)
+			metrics.UpdateClusterAddonStatusMetric(installedOnCluster.ID, dataplaneClusterConfig.ClusterName, metrics.AddonUp)
 		}
 	}
 
@@ -130,20 +130,6 @@ func (p *AddonProvisioner) Provision(cluster api.Cluster, dataplaneClusterConfig
 	}
 
 	return errorOrNil(multiErr)
-}
-
-func (p *AddonProvisioner) updateAddonStatusMetric(clusterName string, installedOnCluster dbapi.AddonInstallation, versionInstalledInOCM *clustersmgmtv1.AddOnVersion, status metrics.AddonStatus) {
-	metrics.UpdateClusterAddonStatusMetric(
-		installedOnCluster.ID,
-		clusterName,
-		versionInstalledInOCM.ID(),
-		versionInstalledInOCM.SourceImage(),
-		versionInstalledInOCM.PackageImage(),
-		installedOnCluster.Version,
-		installedOnCluster.SourceImage,
-		installedOnCluster.PackageImage,
-		status,
-	)
 }
 
 func validateUpToDateAddon(multiErr *multierror.Error, ocmInstallation *clustersmgmtv1.AddOnInstallation, dataPlaneInstallation dbapi.AddonInstallation) *multierror.Error {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -88,13 +88,6 @@ const (
 	LabelDatabaseQueryType   = "query"
 	LabelRegion              = "region"
 	LabelInstanceType        = "instance_type"
-
-	labelAddonOCMVersion          = "ocm_version"
-	labelAddonOCMSourceImage      = "ocm_source_image"
-	labelAddonOCMPackageImage     = "ocm_package_image"
-	labelAddonClusterVersion      = "cluster_version"
-	labelAddonClusterSourceImage  = "cluster_source_image"
-	labelAddonClusterPackageImage = "cluster_package_image"
 )
 
 // JobType metric to capture
@@ -184,12 +177,6 @@ var clusterStatusCapacityLabels = []string{
 var clusterAddonStatusLabels = []string{
 	LabelID,
 	LabelClusterName,
-	labelAddonOCMVersion,
-	labelAddonOCMSourceImage,
-	labelAddonOCMPackageImage,
-	labelAddonClusterVersion,
-	labelAddonClusterSourceImage,
-	labelAddonClusterPackageImage,
 }
 
 // #### Metrics for Dataplane clusters - Start ####
@@ -749,17 +736,10 @@ var clusterAddonStatusMetric = prometheus.NewGaugeVec(
 )
 
 // UpdateClusterAddonStatusMetric updates ClusterAddonStatusMetric Metric
-func UpdateClusterAddonStatusMetric(addonID, clusterName, ocmVersion, ocmSourceImage, ocmPackageImage,
-	clusterVersion, clusterSourceImage, clusterPackageImage string, status AddonStatus) {
+func UpdateClusterAddonStatusMetric(addonID, clusterName string, status AddonStatus) {
 	labels := prometheus.Labels{
-		LabelID:                       addonID,
-		LabelClusterName:              clusterName,
-		labelAddonOCMVersion:          ocmVersion,
-		labelAddonOCMSourceImage:      ocmSourceImage,
-		labelAddonOCMPackageImage:     ocmPackageImage,
-		labelAddonClusterVersion:      clusterVersion,
-		labelAddonClusterSourceImage:  clusterSourceImage,
-		labelAddonClusterPackageImage: clusterPackageImage,
+		LabelID:          addonID,
+		LabelClusterName: clusterName,
 	}
 	clusterAddonStatusMetric.With(labels).Set(float64(status))
 }


### PR DESCRIPTION
## Description
I realized that I misused the label concept in Prometheus. From the [docs](https://prometheus.io/docs/practices/naming/):
```
CAUTION: Remember that every unique combination of key-value label pairs represents a new time series, which can dramatically increase the amount of data stored. Do not use labels to store dimensions with high cardinality (many different label values), such as user IDs, email addresses, or other unbounded sets of values.
```
Basically, every label brings an extra dimension. Because of that I can't build the graph I want.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
