### PR TITLE
ROX-26499: Use RH certified helm operator image for fleetshard operator

### DIFF
--- a/dp-terraform/helm/Dockerfile
+++ b/dp-terraform/helm/Dockerfile
@@ -22,7 +22,8 @@ RUN microdnf install gzip tar && \
 ARG IMAGE_TAG=latest
 RUN yq -i ".global.image.tag = strenv(IMAGE_TAG)" rhacs-terraform/values.yaml
 
-FROM quay.io/operator-framework/helm-operator:v1.36.1
+# RH catalog see: https://catalog.redhat.com/software/containers/openshift4/ose-helm-operator
+FROM registry.redhat.io/openshift4/ose-helm-operator:v4.14.0-202409240108.p0.g0f0d1b2.assembly.stream.el8
 
 ENV HOME=/opt/helm
 ENV ADDON_NAME=acs-fleetshard

--- a/dp-terraform/helm/konflux.Dockerfile
+++ b/dp-terraform/helm/konflux.Dockerfile
@@ -22,7 +22,8 @@ RUN microdnf install gzip tar && \
 ARG IMAGE_TAG=latest
 RUN yq -i ".global.image.tag = strenv(IMAGE_TAG)" rhacs-terraform/values.yaml
 
-FROM quay.io/operator-framework/helm-operator:v1.36.1
+# RH catalog see: https://catalog.redhat.com/software/containers/openshift4/ose-helm-operator
+FROM registry.redhat.io/openshift4/ose-helm-operator:v4.14.0-202409240108.p0.g0f0d1b2.assembly.stream.el8
 
 ENV HOME=/opt/helm
 ENV ADDON_NAME=acs-fleetshard


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Add a new dockerfile for fleetshard operator for Konflux. It is required to use only RH approved images for building on Konflux. This change should unblock building fleetshard operator on Konflux.
This dockerfile will be used in the Konflux bot PR #2063

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

build and run locally 
