### PR TITLE
Bump ACS Operator base image

### DIFF
--- a/dp-terraform/helm/Dockerfile
+++ b/dp-terraform/helm/Dockerfile
@@ -28,7 +28,7 @@ RUN yq -i ".fleetshardSync.image.tag = strenv(FLEETSHARD_SYNC_IMAGE_TAG)" rhacs-
 ARG EMAILSENDER_IMAGE_TAG=main
 RUN yq -i ".emailsender.image.tag = strenv(EMAILSENDER_IMAGE_TAG)" rhacs-terraform/values.yaml
 
-FROM quay.io/operator-framework/helm-operator:v1.33.0
+FROM quay.io/operator-framework/helm-operator:v1.35.0
 
 ENV HOME=/opt/helm
 ENV ADDON_NAME=acs-fleetshard


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
This also should resolve a few fixable vulnerabilities on ACS Dogfooding instance.
There was an issue to upgrade to 1.34 in the past https://github.com/stackrox/acs-fleet-manager/pull/1687
The 1.34 issue might resolved. We can try migrating to 1.35


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

It does not cover full acs fleetshard operator flow
```
cd dp-terraform/helm
podman build -t test-35-sdk .
podman run --rm -it --entrypoint /bin/sh test-35-sdk
```
