### PR TITLE
ROX-23749: allow indexer and scanner egress to kube API

### DIFF
--- a/fleetshard/pkg/central/charts/data/tenant-resources/templates/network-policy-scanner-v4.yaml
+++ b/fleetshard/pkg/central/charts/data/tenant-resources/templates/network-policy-scanner-v4.yaml
@@ -52,6 +52,18 @@ spec:
             cidr: ::/0
             except:
               {{- include "localNetworkCidrRangesIPv6" . | nindent 14 }}
+    - to: # Allow egress to Kube API for mTLS setup for OpenShift monitoring
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-kube-apiserver
+          podSelector:
+            matchLabels:
+              app: openshift-kube-apiserver
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
   policyTypes:
     - Ingress
     - Egress
@@ -99,6 +111,18 @@ spec:
               - { key: app, operator: In, values: [central, scanner-v4-indexer] }
       ports:
         - port: 8443
+          protocol: TCP
+    - to: # Allow egress to Kube API for mTLS setup for OpenShift monitoring
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-kube-apiserver
+          podSelector:
+            matchLabels:
+              app: openshift-kube-apiserver
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
           protocol: TCP
   policyTypes:
     - Ingress


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

From ACS 4.5 onwards, Scanner V4 indexer and matcher require egress access to the Kube API, for mTLS setup for OpenShift monitoring.

See also:
https://github.com/stackrox/acs-fleet-manager/pull/1881
https://github.com/stackrox/stackrox/pull/10982

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
