### PR TITLE
fix: emailsender to DB TLS connection

### DIFF
--- a/.github/workflows/emailsender-central-compatibility.yaml
+++ b/.github/workflows/emailsender-central-compatibility.yaml
@@ -7,11 +7,15 @@ on:
       - main
     paths:
       - 'emailsender/**'
+      - 'scripts/**'
+      - '.github/workflows/emailsender-central-compatibility.yaml'
 
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'emailsender/**'
+      - 'scripts/**'
+      - '.github/workflows/emailsender-central-compatibility.yaml'
 
 jobs:
   e2e-test-on-kind:

--- a/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/emailsender.yaml
@@ -41,6 +41,10 @@ spec:
               value: "/var/run/certs/tls.crt"
             - name: HTTPS_KEY_FILE
               value: "/var/run/certs/tls.key"
+            - name: DATABASE_SSL_MODE
+              value: {{ .Values.emailsender.db.sslMode }}
+            - name: DATABASE_CA_CERT_FILE
+              value: {{ .Values.emailsender.db.caCertFile }}
             {{- if .Values.emailsender.authConfigFromKubernetes }}
             - name: AUTH_CONFIG_FROM_KUBERNETES
               value: "true"

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -72,6 +72,9 @@ emailsender:
   enabled: false
   # Use this in case you apply this manifest against a cluster without service-ca operator
   # to turn of HTTPS and mounting the service-ca certs since they'll not be created
+  db:
+    sslMode: "verify-full"
+    caCertFile: /rds_ca/aws-rds-ca-global-bundle.pem
   enableHTTPS: true
   replicas: 3
   image:

--- a/emailsender/Dockerfile
+++ b/emailsender/Dockerfile
@@ -16,7 +16,7 @@ RUN microdnf install shadow-utils
 
 RUN useradd -u 1001 unprivilegeduser
 ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /rds_ca/aws-rds-ca-global-bundle.pem
-RUN chown unprivilegeduser /rds_ca/aws-rds-ca-global-bundle.pem
+RUN chmod a+rw /rds_ca/aws-rds-ca-global-bundle.pem
 # Switch to non-root user
 USER unprivilegeduser
 

--- a/emailsender/Dockerfile
+++ b/emailsender/Dockerfile
@@ -15,6 +15,8 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9 as standard
 RUN microdnf install shadow-utils
 
 RUN useradd -u 1001 unprivilegeduser
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /rds_ca/aws-rds-ca-global-bundle.pem
+RUN chown unprivilegeduser /rds_ca/aws-rds-ca-global-bundle.pem
 # Switch to non-root user
 USER unprivilegeduser
 

--- a/scripts/ci/central_compatibility/emailsender-values.yaml
+++ b/scripts/ci/central_compatibility/emailsender-values.yaml
@@ -9,6 +9,9 @@ fleetshardSync:
     enabled: false
     subnetGroup: "dummyGroup"
 emailsender:
+  db:
+    sslMode: "disable"
+    caCertFile: ""
   image:
     repo: "quay.io/rhacs-eng/emailsender"
   enabled: true


### PR DESCRIPTION
## Description
Follow up on
#2035 

Fixed the issue we had on integration by making the RDS ca file readable for all users.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

```
# Tested locally by running the image with podman against a AWS RDS DB with public internet access.
docker run -e CLUSTER_ID=test -e DATABASE_HOST='emailsender-test.cluster-cz7zwsnynmtn.us-east-1.rds.amazonaws.com' -e DATABASE_PASSWORD='db-pw' -e DATABASE_SSL_MODE='verify-full' -e DATABASE_CA_CERT_FILE='/rds_ca/aws-rds-ca-global-bundle.pem' --user 1001180000 -v /root/config:/config:z --rm -ti quay.io/rhacs-eng/emailsender:136f53f
```
