### PR TITLE
Add helm parameters for argocd application

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -144,7 +144,7 @@ spec:
         - name: TENANT_DEFAULT_ARGOCD_APP_SOURCE_TARGET_REVISION
           value: {{ .Values.fleetshardSync.gitops.tenantDefaultAppSourceTargetRevision | quote }}
         {{- end }}
-        {{- if (.Values.fleetshardSync.gitops).tenantDefaultArgoCdAppSourcePath }}
+        {{- if (.Values.fleetshardSync.gitops).tenantDefaultAppSourcePath }}
         - name: TENANT_DEFAULT_ARGOCD_APP_SOURCE_PATH
           value: {{ .Values.fleetshardSync.gitops.tenantDefaultAppSourcePath | quote }}
         {{- end }}

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -136,15 +136,15 @@ spec:
           value: {{ .Values.fleetshardSync.printCentralUpdateDiff | quote }}
         - name: ARGOCD_NAMESPACE
           value: {{ .Values.fleetshardSync.argoCdNamespace | quote }}
-        {{- if (.Values.fleetshardSync.gitops).tenantDefaultAppSourceRepoUrl }}
+        {{- if .Values.fleetshardSync.gitops.tenantDefaultAppSourceRepoUrl }}
         - name: TENANT_DEFAULT_ARGOCD_APP_SOURCE_REPO_URL
           value: {{ .Values.fleetshardSync.gitops.tenantDefaultAppSourceRepoUrl | quote }}
         {{- end }}
-        {{- if (.Values.fleetshardSync.gitops).tenantDefaultAppSourceTargetRevision }}
+        {{- if .Values.fleetshardSync.gitops.tenantDefaultAppSourceTargetRevision }}
         - name: TENANT_DEFAULT_ARGOCD_APP_SOURCE_TARGET_REVISION
           value: {{ .Values.fleetshardSync.gitops.tenantDefaultAppSourceTargetRevision | quote }}
         {{- end }}
-        {{- if (.Values.fleetshardSync.gitops).tenantDefaultAppSourcePath }}
+        {{- if .Values.fleetshardSync.gitops.tenantDefaultAppSourcePath }}
         - name: TENANT_DEFAULT_ARGOCD_APP_SOURCE_PATH
           value: {{ .Values.fleetshardSync.gitops.tenantDefaultAppSourcePath | quote }}
         {{- end }}

--- a/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
+++ b/dp-terraform/helm/rhacs-terraform/templates/fleetshard-sync.yaml
@@ -136,6 +136,18 @@ spec:
           value: {{ .Values.fleetshardSync.printCentralUpdateDiff | quote }}
         - name: ARGOCD_NAMESPACE
           value: {{ .Values.fleetshardSync.argoCdNamespace | quote }}
+        {{- if (.Values.fleetshardSync.gitops).tenantDefaultAppSourceRepoUrl }}
+        - name: TENANT_DEFAULT_ARGOCD_APP_SOURCE_REPO_URL
+          value: {{ .Values.fleetshardSync.gitops.tenantDefaultAppSourceRepoUrl | quote }}
+        {{- end }}
+        {{- if (.Values.fleetshardSync.gitops).tenantDefaultAppSourceTargetRevision }}
+        - name: TENANT_DEFAULT_ARGOCD_APP_SOURCE_TARGET_REVISION
+          value: {{ .Values.fleetshardSync.gitops.tenantDefaultAppSourceTargetRevision | quote }}
+        {{- end }}
+        {{- if (.Values.fleetshardSync.gitops).tenantDefaultArgoCdAppSourcePath }}
+        - name: TENANT_DEFAULT_ARGOCD_APP_SOURCE_PATH
+          value: {{ .Values.fleetshardSync.gitops.tenantDefaultAppSourcePath | quote }}
+        {{- end }}
         volumeMounts:
           - mountPath: /var/run/secrets/tokens
             name: tokens

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -50,6 +50,9 @@ fleetshardSync:
       memory: "512Mi"
   gitops:
     enabled: false
+    tenantDefaultAppSourceRepoUrl: ""
+    tenantDefaultAppSourceTargetRevision: ""
+    tenantDefaultAppSourcePath: ""
   targetedOperatorUpgrades:
     enabled: false
   affinity: {}


### PR DESCRIPTION
## Description
Enables specifying the ArgoCD application source using addon parameters

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
