### PR TITLE
chore: skip OperatorGroup for openshift-logging if exists

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/logging/templates/01-logging-04-operator-group.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/logging/templates/01-logging-04-operator-group.yaml
@@ -1,3 +1,4 @@
+{{- if not (lookup "operators.coreos.com/v1" "OperatorGroup" "openshift-logging" "openshift-logging") }}
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -7,3 +8,4 @@ spec:
   targetNamespaces:
     - openshift-logging
   upgradeStrategy: Default
+{{- end}}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Skip helm creating `OperatorGroup` for `openshift-logging` if it exists already to prevent FSS Addon reconciliation error

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

N/A
