### PR TITLE
ROX-27073: add cluster migration e2e test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@
 emailsender-manifests.yaml
 central-chart/
 pids-port-forward
+# temp files created by multicluster e2e tests
+cluster-list.json
+cluster-list2.json
+fm-dataplane-config.yaml
 # Ignore uploaded files in development
 /storage/*
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -253,36 +253,6 @@
         "line_number": 7
       }
     ],
-    "dp-terraform/test/helm_template_test.go": [
-      {
-        "type": "Secret Keyword",
-        "filename": "dp-terraform/test/helm_template_test.go",
-        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
-        "is_verified": false,
-        "line_number": 213
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "dp-terraform/test/helm_template_test.go",
-        "hashed_secret": "ffca30fb84289293406a2f0ddd21e4e76edc4a9d",
-        "is_verified": false,
-        "line_number": 218
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "dp-terraform/test/helm_template_test.go",
-        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
-        "is_verified": false,
-        "line_number": 225
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "dp-terraform/test/helm_template_test.go",
-        "hashed_secret": "2ccb316685a39fe464e9b5c63cd82381ae06d885",
-        "is_verified": false,
-        "line_number": 302
-      }
-    ],
     "e2e/e2e_test.go": [
       {
         "type": "Secret Keyword",
@@ -446,5 +416,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-22T08:35:12Z"
+  "generated_at": "2025-01-22T08:55:38Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -310,15 +310,6 @@
         "line_number": 1343
       }
     ],
-    "internal/dinosaur/pkg/gitops/config_test.go": [
-      {
-        "type": "Secret Keyword",
-        "filename": "internal/dinosaur/pkg/gitops/config_test.go",
-        "hashed_secret": "a87f808651f87e8db9287e2ce1686f3955aab282",
-        "is_verified": false,
-        "line_number": 60
-      }
-    ],
     "internal/dinosaur/pkg/presenters/managedcentral.go": [
       {
         "type": "Secret Keyword",
@@ -494,5 +485,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-22T07:35:59Z"
+  "generated_at": "2025-01-22T08:07:16Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -292,15 +292,6 @@
         "line_number": 298
       }
     ],
-    "fleetshard/pkg/central/cloudprovider/dbclient_moq.go": [
-      {
-        "type": "Secret Keyword",
-        "filename": "fleetshard/pkg/central/cloudprovider/dbclient_moq.go",
-        "hashed_secret": "80519927d0f3ce1efe933f46ca9e05e68e491adc",
-        "is_verified": false,
-        "line_number": 143
-      }
-    ],
     "internal/dinosaur/pkg/api/public/api/openapi.yaml": [
       {
         "type": "Base64 High Entropy String",
@@ -333,13 +324,6 @@
         "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
         "is_verified": false,
         "line_number": 1112
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "internal/dinosaur/pkg/services/dinosaurservice_moq.go",
-        "hashed_secret": "d035c0406b3e8286d3427e91db3497e0e17f0f83",
-        "is_verified": false,
-        "line_number": 1113
       }
     ],
     "pkg/client/fleetmanager/impl/testdata/token": [
@@ -359,20 +343,6 @@
         "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
         "is_verified": false,
         "line_number": 640
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "pkg/client/fleetmanager/mocks/client_moq.go",
-        "hashed_secret": "0ff50155b4f57adeccae93f27dc23efe2a8b7824",
-        "is_verified": false,
-        "line_number": 641
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "pkg/client/fleetmanager/mocks/client_moq.go",
-        "hashed_secret": "5ce1b8d4fb9dae5c02b2017e39e7267a21cea37f",
-        "is_verified": false,
-        "line_number": 650
       }
     ],
     "pkg/client/redhatsso/api/api/openapi.yaml": [
@@ -476,5 +446,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-22T08:33:27Z"
+  "generated_at": "2025-01-22T08:35:12Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -384,15 +384,6 @@
         "line_number": 184
       }
     ],
-    "pkg/shared/secrets/secrets_test.go": [
-      {
-        "type": "Secret Keyword",
-        "filename": "pkg/shared/secrets/secrets_test.go",
-        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-        "is_verified": false,
-        "line_number": 113
-      }
-    ],
     "templates/service-template.yml": [
       {
         "type": "Base64 High Entropy String",
@@ -485,5 +476,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-22T08:07:16Z"
+  "generated_at": "2025-01-22T08:33:27Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -253,13 +253,52 @@
         "line_number": 7
       }
     ],
+    "dp-terraform/test/helm_template_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "dp-terraform/test/helm_template_test.go",
+        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
+        "is_verified": false,
+        "line_number": 213
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "dp-terraform/test/helm_template_test.go",
+        "hashed_secret": "ffca30fb84289293406a2f0ddd21e4e76edc4a9d",
+        "is_verified": false,
+        "line_number": 218
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "dp-terraform/test/helm_template_test.go",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "is_verified": false,
+        "line_number": 225
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "dp-terraform/test/helm_template_test.go",
+        "hashed_secret": "2ccb316685a39fe464e9b5c63cd82381ae06d885",
+        "is_verified": false,
+        "line_number": 302
+      }
+    ],
     "e2e/e2e_test.go": [
       {
         "type": "Secret Keyword",
         "filename": "e2e/e2e_test.go",
         "hashed_secret": "7f38822bc2b03e97325ff310099f457f6f788daf",
         "is_verified": false,
-        "line_number": 294
+        "line_number": 298
+      }
+    ],
+    "fleetshard/pkg/central/cloudprovider/dbclient_moq.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "fleetshard/pkg/central/cloudprovider/dbclient_moq.go",
+        "hashed_secret": "80519927d0f3ce1efe933f46ca9e05e68e491adc",
+        "is_verified": false,
+        "line_number": 143
       }
     ],
     "internal/dinosaur/pkg/api/public/api/openapi.yaml": [
@@ -269,6 +308,15 @@
         "hashed_secret": "5b455797b93de5b6a19633ba22127c8a610f5c1b",
         "is_verified": false,
         "line_number": 1343
+      }
+    ],
+    "internal/dinosaur/pkg/gitops/config_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/gitops/config_test.go",
+        "hashed_secret": "a87f808651f87e8db9287e2ce1686f3955aab282",
+        "is_verified": false,
+        "line_number": 60
       }
     ],
     "internal/dinosaur/pkg/presenters/managedcentral.go": [
@@ -294,6 +342,13 @@
         "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
         "is_verified": false,
         "line_number": 1112
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dinosaur/pkg/services/dinosaurservice_moq.go",
+        "hashed_secret": "d035c0406b3e8286d3427e91db3497e0e17f0f83",
+        "is_verified": false,
+        "line_number": 1113
       }
     ],
     "pkg/client/fleetmanager/impl/testdata/token": [
@@ -313,6 +368,20 @@
         "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
         "is_verified": false,
         "line_number": 640
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/fleetmanager/mocks/client_moq.go",
+        "hashed_secret": "0ff50155b4f57adeccae93f27dc23efe2a8b7824",
+        "is_verified": false,
+        "line_number": 641
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/client/fleetmanager/mocks/client_moq.go",
+        "hashed_secret": "5ce1b8d4fb9dae5c02b2017e39e7267a21cea37f",
+        "is_verified": false,
+        "line_number": 650
       }
     ],
     "pkg/client/redhatsso/api/api/openapi.yaml": [
@@ -322,6 +391,15 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
         "line_number": 184
+      }
+    ],
+    "pkg/shared/secrets/secrets_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/shared/secrets/secrets_test.go",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 113
       }
     ],
     "templates/service-template.yml": [
@@ -416,5 +494,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-18T09:09:37Z"
+  "generated_at": "2025-01-22T07:35:59Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -259,7 +259,7 @@
         "filename": "e2e/e2e_test.go",
         "hashed_secret": "7f38822bc2b03e97325ff310099f457f6f788daf",
         "is_verified": false,
-        "line_number": 304
+        "line_number": 294
       }
     ],
     "internal/dinosaur/pkg/api/public/api/openapi.yaml": [
@@ -312,7 +312,7 @@
         "filename": "pkg/client/fleetmanager/mocks/client_moq.go",
         "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
         "is_verified": false,
-        "line_number": 584
+        "line_number": 640
       }
     ],
     "pkg/client/redhatsso/api/api/openapi.yaml": [

--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,22 @@ test/e2e: $(GINKGO_BIN)
 		 ./e2e/...
 .PHONY: test/e2e
 
+test/e2e/multicluster: $(GINKGO_BIN)
+	CLUSTER_ID=1234567890abcdef1234567890abcdef \
+	ENABLE_CENTRAL_EXTERNAL_CERTIFICATE=$(ENABLE_CENTRAL_EXTERNAL_CERTIFICATE) \
+	GITOPS_CONFIG_PATH=$(GITOPS_CONFIG_FILE) \
+	RUN_MULTICLUSTER_E2E=true
+	$(GINKGO_BIN) -r $(GINKGO_FLAGS) \
+		--randomize-suites \
+		--fail-on-pending --keep-going \
+		--cover --coverprofile=cover.profile \
+		--race --trace \
+		--json-report=e2e-report.json \
+		--timeout=$(TEST_TIMEOUT) \
+		--poll-progress-after=5m \
+		 ./e2e/multicluster
+.PHONY: test/e2e/multicluster
+
 # Deploys the necessary applications to the selected cluster and runs e2e tests inside the container
 # Useful for debugging Openshift CI runs locally
 test/deploy/e2e-dockerized:

--- a/e2e/dns/record_cleanup.go
+++ b/e2e/dns/record_cleanup.go
@@ -1,0 +1,35 @@
+package dns
+
+import (
+	"github.com/aws/aws-sdk-go/service/route53"
+	. "github.com/onsi/gomega"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/public"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/services"
+)
+
+// CleanupCentralRequestRecords deletes all route53 resoruces associated with the centralRequest
+func CleanupCentralRequestRecords(route53Client *route53.Route53, centralRequest public.CentralRequest) {
+	dnsLoader := NewRecordsLoader(route53Client, centralRequest)
+	recordSets := dnsLoader.LoadDNSRecords()
+
+	action := string(services.CentralRoutesActionDelete)
+	changes := []*route53.Change{}
+	for _, rs := range recordSets {
+		c := &route53.Change{
+			Action:            &action,
+			ResourceRecordSet: rs,
+		}
+		changes = append(changes, c)
+	}
+
+	if len(changes) == 0 {
+		return
+	}
+
+	_, err := route53Client.ChangeResourceRecordSets(&route53.ChangeResourceRecordSetsInput{
+		HostedZoneId: dnsLoader.rhacsZone.Name,
+		ChangeBatch:  &route53.ChangeBatch{Changes: changes},
+	})
+
+	Expect(err).ToNot(HaveOccurred())
+}

--- a/e2e/e2e_canary_upgrade_test.go
+++ b/e2e/e2e_canary_upgrade_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stackrox/acs-fleet-manager/e2e/testutil"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/operator"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/public"
@@ -61,7 +62,7 @@ var _ = Describe("Fleetshard-sync Targeted Upgrade", Ordered, func() {
 	})
 
 	BeforeEach(func() {
-		SkipIf(!features.TargetedOperatorUpgrades.Enabled() || !runCanaryUpgradeTests, "Skipping canary upgrade test")
+		testutil.SkipIf(!features.TargetedOperatorUpgrades.Enabled() || !runCanaryUpgradeTests, "Skipping canary upgrade test")
 		option := fmImpl.OptionFromEnv()
 		auth, err := fmImpl.NewStaticAuth(ctx, fmImpl.StaticOption{StaticToken: option.Static.StaticToken})
 		Expect(err).ToNot(HaveOccurred())
@@ -250,7 +251,7 @@ var _ = Describe("Fleetshard-sync Targeted Upgrade", Ordered, func() {
 		It("delete central", func() {
 			Expect(deleteCentralByID(ctx, client, createdCentral.Id)).
 				To(Succeed())
-			Eventually(assertCentralRequestDeprovisioning(ctx, client, createdCentral.Id)).
+			Eventually(testutil.AssertCentralRequestDeprovisioning(ctx, client, createdCentral.Id)).
 				WithTimeout(waitTimeout).
 				WithPolling(defaultPolling).
 				Should(Succeed())

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -14,9 +14,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	openshiftRouteV1 "github.com/openshift/api/route/v1"
+	"github.com/stackrox/acs-fleet-manager/e2e/testutil"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/config"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
-	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/public"
 	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
 	"github.com/stackrox/rox/operator/api/v1alpha1"
@@ -32,8 +32,8 @@ var (
 	dnsEnabled            bool
 	routesEnabled         bool
 	route53Client         *route53.Route53
-	waitTimeout           = getWaitTimeout()
-	extendedWaitTimeout   = getWaitTimeout() * 3
+	waitTimeout           = testutil.GetWaitTimeout()
+	extendedWaitTimeout   = testutil.GetWaitTimeout() * 3
 	dpCloudProvider       = getEnvDefault("DP_CLOUD_PROVIDER", "standalone")
 	dpRegion              = getEnvDefault("DP_REGION", "standalone")
 	fleetManagerEndpoint  = "http://localhost:8000"
@@ -51,18 +51,6 @@ var (
 		RateTCP:       16,
 	}
 )
-
-func getWaitTimeout() time.Duration {
-	timeoutStr, ok := os.LookupEnv("WAIT_TIMEOUT")
-	if ok {
-		timeout, err := time.ParseDuration(timeoutStr)
-		if err == nil {
-			return timeout
-		}
-		fmt.Printf("Error parsing timeout, using default timeout %v: %s\n", defaultTimeout, err)
-	}
-	return defaultTimeout
-}
 
 func getEnvDefault(key, defaultValue string) string {
 	value, ok := os.LookupEnv(key)
@@ -89,7 +77,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	var accessKey, secretKey string
-	dnsEnabled, accessKey, secretKey = isDNSEnabled(routesEnabled)
+	dnsEnabled, accessKey, secretKey = testutil.DNSConfiguration(routesEnabled)
 
 	if dnsEnabled {
 		creds := credentials.NewStaticCredentials(
@@ -123,49 +111,6 @@ func enableTestsGroup(testName string, envName string, defaultValue string) bool
 		GinkgoWriter.Printf("Skipping %s tests. Set %s=true to run these tests", testName, envName)
 	}
 	return false
-}
-
-func isDNSEnabled(routesEnabled bool) (bool, string, string) {
-	accessKey := os.Getenv("ROUTE53_ACCESS_KEY")
-	secretKey := os.Getenv("ROUTE53_SECRET_ACCESS_KEY")
-	enableExternal := os.Getenv("ENABLE_CENTRAL_EXTERNAL_CERTIFICATE")
-	dnsEnabled := accessKey != "" &&
-		secretKey != "" &&
-		enableExternal != "" && routesEnabled
-	return dnsEnabled, accessKey, secretKey
-}
-
-func assertCentralRequestStatus(ctx context.Context, client *fleetmanager.Client, id string, status string) func() error {
-	return func() error {
-		centralRequest, _, err := client.PublicAPI().GetCentralById(ctx, id)
-		if err != nil {
-			return err
-		}
-		if centralRequest.Status != status {
-			return fmt.Errorf("expected centralRequest status %s, got %s", status, centralRequest.Status)
-		}
-		return nil
-	}
-}
-
-func assertCentralRequestReady(ctx context.Context, client *fleetmanager.Client, id string) func() error {
-	return assertCentralRequestStatus(ctx, client, id, constants.CentralRequestStatusReady.String())
-}
-
-func assertCentralRequestProvisioning(ctx context.Context, client *fleetmanager.Client, id string) func() error {
-	return assertCentralRequestStatus(ctx, client, id, constants.CentralRequestStatusProvisioning.String())
-}
-
-func assertCentralRequestDeprovisioning(ctx context.Context, client *fleetmanager.Client, id string) func() error {
-	return assertCentralRequestStatus(ctx, client, id, constants.CentralRequestStatusDeprovision.String())
-}
-
-func assertCentralRequestDeleting(ctx context.Context, client *fleetmanager.Client, id string) func() error {
-	return assertCentralRequestStatus(ctx, client, id, constants.CentralRequestStatusDeleting.String())
-}
-
-func assertCentralRequestAccepted(ctx context.Context, client *fleetmanager.Client, id string) func() error {
-	return assertCentralRequestStatus(ctx, client, id, constants.CentralRequestStatusAccepted.String())
 }
 
 func obtainCentralRequest(ctx context.Context, client *fleetmanager.Client, id string, request *public.CentralRequest) error {
@@ -266,20 +211,6 @@ func assertDeploymentHealthyReplicas(ctx context.Context, namespace, name string
 	}
 }
 
-func assertReencryptIngressRouteExist(ctx context.Context, namespace string, route *openshiftRouteV1.RouteIngress) func() error {
-	return func() error {
-		reencryptIngress, err := routeService.FindReencryptIngress(ctx, namespace)
-		if err != nil {
-			return fmt.Errorf("failed finding reencrypt ingress in namespace %s: %v", namespace, err)
-		}
-		if reencryptIngress == nil {
-			return fmt.Errorf("reencrypt ingress in namespace %s not found", namespace)
-		}
-		*route = *reencryptIngress
-		return nil
-	}
-}
-
 func assertReencryptRouteExist(ctx context.Context, namespace string, route *openshiftRouteV1.Route) func() error {
 	return func() error {
 		reencryptRoute, err := routeService.FindReencryptRoute(ctx, namespace)
@@ -305,11 +236,5 @@ func assertPassthroughRouteExist(ctx context.Context, namespace string, route *o
 		}
 		*route = *passthroughRoute
 		return nil
-	}
-}
-
-func SkipIf(condition bool, message string) {
-	if condition {
-		Skip(message, 1)
 	}
 }

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stackrox/acs-fleet-manager/e2e/testutil"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/config"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
-	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/public"
 	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
 	"github.com/stackrox/rox/operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -111,15 +110,6 @@ func enableTestsGroup(testName string, envName string, defaultValue string) bool
 		GinkgoWriter.Printf("Skipping %s tests. Set %s=true to run these tests", testName, envName)
 	}
 	return false
-}
-
-func obtainCentralRequest(ctx context.Context, client *fleetmanager.Client, id string, request *public.CentralRequest) error {
-	centralRequest, _, err := client.PublicAPI().GetCentralById(ctx, id)
-	if err != nil {
-		return err
-	}
-	*request = centralRequest
-	return nil
 }
 
 func assertStoredSecrets(ctx context.Context, privateAPI fleetmanager.PrivateAPI, centralRequestID string, expected []string) func() error {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -159,7 +159,7 @@ var _ = Describe("Central", Ordered, func() {
 		It("should not expose URLs until the routes are created", func() {
 			testutil.SkipIf(!routesEnabled, skipRouteMsg)
 			var centralRequest public.CentralRequest
-			Expect(obtainCentralRequest(ctx, client, centralRequestID, &centralRequest)).
+			Expect(testutil.ObtainCentralRequest(ctx, client, centralRequestID, &centralRequest)).
 				To(Succeed())
 			Expect(centralRequest.CentralUIURL).To(BeEmpty())
 			Expect(centralRequest.CentralDataURL).To(BeEmpty())
@@ -176,7 +176,7 @@ var _ = Describe("Central", Ordered, func() {
 			testutil.SkipIf(!routesEnabled, skipRouteMsg)
 
 			var centralRequest public.CentralRequest
-			Expect(obtainCentralRequest(ctx, client, centralRequestID, &centralRequest)).
+			Expect(testutil.ObtainCentralRequest(ctx, client, centralRequestID, &centralRequest)).
 				To(Succeed())
 
 			var reencryptRoute openshiftRouteV1.Route
@@ -208,7 +208,7 @@ var _ = Describe("Central", Ordered, func() {
 			testutil.SkipIf(!dnsEnabled, testutil.SkipDNSMsg)
 
 			var centralRequest public.CentralRequest
-			Expect(obtainCentralRequest(ctx, client, centralRequestID, &centralRequest)).
+			Expect(testutil.ObtainCentralRequest(ctx, client, centralRequestID, &centralRequest)).
 				To(Succeed())
 
 			var reencryptIngress openshiftRouteV1.RouteIngress
@@ -359,7 +359,7 @@ var _ = Describe("Central", Ordered, func() {
 		It("should delete external DNS entries", func() {
 			testutil.SkipIf(!dnsEnabled, testutil.SkipDNSMsg)
 			var centralRequest public.CentralRequest
-			Expect(obtainCentralRequest(ctx, client, centralRequestID, &centralRequest)).
+			Expect(testutil.ObtainCentralRequest(ctx, client, centralRequestID, &centralRequest)).
 				To(Succeed())
 			dnsRecordsLoader := dns.NewRecordsLoader(route53Client, centralRequest)
 			Eventually(dnsRecordsLoader.LoadDNSRecords).
@@ -439,7 +439,7 @@ var _ = Describe("Central", Ordered, func() {
 		It("should delete external DNS entries", func() {
 			testutil.SkipIf(!dnsEnabled, testutil.SkipDNSMsg)
 			var centralRequest public.CentralRequest
-			Expect(obtainCentralRequest(ctx, client, centralRequestID, &centralRequest)).
+			Expect(testutil.ObtainCentralRequest(ctx, client, centralRequestID, &centralRequest)).
 				To(Succeed())
 			dnsRecordsLoader := dns.NewRecordsLoader(route53Client, centralRequest)
 			Eventually(dnsRecordsLoader.LoadDNSRecords).
@@ -483,7 +483,7 @@ var _ = Describe("Central", Ordered, func() {
 				WithTimeout(extendedWaitTimeout).
 				WithPolling(defaultPolling).
 				Should(Succeed())
-			Expect(obtainCentralRequest(ctx, client, centralRequestID, &readyCentralRequest)).
+			Expect(testutil.ObtainCentralRequest(ctx, client, centralRequestID, &readyCentralRequest)).
 				To(Succeed())
 		})
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -159,7 +159,7 @@ var _ = Describe("Central", Ordered, func() {
 		It("should not expose URLs until the routes are created", func() {
 			testutil.SkipIf(!routesEnabled, skipRouteMsg)
 			var centralRequest public.CentralRequest
-			Expect(testutil.ObtainCentralRequest(ctx, client, centralRequestID, &centralRequest)).
+			Expect(testutil.GetCentralRequest(ctx, client, centralRequestID, &centralRequest)).
 				To(Succeed())
 			Expect(centralRequest.CentralUIURL).To(BeEmpty())
 			Expect(centralRequest.CentralDataURL).To(BeEmpty())
@@ -176,7 +176,7 @@ var _ = Describe("Central", Ordered, func() {
 			testutil.SkipIf(!routesEnabled, skipRouteMsg)
 
 			var centralRequest public.CentralRequest
-			Expect(testutil.ObtainCentralRequest(ctx, client, centralRequestID, &centralRequest)).
+			Expect(testutil.GetCentralRequest(ctx, client, centralRequestID, &centralRequest)).
 				To(Succeed())
 
 			var reencryptRoute openshiftRouteV1.Route
@@ -208,7 +208,7 @@ var _ = Describe("Central", Ordered, func() {
 			testutil.SkipIf(!dnsEnabled, testutil.SkipDNSMsg)
 
 			var centralRequest public.CentralRequest
-			Expect(testutil.ObtainCentralRequest(ctx, client, centralRequestID, &centralRequest)).
+			Expect(testutil.GetCentralRequest(ctx, client, centralRequestID, &centralRequest)).
 				To(Succeed())
 
 			var reencryptIngress openshiftRouteV1.RouteIngress
@@ -359,7 +359,7 @@ var _ = Describe("Central", Ordered, func() {
 		It("should delete external DNS entries", func() {
 			testutil.SkipIf(!dnsEnabled, testutil.SkipDNSMsg)
 			var centralRequest public.CentralRequest
-			Expect(testutil.ObtainCentralRequest(ctx, client, centralRequestID, &centralRequest)).
+			Expect(testutil.GetCentralRequest(ctx, client, centralRequestID, &centralRequest)).
 				To(Succeed())
 			dnsRecordsLoader := dns.NewRecordsLoader(route53Client, centralRequest)
 			Eventually(dnsRecordsLoader.LoadDNSRecords).
@@ -439,7 +439,7 @@ var _ = Describe("Central", Ordered, func() {
 		It("should delete external DNS entries", func() {
 			testutil.SkipIf(!dnsEnabled, testutil.SkipDNSMsg)
 			var centralRequest public.CentralRequest
-			Expect(testutil.ObtainCentralRequest(ctx, client, centralRequestID, &centralRequest)).
+			Expect(testutil.GetCentralRequest(ctx, client, centralRequestID, &centralRequest)).
 				To(Succeed())
 			dnsRecordsLoader := dns.NewRecordsLoader(route53Client, centralRequest)
 			Eventually(dnsRecordsLoader.LoadDNSRecords).
@@ -483,7 +483,7 @@ var _ = Describe("Central", Ordered, func() {
 				WithTimeout(extendedWaitTimeout).
 				WithPolling(defaultPolling).
 				Should(Succeed())
-			Expect(testutil.ObtainCentralRequest(ctx, client, centralRequestID, &readyCentralRequest)).
+			Expect(testutil.GetCentralRequest(ctx, client, centralRequestID, &readyCentralRequest)).
 				To(Succeed())
 		})
 

--- a/e2e/multicluster/multicluster_migration_test.go
+++ b/e2e/multicluster/multicluster_migration_test.go
@@ -26,8 +26,14 @@ const (
 	dpCloudProvider = "standalone"
 	dpRegion        = "standalone"
 	// the cluster ids configured for given clusters in fleet-manager's cluster config
-	cluster1ID = "cluster-1-id"
-	cluster2ID = "cluster-2-id"
+
+	// This assumes the ID used for cluster configuration
+	// REPO/dev/config/dataplane-cluster-configuration.yaml
+	cluster1ID = "1234567890abcdef1234567890abcdef" // pragma: allowlist secret
+
+	// This assumes the ID set for cluster 2 in deploy script
+	// $REPO/scripts/ci/multicluster_tests/deploy.sh
+	cluster2ID = "1234567890abcdef1234567890abcdeg" // pragma: allowlist secret
 )
 
 var (
@@ -86,7 +92,7 @@ var _ = Describe("Central Migration Test", Ordered, func() {
 		}
 	})
 
-	Describe("CentralRequest pre migration", Ordered, func() {
+	Describe("CentralRequest pre migration", func() {
 		It("should be assigned to cluster1", func() {
 			assertClusterAssignment(cluster1ID, centralRequest.Id, fleetmanagerAdminClient)
 		})
@@ -137,7 +143,7 @@ var _ = Describe("Central Migration Test", Ordered, func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	Describe("CentralRequest post migration", Ordered, func() {
+	Describe("CentralRequest post migration", func() {
 		It("should be assigned to cluster2", func() {
 			assertClusterAssignment(cluster1ID, centralRequest.Id, fleetmanagerAdminClient)
 		})

--- a/e2e/multicluster/multicluster_migration_test.go
+++ b/e2e/multicluster/multicluster_migration_test.go
@@ -1,0 +1,268 @@
+package multicluster
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	openshiftRouteV1 "github.com/openshift/api/route/v1"
+	"github.com/stackrox/acs-fleet-manager/e2e/dns"
+	"github.com/stackrox/acs-fleet-manager/e2e/testutil"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/admin/private"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/public"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/services"
+	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
+	fmImpl "github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager/impl"
+	corev1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	dpCloudProvider = "standalone"
+	dpRegion        = "standalone"
+	// the cluster ids configured for given clusters in fleet-manager's cluster config
+	cluster1ID = "cluster-1-id"
+	cluster2ID = "cluster-2-id"
+)
+
+var (
+	waitTimeout         = testutil.GetWaitTimeout()
+	extendedWaitTimeout = testutil.GetWaitTimeout() * 3
+	defaultPolling      = 5 * time.Second
+)
+
+var _ = Describe("Central Migration Test", Ordered, func() {
+	var fleetmanagerClient *fleetmanager.Client
+	var fleetmanagerAdminClient fleetmanager.AdminAPI
+	var centralRequest public.CentralRequest
+	var namespaceName string
+	var notes []string
+	BeforeAll(func() {
+		options := fmImpl.OptionFromEnv()
+		auth, err := fmImpl.NewStaticAuth(context.Background(), fmImpl.StaticOption{StaticToken: options.Static.StaticToken})
+		Expect(err).ToNot(HaveOccurred())
+		fleetmanagerClient, err = fmImpl.NewClient(fleetManagerEndpoint, auth)
+		Expect(err).ToNot(HaveOccurred())
+
+		adminStaticToken := os.Getenv("STATIC_TOKEN_ADMIN")
+		adminAuth, err := fmImpl.NewStaticAuth(context.Background(), fmImpl.StaticOption{StaticToken: adminStaticToken})
+		Expect(err).ToNot(HaveOccurred())
+		adminClient, err := fmImpl.NewClient(fleetManagerEndpoint, adminAuth)
+		Expect(err).ToNot(HaveOccurred())
+		fleetmanagerAdminClient = adminClient.AdminAPI()
+	})
+
+	AfterAll(func() {
+		// if the Id is empty we've never successfully created a CentralRequest, thus no cleanup necessary
+		if dnsEnabled && centralRequest.Id != "" {
+			dns.CleanupCentralRequestRecords(route53Client, centralRequest)
+		}
+
+		for _, note := range notes {
+			GinkgoWriter.Println(note)
+		}
+	})
+
+	It("should create a CentralRequest", func() {
+		resp, _, err := fleetmanagerClient.PublicAPI().CreateCentral(context.Background(), true, public.CentralRequestPayload{
+			CloudProvider: dpCloudProvider,
+			Region:        dpRegion,
+			MultiAz:       true,
+			Name:          "migration-test",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		centralRequest = resp
+		namespaceName, err = services.FormatNamespace(centralRequest.Id)
+		Expect(err).NotTo(HaveOccurred())
+
+		notes = []string{
+			fmt.Sprintf("Central name: %s", centralRequest.Name),
+			fmt.Sprintf("Central ID: %s", centralRequest.Id),
+		}
+	})
+
+	Describe("CentralRequest pre migration", Ordered, func() {
+		It("should be assigned to cluster1", func() {
+			assertClusterAssignment(cluster1ID, centralRequest.Id, fleetmanagerAdminClient)
+		})
+
+		It("should reach the ready state", func() {
+			Eventually(testutil.AssertCentralRequestReady(context.Background(), fleetmanagerClient, centralRequest.Id)).
+				WithTimeout(extendedWaitTimeout).
+				WithPolling(defaultPolling).
+				Should(Succeed())
+		})
+
+		It("should have DNS CNAME records for cluster1 routes", func() {
+			testutil.SkipIf(!dnsEnabled, testutil.SkipDNSMsg)
+			dnsRecordsLoader := dns.NewRecordsLoader(route53Client, centralRequest)
+			routeService := k8s.NewRouteService(cluster1KubeClient, routeConfig)
+
+			var reencryptIngress openshiftRouteV1.RouteIngress
+			Eventually(testutil.AssertReencryptIngressRouteExist(context.Background(), routeService, namespaceName, &reencryptIngress)).
+				WithTimeout(waitTimeout).
+				WithPolling(defaultPolling).
+				Should(Succeed())
+
+			Eventually(dnsRecordsLoader.LoadDNSRecords).
+				WithTimeout(waitTimeout).
+				WithPolling(3 * defaultPolling).
+				Should(HaveLen(len(dnsRecordsLoader.CentralDomainNames)))
+
+			testutil.AssertDNSMatchesRouter(dnsRecordsLoader.CentralDomainNames, dnsRecordsLoader.LastResult, &reencryptIngress)
+		})
+	})
+
+	Describe("Tenant namespace pre migration", func() {
+		It("should exist on cluster1", func() {
+			ns, err := getNamespace(namespaceName, cluster1KubeClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ns).NotTo(BeNil())
+		})
+		It("should not exist on cluster2", func() {
+			_, err := getNamespace(namespaceName, cluster2KubeClient)
+			Expect(apiErrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
+	It("should trigger CentralRequest migration", func() {
+		_, err := fleetmanagerAdminClient.AssignCentralCluster(context.Background(), centralRequest.Id, private.CentralAssignClusterRequest{
+			ClusterId: cluster2ID,
+		})
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Describe("CentralRequest post migration", Ordered, func() {
+		It("should be assigned to cluster2", func() {
+			assertClusterAssignment(cluster1ID, centralRequest.Id, fleetmanagerAdminClient)
+		})
+		It("should reach the ready state", func() {
+			Eventually(testutil.AssertCentralRequestReady(context.Background(), fleetmanagerClient, centralRequest.Id)).
+				WithTimeout(extendedWaitTimeout).
+				WithPolling(defaultPolling).
+				Should(Succeed())
+		})
+		It("should have DNS CNAME records for cluster2 routes", func() {
+			testutil.SkipIf(!dnsEnabled, testutil.SkipDNSMsg)
+			dnsRecordsLoader := dns.NewRecordsLoader(route53Client, centralRequest)
+			routeService := k8s.NewRouteService(cluster2KubeClient, routeConfig)
+
+			var reencryptIngress openshiftRouteV1.RouteIngress
+			Eventually(testutil.AssertReencryptIngressRouteExist(context.Background(), routeService, namespaceName, &reencryptIngress)).
+				WithTimeout(waitTimeout).
+				WithPolling(defaultPolling).
+				Should(Succeed())
+
+			Eventually(dnsRecordsLoader.LoadDNSRecords).
+				WithTimeout(waitTimeout).
+				WithPolling(3 * defaultPolling).
+				Should(HaveLen(len(dnsRecordsLoader.CentralDomainNames)))
+
+			testutil.AssertDNSMatchesRouter(dnsRecordsLoader.CentralDomainNames, dnsRecordsLoader.LastResult, &reencryptIngress)
+		})
+	})
+
+	Describe("Tenant namespace post migration", func() {
+		It("should not exist on cluster1", func() {
+			// Using Eventually here because fleetshard-sync on cluster1 can take a while to cleanup the NS
+			Eventually(func() error {
+				_, err := getNamespace(namespaceName, cluster1KubeClient)
+				if apiErrors.IsNotFound(err) {
+					return nil
+				}
+
+				if err == nil {
+					return fmt.Errorf("namespace: %q still exists", namespaceName)
+				}
+
+				return err
+			}).
+				WithTimeout(waitTimeout).
+				WithPolling(defaultPolling).
+				Should(Succeed())
+		})
+
+		It("should exist on cluster2", func() {
+			ns, err := getNamespace(namespaceName, cluster2KubeClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ns).NotTo(BeNil())
+		})
+	})
+
+	It("should delete CentralRequest", func() {
+		_, err := fleetmanagerClient.PublicAPI().DeleteCentralById(context.Background(), centralRequest.Id, true)
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func() (int, error) {
+			_, res, err := fleetmanagerClient.PublicAPI().GetCentralById(context.Background(), centralRequest.Id)
+			if res != nil {
+				return res.StatusCode, err
+			}
+
+			return -1, err
+		}).
+			WithTimeout(waitTimeout).
+			WithPolling(defaultPolling).
+			Should(Equal(404))
+	})
+
+})
+
+func assertClusterAssignment(expectedClusterID string, centralID string, adminAPI fleetmanager.AdminAPI) {
+	var clusterAssignment string
+	Eventually(func() (err error) {
+		// assert the cluster ID outside the Eventually, since once we have a non-empty
+		// clusterAssignment it will not change so there is no need to keep polling
+		clusterAssignment, err = getClusterAssignment(centralID, adminAPI)
+		return err
+	}).
+		WithTimeout(waitTimeout).
+		WithPolling(defaultPolling).
+		Should(Succeed())
+
+	Expect(clusterAssignment).To(Equal(expectedClusterID))
+}
+
+func getClusterAssignment(centralID string, adminAPI fleetmanager.AdminAPI) (string, error) {
+	centralList, _, err := adminAPI.GetCentrals(context.Background(), nil)
+	if err != nil {
+		return "", err
+	}
+
+	if len(centralList.Items) == 0 {
+		return "", fmt.Errorf("central list received by admin API is empty")
+	}
+
+	var clusterID string
+	var tenantExists bool
+	for _, central := range centralList.Items {
+		if central.Id == centralID {
+			tenantExists = true
+			clusterID = central.ClusterId
+		}
+	}
+
+	if !tenantExists {
+		return "", fmt.Errorf("CentralRequest with id: %q not found in admin API list", centralID)
+	}
+
+	if clusterID == "" {
+		return "", fmt.Errorf("CentralRequest returned with no assigned clusterID")
+	}
+
+	return clusterID, nil
+}
+
+func getNamespace(name string, kubeClient ctrlClient.Client) (*corev1.Namespace, error) {
+	var namespace *corev1.Namespace
+	if err := kubeClient.Get(context.Background(), ctrlClient.ObjectKey{Name: name}, namespace); err != nil {
+		return nil, fmt.Errorf("getting namespace %q: %w", name, err)
+	}
+
+	return namespace, nil
+}

--- a/e2e/multicluster/multicluster_suite_test.go
+++ b/e2e/multicluster/multicluster_suite_test.go
@@ -33,6 +33,10 @@ var (
 )
 
 func TestMulticlusterE2E(t *testing.T) {
+	if os.Getenv("RUN_MULTICLUSTER_E2E") != "true" {
+		t.Skip("Skip multicluster e2e tests. Set RUN_MULTICLUSTER_E2E=true env variable to enable e2e tests.")
+	}
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "ACSCS Multicluster Suite")
 }

--- a/e2e/multicluster/multicluster_suite_test.go
+++ b/e2e/multicluster/multicluster_suite_test.go
@@ -1,0 +1,80 @@
+package multicluster
+
+import (
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/route53"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stackrox/acs-fleet-manager/e2e/testutil"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/config"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	cluster1KubeClient ctrlClient.Client
+	cluster2KubeClient ctrlClient.Client
+
+	fleetManagerEndpoint = "http://localhost:8000"
+	route53Client        *route53.Route53
+	dnsEnabled           bool
+
+	routeConfig = &config.RouteConfig{
+		ConcurrentTCP: 32,
+		RateHTTP:      128,
+		RateTCP:       16,
+	}
+)
+
+func TestMulticlusterE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ACSCS Multicluster Suite")
+}
+
+var _ = BeforeSuite(func() {
+	cluster1ConfigFile := os.Getenv("CLUSTER_1_KUBECONFIG")
+	cluster2ConfigFile := os.Getenv("CLUSTER_2_KUBECONFIG")
+	Expect(cluster1ConfigFile).ToNot(BeEmpty())
+	Expect(cluster2ConfigFile).ToNot(BeEmpty())
+
+	configC1, err := os.ReadFile(cluster1ConfigFile)
+	Expect(err).ToNot(HaveOccurred())
+	restConfigC1, err := clientcmd.RESTConfigFromKubeConfig(configC1)
+	Expect(err).ToNot(HaveOccurred())
+	cluster1KubeClient = k8s.CreateClientWithConfigOrDie(restConfigC1)
+
+	configC2, err := os.ReadFile(cluster2ConfigFile)
+	Expect(err).ToNot(HaveOccurred())
+	restConfigC2, err := clientcmd.RESTConfigFromKubeConfig(configC2)
+	Expect(err).ToNot(HaveOccurred())
+	cluster2KubeClient = k8s.CreateClientWithConfigOrDie(restConfigC2)
+
+	fmOverride := os.Getenv("FM_URL")
+	if fmOverride != "" {
+		fleetManagerEndpoint = fmOverride
+	}
+
+	routesEnabled, err := k8s.IsRoutesResourceEnabled(cluster1KubeClient)
+	Expect(err).ToNot(HaveOccurred())
+
+	var accessKey, secretKey string
+	dnsEnabled, accessKey, secretKey = testutil.DNSConfiguration(routesEnabled)
+
+	if dnsEnabled {
+		creds := credentials.NewStaticCredentials(
+			accessKey,
+			secretKey,
+			"")
+		sess, err := session.NewSession(aws.NewConfig().WithCredentials(creds))
+		Expect(err).ToNot(HaveOccurred())
+
+		route53Client = route53.New(sess)
+	}
+
+})

--- a/e2e/multicluster/multicluster_suite_test.go
+++ b/e2e/multicluster/multicluster_suite_test.go
@@ -76,5 +76,4 @@ var _ = BeforeSuite(func() {
 
 		route53Client = route53.New(sess)
 	}
-
 })

--- a/e2e/testutil/assert.go
+++ b/e2e/testutil/assert.go
@@ -1,0 +1,80 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/route53"
+	. "github.com/onsi/gomega"
+	openshiftRouteV1 "github.com/openshift/api/route/v1"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/constants"
+	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
+)
+
+// AssertCentralRequestStatus gets the central request from the client by ID and asserts the given status
+func AssertCentralRequestStatus(ctx context.Context, client *fleetmanager.Client, id string, status string) func() error {
+	return func() error {
+		centralRequest, _, err := client.PublicAPI().GetCentralById(ctx, id)
+		if err != nil {
+			return fmt.Errorf("failed to get central: %w", err)
+		}
+		if centralRequest.Status != status {
+			return fmt.Errorf("expected centralRequest status %s, got %s", status, centralRequest.Status)
+		}
+		return nil
+	}
+}
+
+// AssertCentralRequestReady gets the central requests from the client by ID and asserts the ready status
+func AssertCentralRequestReady(ctx context.Context, client *fleetmanager.Client, id string) func() error {
+	return AssertCentralRequestStatus(ctx, client, id, constants.CentralRequestStatusReady.String())
+}
+
+// AssertCentralRequestProvisioning gets the central requests from the client by ID and asserts the provisioning status
+func AssertCentralRequestProvisioning(ctx context.Context, client *fleetmanager.Client, id string) func() error {
+	return AssertCentralRequestStatus(ctx, client, id, constants.CentralRequestStatusProvisioning.String())
+}
+
+// AssertCentralRequestDeprovisioning gets the central requests from the client by ID and asserts the deprovisioning status
+func AssertCentralRequestDeprovisioning(ctx context.Context, client *fleetmanager.Client, id string) func() error {
+	return AssertCentralRequestStatus(ctx, client, id, constants.CentralRequestStatusDeprovision.String())
+}
+
+// AssertCentralRequestDeleting gets the central requests from the client by ID and asserts the deleting status
+func AssertCentralRequestDeleting(ctx context.Context, client *fleetmanager.Client, id string) func() error {
+	return AssertCentralRequestStatus(ctx, client, id, constants.CentralRequestStatusDeleting.String())
+}
+
+// AssertCentralRequestAccepted gets the central requests from the client by ID and asserts the accepted status
+func AssertCentralRequestAccepted(ctx context.Context, client *fleetmanager.Client, id string) func() error {
+	return AssertCentralRequestStatus(ctx, client, id, constants.CentralRequestStatusAccepted.String())
+}
+
+// AssertDNSMatchesRouter asserts that every domain in centralDomainNames is in recordSets and targets
+// the correct hostname given by the routeIngress
+func AssertDNSMatchesRouter(centralDomainNames []string, recordSets []*route53.ResourceRecordSet, routeIngress *openshiftRouteV1.RouteIngress) {
+	for idx, domain := range centralDomainNames {
+		recordSet := recordSets[idx]
+		Expect(recordSet.ResourceRecords).To(HaveLen(1))
+		record := recordSet.ResourceRecords[0]
+		Expect(*recordSet.Name).To(Equal(domain))
+		Expect(*record.Value).To(Equal(routeIngress.RouterCanonicalHostname)) // TODO use route specific ingress instead of comparing with reencryptIngress for all cases
+	}
+}
+
+// AssertReencryptIngressRouteExist asserts that the reencyrpt RouteIngress for a CentralREquest is created
+// and stores it in the given route object
+func AssertReencryptIngressRouteExist(ctx context.Context, routeService *k8s.RouteService, namespace string, route *openshiftRouteV1.RouteIngress) func() error {
+	return func() error {
+		reencryptIngress, err := routeService.FindReencryptIngress(ctx, namespace)
+		if err != nil {
+			return fmt.Errorf("failed finding reencrypt ingress in namespace %s: %v", namespace, err)
+		}
+		if reencryptIngress == nil {
+			return fmt.Errorf("reencrypt ingress in namespace %s not found", namespace)
+		}
+		*route = *reencryptIngress
+		return nil
+	}
+}

--- a/e2e/testutil/testutil.go
+++ b/e2e/testutil/testutil.go
@@ -2,11 +2,14 @@
 package testutil
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/public"
+	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
 )
 
 const defaultTimeout = 5 * time.Minute
@@ -47,4 +50,14 @@ func SkipIf(condition bool, message string) {
 	if condition {
 		Skip(message, 1)
 	}
+}
+
+// ObtainCentralRequest queries fleet-manager public API for the CentralRequest with id and stores in in the given pointer
+func ObtainCentralRequest(ctx context.Context, client *fleetmanager.Client, id string, request *public.CentralRequest) error {
+	centralRequest, _, err := client.PublicAPI().GetCentralById(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to obtain CentralRequest: %w", err)
+	}
+	*request = centralRequest
+	return nil
 }

--- a/e2e/testutil/testutil.go
+++ b/e2e/testutil/testutil.go
@@ -1,0 +1,50 @@
+// Package testutil implements utility routines used in ACSCS e2e tests
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+const defaultTimeout = 5 * time.Minute
+
+var (
+	// SkipDNSMsg is the message printed when DNS e2e tests or assertions should be skipped
+	SkipDNSMsg = "external DNS is not enabled for this test run"
+)
+
+// GetWaitTimeout gets the test wait timeout for polling operation from
+// OS environment WAIT_TIMEOUT or returns the defaultTimeout if unset
+func GetWaitTimeout() time.Duration {
+	timeoutStr, ok := os.LookupEnv("WAIT_TIMEOUT")
+	if ok {
+		timeout, err := time.ParseDuration(timeoutStr)
+		if err == nil {
+			return timeout
+		}
+		fmt.Printf("Error parsing timeout, using default timeout %v: %s\n", defaultTimeout, err)
+	}
+	return defaultTimeout
+}
+
+// DNSConfiguration looks for propper environment variable setup to run e2e tests
+// with Route53 DNS functionality enabled and returns it.
+func DNSConfiguration(routesEnabled bool) (dnsEnabled bool, accessKey string, secretKey string) {
+	accessKey = os.Getenv("ROUTE53_ACCESS_KEY")
+	secretKey = os.Getenv("ROUTE53_SECRET_ACCESS_KEY")
+	enableExternal := os.Getenv("ENABLE_CENTRAL_EXTERNAL_CERTIFICATE")
+	dnsEnabled = accessKey != "" &&
+		secretKey != "" &&
+		enableExternal != "" && routesEnabled
+	return dnsEnabled, accessKey, secretKey
+}
+
+// SkipIf skips a Gingko test container if condition is true
+func SkipIf(condition bool, message string) {
+	if condition {
+		Skip(message, 1)
+	}
+}

--- a/e2e/testutil/testutil.go
+++ b/e2e/testutil/testutil.go
@@ -52,8 +52,8 @@ func SkipIf(condition bool, message string) {
 	}
 }
 
-// ObtainCentralRequest queries fleet-manager public API for the CentralRequest with id and stores in in the given pointer
-func ObtainCentralRequest(ctx context.Context, client *fleetmanager.Client, id string, request *public.CentralRequest) error {
+// GetCentralRequest queries fleet-manager public API for the CentralRequest with id and stores in in the given pointer
+func GetCentralRequest(ctx context.Context, client *fleetmanager.Client, id string, request *public.CentralRequest) error {
 	centralRequest, _, err := client.PublicAPI().GetCentralById(ctx, id)
 	if err != nil {
 		return fmt.Errorf("failed to obtain CentralRequest: %w", err)

--- a/internal/dinosaur/pkg/presenters/admin_dinosaur.go
+++ b/internal/dinosaur/pkg/presenters/admin_dinosaur.go
@@ -29,5 +29,6 @@ func PresentDinosaurRequestAdminEndpoint(request *dbapi.CentralRequest, _ accoun
 		FailedReason:  request.FailedReason,
 		InstanceType:  request.InstanceType,
 		Traits:        request.Traits,
+		ClusterId:     request.ClusterID,
 	}, nil
 }

--- a/pkg/client/fleetmanager/client.go
+++ b/pkg/client/fleetmanager/client.go
@@ -34,6 +34,7 @@ type AdminAPI interface {
 	DeleteDbCentralById(ctx context.Context, id string) (*http.Response, error)
 	CentralRotateSecrets(ctx context.Context, id string, centralRotateSecretsRequest admin.CentralRotateSecretsRequest) (*http.Response, error)
 	UpdateCentralNameById(ctx context.Context, id string, centralUpdateNameRequest admin.CentralUpdateNameRequest) (admin.Central, *http.Response, error)
+	AssignCentralCluster(ctx context.Context, id string, centralAssignClusterRequest admin.CentralAssignClusterRequest) (*http.Response, error)
 }
 
 // Client is a helper struct that wraps around the API clients generated from

--- a/pkg/client/fleetmanager/mocks/client_moq.go
+++ b/pkg/client/fleetmanager/mocks/client_moq.go
@@ -491,6 +491,9 @@ var _ fleetmanager.AdminAPI = &AdminAPIMock{}
 //
 //		// make and configure a mocked fleetmanager.AdminAPI
 //		mockedAdminAPI := &AdminAPIMock{
+//			AssignCentralClusterFunc: func(ctx context.Context, id string, centralAssignClusterRequest admin.CentralAssignClusterRequest) (*http.Response, error) {
+//				panic("mock out the AssignCentralCluster method")
+//			},
 //			CentralRotateSecretsFunc: func(ctx context.Context, id string, centralRotateSecretsRequest admin.CentralRotateSecretsRequest) (*http.Response, error) {
 //				panic("mock out the CentralRotateSecrets method")
 //			},
@@ -513,6 +516,9 @@ var _ fleetmanager.AdminAPI = &AdminAPIMock{}
 //
 //	}
 type AdminAPIMock struct {
+	// AssignCentralClusterFunc mocks the AssignCentralCluster method.
+	AssignCentralClusterFunc func(ctx context.Context, id string, centralAssignClusterRequest admin.CentralAssignClusterRequest) (*http.Response, error)
+
 	// CentralRotateSecretsFunc mocks the CentralRotateSecrets method.
 	CentralRotateSecretsFunc func(ctx context.Context, id string, centralRotateSecretsRequest admin.CentralRotateSecretsRequest) (*http.Response, error)
 
@@ -530,6 +536,15 @@ type AdminAPIMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
+		// AssignCentralCluster holds details about calls to the AssignCentralCluster method.
+		AssignCentralCluster []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ID is the id argument value.
+			ID string
+			// CentralAssignClusterRequest is the centralAssignClusterRequest argument value.
+			CentralAssignClusterRequest admin.CentralAssignClusterRequest
+		}
 		// CentralRotateSecrets holds details about calls to the CentralRotateSecrets method.
 		CentralRotateSecrets []struct {
 			// Ctx is the ctx argument value.
@@ -572,11 +587,52 @@ type AdminAPIMock struct {
 			CentralUpdateNameRequest admin.CentralUpdateNameRequest
 		}
 	}
+	lockAssignCentralCluster  sync.RWMutex
 	lockCentralRotateSecrets  sync.RWMutex
 	lockCreateCentral         sync.RWMutex
 	lockDeleteDbCentralById   sync.RWMutex
 	lockGetCentrals           sync.RWMutex
 	lockUpdateCentralNameById sync.RWMutex
+}
+
+// AssignCentralCluster calls AssignCentralClusterFunc.
+func (mock *AdminAPIMock) AssignCentralCluster(ctx context.Context, id string, centralAssignClusterRequest admin.CentralAssignClusterRequest) (*http.Response, error) {
+	if mock.AssignCentralClusterFunc == nil {
+		panic("AdminAPIMock.AssignCentralClusterFunc: method is nil but AdminAPI.AssignCentralCluster was just called")
+	}
+	callInfo := struct {
+		Ctx                         context.Context
+		ID                          string
+		CentralAssignClusterRequest admin.CentralAssignClusterRequest
+	}{
+		Ctx:                         ctx,
+		ID:                          id,
+		CentralAssignClusterRequest: centralAssignClusterRequest,
+	}
+	mock.lockAssignCentralCluster.Lock()
+	mock.calls.AssignCentralCluster = append(mock.calls.AssignCentralCluster, callInfo)
+	mock.lockAssignCentralCluster.Unlock()
+	return mock.AssignCentralClusterFunc(ctx, id, centralAssignClusterRequest)
+}
+
+// AssignCentralClusterCalls gets all the calls that were made to AssignCentralCluster.
+// Check the length with:
+//
+//	len(mockedAdminAPI.AssignCentralClusterCalls())
+func (mock *AdminAPIMock) AssignCentralClusterCalls() []struct {
+	Ctx                         context.Context
+	ID                          string
+	CentralAssignClusterRequest admin.CentralAssignClusterRequest
+} {
+	var calls []struct {
+		Ctx                         context.Context
+		ID                          string
+		CentralAssignClusterRequest admin.CentralAssignClusterRequest
+	}
+	mock.lockAssignCentralCluster.RLock()
+	calls = mock.calls.AssignCentralCluster
+	mock.lockAssignCentralCluster.RUnlock()
+	return calls
 }
 
 // CentralRotateSecrets calls CentralRotateSecretsFunc.


### PR DESCRIPTION
## Description
- Adds a ginkgo e2e test suite for multicluster test
- First test verifies cluster migration between multiple clusters
- Adds a make target to run the tests test/multicluster/e2e
- Moved common logic with other e2e tests to a `testutils` package
- Change admin CentralRequest presenter to actually set the ClusterId, which is required for the test
- See test manual on how to execute this agains 2 infra clusters
- Extends our k8s client pkg to allow loading config for multiple cluster


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

```
# Start 2 infractl clusters OSD on AWS
# Login to kerberos for secret access
kinit jmalsam

export CLUSTER_TYPE="infra-openshift"
export CLUSTER_1_KUBECONFIG=/Users/johannes/kubes/cluster1
export CLUSTER_2_KUBECONFIG=/Users/johannes/kubes/cluster2
export QUAY_USER=<your user>
export QUAY_TOKEN=<your token>
export ENABLE_CENTRAL_EXTERNAL_CERTIFICATE="true"
export ROUTE53_ACCESS_KEY=<route53-key-id>
export ROUTE53_SECRET_ACCESS_KEY=<route53-secret>
export STATIC_TOKEN=<static-token-from-ci>
export STATIC_TOKEN_ADMIN=<static-admin-token-from-ci>

export INFRA_TOKEN=<your-infra-token>

url=$(infractl artifacts jm-migration-1 --json | jq '.Artifacts[] | select(.Name=="kubeconfig") | .URL' -r)
wget -O $CLUSTER_1_KUBECONFIG $url

url=$(infractl artifacts jm-migration-2 --json | jq '.Artifacts[] | select(.Name=="kubeconfig") | .URL' -r)
wget -O $CLUSTER_2_KUBECONFIG $url

bash scripts/ci/multicluster_tests/deploy.sh

# Verify all services are running like expected
KUBECONFIG=$CLUSTER_1_KUBECONFIG k get pods -n rhacs # fleet-manager and fleetshard-sync must be healthy
KUBECONFIG=$CLUSTER_2_KUBECONFIG k get pods -n rhacs # fleetshard-sync must be healthy, fleet-manager does not exist

make test/multicluster/e2e
```
