### PR TITLE
introduce global.image.tag for rhacs-terraform helm chart

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: emailsender
       containers:
         - name: emailsender
-          image: "{{ .Values.emailsender.image.repo }}:{{ .Values.emailsender.image.tag }}"
+          image: "{{ .Values.emailsender.image.repo }}:{{ .Values.emailsender.image.tag | default .Values.global.image.tag }}"
           imagePullPolicy: IfNotPresent
           command:
             - /acscs/emailsender

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -39,7 +39,7 @@ spec:
         {{- if .ref }}
         image: "{{ .ref }}"
         {{- else }}
-        image: "{{ .repo }}:{{ .tag }}"
+        image: "{{ .repo }}:{{ .tag | default $.Values.global.image.tag }}"
         {{- end }}
         {{- end }}
         imagePullPolicy: IfNotPresent

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -7,7 +7,7 @@ fleetshardSync:
     # can be either a full image reference represented by `ref` or a combination of `repo:tag`. `ref` has a higher priority (if set).
     ref: ""
     repo: "quay.io/app-sre/acs-fleet-manager"
-    tag: "main"
+    tag: null
   # Can be either STATIC_TOKEN or SERVICE_ACCOUNT_TOKEN. By default, uses SERVICE_ACCOUNT_TOKEN.
   authType: "SERVICE_ACCOUNT_TOKEN"
   # OCM refresh token, only required in combination with authType=OCM.
@@ -76,7 +76,7 @@ emailsender:
   replicas: 3
   image:
     repo: "quay.io/app-sre/acscs-emailsender"
-    tag: "main"
+    tag: null
   clusterId: ""
   clusterName: ""
   environment: ""
@@ -278,6 +278,8 @@ scc:
   enabled: true
 
 global:
+  image:
+    tag: "main"
   secretStore:
     aws:
       secretsManagerSecretStoreName: secrets-manager-secret-store # pragma: allowlist secret


### PR DESCRIPTION
## Description
the `global.image.tag` will only be considered if the specific sections do not specify an image tag.

this is a common pattern and can be helpful for app-interface deployments: https://github.com/app-sre/qontract-reconcile/pull/4557

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
