### PR TITLE
Bump golang to 1.22

### DIFF
--- a/.github/workflows/aws-integration.yaml
+++ b/.github/workflows/aws-integration.yaml
@@ -44,10 +44,10 @@ jobs:
       contents: read
     environment: development
     steps:
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
       - name: Cache go module

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
           python-version: '3.12'
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - uses: pre-commit/action@v3.0.1
       - uses: pre-commit/action@v3.0.1
         name: Verify generated files are up-to-date
@@ -81,10 +81,10 @@ jobs:
         uses: n1hility/cancel-previous-runs@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
       - name: Cache go module
@@ -135,10 +135,10 @@ jobs:
           fetch-depth: 0 # Critical for correct image detection in Makefile
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Build and push fleet-manager-tools image to quay.io
         if: github.event_name == 'push'
         env:

--- a/.github/workflows/emailsender-central-compatibility.yaml
+++ b/.github/workflows/emailsender-central-compatibility.yaml
@@ -32,10 +32,10 @@ jobs:
         uses: n1hility/cancel-previous-runs@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up Go 1.21
+      - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Cache go module
         uses: actions/cache@v4
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,7 +91,7 @@ linters-settings:
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: true # require nolint directives to be specific about which linter is being skipped
   staticcheck:
-    go: "1.21"
+    go: "1.22"
     checks: [ all,-ST1000,-ST1001,-ST1003,-ST1005,-SA1019,-SA4001,-ST1016 ]
   wrapcheck: {}
     # ignoreSigRegexps: uncomment to add ignore rules

--- a/.openshift-ci/e2e-runtime/Dockerfile
+++ b/.openshift-ci/e2e-runtime/Dockerfile
@@ -5,7 +5,7 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
 RUN dnf update -y --disablerepo=\* --enablerepo=baseos,appstream && dnf -y install procps make which git gettext jq gcc && dnf clean all && rm -rf /var/cache/dnf
 
-COPY --from=registry.ci.openshift.org/openshift/release:golang-1.21 /usr/local/go /usr/local/go
+COPY --from=registry.ci.openshift.org/openshift/release:golang-1.22 /usr/local/go /usr/local/go
 COPY --from=quay.io/openshift/origin-cli:4.13 /usr/bin/oc /usr/bin
 COPY --from=quay.io/operator-framework/operator-sdk:v1.25 /usr/local/bin/operator-sdk /usr/local/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:1.21 AS build
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:1.22 AS build
 
 USER root
 RUN mkdir /src /rds_ca

--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.21 AS build
+FROM registry.access.redhat.com/ubi8/go-toolset:1.22 AS build
 USER root
 RUN mkdir /src
 WORKDIR /src

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ ACS fleet-manager repository for the ACS managed service.
 
 #### Prerequisites
 
