### PR TITLE
ROX-24040: Set Podman instead of Docker to fix RHEL8 builders

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,15 @@ WORKDIR /src
 RUN go env -w GOCACHE=/go/.cache; \
     go env -w GOMODCACHE=/go/pkg/mod
 
+# We previously used --mount=type=bind in the next RUN command
+# (see https://docs.docker.com/build/guide/mounts/#add-bind-mounts)
+# but this did not work with SELinux volumes and Docker, as only
+# Podman supports the relabel=shared option
+# (see https://docs.podman.io/en/v4.4/markdown/options/mount.html).
+# This adds a layer but works with Docker and Podman.
+COPY go.mod go.sum ./
+
 RUN --mount=type=cache,target=/go/pkg/mod/ \
-     --mount=type=bind,source=go.sum,target=go.sum \
-     --mount=type=bind,source=go.mod,target=go.mod \
       go mod download -x
 
 COPY . ./

--- a/build_push_app_interface.sh
+++ b/build_push_app_interface.sh
@@ -41,6 +41,7 @@ source ./scripts/build_setup.sh
 # Push the image:
 echo "Quay.io user and token is set, will push images to $IMAGE_REPOSITORY"
 make \
+  DOCKER=podman \
   DOCKER_CONFIG="${DOCKER_CONFIG}" \
   QUAY_USER="${QUAY_USER}" \
   QUAY_TOKEN="${QUAY_TOKEN}" \
@@ -51,6 +52,7 @@ make \
   image/push/fleet-manager
 
 make \
+  DOCKER=podman \
   DOCKER_CONFIG="${DOCKER_CONFIG}" \
   QUAY_USER="${QUAY_USER}" \
   QUAY_TOKEN="${QUAY_TOKEN}" \
@@ -62,6 +64,7 @@ make \
   image/push/fleet-manager
 
 make \
+  DOCKER=podman \
   DOCKER_CONFIG="${DOCKER_CONFIG}" \
   QUAY_PROBE_USER="${QUAY_USER}" \
   QUAY_PROBE_TOKEN="${QUAY_TOKEN}" \
@@ -72,6 +75,7 @@ make \
   image/push/probe
 
 make \
+  DOCKER=podman \
   DOCKER_CONFIG="${DOCKER_CONFIG}" \
   QUAY_PROBE_USER="${QUAY_USER}" \
   QUAY_PROBE_TOKEN="${QUAY_TOKEN}" \
@@ -83,6 +87,7 @@ make \
   image/push/probe
 
 make \
+  DOCKER=podman \
   DOCKER_CONFIG="${DOCKER_CONFIG}" \
   QUAY_USER="${QUAY_USER}" \
   QUAY_TOKEN="${QUAY_TOKEN}" \
@@ -93,6 +98,7 @@ make \
   image/push/emailsender
 
 make \
+  DOCKER=podman \
   DOCKER_CONFIG="${DOCKER_CONFIG}" \
   QUAY_USER="${QUAY_USER}" \
   QUAY_TOKEN="${QUAY_TOKEN}" \
@@ -102,3 +108,4 @@ make \
   emailsender_image_repository="${EMAILSENDER_IMAGE_REPOSITORY}" \
   docker/login/fleet-manager \
   image/push/emailsender
+

--- a/build_push_app_interface.sh
+++ b/build_push_app_interface.sh
@@ -108,4 +108,3 @@ make \
   emailsender_image_repository="${EMAILSENDER_IMAGE_REPOSITORY}" \
   docker/login/fleet-manager \
   image/push/emailsender
-


### PR DESCRIPTION
buildx build --push is not yet supported by Podman: https://github.com/containers/buildah/pull/4677
So we switch to single-arch build, then build and push separately to match the other deployments.

Tested:
```
QUAY_USER=ebenshet+ebenshet_quay_robot QUAY_TOKEN=abc123 QUAY_IMAGE_REPOSITORY=ebenshet/myrepo PROBE_QUAY_IMAGE_REPOSITORY=ebenshet/myrepo EMAILSENDER_QUAY_IMAGE_REPOSITORY=ebenshet/myrepo ./build_push_app_interface.sh
```