### PR TITLE
Restore go dependency caching with layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ WORKDIR /src
 RUN go env -w GOCACHE=/go/.cache; \
     go env -w GOMODCACHE=/go/pkg/mod
 
-COPY . ./
-
+COPY go.*  ./
 RUN --mount=type=cache,target=/go/pkg/mod/ \
-      go mod download -x
+      go mod download
+COPY . ./
 
 ARG TARGETARCH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,13 @@ WORKDIR /src
 RUN go env -w GOCACHE=/go/.cache; \
     go env -w GOMODCACHE=/go/pkg/mod
 
+# Use the docker build cache to avoid calling 'go mod download' if go.mod/go.sum have not been changed.
+# Otherwise, use cache mount to cache dependencies between builds.
+# mount=type=bind is intentionally not used to ensure compatibility between docker and podman.
+# See:
+#  - https://docs.docker.com/build/cache/
+#  - https://docs.docker.com/build/guide/mounts/
+#  - https://github.com/containers/podman/issues/15423
 COPY go.*  ./
 RUN --mount=type=cache,target=/go/pkg/mod/ \
       go mod download


### PR DESCRIPTION
## Description
Return docker build cache for go dependencies. Add a descriptive comment.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
