### PR TITLE
ROX-25276: emailsender auth on rosa

### DIFF
--- a/emailsender/config/config.go
+++ b/emailsender/config/config.go
@@ -185,7 +185,7 @@ func (c *AuthConfig) readFromKubernetes() error {
 		return err
 	}
 
-	jwksBytes, err := c.getJWKS(oidcCfg, token)
+	jwksBytes, err := c.getJWKS(token)
 	if err != nil {
 		return err
 	}
@@ -232,8 +232,9 @@ func (c *AuthConfig) getOIDCConfig(token string) (oidcConfig, error) {
 	return oidcCfg, nil
 }
 
-func (c *AuthConfig) getJWKS(oidcCfg oidcConfig, token string) ([]byte, error) {
-	jwksRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", c.k8sSvcURL, c.k8sJWKSPath), nil)
+func (c *AuthConfig) getJWKS(token string) ([]byte, error) {
+	jwksURL := fmt.Sprintf("%s/%s", c.k8sSvcURL, c.k8sJWKSPath)
+	jwksRequest, err := http.NewRequest(http.MethodGet, jwksURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP request for jwks: %w", err)
 	}
@@ -246,7 +247,7 @@ func (c *AuthConfig) getJWKS(oidcCfg oidcConfig, token string) ([]byte, error) {
 	defer utils.IgnoreError(jwksRes.Body.Close)
 
 	if jwksRes.StatusCode != 200 {
-		return nil, fmt.Errorf("jwks key request failed with status code: %d", jwksRes.StatusCode)
+		return nil, fmt.Errorf("jwks key request to %s failed with status code: %d", jwksURL, jwksRes.StatusCode)
 	}
 
 	jwksBytes, err := io.ReadAll(jwksRes.Body)

--- a/emailsender/config/config.go
+++ b/emailsender/config/config.go
@@ -23,7 +23,6 @@ import (
 const (
 	defaultSATokenFile      = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 	defaultKubernetesCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-	k8sAPISvc               = "https://kubernetes.default.svc"
 	wellKnownPath           = ".well-known/openid-configuration"
 )
 
@@ -37,6 +36,7 @@ type Config struct {
 	MetricsAddress            string        `env:"METRICS_ADDRESS" envDefault:":9090"`
 	AuthConfigFile            string        `env:"AUTH_CONFIG_FILE" envDefault:"config/emailsender-authz.yaml"`
 	AuthConfigFromKubernetes  bool          `env:"AUTH_CONFIG_FROM_KUBERNETES" envDefault:"false"`
+	KubernetesSvcURL          string        `env:"KUBERNETES_SVC_URL" envDefault:"https://kubernetes.default.svc"`
 	KubernetesJWKSPath        string        `env:"KUBERNETES_JWKS_PATH" envDefault:"/openid/v1/jwks"`
 	SenderAddress             string        `env:"SENDER_ADDRESS" envDefault:"noreply@mail.rhacs-dev.com"`
 	LimitEmailPerTenant       int           `env:"LIMIT_EMAIL_PER_TENANT" envDefault:"250"`
@@ -104,7 +104,7 @@ func GetConfig() (*Config, error) {
 	auth := &AuthConfig{
 		configFile:  c.AuthConfigFile,
 		saTokenFile: defaultSATokenFile,
-		k8sSvcURL:   k8sAPISvc,
+		k8sSvcURL:   c.KubernetesSvcURL,
 		k8sJWKSPath: c.KubernetesJWKSPath,
 		jwksDir:     os.TempDir(),
 	}

--- a/emailsender/config/config_test.go
+++ b/emailsender/config/config_test.go
@@ -71,30 +71,6 @@ func TestGetConfigFailureEnabledHTTPSOnly(t *testing.T) {
 	assert.Nil(t, cfg)
 }
 
-func TestJWKSPathFromURL(t *testing.T) {
-
-	tests := map[string]struct {
-		url      string
-		expected string
-	}{
-		"crc url": {
-			url:      "https://api-int.crc.testing:6443/openid/v1/jwks",
-			expected: "openid/v1/jwks",
-		},
-		"dataplane internal url": {
-			url:      "https://10.0.145.59:6443/openid/v1/jwks",
-			expected: "openid/v1/jwks",
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			actual := jwksPathFromURL(tc.url)
-			require.Equal(t, tc.expected, actual)
-		})
-	}
-}
-
 // copied from a CRC openid-configuration response
 const exampleOidcCfgContent = `{"issuer":"https://kubernetes.default.svc","jwks_uri":"https://api-int.crc.testing:6443/openid/v1/jwks","response_types_supported":["id_token"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"]}`
 
@@ -121,6 +97,7 @@ func TestAuthConfigFromKubernetes(t *testing.T) {
 	authCfg := &AuthConfig{
 		saTokenFile: tokenFile,
 		httpClient:  fakeK8sClient,
+		k8sJWKSPath: "/test/path",
 		k8sSvcURL:   "localhost.testservice",
 		jwksDir:     testDir,
 	}
@@ -149,7 +126,7 @@ func (f fakeK8sRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 	case strings.Contains(url, wellKnownPath):
 		res.StatusCode = 200
 		res.Body = readCloserFromString(exampleOidcCfgContent)
-	case strings.Contains(url, "jwks"):
+	case strings.Contains(url, "/test/path"):
 		res.StatusCode = 200
 		res.Body = readCloserFromString(exampleJwksContent)
 	default:

--- a/emailsender/config/config_test.go
+++ b/emailsender/config/config_test.go
@@ -140,3 +140,39 @@ func (f fakeK8sRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 func readCloserFromString(s string) io.ReadCloser {
 	return io.NopCloser(strings.NewReader(s))
 }
+
+func TestJoinURLAndPath(t *testing.T) {
+	tests := map[string]struct {
+		url      string
+		path     string
+		expected string
+	}{
+		"leading '/' in path, no trailing '/' in url": {
+			url:      "https://api-int.crc.testing:6443",
+			path:     "/openid/v1/jwks",
+			expected: "https://api-int.crc.testing:6443/openid/v1/jwks",
+		},
+		"no leading '/' in path, trailing '/' in url": {
+			url:      "https://api-int.crc.testing:6443/",
+			path:     "openid/v1/jwks",
+			expected: "https://api-int.crc.testing:6443/openid/v1/jwks",
+		},
+		"no leading '/' in path, no trailing '/' in url": {
+			url:      "https://api-int.crc.testing:6443",
+			path:     "openid/v1/jwks",
+			expected: "https://api-int.crc.testing:6443/openid/v1/jwks",
+		},
+		"leading '/' in path, trailing '/' in url": {
+			url:      "https://api-int.crc.testing:6443/",
+			path:     "/openid/v1/jwks",
+			expected: "https://api-int.crc.testing:6443/openid/v1/jwks",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := joinURLAndPath(tc.url, tc.path)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## Description
Use a configurable `jwks_uri` independent from the openid discovery document for emailsenders internal kubernetes authentication.

This proofs to be more reliable since every K8s distribution we use has `https://kubernetes.default.svc/openid/v1/jwks` for internal access to the jwks keys, while it seems that each distribution (crc, minikube, OSD, ROSA, colima, infra OCP) return different URLs. Those URLs all require different handling:
- K8s Pod IP in URL
- K8s Node IP in URL
- K8s svc DNS in URL
- Public facing URL
- Some require authentication, some don't

If we face a K8s distribution that doesn't follow that pattern we can still modify the URL via the new env configuration values.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

CI is sufficient.

