### PR TITLE
ROX-24936: add abstraction for email.Sender to allow multiple impl

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
@@ -35,6 +35,8 @@ spec:
               value: {{ .Values.fleetshardSync.environment }}
             - name: SENDER_ADDRESS
               value: {{ .Values.emailsender.senderAddress }}
+            - name: EMAIL_PROVIDER
+              value: {{ .Values.emailsender.emailProvider }}
             - name: HTTPS_CERT_FILE
               value: "/var/run/certs/tls.crt"
             - name: HTTPS_KEY_FILE

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -82,6 +82,7 @@ emailsender:
   environment: ""
   senderAddress: "noreply@mail.rhacs-dev.com"
   authConfigFromKubernetes: true
+  emailProvider: "AWS_SES"
   resources:
     requests:
       cpu: "100m"

--- a/emailsender/cmd/app/main.go
+++ b/emailsender/cmd/app/main.go
@@ -69,7 +69,12 @@ func main() {
 		}
 	}()
 
-	emailSender := email.NewEmailSender(ctx, cfg, rateLimiter)
+	emailSender, err := email.NewEmailSender(ctx, cfg, rateLimiter)
+	if err != nil {
+		glog.Errorf("Failed to initialise EmailSender implementaiton: %v", err)
+		os.Exit(1)
+	}
+
 	emailHandler := api.NewEmailHandler(emailSender)
 
 	router, err := api.SetupRoutes(cfg.AuthConfig, emailHandler)

--- a/emailsender/cmd/app/main.go
+++ b/emailsender/cmd/app/main.go
@@ -56,11 +56,6 @@ func main() {
 		os.Exit(1)
 	}
 	rateLimiter := email.NewRateLimiterService(dbConnection, cfg.LimitEmailPerTenant)
-	sesClient, err := email.NewSES(ctx, cfg.SesMaxBackoffDelay, cfg.SesMaxAttempts)
-	if err != nil {
-		glog.Errorf("Failed to initialise SES Client: %v", err)
-		os.Exit(1)
-	}
 
 	cleanupWorker := workers.CleanupEmailSent{
 		DbConn:       dbConnection,
@@ -74,7 +69,7 @@ func main() {
 		}
 	}()
 
-	emailSender := email.NewEmailSender(cfg.SenderAddress, sesClient, rateLimiter)
+	emailSender := email.NewEmailSender(ctx, cfg, rateLimiter)
 	emailHandler := api.NewEmailHandler(emailSender)
 
 	router, err := api.SetupRoutes(cfg.AuthConfig, emailHandler)

--- a/emailsender/cmd/app/main.go
+++ b/emailsender/cmd/app/main.go
@@ -71,7 +71,7 @@ func main() {
 
 	emailSender, err := email.NewEmailSender(ctx, cfg, rateLimiter)
 	if err != nil {
-		glog.Errorf("Failed to initialise EmailSender implementaiton: %v", err)
+		glog.Errorf("Failed to initialise EmailSender implementation: %v", err)
 		os.Exit(1)
 	}
 

--- a/emailsender/config/config.go
+++ b/emailsender/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	SesMaxAttempts            int           `env:"SES_MAX_ATTEMPTS" envDefault:"3"`
 	EmailCleanupPeriodSeconds int           `env:"EMAIL_CLEANUP_PERIOD_SECONDS" envDefault:"300"`
 	EmailCleanupExpiryDays    int           `env:"EMAIL_CLEANUP_EXPIRY_DAYS" envDefault:"2"`
+	EmailProvider             string        `env:"EMAIL_PROVIDER" envDefault:"AWS_SES"`
 	AuthConfig                AuthConfig
 	DatabaseConfig            DbConfig
 }

--- a/emailsender/pkg/email/sender.go
+++ b/emailsender/pkg/email/sender.go
@@ -53,7 +53,7 @@ type LogEmailSender struct {
 
 // Send simulates sending an email by logging given message to glog.
 func (l *LogEmailSender) Send(ctx context.Context, to []string, rawMessage []byte, tenantID string) error {
-	glog.Infof("LogEmailSender.Send called with: to: %s, rawMessage: %s, tenantID: %s, from: %s", to, string(rawMessage), tenantID, l.from)
+	glog.Infof("LogEmailSender.Send called with: to: %s, rawMessage: '%s', tenantID: '%s', from: '%s'", to, string(rawMessage), tenantID, l.from)
 	return nil
 }
 

--- a/emailsender/pkg/email/sender.go
+++ b/emailsender/pkg/email/sender.go
@@ -4,34 +4,70 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
+
+	"github.com/golang/glog"
+	"github.com/stackrox/acs-fleet-manager/emailsender/config"
 	"github.com/stackrox/acs-fleet-manager/emailsender/pkg/metrics"
 )
 
 const fromTemplate = "From: RHACS Cloud Service <%s>\r\n"
+
+const (
+	// EmailProviderAWSSES is the type name for the AWSEmailSender implementation of the Sender interface
+	EmailProviderAWSSES = "AWS_SES"
+	// EmailProviderLog is the type name for the LogEmailSender implementation of the Sender interface
+	EmailProviderLog = "LOG"
+)
 
 // Sender defines the interface to send emails
 type Sender interface {
 	Send(ctx context.Context, to []string, rawMessage []byte, tenantID string) error
 }
 
