### PR TITLE
ROX-25022: emailsender dev docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -955,3 +955,8 @@ clean/go-generated:
 cluster-list:
 	@yq '.clusters | .[0].cluster_dns="$(CLUSTER_DNS)"' $(DATAPLANE_CLUSTER_CONFIG_FILE) -r -o=j -I=0
 .PHONY: cluster-list
+
+CLUSTER_ID ?= test
+run/emailsender:
+	@CLUSTER_ID=$(CLUSTER_ID) go run emailsender/cmd/app/main.go
+.PHONY: run/emailsender

--- a/emailsender/README.md
+++ b/emailsender/README.md
@@ -27,7 +27,9 @@ If you want to send an actual email to your inbox [verify](https://docs.aws.amaz
 
 Emailsender has a rate limit per tenant for sending emails (Default: 250). The tenant is identified by the `sub` claim of the token used to call the API.
 
-[TODO] Reference limit documentation in runbooks repository
+We have this limit to make sure a single tenant can't reach the limit our AWS account has to send emails in a region, because that would block all other tenants from sending emails as well.
+
+All related AWS and emailsender limits and how to change them are document in the [runbooks repository](https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/docs/limits.md):
 
 ## Deployment
 

--- a/emailsender/README.md
+++ b/emailsender/README.md
@@ -1,17 +1,59 @@
 # ACSCS Email Service
 
 The email service which allows sending email notification
-from ACS Central instance without configuring any additional integration.
+from ACS Central tenants without bringing an own SMTP service.
 
+Central tenants call this cluster-internal service by the dedicated notifier integration type [acscsEmail](https://github.com/stackrox/stackrox/tree/master/central/notifiers/acscsemail).
 
 ## Quickstart
 
 ```sh
-# Start email sender service
-CLUSTER_ID=test go run cmd/app/main.go
+make db/setup # if no local db started yet
+make run/emailsender # start email sender service
 
-...
-main.go:65] Creating metrics server...
-main.go:51] Creating api server...
-main.go:75] Application started. Will shut down gracefully on [interrupt terminated].
+# to be able to run a full integration test login
+# to the AWS dev environment before starting the service
+
+# Sample request to send a test email, rawMessage is b64 encoded msg content
+curl localhost:8080/api/v1/acscsemail -v -XPOST \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer $(ocm token)" \
+--data-raw '{"to":["success@simulator.amazonses.com"], "rawMessage":"dGVzdCBtZXNzYWdlIGNvbnRlbnQ="}'
 ```
+
+If you want to send an actual email to your inbox [verify](https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html#verify-email-addresses-procedure) your email address for use in AWS SES using the AWS Web Console for the Dev Account.
+
+## Rate Limitting
+
+Emailsender has a rate limit per tenant for sending emails (Default: 250). The tenant is identified by the `sub` claim of the token used to call the API.
+
+[TODO] Reference limit documentation in runbooks repository
+
+## Deployment
+
+The emailsender is deployed as part of the acs-fleetshard-sync addon. The helm chart is defined in `dp-terraform/helm/rhacs-terraform/templates/emailsender*.yaml`.
+
+The most important helm values are exposed for configuration through the addon.
+
+For more details refer to the addon [documentation](https://spaces.redhat.com/pages/viewpage.action?spaceKey=StackRox&title=ACS+Fleetshard+Addon).
+
+## API Authentication
+
+The emailsender exposes an HTTP/S API. There are 2 authentication methods to call that API.
+
+- OCM Tokens (default for dev setup)
+- Kubernetes Service Accounts (used in ACSCS environment)
+
+### OCM Token Authentication
+
+The file `config/emailsender-authz.yaml` configures the OCM token authentication. On a local machine emailsender will read this file and allow you to call the API using your personal OCM token, provided you are in the organizations listed in `allowed_org_ids`.
+
+To use this authentication type when emailsender is deployed to a K8s cluster you have to create a ConfigMap like this and mount it to the pod. The filepath is configurable by the environment variable `AUTH_CONFIG_FILE`
+
+### Kubernetes Service Account Authentication
+
+The preferred method for authentication when running emailsender in a K8s cluster is to the Kubernetes Service Account. To activate this set the env variable `AUTH_CONFIG_FROM_KUBERNETES=true`.
+
+Emailsender will read the OIDC config used to issue Kubernetes service account token from the Kubernetes API server.
+
+In this authentication mode all service account token with a sub claim matching the regexp `system:serviceaccount:rhacs-[a-z0-9]*:central`.

--- a/emailsender/pkg/db/models.go
+++ b/emailsender/pkg/db/models.go
@@ -3,6 +3,9 @@ package db
 import "time"
 
 // EmailSentByTenant represents how many emails sent by tenant
+// be carefule with backwards compatibility of changes to this struct
+// it is applied to the database by gorm Automigration, so changes
+// to this struct merged to main will immediately affect the DB in integration
 type EmailSentByTenant struct {
 	TenantID  string    `gorm:"index"`
 	CreatedAt time.Time `gorm:"index"` // gorm automatically set to current unix seconds on create


### PR DESCRIPTION
## Description
Extending the dev documentation for emailsender component.

Consistency of the link depends on merges of:
- https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/merge_requests/106
- https://github.com/openshift/openshift-docs/pull/77408

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
