### PR TITLE
ROX-26625: Make Certmonitor Ignore Probe Instances

### DIFF
--- a/fleetshard/main.go
+++ b/fleetshard/main.go
@@ -76,6 +76,10 @@ func main() {
 					Key:      reconciler.TenantIDLabelKey,
 					Operator: metav1.LabelSelectorOpExists,
 				},
+				{
+					Key:      reconciler.ProbeLabelKey,
+					Operator: metav1.LabelSelectorOpDoesNotExist,
+				},
 			},
 		},
 	}

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -74,7 +74,10 @@ const (
 	managedByLabelKey             = "app.kubernetes.io/managed-by"
 	orgIDLabelKey                 = "rhacs.redhat.com/org-id"
 	TenantIDLabelKey              = "rhacs.redhat.com/tenant"
-	centralExpiredAtKey           = "rhacs.redhat.com/expired-at"
+
+	ProbeLabelKey = "rhacs.redhat.com/probe"
+
+	centralExpiredAtKey = "rhacs.redhat.com/expired-at"
 
 	auditLogNotifierKey  = "com.redhat.rhacs.auditLogNotifier"
 	auditLogNotifierName = "Platform Audit Logs"
@@ -1857,13 +1860,17 @@ func (r *CentralReconciler) ensureRouteDeleted(ctx context.Context, routeSupplie
 }
 
 func getTenantLabels(c private.ManagedCentral) map[string]string {
-	return map[string]string{
+	labels := map[string]string{
 		managedByLabelKey:    labelManagedByFleetshardValue,
 		instanceLabelKey:     c.Metadata.Name,
 		orgIDLabelKey:        c.Spec.Auth.OwnerOrgId,
 		TenantIDLabelKey:     c.Id,
 		instanceTypeLabelKey: c.Spec.InstanceType,
 	}
+	if c.Metadata.Internal {
+		labels[ProbeLabelKey] = "true"
+	}
+	return labels
 }
 
 func getTenantAnnotations(c private.ManagedCentral) map[string]string {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
