### PR TITLE
ROX-26478: Use Konflux based images fleetshard emailsender

### DIFF
--- a/dp-terraform/helm/Dockerfile
+++ b/dp-terraform/helm/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install gzip tar && \
         chmod +x /usr/local/bin/yq && \
         rm /tmp/yq_linux_amd64.tar.gz
 
-ARG IMAGE_TAG=main
+ARG IMAGE_TAG=latest
 RUN yq -i ".global.image.tag = strenv(IMAGE_TAG)" rhacs-terraform/values.yaml
 
 FROM quay.io/operator-framework/helm-operator:v1.36.1

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -6,7 +6,7 @@ fleetshardSync:
   image:
     # can be either a full image reference represented by `ref` or a combination of `repo:tag`. `ref` has a higher priority (if set).
     ref: ""
-    repo: "quay.io/app-sre/acs-fleet-manager"
+    repo: "quay.io/redhat-services-prod/acscs-rhacs-tenant/acscs-main/acs-fleet-manager"
     tag: null
   # Can be either STATIC_TOKEN or SERVICE_ACCOUNT_TOKEN. By default, uses SERVICE_ACCOUNT_TOKEN.
   authType: "SERVICE_ACCOUNT_TOKEN"
@@ -78,7 +78,7 @@ emailsender:
   enableHTTPS: true
   replicas: 3
   image:
-    repo: "quay.io/app-sre/acscs-emailsender"
+    repo: "quay.io/redhat-services-prod/acscs-rhacs-tenant/acscs-main/acs-emailsender"
     tag: null
   clusterId: ""
   clusterName: ""
@@ -283,7 +283,7 @@ scc:
 
 global:
   image:
-    tag: "main"
+    tag: "latest"
   secretStore:
     aws:
       secretsManagerSecretStoreName: secrets-manager-secret-store # pragma: allowlist secret

--- a/dp-terraform/test/helm_template_test.go
+++ b/dp-terraform/test/helm_template_test.go
@@ -153,12 +153,12 @@ func TestHelmTemplate_FleetshardSyncDeployment_Image(t *testing.T) {
 	}{
 		{
 			name:      "should set default image repo and tag when no values set",
-			wantImage: "quay.io/app-sre/acs-fleet-manager:main",
+			wantImage: "quay.io/redhat-services-prod/acscs-rhacs-tenant/acscs-main/acs-fleet-manager:latest",
 		},
 		{
 			name:      "should set default image repo when tag is set",
 			tag:       "custom",
-			wantImage: "quay.io/app-sre/acs-fleet-manager:custom",
+			wantImage: "quay.io/redhat-services-prod/acscs-rhacs-tenant/acscs-main/acs-fleet-manager:custom",
 		},
 		{
 			name:      "should set image when repo and tag are set",


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Switch Fleetshard-sync and Emailsender services to Konflux based images. Images are pullable and also have `git_short_sha` tags. Default tag in Konflux is `latest`.

```
podman pull quay.io/redhat-services-prod/acscs-rhacs-tenant/acscs-main/acs-fleet-manager:f636090
Trying to pull quay.io/redhat-services-prod/acscs-rhacs-tenant/acscs-main/acs-fleet-manager:f636090...
Getting image source signatures
Copying blob sha256:83d79038125ccc1484a67d0242d6b6fb16d135546bae21fe4a63b97f0f6e82b5
Copying blob sha256:133388727492505cb9d292d14f00942ad2915ab7df3ec1aabbea88cd25035f7b
Copying blob sha256:9ce83ecc988c9fd2bb533e68e07248d1bdbce9482114eae1ccda583d57c4aa5f
Copying config sha256:5b4b5fb18b359771f67f32837b131bbd1d07f5089fc3455952e6f31f9eb888bf
Writing manifest to image destination
5b4b5fb18b359771f67f32837b131bbd1d07f5089fc3455952e6f31f9eb888bf
```

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

N/A