### PR TITLE
fix: use senderAddress helm value for emailsender

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
@@ -33,6 +33,8 @@ spec:
               value: {{ .Values.fleetshardSync.clusterName }}
             - name: ENVIRONMENT
               value: {{ .Values.fleetshardSync.environment }}
+            - name: SENDER_ADDRESS
+              value: {{ .Values.emailsender.senderAddress }}
             - name: HTTPS_CERT_FILE
               value: "/var/run/certs/tls.crt"
             - name: HTTPS_KEY_FILE


### PR DESCRIPTION
## Description
Actually use the helm value for the emailsender.senderAddress introduced in a previous PR to set the appropriate environment variable for the emailsender deployment.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
