### PR TITLE
ROX-23367: Central Name Validation

### DIFF
--- a/internal/dinosaur/pkg/handlers/validation.go
+++ b/internal/dinosaur/pkg/handlers/validation.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/acs-fleet-manager/pkg/handlers"
 	coreServices "github.com/stackrox/acs-fleet-manager/pkg/services"
 	corev1 "k8s.io/api/core/v1"
+	genericvalidation "k8s.io/apimachinery/pkg/api/validation"
 )
 
 var (
@@ -29,6 +30,9 @@ var (
 // ValidDinosaurClusterName ...
 func ValidDinosaurClusterName(value *string, field string) handlers.Validate {
 	return func() *errors.ServiceError {
+		if errs := genericvalidation.NameIsDNSSubdomain(*value, false); len(errs) > 0 {
+			return errors.MalformedDinosaurClusterName("%s is invalid: %v", field, errs)
+		}
 		if !ValidDinosaurClusterNameRegexp.MatchString(*value) {
 			return errors.MalformedDinosaurClusterName("%s does not match %s", field, ValidDinosaurClusterNameRegexp.String())
 		}


### PR DESCRIPTION
## Description
Validating the names that users specify when creating centrals. When you create a central, this ends up being a Central Kubernetes resource. But Kubernetes has strict rules around the allowed names of object. This PR is to ensure that we're validating the name like Kubernetes does. The scenario we want to prevent is allowing the creation of a Central with a name that is invalid for kubernetes. For example, a name that is not allowed by Kubernetes, could be allowed by FleetManager when creating an instance. Because of that, we changed the validation rules for:

`ValidDinosaurClusterName` in `validation.go` (acs-fleet-manager) to follow the rules from 
                          --> `ValidateCustomResourceDefinition` in `validation.go` (apiextentions-apiserver)


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Testing
validation_test.go

## Jira Ticket
https://issues.redhat.com/browse/ROX-23367
