### PR TITLE
ROX-21530: Updating Cert Expiry Metrics

### DIFF
--- a/fleetshard/main.go
+++ b/fleetshard/main.go
@@ -130,9 +130,10 @@ func main() {
 	k8sInterface := k8s.CreateInterfaceOrDie()
 	informerFactory := informers.NewSharedInformerFactory(k8sInterface, time.Minute)
 	secretInformer := informerFactory.Core().V1().Secrets().Informer()
+	namespaceInformer := informerFactory.Core().V1().Namespaces().Informer()
 	namespaceLister := informerFactory.Core().V1().Namespaces().Lister()
 
-	monitor := certmonitor.NewCertMonitor(certmonitorConfig, informerFactory, secretInformer, namespaceLister)
+	monitor := certmonitor.NewCertMonitor(certmonitorConfig, informerFactory, secretInformer, namespaceInformer, namespaceLister)
 	if err := monitor.Start(); err != nil {
 		glog.Fatalf("Error starting certmonitor: %v", err)
 	}

--- a/fleetshard/pkg/fleetshardmetrics/metrics.go
+++ b/fleetshard/pkg/fleetshardmetrics/metrics.go
@@ -130,11 +130,15 @@ func (m *Metrics) SetCertKeyExpiryMetric(namespace, name, key string, expiry flo
 }
 
 func (m *Metrics) DeleteCertMetric(namespace, name string) {
-	m.CertificatesExpiry.Delete(prometheus.Labels{"namespace": namespace, "secret": name}) // pragma: allowlist secret
+	m.CertificatesExpiry.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "secret": name}) // pragma: allowlist secret
+}
+
+func (m *Metrics) DeleteCertNamespaceMetric(namespace string) {
+	m.CertificatesExpiry.DeletePartialMatch(prometheus.Labels{"namespace": namespace}) // pragma: allowlist secret
 }
 
 func (m *Metrics) DeleteKeyCertMetric(namespace, name, key string) {
-	m.CertificatesExpiry.Delete(prometheus.Labels{"namespace": namespace, "secret": name, "data_key": key}) // pragma: allowlist secret
+	m.CertificatesExpiry.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "secret": name, "data_key": key}) // pragma: allowlist secret
 }
 
 // MetricsInstance return the global Singleton instance for Metrics

--- a/internal/certmonitor/certmonitor_test.go
+++ b/internal/certmonitor/certmonitor_test.go
@@ -333,7 +333,7 @@ func TestCertMonitor(t *testing.T) {
 		Data:       map[string][]byte{"tls-1.crt": generateCertWithExpiration(t, newExpiryTime)},
 	}
 
-	mockNamespace := &v1.Namespace{
+	mockNamespace := &v1.Namespace{ // pragma: allowlist secret
 		ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-1", Name: "secret-1"},
 	}
 

--- a/internal/certmonitor/certmonitor_test.go
+++ b/internal/certmonitor/certmonitor_test.go
@@ -290,7 +290,7 @@ func TestCertMonitor_secretMatches(t *testing.T) {
 	}
 }
 
-// TestCertMonitor func tests certificates event handlers + prometheus metrics handling
+// TestCertMonitor_Secret tests that secret event handlers correctly populate prometheus metrics
 func TestCertMonitor_Secret(t *testing.T) {
 	fleetshardmetrics.MetricsInstance().CertificatesExpiry.Reset()
 
@@ -345,6 +345,7 @@ func TestCertMonitor_Secret(t *testing.T) {
 	verifyPrometheusMetricDelete(t, "namespace-1", "secret-1", "tls.crt")
 }
 
+// TestCertMonitor_Namespace tests that namespace secret handlers remove prometheus metrics when the namespace is deleted
 func TestCertMonitor_Namespace(t *testing.T) {
 	fleetshardmetrics.MetricsInstance().CertificatesExpiry.Reset()
 

--- a/internal/certmonitor/certmonitor_test.go
+++ b/internal/certmonitor/certmonitor_test.go
@@ -334,7 +334,7 @@ func TestCertMonitor(t *testing.T) {
 	}
 
 	mockNamespace := &v1.Namespace{ // pragma: allowlist secret
-		ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-1", Name: "secret-1"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-1"},
 	}
 
 	expirationUnix := float64(expirytime.Unix())

--- a/internal/certmonitor/certmonitor_test.go
+++ b/internal/certmonitor/certmonitor_test.go
@@ -333,6 +333,10 @@ func TestCertMonitor(t *testing.T) {
 		Data:       map[string][]byte{"tls-1.crt": generateCertWithExpiration(t, newExpiryTime)},
 	}
 
+	mockNamespace := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-1", Name: "secret-1"},
+	}
+
 	expirationUnix := float64(expirytime.Unix())
 	certMonitor.handleSecretCreation(secret)
 	verifyPrometheusMetric(t, "namespace-1", "secret-1", "tls.crt", expirationUnix)
@@ -342,6 +346,9 @@ func TestCertMonitor(t *testing.T) {
 	verifyPrometheusMetric(t, "namespace-1", "secret-1", "tls-1.crt", updatedUnix)
 
 	certMonitor.handleSecretDeletion(secretUpdated)
+	verifyPrometheusMetricDelete(t, "namespace-1", "secret-1", "tls.crt")
+
+	certMonitor.handleNamespaceDeletion(mockNamespace)
 	verifyPrometheusMetricDelete(t, "namespace-1", "secret-1", "tls.crt")
 
 }


### PR DESCRIPTION
## Description
Background: Implement monitoring for certificate expiration, tracking and managing of digital certificates expiration dates. Extracts timestamps from certificates and exposes metrics to Prometheus. (FIXED)

In response to error in: https://github.com/stackrox/rhacs-observability-resources/pull/279
Problem: `acs_fleetshard_certificate_expiration_timestamp` - seems to retain all certificates even after their namespaces have been deleted. Combined with the ephemeral instances created by the probe, this creates a very large number of time series. 
Solution: Fixed the handling of metric deletion by:
-adding namespace informer
-implemented `DeletePartialMatch` instead of `Delete`


Previous Certificate Monitoring PR: https://github.com/stackrox/acs-fleet-manager/pull/1946
Previous Certificate Alerting PR: https://github.com/stackrox/rhacs-observability-resources/pull/276

## Tests
Created k9s environment locally with pods/namespaces. Used `create-central.sh` and `delete-central.sh` scripts to test local host metric creation and deletion.


