### PR TITLE
ROX-24936: add AWS integration test for emailsender

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,8 @@ test/aws: $(GOTESTSUM_BIN)
 	RUN_AWS_INTEGRATION=true \
 	$(GOTESTSUM_BIN) --junitfile data/results/aws-integration-tests.xml --format $(GOTESTSUM_FORMAT) -- -p 1 -v -timeout 45m -count=1 \
 		./fleetshard/pkg/central/cloudprovider/awsclient/... \
-		./fleetshard/pkg/cipher/...
+		./fleetshard/pkg/cipher/... \
+		./emailsender/pkg/email/...
 .PHONY: test/aws
 
 # Runs the integration tests.

--- a/emailsender/pkg/email/ses_integration_test.go
+++ b/emailsender/pkg/email/ses_integration_test.go
@@ -1,0 +1,102 @@
+package email
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// awsDevSender is the domain configured for sending in our AWS dev account, see aws config repository
+	awsDevSender        = "noreply@mail.rhacs-dev.com"
+	invalidSender       = "noreply@some.invalid.integration.test.domain"
+	sesSimulatorSuccess = "success@simulator.amazonses.com"
+	defaultMessage      = "this is a test email for AWS integration tests"
+)
+
+type emailTestCase struct {
+	sender       string
+	to           string
+	msg          string
+	requireError bool
+}
+
+var commonTests = map[string]emailTestCase{
+	// The combination of valid/invalid sender tests makes sure the actual AWS SES API is used as opposed
+	// to a mock which would accept both sender identity, even one that is not configure in the aws config repository
+	"succesful email": {
+		sender:       awsDevSender,
+		to:           sesSimulatorSuccess,
+		msg:          defaultMessage,
+		requireError: false,
+	},
+	"error for invalid sender": {
+		sender:       invalidSender,
+		to:           sesSimulatorSuccess,
+		msg:          defaultMessage,
+		requireError: true,
+	},
+}
+
+func TestSendEmail(t *testing.T) {
+	skipIfNotAwsIntegrationTest(t)
+
+	ses, err := NewSES(context.Background(), time.Second*10, 3)
+	require.NoError(t, err, "failed to initizializ SES")
+
+	for name, tc := range commonTests {
+		t.Run(name, func(t *testing.T) {
+			msgID, err := ses.SendEmail(context.Background(), tc.sender, []string{tc.to}, "Test Email", "", tc.msg)
+			if tc.requireError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err, "unexpected error on SendEmail")
+			require.NotEmpty(t, msgID)
+		})
+	}
+}
+
+func TestSendRawEmail(t *testing.T) {
+	skipIfNotAwsIntegrationTest(t)
+
+	ses, err := NewSES(context.Background(), time.Second*10, 3)
+	require.NoError(t, err, "failed to initizializ SES")
+
+	tests := map[string]emailTestCase{
+		"invalid from header": {
+			sender:       awsDevSender,
+			to:           sesSimulatorSuccess,
+			msg:          fmt.Sprintf("From: %s\n%s", invalidSender, defaultMessage),
+			requireError: true,
+		},
+	}
+
+	for k, v := range commonTests {
+		tests[k] = v
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			msgID, err := ses.SendRawEmail(context.Background(), tc.sender, []string{tc.to}, []byte(tc.msg))
+			if tc.requireError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err, "unexpected error on SendEmail")
+			require.NotEmpty(t, msgID)
+		})
+	}
+}
+
+func skipIfNotAwsIntegrationTest(t *testing.T) {
+	if os.Getenv("RUN_AWS_INTEGRATION") != "true" {
+		t.Skip("Skip SES integration tests. Set RUN_AWS_INTEGRATION=true env variable to enable.")
+	}
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
This PR adds a integration to the AWS SES code implemented for the emailsender.

It also changes the Makefile so that this test is executed within the AWS integration test Github Action.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [x] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

- Login to the AWS dev account
- Run: `RUN_AWS_INTEGRATION=true go test github.com/stackrox/acs-fleet-manager/emailsender/pkg/email`    
