### PR TITLE
refactor pull secret reconciler

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -94,8 +94,6 @@ const (
 	authProviderDeclarativeConfigKey = "default-sso-auth-provider"
 	additionalAuthProviderConfigKey  = "additional-auth-provider"
 
-	tenantImagePullSecretName = "stackrox" // pragma: allowlist secret
-
 	helmChartLabelKey  = "helm.sh/chart"
 	helmChartNameLabel = "helm.sh/chart-name"
 
@@ -163,7 +161,8 @@ type CentralReconciler struct {
 	needsReconcileFunc        needsReconcileFunc
 	restoreCentralSecretsFunc restoreCentralSecretsFunc
 
-	namespaceReconciler reconciler
+	namespaceReconciler  reconciler
+	pullSecretReconciler reconciler
 }
 
 // Reconcile takes a private.ManagedCentral and tries to install it into the cluster managed by the fleet-shard.
@@ -2028,7 +2027,8 @@ func NewCentralReconciler(k8sClient ctrlClient.Client, fleetmanagerClient *fleet
 		resourcesChart: resourcesChart,
 		clock:          realClock{},
 
-		namespaceReconciler: newNamespaceReconciler(k8sClient),
+		namespaceReconciler:  newNamespaceReconciler(k8sClient),
+		pullSecretReconciler: newPullSecretReconciler(k8sClient, central.Metadata.Namespace, []byte(opts.TenantImagePullSecret)),
 	}
 	r.needsReconcileFunc = r.needsReconcile
 

--- a/fleetshard/pkg/central/reconciler/reconciler_pullsecret.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_pullsecret.go
@@ -1,0 +1,89 @@
+package reconciler
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	tenantImagePullSecretName = "stackrox" // pragma: allowlist secret
+)
+
+type pullSecretReconciler struct {
+	namespace        string
+	dockerConfigJson []byte
+	clientSet        kubernetes.Interface
+}
+
+func newPullSecretReconciler(clientSet kubernetes.Interface, namespace string, dockerConfigJson []byte) reconciler {
+	return &pullSecretReconciler{
+		namespace:        namespace,
+		dockerConfigJson: dockerConfigJson,
+		clientSet:        clientSet,
+	}
+}
+
+var _ reconciler = &pullSecretReconciler{}
+
+func (p pullSecretReconciler) ensurePresent(ctx context.Context) (context.Context, error) {
+	if len(p.dockerConfigJson) == 0 {
+		return ctx, p.deletePullSecret(ctx)
+	}
+	existing, err := p.clientSet.CoreV1().Secrets(p.namespace).Get(ctx, tenantImagePullSecretName, metav1.GetOptions{})
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			return ctx, p.createPullSecret(ctx)
+		}
+		return ctx, fmt.Errorf("failed to get image pull secret %s/%s: %w", p.namespace, tenantImagePullSecretName, err)
+	}
+	return ctx, p.updatePullSecret(ctx, existing)
+}
+
+func (p pullSecretReconciler) ensureAbsent(ctx context.Context) (context.Context, error) {
+	return ctx, p.deletePullSecret(ctx)
+}
+
+func (p pullSecretReconciler) deletePullSecret(ctx context.Context) error {
+	err := p.clientSet.CoreV1().Secrets(p.namespace).Delete(ctx, tenantImagePullSecretName, metav1.DeleteOptions{})
+	if err != nil && !apiErrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete image pull secret %s/%s: %w", p.namespace, tenantImagePullSecretName, err)
+	}
+	return nil
+}
+
+func (p pullSecretReconciler) createPullSecret(ctx context.Context) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: p.namespace,
+			Name:      tenantImagePullSecretName,
+		},
+		Type: "kubernetes.io/dockerconfigjson",
+		Data: map[string][]byte{
+			".dockerconfigjson": p.dockerConfigJson,
+		},
+	}
+	_, err := p.clientSet.CoreV1().Secrets(p.namespace).Create(ctx, secret, metav1.CreateOptions{
+		FieldManager: fieldManager,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create image pull secret %s/%s: %w", p.namespace, tenantImagePullSecretName, err)
+	}
+	return nil
+}
+
+func (p pullSecretReconciler) updatePullSecret(ctx context.Context, existing *corev1.Secret) error {
+	if bytes.Equal(existing.Data[".dockerconfigjson"], p.dockerConfigJson) {
+		return nil
+	}
+	existing.Data[".dockerconfigjson"] = p.dockerConfigJson
+	_, err := p.clientSet.CoreV1().Secrets(p.namespace).Update(ctx, existing, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update image pull secret %s/%s: %w", p.namespace, tenantImagePullSecretName, err)
+	}
+	return nil
+}

