### PR TITLE
ROX-23709: Fix token expiration

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -142,16 +142,8 @@ spec:
               key: {{ .Values.fleetshardSync.tenantImagePullSecret.key | quote }}
         {{- end }}
         volumeMounts:
-          - mountPath: /var/run/secrets/tokens/aws-token
-            subPath: aws-token
-            name: aws-token
-            readOnly: true
-          {{- if eq "SERVICE_ACCOUNT_TOKEN" .Values.fleetshardSync.authType }}
-          - mountPath: /var/run/secrets/tokens/fleet-manager-token
-            subPath: fleet-manager-token
-            name: fleet-manager-token
-            readOnly: true
-          {{- end }}
+          - mountPath: /var/run/secrets/tokens
+            name: tokens
         ports:
         - name: monitoring
           containerPort: 8080
@@ -163,19 +155,16 @@ spec:
             cpu: {{ .Values.fleetshardSync.resources.requests.cpu | quote }}
             memory: {{ .Values.fleetshardSync.resources.requests.memory | quote }}
       volumes:
-        - name: aws-token
+        - name: tokens
           projected:
             sources:
               - serviceAccountToken:
                   path: aws-token
                   audience: sts.amazonaws.com
                   expirationSeconds: 3600
-        {{- if eq "SERVICE_ACCOUNT_TOKEN" .Values.fleetshardSync.authType }}
-        - name: fleet-manager-token
-          projected:
-            sources:
+              {{- if eq "SERVICE_ACCOUNT_TOKEN" .Values.fleetshardSync.authType }}
               - serviceAccountToken:
                   path: fleet-manager-token
                   audience: acs-fleet-manager-private-api
                   expirationSeconds: 3600
-        {{- end }}
+              {{- end }}


### PR DESCRIPTION
## Description
After the fix in #1889 token is not refreshed by kubelet after 1 hour.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
