### PR TITLE
ROX-27209: Change image pull secret for operator deployments

### DIFF
--- a/dev/env/manifests/fleetshard-operator/07-serviceaccount.yaml
+++ b/dev/env/manifests/fleetshard-operator/07-serviceaccount.yaml
@@ -3,5 +3,3 @@ kind: ServiceAccount
 metadata:
   name: acs-fleetshard-operator
   namespace: "$ACSCS_NAMESPACE"
-imagePullSecrets:
-  - name: acs-fleetshard-operator

--- a/dev/env/manifests/fleetshard-operator/51-fleetshard-cr.yaml
+++ b/dev/env/manifests/fleetshard-operator/51-fleetshard-cr.yaml
@@ -29,8 +29,7 @@ spec:
     secretEncryption:
       type: "local"
     tenantImagePullSecret:
-      name: "fleetshard-sync"
-      key: "tenant-image-pull-secret"
+      name: $TENANT_IMAGE_PULL_SECRET
     nodeSelector: null
     tolerations: null
     addonAutoUpgradeEnabled: false

--- a/dev/env/manifests/fleetshard-sync/01-fleetshard-sync-secrets.yaml
+++ b/dev/env/manifests/fleetshard-sync/01-fleetshard-sync-secrets.yaml
@@ -8,8 +8,6 @@ stringData:
   aws-access-key-id: "${AWS_ACCESS_KEY_ID}"
   aws-secret-access-key: "${AWS_SECRET_ACCESS_KEY}"
   telemetry-storage-key: "${TELEMETRY_STORAGE_KEY}"
-  tenant-image-pull-secret: |
-    ${TENANT_IMAGE_PULL_SECRET}
 ---
 apiVersion: v1
 kind: Secret

--- a/dev/env/scripts/bootstrap.sh
+++ b/dev/env/scripts/bootstrap.sh
@@ -38,7 +38,6 @@ wait_for_default_service_account "$ACSCS_NAMESPACE"
 if [[ "$INHERIT_IMAGEPULLSECRETS" == "true" ]]; then
     create-imagepullsecrets
     inject_ips "$ACSCS_NAMESPACE" "default" "quay-ips"
-    inject_ips "$STACKROX_OPERATOR_NAMESPACE" "default" "quay-ips"
 else
     log "Skipping creation of ImagePullSecrets because INHERIT_IMAGEPULLSECRETS is not true"
 fi

--- a/dev/env/scripts/create-imagepullsecrets
+++ b/dev/env/scripts/create-imagepullsecrets
@@ -69,7 +69,7 @@ function print_auth() {
 
 registry_auth="$(print_auth "$(mkauth "${username}" "${password}")")"
 
-log "Creating quay-ips image pull secret in namespace ${STACKROX_OPERATOR_NAMESPACE}"
+log "Creating rhacs-registry image pull secret in namespace ${STACKROX_OPERATOR_NAMESPACE}"
     resOperatorImage=$(
         cat <<EOF
 apiVersion: v1
@@ -77,7 +77,7 @@ data:
   .dockerconfigjson: ${registry_auth}
 kind: Secret
 metadata:
-  name: quay-ips
+  name: rhacs-registry
   namespace: ${STACKROX_OPERATOR_NAMESPACE}
 type: kubernetes.io/dockerconfigjson
 EOF
@@ -93,20 +93,6 @@ data:
 kind: Secret
 metadata:
   name: quay-ips
-  namespace: $ACSCS_NAMESPACE
-type: kubernetes.io/dockerconfigjson
-EOF
-)
-echo "$res" | $KUBECTL -n "$ACSCS_NAMESPACE" apply -f -
-log "Creating acs-fleetshard-operator pull secret in namespace ${ACSCS_NAMESPACE}"
-res=$(
-    cat <<EOF
-apiVersion: v1
-data:
-  .dockerconfigjson: ${registry_auth}
-kind: Secret
-metadata:
-  name: acs-fleetshard-operator
   namespace: $ACSCS_NAMESPACE
 type: kubernetes.io/dockerconfigjson
 EOF

--- a/dev/env/scripts/up.sh
+++ b/dev/env/scripts/up.sh
@@ -69,7 +69,7 @@ fi
 log "Deploying fleetshard-sync"
 TENANT_IMAGE_PULL_SECRET=""
 if [[ "$INHERIT_IMAGEPULLSECRETS" == "true" ]]; then # pragma: allowlist secret
-    TENANT_IMAGE_PULL_SECRET=$($KUBECTL -n "$ACSCS_NAMESPACE" get secret quay-ips -o jsonpath="{.data['\.dockerconfigjson']}" | base64 -d)
+    TENANT_IMAGE_PULL_SECRET="rhacs-registry" # pragma: allowlist secret
 fi
 export TENANT_IMAGE_PULL_SECRET
 

--- a/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-service-account.yaml
+++ b/fleetshard/pkg/central/charts/data/rhacs-operator/templates/rhacs-operator-service-account.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 imagePullSecrets:
-  - name: acs-fleetshard-operator
+  - name: rhacs-registry
 metadata:
   name: rhacs-operator-controller-manager
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
- Remove `acs-fleetshard-operator` image pull secret
- Reference `rhacs-registry` image pull secret for ACS operator deployments instead
- Change the meaning of `TENANT_IMAGE_PULL_SECRET` env variable. Now it contains secret name, instead of containing its value. This will allow the secret not to be created if `INHERIT_IMAGEPULLSECRETS` is false.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
