### PR TITLE
Remove ocm login in e2e tests

### DIFF
--- a/.openshift-ci/tests/e2e.sh
+++ b/.openshift-ci/tests/e2e.sh
@@ -64,25 +64,6 @@ log "Fleetshard Operator Image: ${FLEETSHARD_OPERATOR_IMAGE:-latest}"
 log "Log directory: ${LOG_DIR:-(none)}"
 log "Executing Auth E2E tests: ${RUN_AUTH_E2E}"
 
-# If auth E2E tests shall be run, ensure we have all authentication related secrets correctly set up.
-if [[ "$RUN_AUTH_E2E" == "true" ]]; then
-    log "Setting up authentication related environment variables for auth E2E tests"
-
-    OCM_OFFLINE_TOKEN=${OCM_OFFLINE_TOKEN:-}
-    if [[ -z "$OCM_OFFLINE_TOKEN" ]]; then
-        die "Error: OCM_OFFLINE_TOKEN not set, which is required for execution of Auth E2E tests"
-    fi
-
-    # Ensure we set the OCM refresh token
-    ocm login --token "${OCM_OFFLINE_TOKEN}"
-    OCM_TOKEN=$(ocm token --refresh)
-    export OCM_TOKEN
-
-    # The RH SSO secrets are correctly set up within vault, the tests will be skipped if they are empty.
-else
-    log "Skipping setup of authentication related environment variables for auth E2E tests because RUN_AUTH_E2E is not set to true"
-fi
-
 if [[ -z "$STATIC_TOKEN" ]]; then
     die "Error: No static token found in the environment.\nPlease set the environment variable STATIC_TOKEN to a valid static token."
 fi

--- a/Makefile
+++ b/Makefile
@@ -640,10 +640,7 @@ test/e2e/probe/run: IMAGE_REF="$(external_image_registry)/$(probe_image_reposito
 test/e2e/probe/run:
 	$(DOCKER) run \
 	-e QUOTA_TYPE="OCM" \
-	-e AUTH_TYPE="OCM" \
 	-e PROBE_NAME="e2e-probe-$$$$" \
-	-e OCM_USERNAME="${OCM_USERNAME}" \
-	-e OCM_TOKEN="${OCM_TOKEN}" \
 	-e FLEET_MANAGER_ENDPOINT="${FLEET_MANAGER_ENDPOINT}" \
 	--rm $(IMAGE_REF) \
 	run


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
