### PR TITLE
Use the github role instead of the technical user in AWS integration tests

### DIFF
--- a/.github/workflows/aws-integration.yaml
+++ b/.github/workflows/aws-integration.yaml
@@ -66,6 +66,7 @@ jobs:
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_AUTH_HELPER: "none"
+          FLEETSHARD_SYNC_SECRET_NAME: "aws-integration-tests" # pragma: allowlist secret
         run: |
           ./dev/env/scripts/exec_fleetshard_sync.sh make test/aws
         timeout-minutes: 50

--- a/dev/env/scripts/exec_fleetshard_sync.sh
+++ b/dev/env/scripts/exec_fleetshard_sync.sh
@@ -16,6 +16,8 @@ if [[ "$ENABLE_EXTERNAL_CONFIG" != "true" ]]; then
 fi
 
 export AWS_AUTH_HELPER="${AWS_AUTH_HELPER:-aws-saml}"
+export FLEETSHARD_SYNC_SECRET_NAME=${FLEETSHARD_SYNC_SECRET_NAME:-fleetshard-sync}
+
 # shellcheck source=scripts/lib/external_config.sh
 source "${GITROOT}/scripts/lib/external_config.sh"
 init_chamber
@@ -29,4 +31,4 @@ ARGS="CLUSTER_ID=${CLUSTER_ID:-$(chamber read "${CLUSTER_NAME}" ID -q -b ssm)} \
     AWS_ROLE_ARN=${FLEETSHARD_SYNC_AWS_ROLE_ARN:-$(chamber read fleetshard-sync AWS_ROLE_ARN -q -b ssm)} \
     $ARGS"
 
-chamber exec fleetshard-sync -b secretsmanager -- sh -c "$ARGS"
+chamber exec "$FLEETSHARD_SYNC_SECRET_NAME" -b secretsmanager -- sh -c "$ARGS"


### PR DESCRIPTION
## Description
Use the github role instead of the technical user in AWS integration tests

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
