### PR TITLE
ROX-24895: Migrate from fluentd logging to vector logging

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/logging/templates/01-logging-03-cluster-logging.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/templates/01-logging-03-cluster-logging.yaml
@@ -19,5 +19,4 @@ spec:
     {{- if .Values.resources }}
     resources: {{ toYaml .Values.resources | nindent 6 }}
     {{- end }}
-    type: "fluentd"
-    fluentd: {}
+    type: "vector"


### PR DESCRIPTION
## Description

This changes the configuration of the openshift-logging operator to change the logging backend from `fluentd` to `vector`. It doesn't change the configuration yet.

See https://access.redhat.com/articles/6999658.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
