### PR TITLE
ROX-26499: Specify IMAGE_TAG for the fleetshard operator build on Konflux

### DIFF
--- a/.tekton/acs-fleetshard-operator-pull-request.yaml
+++ b/.tekton/acs-fleetshard-operator-pull-request.yaml
@@ -233,6 +233,7 @@ spec:
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
+        - IMAGE_TAG=$(tasks.clone-repository.results.short-commit)
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       runAfter:

--- a/.tekton/acs-fleetshard-operator-push.yaml
+++ b/.tekton/acs-fleetshard-operator-push.yaml
@@ -230,6 +230,7 @@ spec:
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
+        - IMAGE_TAG=$(tasks.clone-repository.results.short-commit)
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       runAfter:


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Pass `IMAGE_TAG` env value to the Fleetshard Operator Konflux dockerfile. It should be short git commit SHA like we build it locally or on github actions. `IMAGE_TAG` is a crucial value and sets which fleetshard/emailsender images to run

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~- [ ] Unit and integration tests added~
- [x] Added test description under `Test manual`
~- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
~- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~
~- [ ] Add secret to app-interface Vault or Secrets Manager if necessary~
~- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~
~- [ ] Check AWS limits are reasonable for changes provisioning new resources~
~- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration ~environment

## Test manual

Tested on this PR commit image
```
podman run --rm -it --entrypoint /bin/sh quay.io/redhat-user-workloads/acscs-rhacs-tenant/acscs-main/acs-fleetshard-operator:on-pr-557045c7e76d0e12be51a0420efad1ca1a5e3565
cat rhacs-terraform/values.yaml
...
global:
  image:
    tag: "557045c"
  secretStore:
    aws:
      secretsManagerSecretStoreName: secrets-manager-secret-store # pragma: allowlist secret
      parameterStoreSecretStoreName: parameter-store-secret-store # pragma: allowlist secret
```
