### PR TITLE
ROX-23749: Allow Scanner V4 observability ingress on port 9091

### DIFF
--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/network-policy-scanner-v4.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/network-policy-scanner-v4.yaml
@@ -26,6 +26,8 @@ spec:
       ports:
         - port: 9090
           protocol: TCP
+        - port: 9091
+          protocol: TCP
   egress:
     - to:  # Allow egress to Scanner-v4-db for normal function
         - podSelector:
@@ -81,6 +83,8 @@ spec:
       ports:
         - port: 9090
           protocol: TCP
+        - port: 9091
+          protocol: TCP
   egress:
     - to:  # Allow egress to Scanner-v4-db for normal function
         - podSelector:
@@ -126,6 +130,8 @@ spec:
               - { key: kubernetes.io/metadata.name, operator: In, values: [ rhacs-observability, openshift-monitoring ] }
       ports:
         - port: 9090
+          protocol: TCP
+        - port: 9091
           protocol: TCP
   policyTypes:
     - Ingress


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Need to allow port 9091 because of this change: https://github.com/stackrox/stackrox/pull/10982

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
