### PR TITLE
ROX-24936: emailsender central compatibility test

### DIFF
--- a/.github/workflows/emailsender-central-compatibility.yaml
+++ b/.github/workflows/emailsender-central-compatibility.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: acs-fleet-manager
-          fetch-depth: 0 
+          fetch-depth: 0
       - name: Checkout stackrox/stackrox repository
         uses: actions/checkout@v4
         with:
@@ -59,7 +59,3 @@ jobs:
         uses: helm/kind-action@v1
       - name: Run Test
         run: acs-fleet-manager/scripts/ci/central_compatibility/entrypoint.sh
-
-       
-
-

--- a/.github/workflows/emailsender-central-compatibility.yaml
+++ b/.github/workflows/emailsender-central-compatibility.yaml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   e2e-test-on-kind:
+    timeout-minutes: 45
     name: "Test on kind cluster"
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.head.repo.fork }} # do not run for PRs from forks

--- a/.github/workflows/emailsender-central-compatibility.yaml
+++ b/.github/workflows/emailsender-central-compatibility.yaml
@@ -42,8 +42,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: quay.io
-          username: ${{ secrets.QUAY_RHACS_ENG_FM_RW_USERNAME }}
-          password: ${{ secrets.QUAY_RHACS_ENG_FM_RW_PASSWORD }}
+          username: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
+          password: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
       - name: Checkout this repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/emailsender-central-compatibility.yaml
+++ b/.github/workflows/emailsender-central-compatibility.yaml
@@ -57,5 +57,7 @@ jobs:
           fetch-tags: true
       - name: Create Kind cluster"
         uses: helm/kind-action@v1
+        with:
+          cluster_name: kind
       - name: Run Test
         run: acs-fleet-manager/scripts/ci/central_compatibility/entrypoint.sh

--- a/.github/workflows/emailsender-central-compatibility.yaml
+++ b/.github/workflows/emailsender-central-compatibility.yaml
@@ -55,6 +55,7 @@ jobs:
           repository: stackrox/stackrox
           path: stackrox
           fetch-tags: true
+          fetch-depth: 0
       - name: Create Kind cluster"
         uses: helm/kind-action@v1
         with:

