### PR TITLE
ROX-23260: add external secret for emailsender db config

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender-secret.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender-secret.yaml
@@ -1,0 +1,33 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: emailsender-db-secret
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretStoreRef:
+    name: {{ .Values.global.secretStore.aws.secretsManagerSecretStoreName }}
+    kind: ClusterSecretStore
+  target:
+    name: emailsender-db
+    creationPolicy: Owner
+  data:
+    - secretKey: username # pragma: allowlist secret
+      remoteRef:
+        key: "cluster-{{ .Values.emailsender.clusterName }}-emailsender-db"
+        property: "username"
+    - secretKey: databaseName # pragma: allowlist secret
+      remoteRef:
+        key: "cluster-{{ .Values.emailsender.clusterName }}-emailsender-db"
+        property: "databaseName"
+    - secretKey: host # pragma: allowlist secret
+      remoteRef:
+        key: "cluster-{{ .Values.emailsender.clusterName }}-emailsender-db"
+        property: "host"
+    - secretKey: password # pragma: allowlist secret
+      remoteRef:
+        key: "cluster-{{ .Values.emailsender.clusterName }}-emailsender-db"
+        property: "password" # pragma: allowlist secret
+    - secretKey: port # pragma: allowlist secret
+      remoteRef:
+        key: "cluster-{{ .Values.emailsender.clusterName }}-emailsender-db"
+        property: "port"

--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender-secret.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender-secret.yaml
@@ -11,23 +11,23 @@ spec:
     name: emailsender-db
     creationPolicy: Owner
   data:
-    - secretKey: username # pragma: allowlist secret
+    - secretKey: db.user # pragma: allowlist secret
       remoteRef:
         key: "cluster-{{ .Values.emailsender.clusterName }}-emailsender-db"
         property: "username"
-    - secretKey: databaseName # pragma: allowlist secret
+    - secretKey: db.name # pragma: allowlist secret
       remoteRef:
         key: "cluster-{{ .Values.emailsender.clusterName }}-emailsender-db"
         property: "databaseName"
-    - secretKey: host # pragma: allowlist secret
+    - secretKey: db.host # pragma: allowlist secret
       remoteRef:
         key: "cluster-{{ .Values.emailsender.clusterName }}-emailsender-db"
         property: "host"
-    - secretKey: password # pragma: allowlist secret
+    - secretKey: db.password # pragma: allowlist secret
       remoteRef:
         key: "cluster-{{ .Values.emailsender.clusterName }}-emailsender-db"
         property: "password" # pragma: allowlist secret
-    - secretKey: port # pragma: allowlist secret
+    - secretKey: db.port # pragma: allowlist secret
       remoteRef:
         key: "cluster-{{ .Values.emailsender.clusterName }}-emailsender-db"
         property: "port"

--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
@@ -57,7 +57,7 @@ spec:
               memory: {{ .Values.emailsender.resources.requests.memory | quote }}
           volumeMounts:
           - name: emailsender-db
-            mountPath: /secrets/db
+            mountPath: /secrets
             readOnly: true
         {{- if .Values.emailsender.enableHTTPS }}
           - name: emailsender-tls

--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
@@ -55,8 +55,11 @@ spec:
             requests:
               cpu: {{ .Values.emailsender.resources.requests.cpu | quote }}
               memory: {{ .Values.emailsender.resources.requests.memory | quote }}
-        {{- if .Values.emailsender.enableHTTPS }}
           volumeMounts:
+          - name: emailsender-db
+            mountPath: /secrets/db
+            readOnly: true
+        {{- if .Values.emailsender.enableHTTPS }}
           - name: emailsender-tls
             mountPath: /var/run/certs
             readOnly: true
@@ -66,6 +69,9 @@ spec:
         - name: emailsender-tls
           secret:
             secretName: emailsender-tls # pragma: allowlist secret
+        - name: emailsender-db
+          secret:
+            secretName: emailsender-db # pragma: allowlist secret
     {{- end }}
 ---
 apiVersion: v1


### PR DESCRIPTION
## Description
This PR adds a external secret to emailsender helm chart, that is supposed to make the DB configuration available from an AWS secret.

https://github.com/stackrox/acs-fleet-manager-aws-config/pull/214 is required first, to create the secret that should be load into the cluster.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
