### PR TITLE
ROX-26065: Observability subchart teardown

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -250,7 +250,7 @@
         "filename": "dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml",
         "hashed_secret": "3e513f12b341ed3327bea645a728401b5d0f9ddb",
         "is_verified": false,
-        "line_number": 21
+        "line_number": 22
       }
     ],
     "dp-terraform/helm/rhacs-terraform/charts/secured-cluster/init-bundle.yaml": [
@@ -425,5 +425,5 @@
       }
     ]
   },
-  "generated_at": "2024-10-14T07:07:48Z"
+  "generated_at": "2024-10-17T08:34:41Z"
 }

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-01-namespace.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-01-namespace.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: {{ include "observability.namespace" . }}
   annotations:
-    {{/* Keep the namespace to retain PVCs after uninstall */}}
+    # Keep the namespace to retain PVCs after uninstall
     helm.sh/resource-policy: keep
   labels:
     argocd.argoproj.io/managed-by: openshift-gitops

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-01-namespace.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-01-namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ include "observability.namespace" . }}
+  annotations:
+    {{/* Keep the namespace to retain PVCs after uninstall */}}
+    helm.sh/resource-policy: keep
+  labels:
+    argocd.argoproj.io/managed-by: openshift-gitops

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/templates/01-operator-06-cr.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.customResourceEnabled }}
 apiVersion: observability.redhat.com/v1
 kind: Observability
 metadata:
@@ -101,3 +102,4 @@ spec:
           resources:
             requests:
               storage: {{ .Values.prometheus.resources.requests.storage | quote }}
+{{- end }}

--- a/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/observability/values.yaml
@@ -6,6 +6,7 @@
 # https://github.com/redhat-developer/observability-operator/releases
 observabilityOperatorVersion: "v4.2.1"
 
+customResourceEnabled: true
 github:
   repository: "https://api.github.com/repos/stackrox/rhacs-observability-resources/contents"
   tag: "master"


### PR DESCRIPTION
## Description
#### Problem
When you uninstall the obserability helm subchart, the CR is deleted together with the operator and the namespace, which causes the CR and the namespace to remain stuck in the uninstallation state
 
#### Proposed solution
In order to shutdown the observability operator gracefully you need to perform the following sequence of actions:

1. Set `observability.customResourceEnabled=false` to delete the CR and effectively uninstall prometheus, alertmanager and grafana but, keep the operator and most importantly the PVCs associated with prometheus and alertmanager. 
2. Set `observability.enabled=false` to uninstall the operator

As a result, the `rhacs-observability` namespace and the PVCs are NOT removed in order to retain the existing metrics.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
