### PR TITLE
fix: add emailsender db ssl mode to helm chart values

### DIFF
--- a/.github/workflows/emailsender-central-compatibility.yaml
+++ b/.github/workflows/emailsender-central-compatibility.yaml
@@ -7,13 +7,15 @@ on:
       - main
     paths:
       - 'emailsender/**'
-      - 'scripts/ci/**'
+      - 'scripts/**'
       - '.github/workflows/emailsender-central-compatibility.yaml'
 
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'emailsender/**'
+      - 'scripts/**'
+      - '.github/workflows/emailsender-central-compatibility.yaml'
 
 jobs:
   e2e-test-on-kind:

--- a/.github/workflows/emailsender-central-compatibility.yaml
+++ b/.github/workflows/emailsender-central-compatibility.yaml
@@ -7,6 +7,8 @@ on:
       - main
     paths:
       - 'emailsender/**'
+      - 'scripts/ci/**'
+      - '.github/workflows/emailsender-central-compatibility.yaml'
 
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]

--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
@@ -41,6 +41,8 @@ spec:
               value: "/var/run/certs/tls.crt"
             - name: HTTPS_KEY_FILE
               value: "/var/run/certs/tls.key"
+            - name: DATABASE_SSL_MODE
+              value: {{ .Values.emailsender.db.sslMode }}
             {{- if .Values.emailsender.authConfigFromKubernetes }}
             - name: AUTH_CONFIG_FROM_KUBERNETES
               value: "true"

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -72,6 +72,8 @@ emailsender:
   enabled: false
   # Use this in case you apply this manifest against a cluster without service-ca operator
   # to turn of HTTPS and mounting the service-ca certs since they'll not be created
+  db:
+    sslMode: "verify-full"
   enableHTTPS: true
   replicas: 3
   image:

--- a/scripts/ci/central_compatibility/emailsender-values.yaml
+++ b/scripts/ci/central_compatibility/emailsender-values.yaml
@@ -9,6 +9,8 @@ fleetshardSync:
     enabled: false
     subnetGroup: "dummyGroup"
 emailsender:
+  db:
+    sslMode: "disable"
   image:
     repo: "quay.io/rhacs-eng/emailsender"
   enabled: true


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Adding env variable DATABASE_SSL_MODE and corresponding helm value to the dp-terraform chart.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