--- a/fleetshard/pkg/central/reconciler/reconciler_pullsecret_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_pullsecret_test.go
@@ -1,0 +1,148 @@
+package reconciler
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8sTesting "k8s.io/client-go/testing"
+	"testing"
+)
+
+func Test_pullSecretReconciler(t *testing.T) {
+	tests := []struct {
+		name             string
+		dockerConfigJson string
+		existingSecret   *corev1.Secret
+		wantErr          bool
+		want             *corev1.Secret
+		expectUpdate     bool
+		expectCreate     bool
+		expectDelete     bool
+	}{
+		{
+			name:             "secret should be created if it doesn't exist and dockerConfigJson is not empty",
+			expectCreate:     true,
+			dockerConfigJson: `foo`,
+			want: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tenantImagePullSecretName,
+					Namespace: "test-namespace",
+				},
+				Type: corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{
+					corev1.DockerConfigJsonKey: []byte(`foo`), // pragma: allowlist secret
+				},
+			},
+		}, {
+			name:             "secret should be updated if it exists and dockerConfigJson is not empty and different",
+			expectUpdate:     true,
+			dockerConfigJson: `foo`,
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tenantImagePullSecretName,
+					Namespace: "test-namespace",
+				},
+				Type: corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{
+					corev1.DockerConfigJsonKey: []byte(`bar`), // pragma: allowlist secret
+				},
+			},
+			want: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tenantImagePullSecretName,
+					Namespace: "test-namespace",
+				},
+				Type: corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{
+					corev1.DockerConfigJsonKey: []byte(`foo`), // pragma: allowlist secret
+				},
+			},
+		},
+		{
+			name: "secret should be deleted if it exists and dockerConfigJson is empty",
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tenantImagePullSecretName,
+					Namespace: "test-namespace",
+				},
+				Type: corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{
+					corev1.DockerConfigJsonKey: []byte(`foo`), // pragma: allowlist secret
+				},
+			},
+			dockerConfigJson: "", // pragma: allowlist secret
+			want:             nil,
+			expectDelete:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := []runtime.Object{}
+			if tt.existingSecret != nil { // pragma: allowlist secret
+				objs = append(objs, tt.existingSecret)
+			}
+			clientSet := fake.NewSimpleClientset(objs...)
+
+			updateCount := 0
+			createCount := 0
+			deleteCount := 0
+			clientSet.PrependReactor("create", "secrets", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+				createCount++
+				return false, nil, nil
+			})
+			clientSet.PrependReactor("update", "secrets", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+				updateCount++
+				return false, nil, nil
+			})
+			clientSet.PrependReactor("delete", "secrets", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+				deleteCount++
+				return false, nil, nil
+			})
+
+			reconciler := newPullSecretReconciler(clientSet, "test-namespace", []byte(tt.dockerConfigJson))
+			ctx := context.Background()
+			ctx, err := reconciler.ensurePresent(ctx)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+
+				if tt.expectUpdate {
+					assert.Equal(t, 1, updateCount)
+				} else {
+					assert.Equal(t, 0, updateCount)
+				}
+
+				if tt.expectCreate {
+					assert.Equal(t, 1, createCount)
+				} else {
+					assert.Equal(t, 0, createCount)
+				}
+
+				if tt.expectDelete {
+					assert.Equal(t, 1, deleteCount)
+				} else {
+					assert.Equal(t, 0, deleteCount)
+				}
+
+				if tt.want != nil {
+					got, err := clientSet.CoreV1().Secrets("test-namespace").Get(ctx, tenantImagePullSecretName, metav1.GetOptions{})
+					require.NoError(t, err)
+					assert.Equal(t, tt.want.Name, got.Name)
+					assert.Equal(t, tt.want.Namespace, got.Namespace)
+					assert.Equal(t, tt.want.Type, got.Type)
+					assert.Equal(t, tt.want.Data, got.Data)
+				} else {
+					_, err := clientSet.CoreV1().Secrets("test-namespace").Get(ctx, tenantImagePullSecretName, metav1.GetOptions{})
+					assert.Error(t, err)
+				}
+			}
+		})
+	}
+
+}

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -360,6 +360,7 @@ func TestReconcileLastHashNotUpdatedOnError(t *testing.T) {
 		encryptionKeyGenerator: cipher.AES256KeyGenerator{},
 		secretBackup:           k8s.NewSecretBackup(fakeClient, false),
 		namespaceReconciler:    noopReconciler{},
+		pullSecretReconciler:   noopReconciler{}, // pragma: allowlist secret
 	}
 	r.areSecretsStoredFunc = r.areSecretsStored //pragma: allowlist secret
 	r.needsReconcileFunc = r.needsReconcile


### PR DESCRIPTION
## Description
Extract dedicated `imagePullSecret` reconciler

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
