### PR TITLE
Fix label in dockerfile to follow Konflux requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ WORKDIR /
 ENTRYPOINT ["/usr/local/bin/fleet-manager", "serve"]
 
 LABEL name="fleet-manager" \
-    vendor="Red Hat" \
+    vendor="Red Hat, Inc." \
     version="0.0.1" \
     summary="FleetManager" \
     description="Red Hat Advanced Cluster Security Fleet Manager"


### PR DESCRIPTION
Konflux needs exactly 'Red Hat, Inc.' label in dockerfile
