### PR TITLE
ROX-21531: Remove probe namespace selector from the Observability CR

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
@@ -54,9 +54,6 @@ spec:
     probeSelector:
       matchLabels:
         app: rhacs
-    probeNamespaceSelector:
-      matchLabels:
-        app.kubernetes.io/managed-by: rhacs-fleetshard
     alertManagerResourceRequirement:
       requests:
         cpu: {{ .Values.alertManager.resources.requests.cpu | quote }}


### PR DESCRIPTION
## Description
Since Prometheus can't watch multiple namespaces, remove the namespace selector introduced in #1962

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
