### PR TITLE
ROX-27131: fix tenant ArgoCD environment variable names

### DIFF
--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -36,9 +36,9 @@ type Config struct {
 	// It is required when central images need to fetched from a private Quay registry.
 	// It needs to given as Docker Config JSON object.
 	TenantImagePullSecret                      string `env:"TENANT_IMAGE_PULL_SECRET"`
-	DefaultTenantArgoCdAppSourceRepoURL        string `env:"DEFAULT_TENANT_ARGOCD_APP_SOURCE_REPO_URL" envDefault:"https://github.com/stackrox/acscs-manifests.git"`
-	DefaultTenantArgoCdAppSourceTargetRevision string `env:"DEFAULT_TENANT_ARGOCD_APP_SOURCE_TARGET_REVISION" envDefault:"HEAD"`
-	DefaultTenantArgoCdAppSourcePath           string `env:"DEFAULT_TENANT_ARGOCD_APP_SOURCE_PATH" envDefault:"tenant-resources"`
+	TenantDefaultArgoCdAppSourceRepoURL        string `env:"TENANT_DEFAULT_ARGOCD_APP_SOURCE_REPO_URL" envDefault:"https://github.com/stackrox/acscs-manifests.git"`
+	TenantDefaultArgoCdAppSourceTargetRevision string `env:"TENANT_DEFAULT_ARGOCD_APP_SOURCE_TARGET_REVISION" envDefault:"HEAD"`
+	TenantDefaultArgoCdAppSourcePath           string `env:"TENANT_DEFAULT_ARGOCD_APP_SOURCE_PATH" envDefault:"tenant-resources"`
 	ArgoCdNamespace                            string `env:"ARGOCD_NAMESPACE" envDefault:"openshift-gitops"`
 	ManagedDB                                  ManagedDB
 	Telemetry                                  Telemetry

--- a/fleetshard/pkg/central/reconciler/argo_reconciler.go
+++ b/fleetshard/pkg/central/reconciler/argo_reconciler.go
@@ -26,9 +26,9 @@ type argoReconciler struct {
 
 // ArgoReconcilerOptions defines configuration options for the Argo application reconiliation
 type ArgoReconcilerOptions struct {
-	DefaultTenantArgoCdAppSourceRepoURL        string
-	DefaultTenantArgoCdAppSourceTargetRevision string
-	DefaultTenantArgoCdAppSourcePath           string
+	TenantDefaultArgoCdAppSourceRepoURL        string
+	TenantDefaultArgoCdAppSourceTargetRevision string
+	TenantDefaultArgoCdAppSourcePath           string
 	ArgoCdNamespace                            string
 	ManagedDBEnabled                           bool
 	ClusterName                                string
@@ -158,9 +158,9 @@ func (r *argoReconciler) makeDesiredArgoCDApplication(remoteCentral private.Mana
 				},
 			},
 			Source: &argocd.ApplicationSource{
-				RepoURL:        r.argoOpts.DefaultTenantArgoCdAppSourceRepoURL,
-				TargetRevision: r.argoOpts.DefaultTenantArgoCdAppSourceTargetRevision,
-				Path:           r.argoOpts.DefaultTenantArgoCdAppSourcePath,
+				RepoURL:        r.argoOpts.TenantDefaultArgoCdAppSourceRepoURL,
+				TargetRevision: r.argoOpts.TenantDefaultArgoCdAppSourceTargetRevision,
+				Path:           r.argoOpts.TenantDefaultArgoCdAppSourcePath,
 				Helm: &argocd.ApplicationSourceHelm{
 					ValuesObject: &runtime.RawExtension{
 						Raw: valuesBytes,

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -132,9 +132,9 @@ func (r *Runtime) Start() error {
 	routesAvailable := r.routesAvailable()
 
 	argoReconcilerOpts := centralReconciler.ArgoReconcilerOptions{
-		DefaultTenantArgoCdAppSourceTargetRevision: r.config.DefaultTenantArgoCdAppSourceTargetRevision,
-		DefaultTenantArgoCdAppSourcePath:           r.config.DefaultTenantArgoCdAppSourcePath,
-		DefaultTenantArgoCdAppSourceRepoURL:        r.config.DefaultTenantArgoCdAppSourceRepoURL,
+		TenantDefaultArgoCdAppSourceTargetRevision: r.config.TenantDefaultArgoCdAppSourceTargetRevision,
+		TenantDefaultArgoCdAppSourcePath:           r.config.TenantDefaultArgoCdAppSourcePath,
+		TenantDefaultArgoCdAppSourceRepoURL:        r.config.TenantDefaultArgoCdAppSourceRepoURL,
 		ArgoCdNamespace:                            r.config.ArgoCdNamespace,
 		ManagedDBEnabled:                           r.config.ManagedDB.Enabled,
 		ClusterName:                                r.config.ClusterName,


### PR DESCRIPTION
## Description
https://issues.redhat.com/browse/ROX-27131
Fixes wrong naming of environment variable names pertaining to tenant's ArgoCD applications

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
