### PR TITLE
ROX-26359: Switch Authentication Type Probe Service Update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -640,10 +640,7 @@ test/e2e/probe/run: IMAGE_REF="$(external_image_registry)/$(probe_image_reposito
 test/e2e/probe/run:
 	$(DOCKER) run \
 	-e QUOTA_TYPE="OCM" \
-	-e AUTH_TYPE="OCM" \
 	-e PROBE_NAME="e2e-probe-$$$$" \
-	-e OCM_USERNAME="${OCM_USERNAME}" \
-	-e OCM_TOKEN="${OCM_TOKEN}" \
 	-e FLEET_MANAGER_ENDPOINT="${FLEET_MANAGER_ENDPOINT}" \
 	--rm $(IMAGE_REF) \
 	run

--- a/e2e/run_e2e_stage.sh
+++ b/e2e/run_e2e_stage.sh
@@ -20,4 +20,3 @@ make \
     OCM_TOKEN="${STATIC_OCM_TOKEN}" \
     FLEET_MANAGER_ENDPOINT="${ACS_FLEET_MANAGER_ENDPOINT}" \
   test/e2e/probe/run
-#ask alex if we use it incase we need to remove script

--- a/e2e/run_e2e_stage.sh
+++ b/e2e/run_e2e_stage.sh
@@ -20,3 +20,4 @@ make \
     OCM_TOKEN="${STATIC_OCM_TOKEN}" \
     FLEET_MANAGER_ENDPOINT="${ACS_FLEET_MANAGER_ENDPOINT}" \
   test/e2e/probe/run
+#ask alex if we use it incase we need to remove script

--- a/probe/config/config.go
+++ b/probe/config/config.go
@@ -19,7 +19,6 @@ type Config struct {
 	FleetManagerEndpoint    string        `env:"FLEET_MANAGER_ENDPOINT" envDefault:"http://127.0.0.1:8000"`
 	MetricsAddress          string        `env:"METRICS_ADDRESS" envDefault:":7070"`
 	RHSSOClientID           string        `env:"RHSSO_SERVICE_ACCOUNT_CLIENT_ID"`
-	OCMUsername             string        `env:"OCM_USERNAME"`
 	ProbeName               string        `env:"PROBE_NAME" envDefault:"${HOSTNAME}" envExpand:"true"`
 	ProbeCleanUpTimeout     time.Duration `env:"PROBE_CLEANUP_TIMEOUT" envDefault:"5m"`
 	ProbeHTTPRequestTimeout time.Duration `env:"PROBE_HTTP_REQUEST_TIMEOUT" envDefault:"5s"`
@@ -65,11 +64,6 @@ func GetConfig() (*Config, error) {
 			configErrors.AddError(errors.New("RHSSO_SERVICE_ACCOUNT_CLIENT_ID unset in the environment"))
 		}
 		c.ProbeUsername = fmt.Sprintf("service-account-%s", c.RHSSOClientID)
-	case "OCM":
-		if c.OCMUsername == "" {
-			configErrors.AddError(errors.New("OCM_USERNAME unset in the environment"))
-		}
-		c.ProbeUsername = c.OCMUsername
 	default:
 		configErrors.AddError(errors.New("AUTH_TYPE not supported"))
 	}

--- a/templates/probe-template.yml
+++ b/templates/probe-template.yml
@@ -65,17 +65,17 @@ objects:
                 - name: FLEET_MANAGER_ENDPOINT
                   value: ${FLEET_MANAGER_ENDPOINT}
                 - name: AUTH_TYPE
-                  value: OCM
-                - name: OCM_USERNAME
+                  value: RHSSO
+                - name: RHSSO_SERVICE_ACCOUNT_CLIENT_ID
                   valueFrom:
                     secretKeyRef:
                       name: probe-credentials
-                      key: OCM_USERNAME
-                - name: OCM_TOKEN
+                      key: RHSSO_SERVICE_ACCOUNT_CLIENT_ID
+                - name: RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET
                   valueFrom:
                     secretKeyRef:
                       name: probe-credentials
-                      key: OCM_TOKEN
+                      key: RHSSO_SERVICE_ACCOUNT_CLIENT_SECRET
                 - name: CENTRAL_SPECS
                   value: ${CENTRAL_SPECS}
               ports:


### PR DESCRIPTION
-Switch Authentication type OCM–> RHSSO in Probe Service. 

-And Delete OCM AuthType from Probe Service

Jira ticket: https://issues.redhat.com/browse/ROX-26359

Main Epic: https://issues.redhat.com/browse/ROX-24048