### PR TITLE
fix: add To header to emailsender emails

### DIFF
--- a/emailsender/pkg/email/sender.go
+++ b/emailsender/pkg/email/sender.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/stackrox/acs-fleet-manager/emailsender/config"
@@ -73,7 +74,9 @@ func (s *AWSMailSender) Send(ctx context.Context, to []string, rawMessage []byte
 		return fmt.Errorf("rate limit exceeded for tenant: %s", tenantID)
 	}
 	fromBytes := []byte(fmt.Sprintf(fromTemplate, s.from))
-	raw := bytes.Join([][]byte{fromBytes, rawMessage}, nil)
+	toBytes := []byte(fmt.Sprintf("To: %s\r\n", strings.Join(to, ",")))
+
+	raw := bytes.Join([][]byte{fromBytes, toBytes, rawMessage}, nil)
 	metrics.DefaultInstance().IncSendEmail(tenantID)
 	_, err := s.ses.SendRawEmail(ctx, s.from, to, raw)
 	if err != nil {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
This PR fixes emailsender to set the "To" header of emails sent. The header is explicitly not set by the acscsEmail integration to allow emailsender to append. But that part was forgotten during initial implementation.

This led to emails being send but email clients would show an empty To header.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

```
make db/teardown db/setup

#Login to ocm and AWS dev account before running this

make run/emailsender

curl localhost:8080/api/v1/acscsemail -v -XPOST \
-H "Content-Type: application/json" \
-H "Authorization: Bearer $(ocm token)" \
--data-raw '{"to":["jmalsam@redhat.com"], "rawMessage":"dGVzdCBtZXNzYWdlIGNvbnRlbnQ="}'

# Verify
# 1. Status code is successful and you receive the email
# 2. From and To headers are set like expected

```
