### PR TITLE
Revert "fix: emailsender use TLS for db connections"

### DIFF
--- a/.github/workflows/emailsender-central-compatibility.yaml
+++ b/.github/workflows/emailsender-central-compatibility.yaml
@@ -7,15 +7,11 @@ on:
       - main
     paths:
       - 'emailsender/**'
-      - 'scripts/**'
-      - '.github/workflows/emailsender-central-compatibility.yaml'
 
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'emailsender/**'
-      - 'scripts/**'
-      - '.github/workflows/emailsender-central-compatibility.yaml'
 
 jobs:
   e2e-test-on-kind:

--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
@@ -41,10 +41,6 @@ spec:
               value: "/var/run/certs/tls.crt"
             - name: HTTPS_KEY_FILE
               value: "/var/run/certs/tls.key"
-            - name: DATABASE_SSL_MODE
-              value: {{ .Values.emailsender.db.sslMode }}
-            - name: DATABASE_CA_CERT_FILE
-              value: {{ .Values.emailsender.db.caCertFile }}
             {{- if .Values.emailsender.authConfigFromKubernetes }}
             - name: AUTH_CONFIG_FROM_KUBERNETES
               value: "true"

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -72,9 +72,6 @@ emailsender:
   enabled: false
   # Use this in case you apply this manifest against a cluster without service-ca operator
   # to turn of HTTPS and mounting the service-ca certs since they'll not be created
-  db:
-    sslMode: "verify-full"
-    caCertFile: /rds_ca/aws-rds-ca-global-bundle.pem
   enableHTTPS: true
   replicas: 3
   image:

--- a/emailsender/Dockerfile
+++ b/emailsender/Dockerfile
@@ -15,8 +15,6 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9 as standard
 RUN microdnf install shadow-utils
 
 RUN useradd -u 1001 unprivilegeduser
-ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /rds_ca/aws-rds-ca-global-bundle.pem
-RUN chown unprivilegeduser /rds_ca/aws-rds-ca-global-bundle.pem
 # Switch to non-root user
 USER unprivilegeduser
 

--- a/scripts/ci/central_compatibility/emailsender-values.yaml
+++ b/scripts/ci/central_compatibility/emailsender-values.yaml
@@ -9,9 +9,6 @@ fleetshardSync:
     enabled: false
     subnetGroup: "dummyGroup"
 emailsender:
-  db:
-    sslMode: "disable"
-    caCertFile: ""
   image:
     repo: "quay.io/rhacs-eng/emailsender"
   enabled: true


### PR DESCRIPTION
Reverts stackrox/acs-fleet-manager#2035

It appears that OSD is assigning a different user to run emailsender as opposed to what is defined in the Dockerfile for emailsender. This causes ownership of the CA certificate to be wrong, so emailsender crashes.
