### PR TITLE
fix: emailsender use TLS for db connections

### DIFF
--- a/.github/workflows/emailsender-central-compatibility.yaml
+++ b/.github/workflows/emailsender-central-compatibility.yaml
@@ -7,11 +7,15 @@ on:
       - main
     paths:
       - 'emailsender/**'
+      - 'scripts/**'
+      - '.github/workflows/emailsender-central-compatibility.yaml'
 
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'emailsender/**'
+      - 'scripts/**'
+      - '.github/workflows/emailsender-central-compatibility.yaml'
 
 jobs:
   e2e-test-on-kind:

--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
@@ -43,6 +43,8 @@ spec:
               value: "/var/run/certs/tls.key"
             - name: DATABASE_SSL_MODE
               value: {{ .Values.emailsender.db.sslMode }}
+            - name: DATABASE_CA_CERT_FILE
+              value: {{ .Values.emailsender.db.caCertFile }}
             {{- if .Values.emailsender.authConfigFromKubernetes }}
             - name: AUTH_CONFIG_FROM_KUBERNETES
               value: "true"

--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
@@ -41,6 +41,8 @@ spec:
               value: "/var/run/certs/tls.crt"
             - name: HTTPS_KEY_FILE
               value: "/var/run/certs/tls.key"
+            - name: DATABASE_SSL_MODE
+              value: {{ .Values.emailsender.db.sslMode }}
             {{- if .Values.emailsender.authConfigFromKubernetes }}
             - name: AUTH_CONFIG_FROM_KUBERNETES
               value: "true"

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -72,6 +72,9 @@ emailsender:
   enabled: false
   # Use this in case you apply this manifest against a cluster without service-ca operator
   # to turn of HTTPS and mounting the service-ca certs since they'll not be created
+  db:
+    sslMode: "verify-full"
+    caCertPath: /rds_ca/aws-rds-ca-global-bundle.pem
   enableHTTPS: true
   replicas: 3
   image:

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -74,7 +74,7 @@ emailsender:
   # to turn of HTTPS and mounting the service-ca certs since they'll not be created
   db:
     sslMode: "verify-full"
-    caCertPath: /rds_ca/aws-rds-ca-global-bundle.pem
+    caCertFile: /rds_ca/aws-rds-ca-global-bundle.pem
   enableHTTPS: true
   replicas: 3
   image:

--- a/emailsender/Dockerfile
+++ b/emailsender/Dockerfile
@@ -18,6 +18,8 @@ RUN useradd -u 1001 unprivilegeduser
 # Switch to non-root user
 USER unprivilegeduser
 
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /rds_ca/aws-rds-ca-global-bundle.pem
+
 COPY --from=build /src/emailsender/bin /acscs/
 EXPOSE 8080
 ENTRYPOINT ["/acscs/emailsender"]

--- a/emailsender/Dockerfile
+++ b/emailsender/Dockerfile
@@ -15,10 +15,10 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9 as standard
 RUN microdnf install shadow-utils
 
 RUN useradd -u 1001 unprivilegeduser
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /rds_ca/aws-rds-ca-global-bundle.pem
+RUN chown unprivilegeduser /rds_ca/aws-rds-ca-global-bundle.pem
 # Switch to non-root user
 USER unprivilegeduser
-
-ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /rds_ca/aws-rds-ca-global-bundle.pem
 
 COPY --from=build /src/emailsender/bin /acscs/
 EXPOSE 8080

--- a/scripts/ci/central_compatibility/emailsender-values.yaml
+++ b/scripts/ci/central_compatibility/emailsender-values.yaml
@@ -9,6 +9,9 @@ fleetshardSync:
     enabled: false
     subnetGroup: "dummyGroup"
 emailsender:
+  db:
+    sslMode: "disable"
+    caCertPath: ""
   image:
     repo: "quay.io/rhacs-eng/emailsender"
   enabled: true

--- a/scripts/ci/central_compatibility/emailsender-values.yaml
+++ b/scripts/ci/central_compatibility/emailsender-values.yaml
@@ -11,7 +11,7 @@ fleetshardSync:
 emailsender:
   db:
     sslMode: "disable"
-    caCertPath: ""
+    caCertFile: ""
   image:
     repo: "quay.io/rhacs-eng/emailsender"
   enabled: true


### PR DESCRIPTION
## Description
New attempt for #2028 which includes installing RDS ca cert file into the emailsender container image.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [x] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# Tested with a public AWS RDS DB in our Dev account
# Run the DB manually and get the required values then run a local container and try to connect
podman run -e CLUSTER_ID=test -e DATABASE_HOST='emailsender-local-test.cluster-cz7zwsnynmtn.us-east-1.rds.amazonaws.com' -e DATABASE_PASSWORD='<pw>' -e DATABASE_SSL_MODE='verify-full' -e DATABASE_CA_CERT_FILE='/rds_ca/aws-rds-ca-global-bundle.pem' --privileged -v /root/config:/config --rm -ti quay.io/rhacs-eng/emailsender:a4d1fcb

# The mounted volume above holds the `emailsender-authz.yaml` config file 
```