-* [Golang 1.21+](https://golang.org/dl/)
+* [Golang 1.22+](https://golang.org/dl/)
 * [Docker](https://docs.docker.com/get-docker/) - to create database
 * [ocm cli](https://github.com/openshift-online/ocm-cli/releases) - ocm command line tool
 * [Node.js v12.20+](https://nodejs.org/en/download/) and [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)

--- a/emailsender/Dockerfile
+++ b/emailsender/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.21 AS build
+FROM registry.access.redhat.com/ubi8/go-toolset:1.22 AS build
 USER root
 ENV GOFLAGS="-mod=mod"
 

--- a/fleetshard/pkg/central/reconciler/gen/main.go
+++ b/fleetshard/pkg/central/reconciler/gen/main.go
@@ -213,7 +213,7 @@ func findResourceGVK(resource string) (schema.GroupVersionKind, bool, error) {
 	lines := strings.Split(resource, "\n")
 	apiVersion := ""
 	kind := ""
-	for i := 0; i < len(lines); i++ {
+	for i := range len(lines) {
 		if strings.HasPrefix(lines[i], apiVersionPrefix) {
 			apiVersion = strings.TrimSpace(strings.TrimPrefix(lines[i], apiVersionPrefix))
 			continue

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -871,7 +871,7 @@ func (r *CentralReconciler) areSecretsStored(secretsStored []string) bool {
 	copy(secretsStoredCopy, secretsStored)
 	sort.Strings(secretsStoredCopy)
 
-	for i := 0; i < secretsStoredSize; i++ {
+	for i := range secretsStoredSize {
 		if secretsStoredCopy[i] != expectedSecrets[i] {
 			return false
 		}

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -2627,14 +2627,14 @@ func TestEncyrptionSHASumSameObject(t *testing.T) {
 
 	amount := 1000
 	sums := make([]string, 1000)
-	for i := 0; i < amount; i++ {
+	for i := range amount {
 		enc, err := reconciler.encryptSecrets(testSecrets)
 		require.NoError(t, err)
 		sums[i] = enc.sha256Sum
 	}
 
-	for i := 1; i < amount; i++ {
-		require.Equal(t, sums[i-1], sums[i], "hash of the same object should always be equal but was not")
+	for i := range amount {
+		require.Equal(t, sums[i], sums[i+1], "hash of the same object should always be equal but was not")
 	}
 }
 

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -2633,7 +2633,7 @@ func TestEncyrptionSHASumSameObject(t *testing.T) {
 		sums[i] = enc.sha256Sum
 	}
 
-	for i := range amount {
+	for i := range amount - 1 {
 		require.Equal(t, sums[i], sums[i+1], "hash of the same object should always be equal but was not")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/acs-fleet-manager
 
-go 1.22.10
+go 1.22.9
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/acs-fleet-manager
 
-go 1.21.8
+go 1.22.10
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/pkg/client/ocm/impl/client_impl.go
+++ b/pkg/client/ocm/impl/client_impl.go
@@ -484,14 +484,7 @@ func (c *client) GetQuotaCostsForProduct(organizationID, resourceName, product s
 
 	req := quotaCostClient.List().Parameter("fetchRelatedResources", true).Parameter("fetchCloudAccounts", true)
 
-	// TODO: go 1.21 can infer the following generic arguments from req
-	//       automatically, so this indirection becomes unnecessary.
-	fetchQuotaCosts := fetchPages[*amsv1.QuotaCostListRequest,
-		*amsv1.QuotaCostListResponse,
-		*amsv1.QuotaCostList,
-		*amsv1.QuotaCost,
-	]
-	err := fetchQuotaCosts(req, 100, 1000, func(qc *amsv1.QuotaCost) bool {
+	err := fetchPages(req, 100, 1000, func(qc *amsv1.QuotaCost) bool {
 		relatedResourcesList := qc.RelatedResources()
 		for _, relatedResource := range relatedResourcesList {
 			if relatedResource.ResourceName() == resourceName && relatedResource.Product() == product {

--- a/pkg/client/ocm/impl/client_test.go
+++ b/pkg/client/ocm/impl/client_test.go
@@ -9,13 +9,7 @@ import (
 func TestFetchPages(t *testing.T) {
 	testPager := NewMoqPager(make([]testDataType, 21))
 	n := 0
-	// TODO: go 1.21 can infer the generic parameters from testPager.
-	testFetcher := fetchPages[
-		*paginatedRequestMoqImpl,
-		*paginatedResponseMoqImpl,
-		*paginatedResponseMoqImpl,
-		testDataType]
-	err := testFetcher(testPager, 5, 30, func(_ testDataType) bool {
+	err := fetchPages(testPager, 5, 30, func(_ testDataType) bool {
 		n++
 		return true
 	})
@@ -23,7 +17,7 @@ func TestFetchPages(t *testing.T) {
 	assert.Equal(t, 21, n, "Should fetch data from all pages")
 
 	n = 0
-	err = testFetcher(testPager, 5, 30, func(_ testDataType) bool {
+	err = fetchPages(testPager, 5, 30, func(_ testDataType) bool {
 		n++
 		return n < 11
 	})
@@ -31,7 +25,7 @@ func TestFetchPages(t *testing.T) {
 	assert.Equal(t, 11, n, "Should stop if the functor returns false")
 
 	n = 0
-	err = testFetcher(testPager, 5, 2, func(_ testDataType) bool {
+	err = fetchPages(testPager, 5, 2, func(_ testDataType) bool {
 		n++
 		return true
 	})
@@ -39,7 +33,7 @@ func TestFetchPages(t *testing.T) {
 	assert.Equal(t, 5*2, n, "Should iterate over all pages until error")
 
 	n = 0
-	err = testFetcher(testPager, 5, 5, func(_ testDataType) bool {
+	err = fetchPages(testPager, 5, 5, func(_ testDataType) bool {
 		n++
 		return true
 	})

--- a/pkg/client/redhatsso/serviceaccounts/integration/client_test.go
+++ b/pkg/client/redhatsso/serviceaccounts/integration/client_test.go
@@ -41,7 +41,7 @@ func Test_SSOClient_GetServiceAccounts(t *testing.T) {
 	api := getServiceAccountsAPI(server.BaseURL(), clientID, clientSecret)
 
 	// create 20 service accounts
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		_, _, err := api.CreateServiceAccount(emptyCtx).
 			ServiceAccountCreateRequestData(createRequestData(fmt.Sprintf("test_%d", i), fmt.Sprintf("test account %d", i))).
 			Execute()
@@ -68,7 +68,7 @@ func Test_SSOClient_GetServiceAccount(t *testing.T) {
 
 	var serviceAccountList []serviceaccountsclient.ServiceAccountData
 	// create 20 service accounts
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		serviceAccount, _, err := api.CreateServiceAccount(emptyCtx).
 			ServiceAccountCreateRequestData(createRequestData(fmt.Sprintf("test_%d", i), fmt.Sprintf("test account %d", i))).
 			Execute()
@@ -142,7 +142,7 @@ func Test_SSOClient_DeleteServiceAccount(t *testing.T) {
 	api := getServiceAccountsAPI(server.BaseURL(), clientID, clientSecret)
 
 	// create 20 service accounts
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		_, _, err := api.CreateServiceAccount(emptyCtx).
 			ServiceAccountCreateRequestData(createRequestData(fmt.Sprintf("test_%d", i), fmt.Sprintf("test account %d", i))).
 			Execute()
@@ -176,7 +176,7 @@ func Test_SSOClient_UpdateServiceAccount(t *testing.T) {
 	client := getServiceAccountsAPI(server.BaseURL(), clientID, clientSecret)
 
 	// create 20 service accounts
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		_, _, err := client.CreateServiceAccount(emptyCtx).
 			ServiceAccountCreateRequestData(createRequestData(fmt.Sprintf("test_%d", i), fmt.Sprintf("test account %d", i))).
 			Execute()

--- a/pkg/db/model_type_check.go
+++ b/pkg/db/model_type_check.go
@@ -15,7 +15,7 @@ func IsStructWithoutPointers(s any) bool {
 		return false
 	}
 
-	for i := 0; i < typ.NumField(); i++ {
+	for i := range typ.NumField() {
 		if typ.Field(i).Type.Kind() == reflect.Ptr {
 			return false
 		}

--- a/pkg/services/account/account_mock.go
+++ b/pkg/services/account/account_mock.go
@@ -37,7 +37,7 @@ func (a mock) GetOrganization(filter string) (*Organization, error) {
 func buildMockOrganizationList(count int) *OrganizationList {
 	var mockOrgs []*Organization
 
-	for i := 0; i < count; i++ {
+	for i := range count {
 		mockOrgs = append(mockOrgs,
 			&Organization{
 				ID:            fmt.Sprintf(mockOrgIDTemplate, i),

--- a/probe/Dockerfile
+++ b/probe/Dockerfile
@@ -1,10 +1,10 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.21 AS build
+FROM registry.access.redhat.com/ubi8/go-toolset:1.22 AS build
 USER root
 ENV GOFLAGS="-mod=mod"
 
 RUN mkdir /src
 WORKDIR /src
-RUN CGO_ENABLED=0 go install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@v1.21.2
+RUN CGO_ENABLED=0 go install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@v1.22.1
 COPY go.*  ./
 RUN go mod download
 COPY . ./

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/acs-fleet-manager/tools
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-bindata/go-bindata/v3 v3.1.4-0.20210427095211-26949cc13d95


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Migrate to 1.22 golang
_Note_: `ubi8/go-toolset` support only 1.22.9 golang version ATM

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual


```
make binary
```
