### PR TITLE
ROX-26424: Add service account with quay secret to ACSCS probe service

### DIFF
--- a/templates/probe-template.yml
+++ b/templates/probe-template.yml
@@ -39,6 +39,14 @@ parameters:
     displayName: Memory Limits
     value: 128Mi
 objects:
+  - kind: ServiceAccount
+    apiVersion: v1
+    metadata:
+      name: probe
+      labels:
+        app: probe
+    imagePullSecrets:
+      - name: quay.io
   - apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -89,6 +97,8 @@ objects:
                   cpu: ${CPU_LIMITS}
                   memory: ${MEMORY_LIMITS}
           terminationGracePeriodSeconds: 300
+          serviceAccount: probe
+          serviceAccountName: probe
   - kind: Service
     apiVersion: v1
     metadata:


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Add serviceAccount with quay secret to ACSCS probe service. It should fix lack of permission to pull images from Konflux quay org on app-interface for the service

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

N/A
