### PR TITLE
ROX-27209: Create external secrets for quay image pull secrets

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-secrets.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-secrets.yaml
@@ -88,7 +88,7 @@ spec:
       remoteRef:
         key: "secured-cluster"
         property: "sensor_key"
-{{- if and (ne .Values.pullSecret "") .Values.createPullSecret  }}
+{{- if and .Values.pullSecret .Values.createPullSecret }}
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret

--- a/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-secrets.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/templates/secured-cluster-secrets.yaml
@@ -88,3 +88,23 @@ spec:
       remoteRef:
         key: "secured-cluster"
         property: "sensor_key"
+{{- if and (ne .Values.pullSecret "") .Values.createPullSecret  }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.pullSecret }}
+  namespace: {{ include "secured-cluster.namespace" . }}
+spec:
+  secretStoreRef:
+    name: {{ .Values.global.secretStore.aws.secretsManagerSecretStoreName }}
+    kind: ClusterSecretStore
+    target:
+      name: {{ .Values.pullSecret }}
+      creationPolicy: Owner
+    data:
+      - secretKey: .dockerconfigjson # pragma: allowlist secret
+        remoteRef:
+          key: "quay/rhacs-eng"
+          property: ".dockerconfigjson"
+{{- end }}

--- a/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/secured-cluster/values.yaml
@@ -1,6 +1,7 @@
 # Optional name of a secret that should be used by the SecuredCluster
 # deployments to pull images
 pullSecret: ""
+createPullSecret: false
 
 clusterName: ""
 centralEndpoint: ""

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-secret.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync-secret.yaml
@@ -44,3 +44,25 @@ spec:
       remoteRef:
         key: "/fleetshard-sync/aws_role_arn"
 {{- end }}
+{{- with .Values.fleetshardSync.tenantImagePullSecret }}
+{{- if and .create .name }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  secretStoreRef:
+    name: {{ $.Values.global.secretStore.aws.secretsManagerSecretStoreName }}
+    kind: ClusterSecretStore
+    target:
+      name: {{ .name }}
+      creationPolicy: Owner
+    data:
+      - secretKey: {{ .key }} # pragma: allowlist secret
+        remoteRef:
+          key: "quay/rhacs-eng"
+          property: ".dockerconfigjson"
+{{- end }}
+{{- end }}

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -64,6 +64,7 @@ fleetshardSync:
   tenantImagePullSecret:
     name: ""
     key: .dockerconfigjson
+    create: false
   printCentralUpdateDiff: false
   argoCdNamespace: openshift-gitops
 


### PR DESCRIPTION
## Description
Conditionally load image pull secrets from Secrets Manager 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
