### PR TITLE
ROX-23967: Add more tenant network policy tests

### DIFF
--- a/.openshift-ci/tests/netpol-test.sh
+++ b/.openshift-ci/tests/netpol-test.sh
@@ -158,7 +158,7 @@ test_connectivity_from_central() {
     test_central_connectivity_to_different_namespace "${SERVICE_NS}" "${CLIENT_NS}" scanner-v4-db
     test_central_connectivity_to_different_namespace "${SERVICE_NS}" "${CLIENT_NS}" other-app
 
-    # connections from these apps should *not* be allowed within the same namespace
+    # connections to these apps should not be allowed within the same namespace
     test_central_connectivity_into_same_namespace "${SERVICE_NS}" scanner-db
     test_central_connectivity_into_same_namespace "${SERVICE_NS}" scanner-v4-db
     test_central_connectivity_into_same_namespace "${SERVICE_NS}" other-app

--- a/.openshift-ci/tests/netpol-test.sh
+++ b/.openshift-ci/tests/netpol-test.sh
@@ -6,23 +6,31 @@ export GITROOT
 # shellcheck source=/dev/null
 source "${GITROOT}/dev/env/scripts/lib.sh"
 
+SERVICE_STARTUP_WAIT_TIME="2m"
+CLIENT_STARTUP_WAIT_TIME="1m"
+
 # Tests that a connection is allowed without network policies, and that it's disallowed after applying the policies (in either namespaces)
 test_central_connectivity_from_different_namespace() {
+    echo "Running ${FUNCNAME[0]}" "$@"
+
     local CENTRAL_NS="$1"
     local CLIENT_NS="$2"
     local CLIENT_NAME="$3"
     local SERVICE_HOST="$4"
 
-    helm install fake-client "${GITROOT}/test/network-policy/fake-client" --set name="${CLIENT_NAME}" --set service.host="${SERVICE_HOST}" --namespace "${CLIENT_NS}" --create-namespace
-    $KUBECTL -n "${CLIENT_NS}" wait --for=condition=Available deployment/"${CLIENT_NAME}"
+    helm install fake-client "${GITROOT}/test/network-policy/fake-client" --set name="${CLIENT_NAME}" \
+        --set service.host="${SERVICE_HOST}" --namespace "${CLIENT_NS}" --create-namespace
+    $KUBECTL -n "${CLIENT_NS}" wait --for=condition=Available deployment/"${CLIENT_NAME}" --timeout "${CLIENT_STARTUP_WAIT_TIME}"
 
-    helm install client-netpol "${GITROOT}/fleetshard/pkg/central/charts/data/tenant-resources" --namespace "${CLIENT_NS}" --set secureTenantNetwork=true
+    helm install client-netpol "${GITROOT}/fleetshard/pkg/central/charts/data/tenant-resources" --namespace "${CLIENT_NS}" \
+        --set secureTenantNetwork=true
     $KUBECTL -n "${CLIENT_NS}" wait --for=condition=Available=false deployment/"${CLIENT_NAME}"
 
     helm uninstall client-netpol --namespace "${CLIENT_NS}"
     $KUBECTL -n "${CLIENT_NS}" wait --for=condition=Available deployment/"${CLIENT_NAME}"
 
-    helm install central-netpol "${GITROOT}/fleetshard/pkg/central/charts/data/tenant-resources" --namespace "${CENTRAL_NS}" --set secureTenantNetwork=true
+    helm install central-netpol "${GITROOT}/fleetshard/pkg/central/charts/data/tenant-resources" --namespace "${CENTRAL_NS}" \
+        --set secureTenantNetwork=true
     $KUBECTL -n "${CLIENT_NS}" wait --for=condition=Available=false deployment/"${CLIENT_NAME}"
 
     helm uninstall central-netpol --namespace "${CENTRAL_NS}"
@@ -32,14 +40,18 @@ test_central_connectivity_from_different_namespace() {
 # Tests that a connection is allowed without network policies, and that it's disallowed after applying the policies
 test_central_connectivity_from_same_namespace()
 {
+    echo "Running ${FUNCNAME[0]}" "$@"
+
     local CLIENT_NS="$1"
     local CLIENT_NAME="$2"
     local SERVICE_HOST="$3"
 
-    helm install fake-client "${GITROOT}/test/network-policy/fake-client" --set name="${CLIENT_NAME}" --namespace "${CLIENT_NS}" --set service.host="${SERVICE_HOST}"
-    $KUBECTL -n "${CLIENT_NS}" wait --for=condition=Available deployment/"${CLIENT_NAME}"
+    helm install fake-client "${GITROOT}/test/network-policy/fake-client" --set name="${CLIENT_NAME}" --namespace "${CLIENT_NS}" \
+        --set service.host="${SERVICE_HOST}"
+    $KUBECTL -n "${CLIENT_NS}" wait --for=condition=Available deployment/"${CLIENT_NAME}" --timeout "${CLIENT_STARTUP_WAIT_TIME}"
 
-    helm install tenant-netpol "${GITROOT}/fleetshard/pkg/central/charts/data/tenant-resources" --namespace "${CLIENT_NS}" --set secureTenantNetwork=true
+    helm install tenant-netpol "${GITROOT}/fleetshard/pkg/central/charts/data/tenant-resources" --namespace "${CLIENT_NS}" \
+        --set secureTenantNetwork=true
     $KUBECTL -n "${CLIENT_NS}" wait --for=condition=Available=false deployment/"${CLIENT_NAME}"
 
     helm uninstall tenant-netpol --namespace "${CLIENT_NS}"
@@ -49,25 +61,29 @@ test_central_connectivity_from_same_namespace()
 # Tests that a connection is allowed even with the network policies applied
 test_central_connection_allowed()
 {
+    echo "Running ${FUNCNAME[0]}" "$@"
+
     local CLIENT_NS="$1"
     local CLIENT_NAME="$2"
     local SERVICE_HOST="$3"
 
-    helm install tenant-netpol "${GITROOT}/fleetshard/pkg/central/charts/data/tenant-resources" --namespace "${CLIENT_NS}" --set secureTenantNetwork=true
-    helm install fake-client "${GITROOT}/test/network-policy/fake-client" --set name="${CLIENT_NAME}" --namespace "${CLIENT_NS}" --set service.host="${SERVICE_HOST}"
-    $KUBECTL -n "${CLIENT_NS}" wait --for=condition=Available deployment/"${CLIENT_NAME}"
+    helm install tenant-netpol "${GITROOT}/fleetshard/pkg/central/charts/data/tenant-resources" --namespace "${CLIENT_NS}" \
+        --set secureTenantNetwork=true
+    helm install fake-client "${GITROOT}/test/network-policy/fake-client" --set name="${CLIENT_NAME}" --namespace "${CLIENT_NS}" \
+        --set service.host="${SERVICE_HOST}"
+    $KUBECTL -n "${CLIENT_NS}" wait --for=condition=Available deployment/"${CLIENT_NAME}" --timeout "${CLIENT_STARTUP_WAIT_TIME}"
 
     helm uninstall tenant-netpol --namespace "${CLIENT_NS}"
     helm uninstall fake-client --namespace "${CLIENT_NS}"
 }
 
 # Tests connectivity to a fake Central from various different sources
-test_central_connectivity() {
+test_connectivity_to_central() {
     local CENTRAL_NS="rhacs-fake-service"
     local CLIENT_NS="rhacs-fake-client"
 
     helm install fake-central "${GITROOT}/test/network-policy/fake-service" --namespace "${CENTRAL_NS}" --create-namespace
-    $KUBECTL -n "${CENTRAL_NS}" wait --for=condition=Available deployment/central
+    $KUBECTL -n "${CENTRAL_NS}" wait --for=condition=Available deployment/central --timeout "${SERVICE_STARTUP_WAIT_TIME}"
 
     # use the IP to make sure access is denied because of the policy (as opposed to the client not having DNS access)
     local SERVICE_IP
@@ -96,4 +112,60 @@ test_central_connectivity() {
     $KUBECTL delete ns "${CLIENT_NS}"
 }
 
-test_central_connectivity
+test_central_connectivity_to_different_namespace() {
+    echo "Running ${FUNCNAME[0]}" "$@"
+
+    local SERVICE_NS="$1"
+    local CENTRAL_NS="$2"
+    local SERVICE_NAME="$3"
+
+    helm install fake-service "${GITROOT}/test/network-policy/fake-service" --namespace "${SERVICE_NS}" --create-namespace \
+        --set name="${SERVICE_NAME}"
+    $KUBECTL -n "${SERVICE_NS}" wait --for=condition=Available deployment/"${SERVICE_NAME}" --timeout "${SERVICE_STARTUP_WAIT_TIME}"
+
+    # use the IP to make sure access is denied because of the policy (as opposed to the client not having DNS access)
+    local SERVICE_IP
+    SERVICE_IP=$($KUBECTL -n "${SERVICE_NS}" get service "${SERVICE_NAME}"-service -o jsonpath='{.spec.clusterIP}')
+
+    helm install fake-central "${GITROOT}/test/network-policy/fake-client" --set name=central --namespace "${CENTRAL_NS}" \
+        --create-namespace --set service.host="${SERVICE_IP}"
+    $KUBECTL -n "${CENTRAL_NS}" wait --for=condition=Available deployment/central --timeout "${CLIENT_STARTUP_WAIT_TIME}"
+
+    helm install central-netpol "${GITROOT}/fleetshard/pkg/central/charts/data/tenant-resources" --namespace "${CENTRAL_NS}" \
+        --set secureTenantNetwork=true
+    $KUBECTL -n "${CENTRAL_NS}" wait --for=condition=Available=false deployment/central
+
+    helm uninstall central-netpol --namespace "${CENTRAL_NS}"
+    helm uninstall fake-central --namespace "${CENTRAL_NS}"
+    helm uninstall fake-service --namespace "${SERVICE_NS}"
+}
+
+test_central_connectivity_into_same_namespace() {
+    test_central_connectivity_to_different_namespace "$1" "$1" "$2"
+}
+
+# Tests connectivity from a fake Central to different destinations
+test_connectivity_from_central() {
+    local SERVICE_NS="rhacs-fake-service"
+    local CLIENT_NS="rhacs-fake-client"
+
+    # no connections between tenant namespaces should be allowed
+    test_central_connectivity_to_different_namespace "${SERVICE_NS}" "${CLIENT_NS}" central
+    test_central_connectivity_to_different_namespace "${SERVICE_NS}" "${CLIENT_NS}" scanner
+    test_central_connectivity_to_different_namespace "${SERVICE_NS}" "${CLIENT_NS}" scanner-db
+    test_central_connectivity_to_different_namespace "${SERVICE_NS}" "${CLIENT_NS}" scanner-v4-indexer
+    test_central_connectivity_to_different_namespace "${SERVICE_NS}" "${CLIENT_NS}" scanner-v4-matcher
+    test_central_connectivity_to_different_namespace "${SERVICE_NS}" "${CLIENT_NS}" scanner-v4-db
+    test_central_connectivity_to_different_namespace "${SERVICE_NS}" "${CLIENT_NS}" other-app
+
+    # connections from these apps should *not* be allowed within the same namespace
+    test_central_connectivity_into_same_namespace "${SERVICE_NS}" scanner-db
+    test_central_connectivity_into_same_namespace "${SERVICE_NS}" scanner-v4-db
+    test_central_connectivity_into_same_namespace "${SERVICE_NS}" other-app
+
+    $KUBECTL delete ns "${SERVICE_NS}"
+    $KUBECTL delete ns "${CLIENT_NS}"
+}
+
+test_connectivity_to_central
+test_connectivity_from_central


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

More tenant network policy tests, to cover more cases.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

```
# To run tests locally run:
cd .openshift-ci/tests
KUBECTL=oc ./netpol-test.sh
```