-// MailSender is the default implementation for the Sender interface
-type MailSender struct {
+// NewEmailSender return a initialized Sender implementation according to the provider configured in cfg.EmailProvider
+func NewEmailSender(ctx context.Context, cfg *config.Config, rateLimiter RateLimiter) Sender {
+	switch cfg.EmailProvider {
+	case EmailProviderLog:
+		return &LogEmailSender{
+			from: cfg.SenderAddress,
+		}
+	default:
+		// EmailProviderAWSSES is the default
+		ses, err := NewSES(ctx, cfg.SesMaxBackoffDelay, cfg.SesMaxAttempts)
+		if err != nil {
+			glog.Errorf("Failed to initialise SES Client: %v", err)
+			os.Exit(1)
+		}
+		return &AWSMailSender{
+			from:        cfg.SenderAddress,
+			ses:         ses,
+			rateLimiter: rateLimiter,
+		}
+
+	}
+}
+
+// LogEmailSender is a Sender implementation that logs email messages to glog
+type LogEmailSender struct {
+	from string
+}
+
+// Send simulates sending an email by logging given message to glog.
+func (l *LogEmailSender) Send(ctx context.Context, to []string, rawMessage []byte, tenantID string) error {
+	glog.Infof("LogEmailSender.Send called with: to: %s, rawMessage: %s, tenantID: %s, from: %s", to, string(rawMessage), tenantID, l.from)
+	return nil
+}
+
+// AWSMailSender is the default implementation for the Sender interface
+type AWSMailSender struct {
 	from        string
 	ses         *SES
 	rateLimiter RateLimiter
 }
 
-// NewEmailSender returns a new MailSender instance
-func NewEmailSender(from string, ses *SES, rateLimiter RateLimiter) *MailSender {
-	return &MailSender{
-		from:        from,
-		ses:         ses,
-		rateLimiter: rateLimiter,
-	}
-}
-
 // Send sends an email to the given AWS SES
-func (s *MailSender) Send(ctx context.Context, to []string, rawMessage []byte, tenantID string) error {
+func (s *AWSMailSender) Send(ctx context.Context, to []string, rawMessage []byte, tenantID string) error {
 	// Even though AWS adds the "from" handler we need to set it to the message to show
 	// an alias in email inboxes. It is more human friendly (noreply@rhacs-dev.com vs. RHACS Cloud Service)
 	if !s.rateLimiter.IsAllowed(tenantID) {

--- a/emailsender/pkg/email/sender_test.go
+++ b/emailsender/pkg/email/sender_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/ses"
 )
@@ -58,7 +59,7 @@ func TestSend_Success(t *testing.T) {
 		},
 	}
 	mockedSES := &SES{sesClient: mockClient}
-	mockedSender := MailSender{
+	mockedSender := AWSMailSender{
 		from,
 		mockedSES,
 		mockedRateLimiter,
@@ -83,7 +84,7 @@ func TestSend_LimitExceeded(t *testing.T) {
 		},
 	}
 	mockedSES := &SES{sesClient: mockClient}
-	mockedSender := MailSender{
+	mockedSender := AWSMailSender{
 		"from@example.com",
 		mockedSES,
 		mockedRateLimiter,

--- a/emailsender/pkg/email/ses.go
+++ b/emailsender/pkg/email/ses.go
@@ -4,8 +4,9 @@ package email
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"


### PR DESCRIPTION
## Description

This PR adds:
- A abstraction layer to be able to create different email.Sender interface implementation
- Configuration options to determine which concrete implementation to use
- A LogEmailSender implementation fo the email.Sender interface

I want to use the new LogEmailSender implementation to be able to run central <> emailsender API compatibility tests without having to provide AWS credentials. This tests will be running in both repositories stackrox/stackrox and stackrox/acs-fleet-manager and I don't want to provide stackrox/stackrox credentials to access any ACSCS cloud accounts.


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~~[ ] Unit and integration tests added~~ -> current tests are sufficient.
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- ~~[ ] Add secret to app-interface Vault or Secrets Manager if necessary~~
- ~~[ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
- ~~[ ] Check AWS limits are reasonable for changes provisioning new resources~~
- [x] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

```bash
# Login to AWS dev account first
make db/setup
make run/emailsender
ocm login --use-device-code --url prod

# make sure the AWS logic still works, by seeing following request succeed
curl localhost:8080/api/v1/acscsemail -v -XPOST \
-H "Content-Type: application/json" \
-H "Authorization: Bearer $(ocm token)" \
--data-raw '{"to":["success@simulator.amazonses.com"], "rawMessage":"dGVzdCBtZXNzYWdlIGNvbnRlbnQ="}'

# make sure the Log logic works if configured
 curl localhost:8080/api/v1/acscsemail -v -XPOST \
-H "Content-Type: application/json" \
-H "Authorization: Bearer $(ocm token)" \
--data-raw '{"to":["success@simulator.amazonses.com"], "rawMessage":"dGVzdCBtZXNzYWdlIGNvbnRlbnQ="}'

# yields a log at emailsender
LogEmailSender.Send called with: to: [success@simulator.amazonses.com], rawMessage: test message content, tenantID: f:528d76ff-f708-43ed-8cd5-fe16f4fe0ce6:rh-ee-jmalsam, from: noreply@mail.rhacs-dev.com

```
