### PR TITLE
fix: Makefile docker command for fleetshard-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -620,7 +620,7 @@ image/push/internal: docker/login/internal
 
 image/build/fleetshard-operator: IMAGE_REF="$(external_image_registry)/fleetshard-operator:$(image_tag)"
 image/build/fleetshard-operator:
-	$(DOCKER) build -t $(IMAGE_REF) --build-arg IMAGE_TAG=$(image_tag) --load ${PROJECT_PATH}/dp-terraform/helm
+	$(DOCKER) buildx build -t $(IMAGE_REF) --build-arg IMAGE_TAG=$(image_tag) --load ${PROJECT_PATH}/dp-terraform/helm
 .PHONY: image/build/fleetshard-operator
 
 image/push/fleetshard-operator: IMAGE_REF="$(external_image_registry)/fleetshard-operator:$(image_tag)"


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
The Makefile target `image/build/fleetshard-operator` is failing for me because `--load` is a docker buildx only option.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual
```
# does not work with the old command, and works with the new command
make deploy/bootstrap deploy/dev
```
