### PR TITLE
ROX-25389: Add a flag for the blackbox exporter deployment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.54.2
+    rev: v1.59.1
     hooks:
       - id: golangci-lint
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,13 @@ test/integration/dinosaur: $(GOTESTSUM_BIN)
 				./internal/dinosaur/test/integration/...
 .PHONY: test/integration/dinosaur
 
-test/integration: test/integration/dinosaur
+test/dp-terraform: $(GOTESTSUM_BIN)
+	#@helm dependencies build ./dp-terraform/helm/rhacs-terraform
+	$(GOTESTSUM_BIN) --format $(GOTESTSUM_FORMAT) -- -p 1 -ldflags -s -v -timeout $(TEST_TIMEOUT) -count=1 $(TESTFLAGS) \
+				./dp-terraform/test/...
+.PHONY: test/dp-terraform
+
+test/integration: test/integration/dinosaur test/dp-terraform
 .PHONY: test/integration
 
 # remove OSD cluster after running tests against real OCM

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
@@ -19,7 +19,7 @@ spec:
   retention: {{ .Values.retention | quote }}
   selfContained:
     alertManagerConfigSecret: rhacs-alertmanager-configuration
-    disableBlackboxExporter: true
+    disableBlackboxExporter: {{ ne true .Values.blackboxExporterEnabled }}
     # Disable logging features of the operator, because we set up the logging operator
     # ourselves via the logging sub-chart.
     disableLogging: true

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
@@ -82,3 +82,5 @@ affinity: {}
 tolerations: []
 
 # observability operator doesn't expose nodeSelector
+
+blackboxExporterEnabled: false

--- a/dp-terraform/test/helm_template_test.go
+++ b/dp-terraform/test/helm_template_test.go
@@ -25,9 +25,9 @@ func TestHelmTemplate_FleetshardSyncDeployment_ServiceAccountTokenAuthType(t *te
 	require.Equal(t, "fleetshard-sync", container.Name)
 
 	volumes := deployment.Spec.Template.Spec.Volumes
-	require.Equal(t, 2, len(volumes))
-	volume := volumes[1]
-	require.Equal(t, "fleet-manager-token", volume.Name)
+	require.Equal(t, 1, len(volumes))
+	volume := volumes[0]
+	require.Equal(t, "tokens", volume.Name)
 
 	envVars := container.Env
 	require.Equal(t, "SERVICE_ACCOUNT_TOKEN", findEnvVar("AUTH_TYPE", envVars).Value)


### PR DESCRIPTION
## Description
Add a flag to the dp-terraform helm chart in order to conditionally deploy the blackbox exporter.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
