### PR TITLE
fix: add a cleanup job for email events

### DIFF
--- a/emailsender/cmd/app/main.go
+++ b/emailsender/cmd/app/main.go
@@ -64,8 +64,8 @@ func main() {
 
 	cleanupWorker := workers.CleanupEmailSent{
 		DbConn:       dbConnection,
-		Period:       time.Second * 60,
-		ExpiredAfter: time.Hour * 48,
+		Period:       time.Second * time.Duration(cfg.EmailCleanupPeriodSeconds) * 60,
+		ExpiredAfter: time.Hour * time.Duration(cfg.EmailCleanupExpiryDays) * 24,
 	}
 	go func() {
 		err := cleanupWorker.Run(shutdownCtx)

--- a/emailsender/config/config.go
+++ b/emailsender/config/config.go
@@ -30,20 +30,22 @@ const (
 
 // Config contains this application's runtime configuration.
 type Config struct {
-	ClusterID                string        `env:"CLUSTER_ID"`
-	ServerAddress            string        `env:"SERVER_ADDRESS" envDefault:":8080"`
-	EnableHTTPS              bool          `env:"ENABLE_HTTPS" envDefault:"false"`
-	HTTPSCertFile            string        `env:"HTTPS_CERT_FILE" envDefault:""`
-	HTTPSKeyFile             string        `env:"HTTPS_KEY_FILE" envDefault:""`
-	MetricsAddress           string        `env:"METRICS_ADDRESS" envDefault:":9090"`
-	AuthConfigFile           string        `env:"AUTH_CONFIG_FILE" envDefault:"config/emailsender-authz.yaml"`
-	AuthConfigFromKubernetes bool          `env:"AUTH_CONFIG_FROM_KUBERNETES" envDefault:"false"`
-	SenderAddress            string        `env:"SENDER_ADDRESS" envDefault:"noreply@mail.rhacs-dev.com"`
-	LimitEmailPerTenant      int           `env:"LIMIT_EMAIL_PER_TENANT" envDefault:"250"`
-	SesMaxBackoffDelay       time.Duration `env:"SES_MAX_BACKOFF_DELAY" envDefault:"5s"`
-	SesMaxAttempts           int           `env:"SES_MAX_ATTEMPTS" envDefault:"3"`
-	AuthConfig               AuthConfig
-	DatabaseConfig           DbConfig
+	ClusterID                 string        `env:"CLUSTER_ID"`
+	ServerAddress             string        `env:"SERVER_ADDRESS" envDefault:":8080"`
+	EnableHTTPS               bool          `env:"ENABLE_HTTPS" envDefault:"false"`
+	HTTPSCertFile             string        `env:"HTTPS_CERT_FILE" envDefault:""`
+	HTTPSKeyFile              string        `env:"HTTPS_KEY_FILE" envDefault:""`
+	MetricsAddress            string        `env:"METRICS_ADDRESS" envDefault:":9090"`
+	AuthConfigFile            string        `env:"AUTH_CONFIG_FILE" envDefault:"config/emailsender-authz.yaml"`
+	AuthConfigFromKubernetes  bool          `env:"AUTH_CONFIG_FROM_KUBERNETES" envDefault:"false"`
+	SenderAddress             string        `env:"SENDER_ADDRESS" envDefault:"noreply@mail.rhacs-dev.com"`
+	LimitEmailPerTenant       int           `env:"LIMIT_EMAIL_PER_TENANT" envDefault:"250"`
+	SesMaxBackoffDelay        time.Duration `env:"SES_MAX_BACKOFF_DELAY" envDefault:"5s"`
+	SesMaxAttempts            int           `env:"SES_MAX_ATTEMPTS" envDefault:"3"`
+	EmailCleanupPeriodSeconds int           `env:"EMAIL_CLEANUP_PERIOD_SECONDS" envDefault:"300"`
+	EmailCleanupExpiryDays    int           `env:"EMAIL_CLEANUP_EXPIRY_DAYS" envDefault:"2"`
+	AuthConfig                AuthConfig
+	DatabaseConfig            DbConfig
 }
 
 type DbConfig struct {

--- a/emailsender/pkg/db/mock.go
+++ b/emailsender/pkg/db/mock.go
@@ -1,0 +1,28 @@
+package db
+
+import "time"
+
+type MockDatabaseClient struct {
+	CalledInsertEmailSentByTenant    bool
+	CalledCountEmailSentByTenantFrom bool
+	CalledCleanupEmailSentByTenant   bool
+
+	InsertEmailSentByTenantFunc    func(tenantID string) error
+	CountEmailSentByTenantFromFunc func(tenantID string, from time.Time) (int64, error)
+	CleanupEmailSentByTenantFunc   func(before time.Time) (int64, error)
+}
+
+func (m *MockDatabaseClient) InsertEmailSentByTenant(tenantID string) error {
+	m.CalledInsertEmailSentByTenant = true
+	return m.InsertEmailSentByTenantFunc(tenantID)
+}
+
+func (m *MockDatabaseClient) CountEmailSentByTenantSince(tenantID string, from time.Time) (int64, error) {
+	m.CalledCountEmailSentByTenantFrom = true
+	return m.CountEmailSentByTenantFromFunc(tenantID, from)
+}
+
+func (m *MockDatabaseClient) CleanupEmailSentByTenant(before time.Time) (int64, error) {
+	m.CalledCleanupEmailSentByTenant = true
+	return m.CleanupEmailSentByTenantFunc(before)
+}

--- a/emailsender/pkg/workers/cleanup.go
+++ b/emailsender/pkg/workers/cleanup.go
@@ -1,0 +1,40 @@
+package workers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/stackrox/acs-fleet-manager/emailsender/pkg/db"
+)
+
+// CleanupEmailSent is a worker used to periodically cleanup EmailSentByTenant events
+// stored in the database connection that are no longer needed to enforce rate limitting
+type CleanupEmailSent struct {
+	DbConn       db.DatabaseClient
+	Period       time.Duration
+	ExpiredAfter time.Duration
+}
+
+// Run periodically executes a cleanup query against the given DB Connection
+func (c *CleanupEmailSent) Run(ctx context.Context) error {
+	ticker := time.NewTicker(c.Period)
+
+	glog.Info("Starting CleanupEmailSent worker...")
+	for {
+		select {
+		case <-ctx.Done():
+			ticker.Stop()
+			return fmt.Errorf("stopped cleanup worker: %w", context.Canceled)
+		case <-ticker.C:
+			numDeleted, err := c.DbConn.CleanupEmailSentByTenant(time.Now().Add(-c.ExpiredAfter))
+			if err != nil {
+				glog.Errorf("failed to cleanup EmailSentByTenant: %v", err)
+			}
+
+			glog.Infof("deleted %d expired EmailSentByTenant events from DB", numDeleted)
+		}
+	}
+
+}

--- a/emailsender/pkg/workers/cleanup_test.go
+++ b/emailsender/pkg/workers/cleanup_test.go
@@ -1,0 +1,48 @@
+package workers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackrox/acs-fleet-manager/emailsender/pkg/db"
+	"github.com/stretchr/testify/require"
+)
+
+var testTimeout = time.Second * 10
+
+func TestCleanupEmailSent(t *testing.T) {
+	mockDB := &db.MockDatabaseClient{
+		CleanupEmailSentByTenantFunc: func(before time.Time) (int64, error) { return 5, nil },
+	}
+
+	cleanup := &CleanupEmailSent{
+		Period:       time.Second * 1,
+		ExpiredAfter: time.Hour * 48,
+		DbConn:       mockDB,
+	}
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*3)
+	defer cancel()
+
+	timeoutTimer := time.NewTimer(testTimeout)
+	defer timeoutTimer.Stop()
+
+	var errChannel = make(chan error)
+
+	go func() {
+		err := cleanup.Run(ctx)
+		errChannel <- err
+	}()
+
+	select {
+	case err := <-errChannel:
+		// Expect DB cleanup to be called at least once since this has been running for 3 seconds
+		// until the context gets canceled
+		require.True(t, mockDB.CalledCleanupEmailSentByTenant, "expected db cleanup to be called, but was not")
+		require.ErrorIs(t, err, context.Canceled)
+	case <-timeoutTimer.C:
+		t.Fatal("cleanup did not stop on canceled context")
+	}
+
+}


### PR DESCRIPTION
## Description

We don't cleanup emails that we don't longer need to enforce our 24h rolling window for rate limits.

This can lead to a ever growing DB and performance penalties for a long running emailsender DB.

This PR solves this problem by adding a background job that periodically deletes all email sent events older than 2 days.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

```
# To run tests locally run:
make db/teardown db/setup
CLUSTER_ID=CLUSTER_ID go run emailsender/cmd/app/main.go

# Create a few test events by directly connecting to DB
make db/psql
# Run this command a few times to create "unexpired" events
INSERT INTO email_sent_by_tenants (tenant_id, created_at) VALUES ('test', NOW()');
# Run this command a few times to create "expired" events
INSERT INTO email_sent_by_tenants (tenant_id, created_at) VALUES ('test', NOW()- INTERVAL '3 DAY');

# Make sure after configured interval for the worker (2 minutes) the expired events are
# deleted, while "new" events are still in the DB
```
