### PR TITLE
ROX-23258: add emailsender to egress NP for central

### DIFF
--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/network-policy-central.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/network-policy-central.yaml
@@ -88,6 +88,18 @@ spec:
           protocol: TCP
         - port: 6443
           protocol: TCP
+    - to:  # Allow egress to emailsender
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: rhacs
+          podSelector:
+            matchLabels:
+              app: emailsender
+      ports:
+        - port: 8080
+          protocol: TCP
+        - port: 443
+          protocol: TCP
     - to:  # Allow egress to external Internet
         - ipBlock:
             cidr: 0.0.0.0/0


### PR DESCRIPTION
## Description
This PR adds the cluster internal emailsender service/pods to the allowed egress traffic for the tenant-central network policy.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
