### PR TITLE
ROX-25966: Make sender alias configurable

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
@@ -36,7 +36,7 @@ spec:
             - name: SENDER_ADDRESS
               value: {{ .Values.emailsender.senderAddress }}
             - name: SENDER_ALIAS
-              value: { { .Values.emailsender.senderAlias } }
+              value: {{ .Values.emailsender.senderAlias }}
             - name: EMAIL_PROVIDER
               value: {{ .Values.emailsender.emailProvider }}
             - name: HTTPS_CERT_FILE

--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
@@ -35,6 +35,8 @@ spec:
               value: {{ .Values.fleetshardSync.environment }}
             - name: SENDER_ADDRESS
               value: {{ .Values.emailsender.senderAddress }}
+            - name: SENDER_ALIAS
+              value: { { .Values.emailsender.senderAlias } }
             - name: EMAIL_PROVIDER
               value: {{ .Values.emailsender.emailProvider }}
             - name: HTTPS_CERT_FILE

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -81,6 +81,7 @@ emailsender:
   clusterName: ""
   environment: ""
   senderAddress: "noreply@mail.rhacs-dev.com"
+  senderAlias: "RHACS Cloud Service"
   authConfigFromKubernetes: true
   emailProvider: "AWS_SES"
   resources:

--- a/emailsender/config/config.go
+++ b/emailsender/config/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	KubernetesSvcURL          string        `env:"KUBERNETES_SVC_URL" envDefault:"https://kubernetes.default.svc"`
 	KubernetesJWKSPath        string        `env:"KUBERNETES_JWKS_PATH" envDefault:"openid/v1/jwks"`
 	SenderAddress             string        `env:"SENDER_ADDRESS" envDefault:"noreply@mail.rhacs-dev.com"`
+	SenderAlias               string        `env:"SENDER_ALIAS" envDefault:"RHACS Cloud Service"`
 	LimitEmailPerTenant       int           `env:"LIMIT_EMAIL_PER_TENANT" envDefault:"250"`
 	SesMaxBackoffDelay        time.Duration `env:"SES_MAX_BACKOFF_DELAY" envDefault:"5s"`
 	SesMaxAttempts            int           `env:"SES_MAX_ATTEMPTS" envDefault:"3"`

--- a/emailsender/pkg/email/sender_test.go
+++ b/emailsender/pkg/email/sender_test.go
@@ -33,6 +33,7 @@ func (m *MockedRateLimiter) PersistEmailSendEvent(tenantID string) error {
 
 func TestSend_Success(t *testing.T) {
 	from := "sender@example.com"
+	fromAlias := "RHACS Cloud Service"
 	to := []string{"to1@example.com", "to2@example.com"}
 	subject := "Test subject"
 	textBody := "text body"
@@ -62,6 +63,7 @@ func TestSend_Success(t *testing.T) {
 	mockedSES := &SES{sesClient: mockClient}
 	mockedSender := AWSMailSender{
 		from,
+		fromAlias,
 		mockedSES,
 		mockedRateLimiter,
 	}
@@ -87,6 +89,7 @@ func TestSend_LimitExceeded(t *testing.T) {
 	mockedSES := &SES{sesClient: mockClient}
 	mockedSender := AWSMailSender{
 		"from@example.com",
+		"from-alias",
 		mockedSES,
 		mockedRateLimiter,
 	}
@@ -100,6 +103,7 @@ func TestSend_LimitExceeded(t *testing.T) {
 
 func TestSendAppendsFromAndTo(t *testing.T) {
 	from := "sender@example.com"
+	fromAlias := "RHACS Cloud Service"
 	to := []string{"to1@example.com", "to2@example.com"}
 	textBody := "text body"
 	tenantID := "test-tenant-id"
@@ -126,6 +130,7 @@ func TestSendAppendsFromAndTo(t *testing.T) {
 	mockedSES := &SES{sesClient: mockClient}
 	sender := AWSMailSender{
 		from,
+		fromAlias,
 		mockedSES,
 		mockedRateLimiter,
 	}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
- Make sender alias configurable via env
- Make `EmailProviderAWSSES` explicitly used

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
