### PR TITLE
ROX-25966: Add tenantID to email from alias

### DIFF
--- a/emailsender/pkg/email/sender.go
+++ b/emailsender/pkg/email/sender.go
@@ -11,13 +11,14 @@ import (
 	"github.com/stackrox/acs-fleet-manager/emailsender/pkg/metrics"
 )
 
-const fromTemplate = "From: RHACS Cloud Service <%s>\r\n"
-
 const (
 	// EmailProviderAWSSES is the type name for the AWSEmailSender implementation of the Sender interface
 	EmailProviderAWSSES = "AWS_SES"
 	// EmailProviderLog is the type name for the LogEmailSender implementation of the Sender interface
 	EmailProviderLog = "LOG"
+
+	toFormat   = "To: %s\r\n"
+	fromFormat = "From: RHACS Cloud Service %s <%s>\r\n"
 )
 
 // Sender defines the interface to send emails
@@ -73,8 +74,8 @@ func (s *AWSMailSender) Send(ctx context.Context, to []string, rawMessage []byte
 		metrics.DefaultInstance().IncThrottledSendEmail(tenantID)
 		return fmt.Errorf("rate limit exceeded for tenant: %s", tenantID)
 	}
-	fromBytes := []byte(fmt.Sprintf(fromTemplate, s.from))
-	toBytes := []byte(fmt.Sprintf("To: %s\r\n", strings.Join(to, ",")))
+	fromBytes := []byte(fmt.Sprintf(fromFormat, tenantID, s.from))
+	toBytes := []byte(fmt.Sprintf(toFormat, strings.Join(to, ",")))
 
 	raw := bytes.Join([][]byte{fromBytes, toBytes, rawMessage}, nil)
 	metrics.DefaultInstance().IncSendEmail(tenantID)

--- a/emailsender/pkg/email/sender_test.go
+++ b/emailsender/pkg/email/sender_test.go
@@ -139,7 +139,7 @@ func TestSendAppendsFromAndTo(t *testing.T) {
 	require.NotEmpty(t, msg)
 
 	stringMsg := string(msg)
-	require.Contains(t, stringMsg, "From: RHACS Cloud Service <sender@example.com>\r\n")
+	require.Contains(t, stringMsg, "From: RHACS Cloud Service test-tenant-id <sender@example.com>\r\n")
 	require.Contains(t, stringMsg, "To: to1@example.com,to2@example.com\r\n")
 
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Add tenantID to the email sender Alias to make it clear that email sent for specific instance 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

N/A
