### PR TITLE
fix: default for make test/integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,7 +337,7 @@ test/aws: $(GOTESTSUM_BIN)
 #   make test/integration TESTFLAGS="-run TestAccountsGet"  runs TestAccountsGet
 #   make test/integration TESTFLAGS="-short"                skips long-run tests
 test/integration/dinosaur: $(GOTESTSUM_BIN)
-	$(GOTESTSUM_BIN) --junitfile data/results/fleet-manager-integration-tests.xml --format $(GOTESTSUM_FORMAT) -- -p 1 -ldflags -s -v -timeout $(TEST_TIMEOUT) -count=1 $(TESTFLAGS) \
+	OCM_ENV=integration $(GOTESTSUM_BIN)  --junitfile data/results/fleet-manager-integration-tests.xml --format $(GOTESTSUM_FORMAT) -- -p 1 -ldflags -s -v -timeout $(TEST_TIMEOUT) -count=1 $(TESTFLAGS) \
 				./internal/dinosaur/test/integration/...
 .PHONY: test/integration/dinosaur
 

--- a/Makefile
+++ b/Makefile
@@ -337,7 +337,7 @@ test/aws: $(GOTESTSUM_BIN)
 #   make test/integration TESTFLAGS="-run TestAccountsGet"  runs TestAccountsGet
 #   make test/integration TESTFLAGS="-short"                skips long-run tests
 test/integration/dinosaur: $(GOTESTSUM_BIN)
-	OCM_ENV=integration $(GOTESTSUM_BIN)  --junitfile data/results/fleet-manager-integration-tests.xml --format $(GOTESTSUM_FORMAT) -- -p 1 -ldflags -s -v -timeout $(TEST_TIMEOUT) -count=1 $(TESTFLAGS) \
+	OCM_ENV=integration $(GOTESTSUM_BIN) --junitfile data/results/fleet-manager-integration-tests.xml --format $(GOTESTSUM_FORMAT) -- -p 1 -ldflags -s -v -timeout $(TEST_TIMEOUT) -count=1 $(TESTFLAGS) \
 				./internal/dinosaur/test/integration/...
 .PHONY: test/integration/dinosaur
 


### PR DESCRIPTION
## Description
By default make test/integration does not set any OCM_ENV environment variable. Because of that local executions usually fails with 5 failing tests while CI execution succeeds because it sets OCM_ENV=integration in the workflow definition.

Since those tests are integration tests and expect to have OCM_ENV=integration set to succeed this env variable should be set by default for the Makefile target.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make test/integration
```
