### PR TITLE
Switch ACS operator in dev gitops config to fast stream

### DIFF
--- a/dev/config/gitops-config.yaml
+++ b/dev/config/gitops-config.yaml
@@ -1,11 +1,11 @@
 rhacsOperators:
   crdUrls:
-    - https://raw.githubusercontent.com/stackrox/stackrox/4.4.2/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
-    - https://raw.githubusercontent.com/stackrox/stackrox/4.4.2/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+    - https://raw.githubusercontent.com/stackrox/stackrox/4.4.4/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+    - https://raw.githubusercontent.com/stackrox/stackrox/4.4.4/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
   operators:
-    - deploymentName: "rhacs-operator-4.4.2"
-      image: "quay.io/rhacs-eng/stackrox-operator:4.4.2"
-      centralLabelSelector: "rhacs.redhat.com/version-selector=4.4.2"
+    - deploymentName: "rhacs-operator-fast-stream"
+      image: "quay.io/rhacs-eng/stackrox-operator:4.6.x-233-gd6b1869836-fast"
+      centralLabelSelector: "rhacs.redhat.com/version-selector=fast-stream"
       securedClusterReconcilerEnabled: false
 verticalPodAutoscaling:
   recommenders: []
@@ -41,10 +41,10 @@ centrals:
     - instanceIds:
         - "*"
       patch: |
-        # Set label for all centrals to 4.4.2
+        # Set label for all centrals to fast-stream
         metadata:
           labels:
-            rhacs.redhat.com/version-selector: "4.4.2"
+            rhacs.redhat.com/version-selector: "fast-stream"
         # Adjust centrals for development environment
         spec:
           monitoring:


### PR DESCRIPTION
## Description
Switch ACS operator in dev gitops config to fast stream **mainly for arm64 support**.  

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
