### PR TITLE
ROX-26421: add backoff logic if addon is stuck in upgrading

### DIFF
--- a/internal/dinosaur/pkg/services/addon.go
+++ b/internal/dinosaur/pkg/services/addon.go
@@ -25,7 +25,7 @@ const fleetshardImageTagParameter = "fleetshardSyncImageTag"
 // by sending too many addon upgrade requests. The limit is 1000. A backoff
 // of 20 minutes would result in 504 requests per week, which leaves some space
 // for other openshift components to call the API as well.
-const addonUpgradeBackoffSeconds = 1200
+const addonUpgradeBackoff = 20 * time.Minute
 
 type updateAddonStatusMetricFunc func(addonID, clusterName string, status metrics.AddonStatus)
 
@@ -251,7 +251,7 @@ func (p *AddonProvisioner) updateAddon(clusterID string, config gitops.AddonConf
 }
 
 func (p *AddonProvisioner) backoffUpgradeRequest() bool {
-	return p.lastStatus == metrics.AddonUpgrade && time.Since(p.lastUpgradeRequestTime) < time.Second*addonUpgradeBackoffSeconds
+	return p.lastStatus == metrics.AddonUpgrade && time.Since(p.lastUpgradeRequestTime) < addonUpgradeBackoff
 }
 
 func (p *AddonProvisioner) uninstallAddon(clusterID string, addonID string) error {

--- a/internal/dinosaur/pkg/services/addon.go
+++ b/internal/dinosaur/pkg/services/addon.go
@@ -234,8 +234,6 @@ func (p *AddonProvisioner) newInstallation(config gitops.AddonConfig) (*clusters
 
 func (p *AddonProvisioner) updateAddon(clusterID string, config gitops.AddonConfig) error {
 	if p.backoffUpgradeRequest() {
-		// if a upgrade request was send and the last status has not changed to something else than upgrade
-		// in the meantime the upgrade is stuck and we need to backoff to prevent limits on the OCM service log API
 		glog.V(5).Infof("update addon request backoff for cluster: %s", clusterID)
 		return nil
 	}

--- a/internal/dinosaur/pkg/services/addon.go
+++ b/internal/dinosaur/pkg/services/addon.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/golang/glog"
 	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -20,6 +21,12 @@ import (
 
 const fleetshardImageTagParameter = "fleetshardSyncImageTag"
 
+// This backoff was introduced to prevent reaching OCM service log limits
+// by sending too many addon upgrade requests. The limit is 1000. A backoff
+// of 15 minutes would result in 504 requests per week, which leaves some space
+// for other openshift components to call the API as well.
+const addonUpgradeBackoffSeconds = 900
+
 type updateAddonStatusMetricFunc func(addonID, clusterName string, status metrics.AddonStatus)
 
 // AddonProvisioner keeps addon installations on the data plane clusters up-to-date
@@ -27,6 +34,8 @@ type AddonProvisioner struct {
 	ocmClient                   ocm.Client
 	customizations              []addonCustomization
 	updateAddonStatusMetricFunc updateAddonStatusMetricFunc
+	lastStatus                  metrics.AddonStatus
+	lastUpgradeRequestTime      time.Time
 }
 
 // NewAddonProvisioner creates a new instance of AddonProvisioner
@@ -224,6 +233,13 @@ func (p *AddonProvisioner) newInstallation(config gitops.AddonConfig) (*clusters
 }
 
 func (p *AddonProvisioner) updateAddon(clusterID string, config gitops.AddonConfig) error {
+	if p.backoffUpgradeRequest() {
+		// if a upgrade request was send and the last status has not changed to something else than upgrade
+		// in the meantime the upgrade is stuck and we need to backoff to prevent limits on the OCM service log API
+		glog.V(5).Infof("update addon request backoff for cluster: %s", clusterID)
+		return nil
+	}
+
 	update, err := p.newInstallation(config)
 	if err != nil {
 		return err
@@ -233,6 +249,10 @@ func (p *AddonProvisioner) updateAddon(clusterID string, config gitops.AddonConf
 	}
 	glog.V(5).Infof("Addon %s has been updated on the cluster %s", config.ID, clusterID)
 	return nil
+}
+
+func (p *AddonProvisioner) backoffUpgradeRequest() bool {
+	return p.lastStatus == metrics.AddonUpgrade && time.Since(p.lastUpgradeRequestTime) < time.Second*addonUpgradeBackoffSeconds
 }
 
 func (p *AddonProvisioner) uninstallAddon(clusterID string, addonID string) error {

--- a/internal/dinosaur/pkg/services/addon.go
+++ b/internal/dinosaur/pkg/services/addon.go
@@ -23,9 +23,9 @@ const fleetshardImageTagParameter = "fleetshardSyncImageTag"
 
 // This backoff was introduced to prevent reaching OCM service log limits
 // by sending too many addon upgrade requests. The limit is 1000. A backoff
-// of 15 minutes would result in 504 requests per week, which leaves some space
+// of 20 minutes would result in 504 requests per week, which leaves some space
 // for other openshift components to call the API as well.
-const addonUpgradeBackoffSeconds = 900
+const addonUpgradeBackoffSeconds = 1200
 
 type updateAddonStatusMetricFunc func(addonID, clusterName string, status metrics.AddonStatus)
 
@@ -244,6 +244,7 @@ func (p *AddonProvisioner) updateAddon(clusterID string, config gitops.AddonConf
 	if err != nil {
 		return err
 	}
+	p.lastUpgradeRequestTime = time.Now()
 	if err := p.ocmClient.UpdateAddonInstallation(clusterID, update); err != nil {
 		return fmt.Errorf("update addon %s: %w", update.ID(), err)
 	}

--- a/internal/dinosaur/pkg/services/addon_test.go
+++ b/internal/dinosaur/pkg/services/addon_test.go
@@ -662,6 +662,13 @@ func TestAddonProvisioner_Provision(t *testing.T) {
 			if tt.want != nil {
 				tt.want(tt.fields.ocmClient)
 			}
+
+			if tt.fields.ocmClient != nil {
+				if len(tt.fields.ocmClient.UpdateAddonInstallationCalls()) > 0 {
+					Expect(p.lastUpgradeRequestTime).NotTo(Equal(time.Time{}))
+				}
+			}
+
 			Expect(updates).To(Equal(tt.wantStatuses))
 		})
 	}

--- a/internal/dinosaur/pkg/services/addon_test.go
+++ b/internal/dinosaur/pkg/services/addon_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -893,4 +894,66 @@ func TestAddonProvisioner_NewAddonProvisioner(t *testing.T) {
 	Expect(baseConfigPtr.ClientID).To(Equal("base-client-id"))
 	Expect(baseConfigPtr.ClientSecret).To(Equal("base-client-secret"))
 	Expect(baseConfigPtr.SelfToken).To(Equal("base-token"))
+}
+
+func TestAddonProvisioner_Provision_UpgradeBackoff(t *testing.T) {
+	RegisterTestingT(t)
+
+	ocmMock := &ocm.ClientMock{
+		GetAddonInstallationFunc: func(clusterID string, addonID string) (*clustersmgmtv1.AddOnInstallation, *errors.ServiceError) {
+			object, err := clustersmgmtv1.NewAddOnInstallation().
+				ID(addonID).
+				Addon(clustersmgmtv1.NewAddOn().ID(addonID)).
+				AddonVersion(clustersmgmtv1.NewAddOnVersion().ID("0.2.0")).
+				State(clustersmgmtv1.AddOnInstallationStateReady).
+				Build()
+			Expect(err).To(Not(HaveOccurred()))
+			return object, nil
+		},
+		GetAddonVersionFunc: func(addonID string, version string) (*clustersmgmtv1.AddOnVersion, error) {
+			return clustersmgmtv1.NewAddOnVersion().
+				ID("0.2.0").
+				SourceImage("quay.io/osd-addons/acs-fleetshard-index@sha256:71eaaccb4d3962043eac953fb3c19a6cc6a88b18c472dd264efc5eb3da4960ac").
+				PackageImage("quay.io/osd-addons/acs-fleetshard-package@sha256:3e4fc039662b876c83dd4b48a9608d6867a12ab4932c5b7297bfbe50ba8ee61c").
+				Build()
+		},
+		UpdateAddonInstallationFunc: func(clusterID string, addon *clustersmgmtv1.AddOnInstallation) error {
+			return nil
+		},
+	}
+	addonConfig := ocmImpl.AddonConfig{
+		FleetshardSyncImageTag:        "0307e03",
+		InheritFleetshardSyncImageTag: true,
+	}
+	p := &AddonProvisioner{
+		ocmClient:              ocmMock,
+		customizations:         initCustomizations(addonConfig),
+		lastStatus:             metrics.AddonUpgrade,
+		lastUpgradeRequestTime: time.Now(),
+	}
+	err := p.Provision(api.Cluster{
+		Addons: addonsJSON([]dbapi.AddonInstallation{
+			{
+				ID:                  "acs-fleetshard",
+				Version:             "0.2.0",
+				SourceImage:         "quay.io/osd-addons/acs-fleetshard-index@sha256:71eaaccb4d3962043eac953fb3c19a6cc6a88b18c472dd264efc5eb3da4960ac",
+				PackageImage:        "quay.io/osd-addons/acs-fleetshard-package@sha256:3e4fc039662b876c83dd4b48a9608d6867a12ab4932c5b7297bfbe50ba8ee61c",
+				ParametersSHA256Sum: "3e4fc039662b876c83dd4b48a9608d6867a12ab4932c5b7297bfbe50ba8ee61c", // pragma: allowlist secret
+			},
+		}),
+	},
+		gitops.DataPlaneClusterConfig{
+			Addons: []gitops.AddonConfig{
+				{
+					ID:      "acs-fleetshard",
+					Version: "0.3.0",
+					Parameters: map[string]string{
+						"fleetshardSyncImageTag": "inherit",
+					},
+				},
+			},
+		})
+
+	Expect(err).To(Not(HaveOccurred()))
+	Expect(ocmMock.UpdateAddonInstallationCalls()).To(BeEmpty())
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
This PR prevents sending to many upgrade requests to OCM in case the addon is stuck in an upgrading state. It limits update requests to once every 20 minutes.

This was introduced due to a incident where fleet-managers update calls reached the OCM service logs limit and thus caused cluster features like z stream updates to fail.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
