### PR TITLE
Bump Addon operator-sdk to 1.36

### DIFF
--- a/dev/env/manifests/fleetshard-operator/28-deployment.yaml
+++ b/dev/env/manifests/fleetshard-operator/28-deployment.yaml
@@ -23,10 +23,6 @@ spec:
         image: "${FLEETSHARD_OPERATOR_IMAGE}"
         name: manager
         env:
-          - name: WATCH_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: ADDON_NAME
             value: acs-fleetshard-dev
         securityContext:

--- a/dp-terraform/helm/Dockerfile
+++ b/dp-terraform/helm/Dockerfile
@@ -28,7 +28,7 @@ RUN yq -i ".fleetshardSync.image.tag = strenv(FLEETSHARD_SYNC_IMAGE_TAG)" rhacs-
 ARG EMAILSENDER_IMAGE_TAG=main
 RUN yq -i ".emailsender.image.tag = strenv(EMAILSENDER_IMAGE_TAG)" rhacs-terraform/values.yaml
 
-FROM quay.io/operator-framework/helm-operator:v1.33.0
+FROM quay.io/operator-framework/helm-operator:v1.36.0
 
 ENV HOME=/opt/helm
 ENV ADDON_NAME=acs-fleetshard


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Bump Addon operator-sdk to 1.36 to address CVE fixes. Also dropped `WATCH_NAMESPACE` which might cause e2e tests to fail with the new version

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
