### PR TITLE
ROX-24458: Add podman support for dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,10 @@ WORKDIR /src
 RUN go env -w GOCACHE=/go/.cache; \
     go env -w GOMODCACHE=/go/pkg/mod
 
-RUN --mount=type=cache,target=/go/pkg/mod/ \
-     --mount=type=bind,source=go.sum,target=go.sum \
-     --mount=type=bind,source=go.mod,target=go.mod \
-      go mod download -x
-
 COPY . ./
+
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+      go mod download -x
 
 ARG TARGETARCH
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
I was not able to find the root cause but current dockerfile is failing if build with podman. Somehow `go mod download` do not see mounts with podman build but docker build works totally fine at the same time. This PR changes building a little so both podman and docker can build the image.
*NOTE:* I increased memory for podman machine locally because otherwise it is getting OMMed when building the Dockerfile. I dont know podman machine parameters on appSRE node.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual


```
docker build -t fm .
// OK

podman build -t fm .
// OK
```
