### PR TITLE
chore: remove broken references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 # ACS Fleet Manager
-[![Dinosaur counter](https://dinosaurs.rhacs-dev.com/)](https://sourcegraph.com/search?q=context:global+repo:stackrox/acs-fleet-manager+dinosaur+count:all&patternType=standard)
-
-[![Build Status](https://ci.ext.devshift.net/view/acs-fleet-manager/job/stackrox-acs-fleet-manager-build-and-push-main/badge/icon)](https://ci.ext.devshift.net/view/acs-fleet-manager/job/stackrox-acs-fleet-manager-build-and-push-main/)
 
 ACS fleet-manager repository for the ACS managed service.
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

We've got broken references to external services in the README.md overview. Even if not broken, I don't think those refs provide a lot of value so I suggest to just remove them.

![image](https://github.com/user-attachments/assets/3a4e6594-e4a9-4ddb-978a-2fcaaca7424d)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
