### PR TITLE
Add additional argoCD parameters for Central CRs

### DIFF
--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -1908,7 +1908,7 @@ func (r *CentralReconciler) makeDesiredArgoCDApplication(ctx context.Context, re
 			return nil, fmt.Errorf("getting Central DB connection string: %w", err)
 		}
 
-		values["centralDbSecretName"] = centralDbSecretName
+		values["centralDbSecretName"] = centralDbSecretName // pragma: allowlist secret
 		values["centralDbConnectionString"] = centralDBConnectionString
 
 		dbCA, err := postgres.GetDatabaseCACertificates()

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -1871,11 +1871,6 @@ func (r *CentralReconciler) ensureArgoCdApplicationExists(ctx context.Context, r
 
 func (r *CentralReconciler) makeDesiredArgoCDApplication(ctx context.Context, remoteCentral private.ManagedCentral) (*argocd.Application, error) {
 
-	expiredAt := ""
-	if remoteCentral.Metadata.ExpiredAt != nil {
-		expiredAt = remoteCentral.Metadata.ExpiredAt.Format(time.RFC3339)
-	}
-
 	values := map[string]interface{}{
 		"environment":                 r.environment,
 		"clusterName":                 r.clusterName,
@@ -1884,7 +1879,6 @@ func (r *CentralReconciler) makeDesiredArgoCDApplication(ctx context.Context, re
 		"instanceId":                  remoteCentral.Id,
 		"instanceName":                remoteCentral.Metadata.Name,
 		"instanceType":                remoteCentral.Spec.InstanceType,
-		"instanceExpiredAt":           expiredAt,
 		"isInternal":                  remoteCentral.Metadata.Internal,
 		"telemetryStorageKey":         r.telemetry.StorageKey,
 		"telemetryStorageEndpoint":    r.telemetry.StorageEndpoint,
@@ -1902,6 +1896,10 @@ func (r *CentralReconciler) makeDesiredArgoCDApplication(ctx context.Context, re
 				"enabled": true,
 			},
 		},
+	}
+
+	if remoteCentral.Metadata.ExpiredAt != nil {
+		values["expiredAt"] = remoteCentral.Metadata.ExpiredAt.Format(time.RFC3339)
 	}
 
 	if r.managedDBEnabled {


### PR DESCRIPTION
## Description
Adding required argoCD application parameters in preparation of moving Central CRs to ArgoCD

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
