### PR TITLE
Use emailsender clusterName in secret

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender-secret.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender-secret.yaml
@@ -13,24 +13,23 @@ spec:
   data:
     - secretKey: db.user # pragma: allowlist secret
       remoteRef:
-        # TODO: use emailsender.clusterName once it is available via Addon flow
-        key: "cluster-{{ .Values.fleetshardSync.clusterName }}-emailsender-db"
+        key: "cluster-{{ .Values.emailsender.clusterName }}-emailsender-db"
         property: "username"
     - secretKey: db.name # pragma: allowlist secret
       remoteRef:
-        key: "cluster-{{ .Values.fleetshardSync.clusterName }}-emailsender-db"
+        key: "cluster-{{ .Values.emailsender.clusterName }}-emailsender-db"
         property: "databaseName"
     - secretKey: db.host # pragma: allowlist secret
       remoteRef:
-        key: "cluster-{{ .Values.fleetshardSync.clusterName }}-emailsender-db"
+        key: "cluster-{{ .Values.emailsender.clusterName }}-emailsender-db"
         property: "host"
     - secretKey: db.password # pragma: allowlist secret
       remoteRef:
-        key: "cluster-{{ .Values.fleetshardSync.clusterName }}-emailsender-db"
+        key: "cluster-{{ .Values.emailsender.clusterName }}-emailsender-db"
         property: "password" # pragma: allowlist secret
     - secretKey: db.port # pragma: allowlist secret
       remoteRef:
-        key: "cluster-{{ .Values.fleetshardSync.clusterName }}-emailsender-db"
+        key: "cluster-{{ .Values.emailsender.clusterName }}-emailsender-db"
         property: "port"
 ---
 apiVersion: external-secrets.io/v1beta1


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
