### PR TITLE
ROX-26027: add argoCD labels to tenant namespaces

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -56,6 +56,9 @@ const (
 
 	helmReleaseName = "tenant-resources"
 
+	argoCdManagedBy          = "argocd.argoproj.io/managed-by"
+	openshiftGitopsNamespace = "openshift-gitops"
+
 	centralPVCAnnotationKey   = "platform.stackrox.io/obsolete-central-pvc"
 	managedServicesAnnotation = "platform.stackrox.io/managed-services"
 	envAnnotationKey          = "rhacs.redhat.com/environment"
@@ -1870,7 +1873,12 @@ func getTenantAnnotations(c private.ManagedCentral) map[string]string {
 }
 
 func getNamespaceLabels(c private.ManagedCentral) map[string]string {
-	return getTenantLabels(c)
+	ret := map[string]string{}
+	for k, v := range getTenantLabels(c) {
+		ret[k] = v
+	}
+	ret[argoCdManagedBy] = openshiftGitopsNamespace
+	return ret
 }
 
 func getNamespaceAnnotations(c private.ManagedCentral) map[string]string {

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -2184,6 +2184,7 @@ func TestReconciler_reconcileNamespace(t *testing.T) {
 						"rhacs.redhat.com/instance-type": "standard",
 						"rhacs.redhat.com/org-id":        "12345",
 						"rhacs.redhat.com/tenant":        "cb45idheg5ip6dq1jo4g",
+						"argocd.argoproj.io/managed-by":  "openshift-gitops",
 					},
 					Annotations: map[string]string{
 						"rhacs.redhat.com/org-name": "org-name",
@@ -2204,6 +2205,7 @@ func TestReconciler_reconcileNamespace(t *testing.T) {
 						"rhacs.redhat.com/instance-type": "wrong",
 						"rhacs.redhat.com/org-id":        "wrong",
 						"rhacs.redhat.com/tenant":        "wrong",
+						"argocd.argoproj.io/managed-by":  "wrong",
 					},
 					Annotations: map[string]string{
 						"rhacs.redhat.com/org-name": "wrong",
@@ -2220,6 +2222,7 @@ func TestReconciler_reconcileNamespace(t *testing.T) {
 						"rhacs.redhat.com/instance-type": "standard",
 						"rhacs.redhat.com/org-id":        "12345",
 						"rhacs.redhat.com/tenant":        "cb45idheg5ip6dq1jo4g",
+						"argocd.argoproj.io/managed-by":  "openshift-gitops",
 					},
 					Annotations: map[string]string{
 						"rhacs.redhat.com/org-name": "org-name",
@@ -2239,6 +2242,7 @@ func TestReconciler_reconcileNamespace(t *testing.T) {
 						"rhacs.redhat.com/instance-type": "standard",
 						"rhacs.redhat.com/org-id":        "12345",
 						"rhacs.redhat.com/tenant":        "cb45idheg5ip6dq1jo4g",
+						"argocd.argoproj.io/managed-by":  "openshift-gitops",
 						"extra":                          "extra",
 					},
 					Annotations: map[string]string{
@@ -2257,6 +2261,7 @@ func TestReconciler_reconcileNamespace(t *testing.T) {
 						"rhacs.redhat.com/instance-type": "standard",
 						"rhacs.redhat.com/org-id":        "12345",
 						"rhacs.redhat.com/tenant":        "cb45idheg5ip6dq1jo4g",
+						"argocd.argoproj.io/managed-by":  "openshift-gitops",
 						"extra":                          "extra",
 					},
 					Annotations: map[string]string{
@@ -2278,6 +2283,7 @@ func TestReconciler_reconcileNamespace(t *testing.T) {
 						"rhacs.redhat.com/instance-type": "standard",
 						"rhacs.redhat.com/org-id":        "12345",
 						"rhacs.redhat.com/tenant":        "cb45idheg5ip6dq1jo4g",
+						"argocd.argoproj.io/managed-by":  "openshift-gitops",
 					},
 					Annotations: map[string]string{
 						"rhacs.redhat.com/org-name": "org-name",
@@ -2294,6 +2300,7 @@ func TestReconciler_reconcileNamespace(t *testing.T) {
 						"rhacs.redhat.com/instance-type": "standard",
 						"rhacs.redhat.com/org-id":        "12345",
 						"rhacs.redhat.com/tenant":        "cb45idheg5ip6dq1jo4g",
+						"argocd.argoproj.io/managed-by":  "openshift-gitops",
 					},
 					Annotations: map[string]string{
 						"rhacs.redhat.com/org-name": "org-name",


### PR DESCRIPTION
## Description
For ArgoCD to be allowed to manage resources in tenant namespaces, these namespaces must have a label

See https://docs.openshift.com/container-platform/4.10/cicd/gitops/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.html#creating-an-application-by-using-the-oc-tool_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] ~~Added test description under `Test manual`~~
- [ ] ~~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- [ ] ~~Add secret to app-interface Vault or Secrets Manager if necessary~~
- [ ] ~~RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
- [ ] ~~Check AWS limits are reasonable for changes provisioning new resources~~
- [ ] ~~(If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment~~

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
