### PR TITLE
fix: type assertion failure for RHSSO creating dynamic client apierror log

### DIFF
--- a/internal/dinosaur/pkg/rhsso/augment.go
+++ b/internal/dinosaur/pkg/rhsso/augment.go
@@ -29,7 +29,7 @@ func AugmentWithDynamicAuthConfig(ctx context.Context, r *dbapi.CentralRequest, 
 		RedirectUris: redirectURIs,
 	})
 	if err != nil {
-		if apiError, ok := err.(*api.GenericOpenAPIError); ok {
+		if apiError, ok := err.(api.GenericOpenAPIError); ok {
 			glog.Errorf("Error response when creating RHSSO dynamic client: %s", string(apiError.Body()))
 		}
 		return errors.Wrapf(err, "failed to create RHSSO dynamic client for %s", r.ID)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

The PR fixes type asserting.

There is no `Error response when creating RHSSO dynamic client` error logs if RHSSO returns 4xx responses. The issue is that `CreateAcsClient` openAPI generated function returns `GenericOpenAPIError` in case of API error not a pointer.


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

N/A