### PR TITLE
ROX-26745: Fix konflux based ACS fleetshard operator ignoring subchart default values override

### DIFF
--- a/dp-terraform/helm/konflux.Dockerfile
+++ b/dp-terraform/helm/konflux.Dockerfile
@@ -19,6 +19,13 @@ RUN microdnf install gzip tar && \
         chmod +x /usr/local/bin/yq && \
         rm /tmp/yq_linux_amd64.tar.gz
 
+# Fix ignored securityContext.runAsUser set to null in values.yaml file.
+# Manually dropping  securityContext.runAsUser value from the external secret subchart.
+# This could be fixed with ose-helm-operator version bump.
+# See: https://github.com/operator-framework/operator-sdk/issues/6635
+RUN cd rhacs-terraform/charts && for filename in *.tgz; do tar -xf "$filename" && rm -f "$filename"; done && \
+        yq -i 'del(.securityContext.runAsUser) | del(.webhook.securityContext.runAsUser) | del(.certController.securityContext.runAsUser)' external-secrets/values.yaml
+
 ARG IMAGE_TAG=latest
 RUN yq -i ".global.image.tag = strenv(IMAGE_TAG)" rhacs-terraform/values.yaml
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

There is an external-secrets helm subchart. It has a `securityContext.runAsUser: 1000` default value. Openshift doesn't allow to use 1000 user. That's why there [is an override](https://github.com/stackrox/acs-fleet-manager/blob/main/dp-terraform/helm/rhacs-terraform/values.yaml#L258) in the `values.yaml`.

There is separate Konflux Dockerfile for ACS Fleetshard Operator. It uses a trusted helm operator image but unfortunately this image has [a bug](https://github.com/operator-framework/operator-sdk/issues/6635) which ignores overriding default values for the subchart. Because of that setting to null  `securityContext.runAsUser` for external secrets is ignored. Which leads to violating scc

This PR should fix it by manually dropping `runAsUser` value from the external secret subchart.
  

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual


```
podman buildx build -t "quay.io/rhacs-eng/fleetshard-operator:fixedsc" --build-arg IMAGE_TAG=12345678 --load /Users/akurlov/projects/acs-fleet-manager/dp-terraform/helm -f konflux.Dockerfile

podman run --rm -it --user root --entrypoint /bin/sh quay.io/rhacs-eng/fleetshard-operator:fixedsc

cat external-secrets/values.yaml
....
 securityContext:
    allowPrivilegeEscalation: false
    capabilities:
      drop:
        - ALL
    readOnlyRootFilesystem: true
    runAsNonRoot: true
    seccompProfile:
      type: RuntimeDefault
 ....
```