--- a/.github/workflows/emailsender-central-compatibility.yaml
+++ b/.github/workflows/emailsender-central-compatibility.yaml
@@ -1,0 +1,65 @@
+
+name: emailsender-central-compatibility
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'emailsender/**'
+
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'emailsender/**'
+
+jobs:
+  e2e-test-on-kind:
+    name: "Test on kind cluster"
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.head.repo.fork }} # do not run for PRs from forks
+    permissions:
+      id-token: write
+      contents: read
+    environment: development
+    steps:
+      - name: Cancel Previous Runs
+        uses: n1hility/cancel-previous-runs@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+      - name: Cache go module
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_RHACS_ENG_FM_RW_USERNAME }}
+          password: ${{ secrets.QUAY_RHACS_ENG_FM_RW_PASSWORD }}
+      - name: Checkout this repository
+        uses: actions/checkout@v4
+        with:
+          path: acs-fleet-manager
+          fetch-depth: 0 
+      - name: Checkout stackrox/stackrox repository
+        uses: actions/checkout@v4
+        with:
+          repository: stackrox/stackrox
+          path: stackrox
+          fetch-tags: true
+      - name: Create Kind cluster"
+        uses: helm/kind-action@v1
+      - name: Run Test
+        run: acs-fleet-manager/scripts/ci/central_compatibility/entrypoint.sh
+
+       
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,9 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
-
+emailsender-manifests.yaml
+central-chart/
+pids-port-forward
 # Ignore uploaded files in development
 /storage/*
 

--- a/Makefile
+++ b/Makefile
@@ -983,6 +983,10 @@ full-image-tag:
 	@echo "$(IMAGE_NAME):$(image_tag)"
 .PHONY: full-image-tag
 
+image-name/emailsender:
+	@echo "$(external_image_registry)/$(emailsender_image_repository)"
+.PHONY: image-name/emailsender
+
 image-tag/emailsender:
 	@echo "$(external_image_registry)/$(emailsender_image_repository):$(image_tag)"
 .PHONY: image-tag/emailsender

--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -205,6 +205,34 @@ PATH: ${PATH}
 EOF
 }
 
+wait_for_img() {
+    local img="$1"
+    local seconds="${2:-1200}"
+    local backoff=30
+
+    local start
+    start="$(date +%s)"
+    local time_diff=0
+
+    echo "Waiting for $img to become available..."
+    while [ "$time_diff" -le "$seconds" ]
+    do
+        # the grep depends on the error message docker prints if manifest is not found
+        if ! docker manifest inspect "$img" 2>&1 | grep "no such manifest"; then
+            echo "remote image: $img is available."
+            return 0
+        fi
+
+        local unix_seconds_now
+        unix_seconds_now="$(date +%s)"
+        time_diff=$(( unix_seconds_now - start))
+        sleep "$backoff"
+    done
+
+    echo "Timed out waiting for remote image: $img to become available"
+    return 1
+}
+
 wait_for_container_to_appear() {
     local namespace="$1"
     local pod_selector="$2"

--- a/emailsender/compatibility/emailsender_central_test.go
+++ b/emailsender/compatibility/emailsender_central_test.go
@@ -1,0 +1,46 @@
+//go:build test_central_compatibility
+
+package compatibility
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	centralURLFmt    = "https://%s:%s@localhost:8443" // pragma: allowlist secret
+	testNotifierPath = "/v1/notifiers/test"
+	adminUser        = "admin"
+)
+
+//go:embed post-acscsemail-integration.json
+var notifierPayload []byte
+
+func TestACSCSEmailNotifier(t *testing.T) {
+	adminPW := os.Getenv("ADMIN_PW")
+	require.NotEmpty(t, adminPW, "AMDIN_PW is not set in environment")
+
+	url := fmt.Sprintf(centralURLFmt, adminUser, adminPW)
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(notifierPayload))
+	require.NoError(t, err, "failed to build http request")
+
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err, "failed to send notifier test requests to central")
+	defer res.Body.Close()
+
+	status := res.StatusCode
+	if status == 200 {
+		return
+	}
+
+	resBody, err := io.ReadAll(res.Body)
+	require.NoError(t, err, "failed to read response body of response")
+	t.Fatalf("requests has status code: %d, with body: %s", status, string(resBody))
+}

--- a/emailsender/compatibility/emailsender_central_test.go
+++ b/emailsender/compatibility/emailsender_central_test.go
@@ -4,6 +4,7 @@ package compatibility
 
 import (
 	"bytes"
+	"crypto/tls"
 	_ "embed"
 	"fmt"
 	"io"
@@ -31,7 +32,14 @@ func TestACSCSEmailNotifier(t *testing.T) {
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(notifierPayload))
 	require.NoError(t, err, "failed to build http request")
 
-	res, err := http.DefaultClient.Do(req)
+	httpClient := http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+	res, err := httpClient.Do(req)
 	require.NoError(t, err, "failed to send notifier test requests to central")
 	defer res.Body.Close()
 

--- a/emailsender/compatibility/post-acscsemail-integration.json
+++ b/emailsender/compatibility/post-acscsemail-integration.json
@@ -1,0 +1,8 @@
+{
+  "id": "",
+  "name": "testACSCS",
+  "type": "acscsEmail",
+  "labelDefault": "soem-mail@test.some.domain",
+  "labelKey": "",
+  "uiEndpoint": "https://localhost:8443"
+}

--- a/scripts/ci/central_compatibility/central-values.yaml
+++ b/scripts/ci/central_compatibility/central-values.yaml
@@ -1,0 +1,46 @@
+env:
+  managedServices: true
+allowNonstandardNamespace: true
+central:
+  resources:
+    requests:
+      memory: "200Mi"
+      cpu: "150m"
+    limits:
+      memory: "300Mi"
+      cpu: "200m"
+  db:
+    resources:
+      requests:
+        memory: "200Mi"
+        cpu: "200m"
+      limits:
+        memory: "300Mi"
+        cpu: "300m"
+    persistence:
+      persistentVolumeClaim:
+        size: 10Gi
+  persistence:
+    none: true
+  adminPassword:
+    value: "letmein"
+scanner:
+  replicas: 1
+  resources:
+    requests:
+      memory: "200Mi"
+      cpu: "200m"
+    limits:
+      memory: "300Mi"
+      cpu: "300m"
+  dbResources:
+    requests:
+      memory: "200Mi"
+      cpu: "200m"
+    limits:
+      memory: "300Mi"
+      cpu: "300m"
+customize:
+  central:
+    envVars:
+      ROX_ACSCS_EMAIL_URL: "http://emailsender.rhacs.svc:443"

--- a/scripts/ci/central_compatibility/central-values.yaml
+++ b/scripts/ci/central_compatibility/central-values.yaml
@@ -25,6 +25,7 @@ central:
   adminPassword:
     value: "letmein"
 scanner:
+  disable: true
   replicas: 1
   resources:
     requests:

--- a/scripts/ci/central_compatibility/emailsender-db.yaml
+++ b/scripts/ci/central_compatibility/emailsender-db.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: emailsender-db
+  name: emailsender-db
+  namespace: rhacs
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: emailsender-db
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: emailsender-db
+    spec:
+      containers:
+      - image: postgres:13
+        name: postgres
+        ports:
+        - containerPort: 5432
+        resources:
+          requests:
+            cpu: "100m"
+            memory: 250Mi
+          limits:
+            cpu: "150m"
+            memory: 300Mi
+        env:
+        - name: POSTGRES_PASSWORD
+          value: "postgres"
+        - name: POSTGRES_USER
+          value: "postgres"
+        - name: POSTGRES_DB
+          value: "postgres"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: emailsender-db
+  name: emailsender-db
+  namespace: rhacs
+spec:
+  ports:
+  - name: 5432-5432
+    port: 5432
+    protocol: TCP
+    targetPort: 5432
+  selector:
+    app: emailsender-db
+  type: ClusterIP
+---
+apiVersion: v1
+data:
+  db.host: ZW1haWxzZW5kZXItZGI=
+kind: Secret
+metadata:
+  name: emailsender-db
+  namespace: rhacs
+---
+apiVersion: v1
+data:
+  aws-role-arn: "cGxhY2Vob2xkZXIK"
+kind: Secret
+metadata:
+  name: emailsender-parameters
+  namespace: rhacs

--- a/scripts/ci/central_compatibility/emailsender-values.yaml
+++ b/scripts/ci/central_compatibility/emailsender-values.yaml
@@ -1,0 +1,21 @@
+# This values file is used to render emailsender related kubernetes resources
+# in context of emailsender <> central compatiblity tests. Values that are not
+# below the emailsender field are the minimum required values for the helm chart
+fleetshardSync:
+  clusterName: test
+  clusterId: test
+  environment: dev
+  managedDB:
+    enabled: false
+    subnetGroup: "dummyGroup"
+emailsender:
+  image:
+    repo: "quay.io/rhacs-eng/emailsender"
+  enabled: true
+  enableHTTPS: false
+  clusterName: test
+  replicas: 1
+  authConfigFromKubernetes: true
+secured-cluster:
+  clusterName: test
+  centralEndpoint: dummyEndpoint

--- a/scripts/ci/central_compatibility/entrypoint.sh
+++ b/scripts/ci/central_compatibility/entrypoint.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "$ROOT_DIR/scripts/ci/lib.sh"
+source "$ROOT_DIR/scripts/lib/log.sh"
+source "$ROOT_DIR/dev/env/scripts/lib.sh"
+
+export EMAILSENDER_NS="rhacs"
+export CENTRAL_NS="rhacs-tenant"
+
+function log_failure() {
+  log "Test failed with status: $?" 
+  log "Starting to log cluster resources and container logs..."
+
+  log "***** START EMAILSENDER RESOURCES *****"
+    kubectl describe deploy -n "$EMAILSENDER_NS" emailsender
+    kubectl describe pods -n "$EMAILSENDER_NS" -l app=emailsender 
+    kubectl logs -n "$EMAILSENDER_NS" --prefix --all-containers -l app=emailsender
+
+    kubectl describe deploy -n "$EMAILSENDER_NS" emailsender-db
+    kubectl describe pods -n "$EMAILSENDER_NS" -l app=emailsender-db
+    kubectl logs -n "$EMAILSENDER_NS" --prefix --all-containers -l app=emailsender-db
+  log "***** END EMAILSENDER RESOURCES *****"
+
+  log "***** START STACKROX KUBERNETES RESOURCES *****"
+    kubectl describe deploy -n "$CENTRAL_NS"
+    kubectl describe pods -n "$CENTRAL_NS"
+    kubectl logs -n "$CENTRAL_NS" --prefix --all-containers -l "app.kubernetes.io/name=stackrox"
+  log "***** END STACKROX KUBERNETES RESOURCES *****"
+  exit 1
+}
+
+touch pids-port-forward
+
+if bash "$SOURCE_DIR/run_compatibilty_test.sh" ; then
+  exit 0
+else
+  log_failure
+fi
+
+cat pids-port-forwad | xargs kill
+
+

--- a/scripts/ci/central_compatibility/entrypoint.sh
+++ b/scripts/ci/central_compatibility/entrypoint.sh
@@ -3,7 +3,7 @@
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-cd $ROOT_DIR
+cd "$ROOT_DIR"
 
 source "$ROOT_DIR/scripts/ci/lib.sh"
 source "$ROOT_DIR/scripts/lib/log.sh"
@@ -13,33 +13,31 @@ export EMAILSENDER_NS="rhacs"
 export CENTRAL_NS="rhacs-tenant"
 
 function log_failure() {
-  log "Test failed with status: $?" 
+  log "Test failed with status: $?"
   log "Starting to log cluster resources and container logs..."
 
   log "***** START EMAILSENDER RESOURCES *****"
-    kubectl describe deploy -n "$EMAILSENDER_NS" emailsender
-    kubectl describe pods -n "$EMAILSENDER_NS" -l app=emailsender 
-    kubectl logs -n "$EMAILSENDER_NS" --prefix --all-containers -l app=emailsender
+  kubectl describe deploy -n "$EMAILSENDER_NS" emailsender
+  kubectl describe pods -n "$EMAILSENDER_NS" -l app=emailsender
+  kubectl logs -n "$EMAILSENDER_NS" --prefix --all-containers -l app=emailsender
 
-    kubectl describe deploy -n "$EMAILSENDER_NS" emailsender-db
-    kubectl describe pods -n "$EMAILSENDER_NS" -l app=emailsender-db
-    kubectl logs -n "$EMAILSENDER_NS" --prefix --all-containers -l app=emailsender-db
+  kubectl describe deploy -n "$EMAILSENDER_NS" emailsender-db
+  kubectl describe pods -n "$EMAILSENDER_NS" -l app=emailsender-db
+  kubectl logs -n "$EMAILSENDER_NS" --prefix --all-containers -l app=emailsender-db
   log "***** END EMAILSENDER RESOURCES *****"
 
   log "***** START STACKROX KUBERNETES RESOURCES *****"
-    kubectl describe deploy -n "$CENTRAL_NS"
-    kubectl describe pods -n "$CENTRAL_NS"
-    kubectl logs -n "$CENTRAL_NS" --prefix --all-containers -l "app.kubernetes.io/name=stackrox"
+  kubectl describe deploy -n "$CENTRAL_NS"
+  kubectl describe pods -n "$CENTRAL_NS"
+  kubectl logs -n "$CENTRAL_NS" --prefix --all-containers -l "app.kubernetes.io/name=stackrox"
   log "***** END STACKROX KUBERNETES RESOURCES *****"
 }
 
-bash "$SOURCE_DIR/run_compatibilty_test.sh"
+bash "$SOURCE_DIR/run_compatibility_test.sh"
 EXIT_CODE="$?"
 if [ "$EXIT_CODE" -ne "0" ]; then
   log_failure
 fi
 
-stat /tmp/pids-port-forward > /dev/null 2>&1 && cat /tmp/pids-port-forward | xargs kill
-exit $EXIT_CODE
-
-
+stat /tmp/pids-port-forward > /dev/null 2>&1 && xargs kill < /tmp/pids-port-forward
+exit "$EXIT_CODE"

--- a/scripts/ci/central_compatibility/entrypoint.sh
+++ b/scripts/ci/central_compatibility/entrypoint.sh
@@ -13,7 +13,7 @@ export EMAILSENDER_NS="rhacs"
 export CENTRAL_NS="rhacs-tenant"
 
 function log_failure() {
-  log "Test failed with status: $?"
+  log "Test failed with status: $EXIT_CODE"
   log "Starting to log cluster resources and container logs..."
 
   log "***** START EMAILSENDER RESOURCES *****"

--- a/scripts/ci/central_compatibility/entrypoint.sh
+++ b/scripts/ci/central_compatibility/entrypoint.sh
@@ -3,6 +3,8 @@
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+cd $ROOT_DIR
+
 source "$ROOT_DIR/scripts/ci/lib.sh"
 source "$ROOT_DIR/scripts/lib/log.sh"
 source "$ROOT_DIR/dev/env/scripts/lib.sh"
@@ -29,17 +31,18 @@ function log_failure() {
     kubectl describe pods -n "$CENTRAL_NS"
     kubectl logs -n "$CENTRAL_NS" --prefix --all-containers -l "app.kubernetes.io/name=stackrox"
   log "***** END STACKROX KUBERNETES RESOURCES *****"
-  exit 1
 }
 
 touch pids-port-forward
 
-if bash "$SOURCE_DIR/run_compatibilty_test.sh" ; then
-  exit 0
-else
+bash "$SOURCE_DIR/run_compatibilty_test.sh"
+EXIT_CODE="$?"
+
+if [ "$EXIT_CODE" -ne 0 ]; then
   log_failure
 fi
 
 cat pids-port-forwad | xargs kill
+exit $EXIT_CODE
 
 

--- a/scripts/ci/central_compatibility/entrypoint.sh
+++ b/scripts/ci/central_compatibility/entrypoint.sh
@@ -33,16 +33,13 @@ function log_failure() {
   log "***** END STACKROX KUBERNETES RESOURCES *****"
 }
 
-touch pids-port-forward
-
 bash "$SOURCE_DIR/run_compatibilty_test.sh"
 EXIT_CODE="$?"
-
-if [ "$EXIT_CODE" -ne 0 ]; then
+if [ "$EXIT_CODE" -ne "0" ]; then
   log_failure
 fi
 
-cat pids-port-forwad | xargs kill
+stat /tmp/pids-port-forward > /dev/null 2>&1 && cat /tmp/pids-port-forward | xargs kill
 exit $EXIT_CODE
 
 

--- a/scripts/ci/central_compatibility/run_compatibility_test.sh
+++ b/scripts/ci/central_compatibility/run_compatibility_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -eux
 
 # Deploy a kind cluster previously to running this script
 # This script expects:
@@ -64,12 +64,12 @@ log "Starting to deploy central services..."
 # use nightly if GH action running for acs-fleet-manager
 # use the stackrox tag otherwise
 log "Running for repository: $GITHUB_REPOSITORY"
-if [ "$GITHUB_REPOSITORY" = "stackrox/acs-fleet-manager" ]; then
+if [ "$GITHUB_REPOSITORY" = "stackrox/stackrox" ]; then
+  ACS_VERSION="$(make --no-print-directory -C "$STACKROX_DIR" tag)"
+else
   git -C "$STACKROX_DIR" fetch --tags
   ACS_VERSION="$(git -C "$STACKROX_DIR" tag | grep nightly | tail -n 1)"
   git -C "$STACKROX_DIR" checkout "$ACS_VERSION"
-else
-  ACS_VERSION="$(make --no-print-directory -C "$STACKROX_DIR" tag)"
 fi
 
 log "ACS version: $ACS_VERSION"

--- a/scripts/ci/central_compatibility/run_compatibility_test.sh
+++ b/scripts/ci/central_compatibility/run_compatibility_test.sh
@@ -55,7 +55,8 @@ log "Starting to deploy central services..."
 # use the stackrox tag otherwise
 log "Running for repository: $GITHUB_REPOSITORY"
 if [ "$GITHUB_REPOSITORY" = "stackrox/acs-fleet-manager" ]; then
-  ACS_VERSION="$( git -C "$STACKROX_DIR" tag | grep nightly | tail -n 1 )"
+  git -C "$STACKROX_DIR" fetch --tags
+  ACS_VERSION="$(git -C "$STACKROX_DIR" tag | grep nightly | tail -n 1)"
   git -C "$STACKROX_DIR" checkout "$ACS_VERSION"
 else
   ACS_VERSION="$(make --no-print-directory -C "$STACKROX_DIR" tag)"

--- a/scripts/ci/central_compatibility/run_compatibility_test.sh
+++ b/scripts/ci/central_compatibility/run_compatibility_test.sh
@@ -34,6 +34,7 @@ kind load docker-image "${EMAILSENDER_IMG}"
 kubectl create ns $EMAILSENDER_NS -o yaml --dry-run=client | kubectl apply -f -
 kubectl create ns $CENTRAL_NS -o yaml --dry-run=client | kubectl apply -f -
 
+helm repo add external-secrets https://charts.external-secrets.io/
 helm dependency build "${EMAILSENDER_HELM_DIR}"
 # Render emailsender kubernetes resources
 helm template --namespace "${EMAILSENDER_NS}" \

--- a/scripts/ci/central_compatibility/run_compatibility_test.sh
+++ b/scripts/ci/central_compatibility/run_compatibility_test.sh
@@ -73,7 +73,9 @@ IMAGES_TO_PULL=(
   "$CENTRAL_DB_IMG_NAME:$ACS_VERSION"
 )
 
+IMG_WAIT_TIMEOUT_SECONDS="${IMG_WAIT_TIMEOUT_SECONDS:-1200}"
 for img in "${IMAGES_TO_PULL[@]}"; do
+  wait_for_image "$img" "$IMG_WAIT_TIMEOUT_SECONDS"
   pull_to_kind "$img"
 done
 

--- a/scripts/ci/central_compatibility/run_compatibility_test.sh
+++ b/scripts/ci/central_compatibility/run_compatibility_test.sh
@@ -25,10 +25,10 @@ function pull_to_kind() {
   kind load docker-image "${img}"
 }
 
-EMAILSENDER_IMG_TAG="$(make -C "$ROOT_DIR" tag)"
-EMAILSENDER_IMG_NAME="$(make -C "$ROOT_DIR" image-name/emailsender)"
-EMAILSENDER_IMG="$(make -C "$ROOT_DIR" image-tag/emailsender)"
-make -C "$ROOT_DIR" image/build/emailsender
+EMAILSENDER_IMG_TAG="$(make --no-print-directory -C "$ROOT_DIR" tag)"
+EMAILSENDER_IMG_NAME="$(make --no-print-directory -C "$ROOT_DIR" image-name/emailsender)"
+EMAILSENDER_IMG="$(make --no-print-directory -C "$ROOT_DIR" image-tag/emailsender)"
+make --no-print-directory -C "$ROOT_DIR" image/build/emailsender
 kind load docker-image "${EMAILSENDER_IMG}"
 
 kubectl create ns $EMAILSENDER_NS -o yaml --dry-run=client | kubectl apply -f -
@@ -51,9 +51,9 @@ kubectl apply -f "${SOURCE_DIR}/emailsender-db.yaml"
 if [ "$GITHUB_REPOSITORY" = "stackrox/acs-fleet-manager" ]; then
   ACS_VERSION="$( git -C "$STACKROX_DIR" tag | grep nightly | tail -n 1 )"
   git -C "$STACKROX_DIR" checkout "$ACS_VERSION"
-  SCANNER_VERSION="$(make -C "$STACKROX_DIR" scanner-tag)"
+  SCANNER_VERSION="$(make --no-print-directory -C "$STACKROX_DIR" scanner-tag)"
 else
-  ACS_VERSION="$(make -C "$STACKROX_DIR" tag)"
+  ACS_VERSION="$(make --no-print-directory -C "$STACKROX_DIR" tag)"
 fi
 
 IMG_REPO="quay.io/rhacs-eng"
@@ -73,7 +73,7 @@ for img in "${IMAGES_TO_PULL[@]}"; do
   pull_to_kind "$img"
 done
 
-make -C "$STACKROX_DIR" cli_host-arch cli-install
+make --no-print-directory -C "$STACKROX_DIR" cli_host-arch cli-install
 
 # --remove to make this script rerunnable on a local machine
 roxctl helm output central-services --remove --output-dir ./central-chart

--- a/scripts/ci/central_compatibility/run_compatibility_test.sh
+++ b/scripts/ci/central_compatibility/run_compatibility_test.sh
@@ -75,7 +75,7 @@ IMAGES_TO_PULL=(
 
 IMG_WAIT_TIMEOUT_SECONDS="${IMG_WAIT_TIMEOUT_SECONDS:-1200}"
 for img in "${IMAGES_TO_PULL[@]}"; do
-  wait_for_image "$img" "$IMG_WAIT_TIMEOUT_SECONDS"
+  wait_for_img "$img" "$IMG_WAIT_TIMEOUT_SECONDS"
   pull_to_kind "$img"
 done
 

--- a/scripts/ci/central_compatibility/run_compatibility_test.sh
+++ b/scripts/ci/central_compatibility/run_compatibility_test.sh
@@ -22,7 +22,17 @@ source "$ROOT_DIR/dev/env/scripts/lib.sh"
 
 function pull_to_kind() {
   local img=$1
-  docker pull "${img}"
+  local retry="${2:-5}"
+  local backoff=30
+
+  for _ in $(seq "$retry"); do
+    if docker pull "${img}"; then
+      break
+    fi
+
+    sleep "$backoff"
+  done
+
   kind load docker-image "${img}"
 }
 

--- a/scripts/ci/central_compatibility/run_compatibility_test.sh
+++ b/scripts/ci/central_compatibility/run_compatibility_test.sh
@@ -77,7 +77,7 @@ for img in "${IMAGES_TO_PULL[@]}"; do
   pull_to_kind "$img"
 done
 
-make --no-print-directory -C "$STACKROX_DIR" cli_host-arch
+TAG="$ACS_VERSION" make --no-print-directory -C "$STACKROX_DIR" cli_host-arch
 GOARCH="$(go env GOARCH)"
 GOOS="$(go env GOOS)"
 

--- a/scripts/ci/central_compatibility/run_compatibility_test.sh
+++ b/scripts/ci/central_compatibility/run_compatibility_test.sh
@@ -62,22 +62,15 @@ else
   ACS_VERSION="$(make --no-print-directory -C "$STACKROX_DIR" tag)"
 fi
 
-SCANNER_VERSION="$(make --no-print-directory -C "$STACKROX_DIR" scanner-tag)"
-
 log "ACS version: $ACS_VERSION"
-log "Scanner version: $SCANNER_VERSION"
 
 IMG_REPO="quay.io/rhacs-eng"
 MAIN_IMG_NAME="$IMG_REPO/main"
 CENTRAL_DB_IMG_NAME="$IMG_REPO/central-db"
-SCANNER_IMG_NAME="$IMG_REPO/scanner"
-SCANNER_DB_IMG_NAME="$IMG_REPO/scanner-db"
 
 IMAGES_TO_PULL=(
   "$MAIN_IMG_NAME:$ACS_VERSION"
   "$CENTRAL_DB_IMG_NAME:$ACS_VERSION"
-  "$SCANNER_IMG_NAME:$SCANNER_VERSION"
-  "$SCANNER_DB_IMG_NAME:$SCANNER_VERSION"
 )
 
 for img in "${IMAGES_TO_PULL[@]}"; do

--- a/scripts/ci/central_compatibility/run_compatibility_test.sh
+++ b/scripts/ci/central_compatibility/run_compatibility_test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Deploy a kind cluster previously to running this script
+# This script expects:
+# 1. stackrox/stackrox repo to be available at the execution path with directory name stackrox
+# 2. acs-fleet-manager repo to be available at the execution path with directory name acs-fleet-manager
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EMAILSENDER_HELM_DIR="$ROOT_DIR/dp-terraform/helm/rhacs-terraform"
+
+source "$ROOT_DIR/scripts/ci/lib.sh"
+source "$ROOT_DIR/scripts/lib/log.sh"
+source "$ROOT_DIR/dev/env/scripts/lib.sh"
+
+function pull_to_kind() {
+  local img=$1
+  docker pull "${img}"
+  kind load docker-image "${img}"
+}
+
+EMAILSENDER_IMG_TAG="$(make -C "$ROOT_DIR" tag)"
+EMAILSENDER_IMG_NAME="$(make -C "$ROOT_DIR" image-name/emailsender)"
+EMAILSENDER_IMG="$(make -C "$ROOT_DIR" image-tag/emailsender)"
+make -C "$ROOT_DIR" image/build/emailsender
+kind load docker-image "${EMAILSENDER_IMG}"
+
+EMAILSENDER_NS="rhacs"
+CENTRAL_NS="rhacs-tenant"
+
+kubectl create ns $EMAILSENDER_NS
+kubectl create ns $CENTRAL_NS
+
+# Render emailsender kubernetes resources
+helm template --namespace "${EMAILSENDER_NS}" \
+  -f "${SOURCE_DIR}/emailsender-values.yaml" "${EMAILSENDER_HELM_DIR}" \
+  --set emailsender.image.repo="${EMAILSENDER_IMG_NAME}" \
+  --set emailsender.image.tag="${EMAILSENDER_IMG_TAG}" \
+  | yq e '. | select(.metadata.name == "emailsender")' \
+  > emailsender-manifests.yaml
+
+kubectl apply -f emailsender-manifests.yaml
+kubectl apply -f "${SOURCE_DIR}/emailsender-db.yaml"
+
+# use nightly if GH action running for acs-fleet-manager
+# use the stackrox tag otherwise
+if [ "$GITHUB_REPOSITORY" = "stackrox/acs-fleet-manager" ]; then
+  ACS_VERSION="$( git -C stackrox tag | grep nightly | tail -n 1 )"
+  git -C stackrox checkout "$ACS_VERSION"
+  SCANNER_VERSION="$(make -C stackrox scanner-tag)"
+else
+  ACS_VERSION="$(make -C stackrox tag)"
+fi
+
+
+MAIN_IMG="quay.io/rhacs-eng/main:$ACS_VERSION"
+
+IMAGES_TO_PULL=(
+  "$MAIN_IMG"
+  "quay.io/rhacs-eng/central-db:$ACS_VERSION"
+  "quay.io/rhacs-eng/scanner:$SCANNER_VERSION"
+  "quay.io/rhacs-eng/scanner-db:$SCANNER_VERSION"
+)
+
+for img in "${IMAGES_TO_PULL[@]}"; do
+  pull_to_kind "$img"
+done
+
+container_id="$(docker create "$MAIN_IMG")"
+docker cp "$container_id:/stackrox/roxctl" /tmp/roxctl
+
+export ADMIN_PW="letmein"
+
+/tmp/roxctl helm output central-services --output-dir ./central-chart
+helm install -n $CENTRAL_NS stackrox-central-services ./central-chart \
+  -f "${SOURCE_DIR}/central-values.yaml" \
+  --set "central.adminPassword.values=$ADMIN_PW"
+
+wait_for_container_to_become_ready "$CENTRAL_NS" "application=central" "central"
+wait_for_container_to_become_ready "$EMAILSENDER_NS" "application=emailsender" "emailsender"
+
+kubectl port-forward -n $CENTRAL_NS svc/central 8443:443 >/dev/null &
+
+cd acs-fleet-manager
+go test -tags=test_central_compatibility ./emailsender/compatibility

--- a/scripts/ci/central_compatibility/run_compatibility_test.sh
+++ b/scripts/ci/central_compatibility/run_compatibility_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 
 # Deploy a kind cluster previously to running this script
 # This script expects:

--- a/scripts/ci/central_compatibility/run_compatibility_test.sh
+++ b/scripts/ci/central_compatibility/run_compatibility_test.sh
@@ -90,7 +90,7 @@ wait_for_container_to_become_ready "$CENTRAL_NS" "app=central" "central"
 wait_for_container_to_become_ready "$EMAILSENDER_NS" "app=emailsender" "emailsender"
 
 kubectl port-forward -n "$CENTRAL_NS" svc/central 8443:443 >/dev/null &
-echo $! >> pids-port-forward
+echo $! >> /tmp/pids-port-forward
 
 cd "$ROOT_DIR"
 go test -tags=test_central_compatibility ./emailsender/compatibility

--- a/scripts/ci/central_compatibility/run_compatibility_test.sh
+++ b/scripts/ci/central_compatibility/run_compatibility_test.sh
@@ -48,6 +48,9 @@ helm template --namespace "${EMAILSENDER_NS}" \
 kubectl apply -f emailsender-manifests.yaml
 kubectl apply -f "${SOURCE_DIR}/emailsender-db.yaml"
 
+log "Emailsender deployed to Kind."
+
+log "Starting to deploy central services..."
 # use nightly if GH action running for acs-fleet-manager
 # use the stackrox tag otherwise
 if [ "$GITHUB_REPOSITORY" = "stackrox/acs-fleet-manager" ]; then
@@ -57,6 +60,8 @@ if [ "$GITHUB_REPOSITORY" = "stackrox/acs-fleet-manager" ]; then
 else
   ACS_VERSION="$(make --no-print-directory -C "$STACKROX_DIR" tag)"
 fi
+
+log "Running with ACS version: $ACS_VERSION"
 
 IMG_REPO="quay.io/rhacs-eng"
 MAIN_IMG_NAME="$IMG_REPO/main"

--- a/scripts/ci/central_compatibility/run_compatibility_test.sh
+++ b/scripts/ci/central_compatibility/run_compatibility_test.sh
@@ -77,10 +77,13 @@ for img in "${IMAGES_TO_PULL[@]}"; do
   pull_to_kind "$img"
 done
 
-make --no-print-directory -C "$STACKROX_DIR" cli_host-arch cli-install
+make --no-print-directory -C "$STACKROX_DIR" cli_host-arch
+GOARCH="$(go env GOARCH)"
+GOOS="$(go env GOOS)"
 
+ROXCTL="$STACKROX_DIR/bin/${GOOS}_${GOARCH}/roxctl"
 # --remove to make this script rerunnable on a local machine
-roxctl helm output central-services --remove --output-dir ./central-chart
+$ROXCTL helm output central-services --remove --output-dir ./central-chart
 
 # Using ACS_VERSION explicitly here since it would otherwise not use the nightly build tag
 helm upgrade --install -n $CENTRAL_NS stackrox-central-services ./central-chart \

--- a/scripts/ci/central_compatibility/run_compatibility_test.sh
+++ b/scripts/ci/central_compatibility/run_compatibility_test.sh
@@ -53,15 +53,18 @@ log "Emailsender deployed to Kind."
 log "Starting to deploy central services..."
 # use nightly if GH action running for acs-fleet-manager
 # use the stackrox tag otherwise
+log "Running for repository: $GITHUB_REPOSITORY"
 if [ "$GITHUB_REPOSITORY" = "stackrox/acs-fleet-manager" ]; then
   ACS_VERSION="$( git -C "$STACKROX_DIR" tag | grep nightly | tail -n 1 )"
   git -C "$STACKROX_DIR" checkout "$ACS_VERSION"
-  SCANNER_VERSION="$(make --no-print-directory -C "$STACKROX_DIR" scanner-tag)"
 else
   ACS_VERSION="$(make --no-print-directory -C "$STACKROX_DIR" tag)"
 fi
 
-log "Running with ACS version: $ACS_VERSION"
+SCANNER_VERSION="$(make --no-print-directory -C "$STACKROX_DIR" scanner-tag)"
+
+log "ACS version: $ACS_VERSION"
+log "Scanner version: $SCANNER_VERSION"
 
 IMG_REPO="quay.io/rhacs-eng"
 MAIN_IMG_NAME="$IMG_REPO/main"

--- a/scripts/ci/central_compatibility/run_compatibility_test.sh
+++ b/scripts/ci/central_compatibility/run_compatibility_test.sh
@@ -13,7 +13,7 @@ EMAILSENDER_NS="rhacs"
 CENTRAL_NS="rhacs-tenant"
 export ADMIN_PW="letmein"
 
-cd $ROOT_DIR
+cd "$ROOT_DIR"
 
 source "$ROOT_DIR/scripts/ci/lib.sh"
 source "$ROOT_DIR/scripts/lib/log.sh"
@@ -85,7 +85,7 @@ helm upgrade --install -n $CENTRAL_NS stackrox-central-services ./central-chart 
   --set "central.image.tag=$ACS_VERSION" \
   --set "central.db.image.tag=$ACS_VERSION"
 
-export KUBECTL=$(which kubectl)
+KUBECTL="$(which kubectl)"
 wait_for_container_to_become_ready "$CENTRAL_NS" "app=central" "central"
 wait_for_container_to_become_ready "$EMAILSENDER_NS" "app=emailsender" "emailsender"
 

--- a/scripts/ci/central_compatibility/run_compatibility_test.sh
+++ b/scripts/ci/central_compatibility/run_compatibility_test.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EMAILSENDER_HELM_DIR="$ROOT_DIR/dp-terraform/helm/rhacs-terraform"
-STACKROX_DIR="$(pwd)/stackrox"
+STACKROX_DIR="$(cd "$ROOT_DIR/../stackrox" && pwd)"
+
 EMAILSENDER_NS="rhacs"
 CENTRAL_NS="rhacs-tenant"
 export ADMIN_PW="letmein"


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Adds a Github Action to test compatibility of central <> emailsender:
- Uses Kind to setup a K8s cluster in an ubuntu node
- Deploys a stackrox nightly and a fresh build emailsender to kind
- Tests if central can send notification to emailsender via central API

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [x] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [x] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

To run locally:
```
# Checkout both repositories stackrox/stackrox and stackrox/acs-fleet-manager in the same folder so that paths are:
# workspace/stackrox
# workspace/acs-fleet-manager
mkdir workspace
cd workspace
git clone git@github.com:stackrox/stackrox.git
git clone git@github.com:stackrox/acs-fleet-manager.git    

export GITHUB_REPOSITORY=acs-fleet-manager
bash scripts/ci/central_compatibility/entrypoint.sh
```
