### PR TITLE
ROX-24523: Move central to ArgoCD

### DIFF
--- a/dev/config/gitops-config.yaml
+++ b/dev/config/gitops-config.yaml
@@ -4,13 +4,17 @@ rhacsOperators:
     - https://raw.githubusercontent.com/stackrox/stackrox/4.5.4/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
   operators:
     - deploymentName: "rhacs-operator-dev"
-      image: "quay.io/rhacs-eng/stackrox-operator:4.5.4"
+      image: "quay.io/rhacs-eng/stackrox-operator:4.6.0-rc.2-2-g8e97af1bf5-fast"
       centralLabelSelector: "rhacs.redhat.com/version-selector=dev"
       securedClusterReconcilerEnabled: false
 verticalPodAutoscaling:
   recommenders: []
 tenantResources:
   default: |
+    rolloutGroup: "dev"
+    argoCd:
+      enabled: true
+      centralEnabled: false
     labels:
       app.kubernetes.io/managed-by: rhacs-fleetshard
       app.kubernetes.io/instance: "{{ .Name }}"
@@ -20,9 +24,7 @@ tenantResources:
     annotations:
       rhacs.redhat.com/org-name: "{{ .OrganizationName }}"
     secureTenantNetwork: false
-    centralRdsCidrBlock: "10.1.0.0/16"
-    argoCd:
-      enabled: true
+    centralRdsCidrBlock: "10.1.0.0/16"    
     verticalPodAutoscalers:
       central:
         enabled: true

--- a/dev/config/gitops-config.yaml
+++ b/dev/config/gitops-config.yaml
@@ -32,11 +32,11 @@ tenantResources:
         memory: 100Mi
 
     scannerResources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: 100m
-          memory: 100Mi
+      limits:
+        memory: 2Gi
+      requests:
+        cpu: 100m
+        memory: 100Mi
     
     scannerDbResources:
       limits:

--- a/dev/config/gitops-config.yaml
+++ b/dev/config/gitops-config.yaml
@@ -23,7 +23,7 @@ tenantResources:
       requests:
         cpu: 100m
         memory: 100Mi
-    
+
     centralDbResources:
       limits:
         memory: 1Gi
@@ -37,14 +37,14 @@ tenantResources:
       requests:
         cpu: 100m
         memory: 100Mi
-    
+
     scannerDbResources:
       limits:
         memory: 3Gi
       requests:
         cpu: 100m
         memory: 100Mi
-    
+
     labels:
       app.kubernetes.io/managed-by: rhacs-fleetshard
       app.kubernetes.io/instance: "{{ .Name }}"
@@ -54,9 +54,9 @@ tenantResources:
     annotations:
       rhacs.redhat.com/org-name: "{{ .OrganizationName }}"
     secureTenantNetwork: false
-    
+
     centralRdsCidrBlock: "10.1.0.0/16"
-    
+
     verticalPodAutoscalers:
       central:
         enabled: true

--- a/dev/config/gitops-config.yaml
+++ b/dev/config/gitops-config.yaml
@@ -16,7 +16,7 @@ tenantResources:
     argoCd:
       enabled: true
       centralEnabled: true
-    
+
     centralResources:
       limits:
         memory: 1Gi

--- a/dev/config/gitops-config.yaml
+++ b/dev/config/gitops-config.yaml
@@ -12,9 +12,39 @@ verticalPodAutoscaling:
 tenantResources:
   default: |
     rolloutGroup: "dev"
+
     argoCd:
       enabled: true
       centralEnabled: true
+    
+    centralResources:
+      limits:
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 100Mi
+    
+    centralDbResources:
+      limits:
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 100Mi
+
+    scannerResources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: 100m
+          memory: 100Mi
+    
+    scannerDbResources:
+      limits:
+        memory: 3Gi
+      requests:
+        cpu: 100m
+        memory: 100Mi
+    
     labels:
       app.kubernetes.io/managed-by: rhacs-fleetshard
       app.kubernetes.io/instance: "{{ .Name }}"
@@ -25,6 +55,7 @@ tenantResources:
       rhacs.redhat.com/org-name: "{{ .OrganizationName }}"
     secureTenantNetwork: false
     centralRdsCidrBlock: "10.1.0.0/16"    
+    
     verticalPodAutoscalers:
       central:
         enabled: true

--- a/dev/config/gitops-config.yaml
+++ b/dev/config/gitops-config.yaml
@@ -4,7 +4,7 @@ rhacsOperators:
     - https://raw.githubusercontent.com/stackrox/stackrox/4.5.4/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
   operators:
     - deploymentName: "rhacs-operator-dev"
-      image: "quay.io/rhacs-eng/stackrox-operator:4.6.0-rc.2-2-g8e97af1bf5-fast"
+      image: "quay.io/rhacs-eng/stackrox-operator:4.5.4"
       centralLabelSelector: "rhacs.redhat.com/version-selector=dev"
       securedClusterReconcilerEnabled: false
 verticalPodAutoscaling:
@@ -14,7 +14,7 @@ tenantResources:
     rolloutGroup: "dev"
     argoCd:
       enabled: true
-      centralEnabled: false
+      centralEnabled: true
     labels:
       app.kubernetes.io/managed-by: rhacs-fleetshard
       app.kubernetes.io/instance: "{{ .Name }}"

--- a/dev/config/gitops-config.yaml
+++ b/dev/config/gitops-config.yaml
@@ -54,7 +54,8 @@ tenantResources:
     annotations:
       rhacs.redhat.com/org-name: "{{ .OrganizationName }}"
     secureTenantNetwork: false
-    centralRdsCidrBlock: "10.1.0.0/16"    
+    
+    centralRdsCidrBlock: "10.1.0.0/16"
     
     verticalPodAutoscalers:
       central:

--- a/dev/env/manifests/openshift-gitops/04-clusterrole.yaml
+++ b/dev/env/manifests/openshift-gitops/04-clusterrole.yaml
@@ -1,0 +1,23 @@
+# Allows the ArgoCD application controller to manage additional resources
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: custom-acscs-openshift-gitops
+rules:
+  - apiGroups: [ "platform.stackrox.io" ]
+    resources: [ "centrals" ]
+    verbs: [ "*" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: custom-acscs-openshift-gitops
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: custom-acscs-openshift-gitops
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -2098,6 +2098,7 @@ metadata:
 				},
 				Spec: v1alpha1.CentralSpec{
 					Central: &v1alpha1.CentralComponentSpec{
+						AdminPasswordGenerationDisabled: pointer.Bool(true),
 						Exposure: &v1alpha1.Exposure{
 							Route: &v1alpha1.ExposureRoute{
 								Enabled: pointer.Bool(false),


### PR DESCRIPTION
## Description

This PR allows toggling the reconciliation of the Central CR by ArgoCD.

TODO before merging/enabling: Change the gitops configuration, so that the overrides are migrated to `tenantResourcesValues`

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~~Unit and integration tests added~~
- [x] Added test description under `Test manual`
- [ ] ~~Documentation added if necessary (i.e. changes to dev setup, test execution, ...)~~
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] ~~Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~~
- [ ] ~~Add secret to app-interface Vault or Secrets Manager if necessary~~
- [ ] ~~RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)~~
- [ ] ~~Check AWS limits are reasonable for changes provisioning new resources~~
- [ ] ~~(If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment~~

## Test manual

1. In the gitops config, toggle `tenantResourcesValues.argoCd.centralEnabled` on or off
2. Observe that ArgoCD reconciles the Central CR resource
3. Observe that the Argo-CD- and Fleetshard- reconciler Centrals are mostly the same.
