### PR TITLE
ROX-27129: extract managed-db-reconciler

### DIFF
--- a/fleetshard/pkg/central/reconciler/managed_db_reconciler.go
+++ b/fleetshard/pkg/central/reconciler/managed_db_reconciler.go
@@ -1,0 +1,230 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/cloudprovider"
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/postgres"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
+	corev1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type managedDbReconciler struct {
+	client                      ctrlClient.Client
+	managedDBProvisioningClient cloudprovider.DBClient
+	managedDBInitFunc           postgres.CentralDBInitFunc
+}
+
+func newManagedDbReconciler(client ctrlClient.Client, managedDBProvisioningClient cloudprovider.DBClient, managedDBInitFunc postgres.CentralDBInitFunc) *managedDbReconciler {
+	return &managedDbReconciler{
+		client:                      client,
+		managedDBProvisioningClient: managedDBProvisioningClient,
+		managedDBInitFunc:           managedDBInitFunc,
+	}
+}
+
+func (r *managedDbReconciler) ensureDeleted(ctx context.Context, remoteCentral private.ManagedCentral) (bool, error) {
+	// skip Snapshot for remoteCentral created by probe
+	skipSnapshot := remoteCentral.Metadata.Internal
+
+	databaseID, err := r.getDatabaseID(ctx, remoteCentral.Metadata.Namespace, remoteCentral.Id)
+	if err != nil {
+		return false, fmt.Errorf("getting DB ID: %w", err)
+	}
+
+	err = r.managedDBProvisioningClient.EnsureDBDeprovisioned(databaseID, skipSnapshot)
+	if err != nil {
+		if errors.Is(err, cloudprovider.ErrDBBackupInProgress) {
+			glog.Infof("Can not delete Central DB for: %s, backup in progress", remoteCentral.Metadata.Namespace)
+			return false, nil
+		}
+
+		return false, fmt.Errorf("deprovisioning DB: %v", err)
+	}
+	return true, nil
+}
+
+// getDatabaseID returns the cloud database ID for a central tenant.
+// By default the database ID is equal to the centralID. It can be overridden by a ConfigMap.
+func (r *managedDbReconciler) getDatabaseID(ctx context.Context, remoteCentralNamespace, centralID string) (string, error) {
+	configMap := &corev1.ConfigMap{}
+	err := r.client.Get(ctx, ctrlClient.ObjectKey{Namespace: remoteCentralNamespace, Name: centralDbOverrideConfigMap}, configMap)
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			return centralID, nil
+		}
+
+		return centralID, fmt.Errorf("getting central DB ID override ConfigMap: %w", err)
+	}
+
+	overrideValue, exists := configMap.Data["databaseID"]
+	if exists {
+		glog.Infof("The database ID for Central %s is overridden with: %s", centralID, overrideValue)
+		return overrideValue, nil
+	}
+
+	glog.Infof("The %s ConfigMap exists but contains no databaseID field, using default: %s", centralDbOverrideConfigMap, centralID)
+	return centralID, nil
+}
+
+func (r *managedDbReconciler) getCentralDBConnectionString(ctx context.Context, remoteCentral *private.ManagedCentral) (string, error) {
+	centralDBUserExists, err := r.centralDBUserExists(ctx, remoteCentral.Metadata.Namespace)
+	if err != nil {
+		return "", err
+	}
+
+	// If a Central DB user already exists, it means the managed DB was already
+	// provisioned and successfully created (access to a running Postgres instance is a
+	// precondition to create this user)
+	if !centralDBUserExists {
+		if err := r.ensureManagedCentralDBInitialized(ctx, remoteCentral); err != nil {
+			return "", fmt.Errorf("initializing managed DB: %w", err)
+		}
+	}
+
+	databaseID, err := r.getDatabaseID(ctx, remoteCentral.Metadata.Namespace, remoteCentral.Id)
+	if err != nil {
+		return "", fmt.Errorf("getting DB ID: %w", err)
+	}
+
+	dbConnection, err := r.managedDBProvisioningClient.GetDBConnection(databaseID)
+	if err != nil {
+		if !errors.Is(err, cloudprovider.ErrDBNotFound) {
+			return "", fmt.Errorf("getting RDS DB connection data: %w", err)
+		}
+
+		glog.Infof("expected DB for %s not found, trying to restore...", remoteCentral.Id)
+		// Using no password because we try to restore from backup
+		err := r.managedDBProvisioningClient.EnsureDBProvisioned(ctx, remoteCentral.Id, remoteCentral.Id, "", remoteCentral.Metadata.Internal)
+		if err != nil {
+			return "", fmt.Errorf("trying to restore DB: %w", err)
+		}
+	}
+
+	return dbConnection.GetConnectionForUserAndDB(dbCentralUserName, postgres.CentralDBName).WithSSLRootCert(postgres.DatabaseCACertificatePathCentral).AsConnectionString(), nil
+}
+
+func (r *managedDbReconciler) centralDBUserExists(ctx context.Context, remoteCentralNamespace string) (bool, error) {
+	secret := &corev1.Secret{}
+	err := r.client.Get(ctx, ctrlClient.ObjectKey{Namespace: remoteCentralNamespace, Name: centralDbSecretName}, secret)
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("getting central DB secret: %w", err)
+	}
+
+	if secret.Annotations == nil {
+		// if the annotation section is missing, assume it's the master password
+		return false, nil
+	}
+
+	dbUserType, exists := secret.Annotations[dbUserTypeAnnotation]
+	if !exists {
+		// legacy Centrals use the master password and do not have this annotation
+		return false, nil
+	}
+
+	return dbUserType == dbUserTypeCentral, nil
+}
+
+func (r *managedDbReconciler) ensureManagedCentralDBInitialized(ctx context.Context, remoteCentral *private.ManagedCentral) error {
+	remoteCentralNamespace := remoteCentral.Metadata.Namespace
+
+	centralDBSecretExists, err := r.centralDBSecretExists(ctx, remoteCentralNamespace)
+	if err != nil {
+		return err
+	}
+
+	if !centralDBSecretExists {
+		dbMasterPassword, err := generateDBPassword()
+		if err != nil {
+			return fmt.Errorf("generating Central DB master password: %w", err)
+		}
+		if err := r.ensureCentralDBSecretExists(ctx, remoteCentralNamespace, dbUserTypeMaster, dbMasterPassword); err != nil {
+			return fmt.Errorf("ensuring that DB secret exists: %w", err)
+		}
+	}
+
+	dbMasterPassword, err := r.getDBPasswordFromSecret(ctx, remoteCentralNamespace)
+	if err != nil {
+		return fmt.Errorf("getting DB password from secret: %w", err)
+	}
+
+	databaseID, err := r.getDatabaseID(ctx, remoteCentralNamespace, remoteCentral.Id)
+	if err != nil {
+		return fmt.Errorf("getting DB ID: %w", err)
+	}
+
+	err = r.managedDBProvisioningClient.EnsureDBProvisioned(ctx, databaseID, remoteCentral.Id, dbMasterPassword, remoteCentral.Metadata.Internal)
+	if err != nil {
+		return fmt.Errorf("provisioning RDS DB: %w", err)
+	}
+
+	dbConnection, err := r.managedDBProvisioningClient.GetDBConnection(databaseID)
+	if err != nil {
+		return fmt.Errorf("getting RDS DB connection data: %w", err)
+	}
+
+	dbCentralPassword, err := generateDBPassword()
+	if err != nil {
+		return fmt.Errorf("generating Central DB password: %w", err)
+	}
+	err = r.managedDBInitFunc(ctx, dbConnection.WithPassword(dbMasterPassword).WithSSLRootCert(postgres.DatabaseCACertificatePathFleetshard),
+		dbCentralUserName, dbCentralPassword)
+	if err != nil {
+		return fmt.Errorf("initializing managed DB: %w", err)
+	}
+
+	// Replace the password stored in the secret. This replaces the master password (the password of the
+	// rds_superuser account) with the password of the Central user. Note that we don't store
+	// the master password anywhere from this point on.
+	err = r.ensureCentralDBSecretExists(ctx, remoteCentralNamespace, dbUserTypeCentral, dbCentralPassword)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *managedDbReconciler) centralDBSecretExists(ctx context.Context, remoteCentralNamespace string) (bool, error) {
+	return checkSecretExists(ctx, r.client, remoteCentralNamespace, centralDbSecretName)
+}
+
+func (r *managedDbReconciler) ensureCentralDBSecretExists(ctx context.Context, remoteCentralNamespace, userType, password string) error {
+	setPasswordFunc := func(secret *corev1.Secret, userType, password string) {
+		secret.Data = map[string][]byte{"password": []byte(password)}
+		if secret.Annotations == nil {
+			secret.Annotations = make(map[string]string)
+		}
+		secret.Annotations[dbUserTypeAnnotation] = userType
+	}
+	return ensureSecretExists(ctx, r.client, remoteCentralNamespace, centralDbSecretName, func(secret *corev1.Secret) error {
+		setPasswordFunc(secret, userType, password)
+		return nil
+	})
+}
+
+func (r *managedDbReconciler) getDBPasswordFromSecret(ctx context.Context, centralNamespace string) (string, error) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: centralDbSecretName,
+		},
+	}
+	err := r.client.Get(ctx, ctrlClient.ObjectKey{Namespace: centralNamespace, Name: centralDbSecretName}, secret)
+	if err != nil {
+		return "", fmt.Errorf("getting Central DB password from secret: %w", err)
+	}
+
+	if dbPassword, ok := secret.Data["password"]; ok {
+		return string(dbPassword), nil
+	}
+
+	return "", fmt.Errorf("central DB secret does not contain password field: %w", err)
+}

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -144,9 +144,8 @@ type CentralReconciler struct {
 	auditLogging           config.AuditLogging
 	encryptionKeyGenerator cipher.KeyGenerator
 
-	managedDBEnabled            bool
-	managedDBProvisioningClient cloudprovider.DBClient
-	managedDBInitFunc           postgres.CentralDBInitFunc
+	managedDbReconciler *managedDbReconciler
+	managedDBEnabled    bool
 
 	wantsAuthProvider      bool
 	hasAuthProvider        bool
@@ -415,7 +414,7 @@ func (r *CentralReconciler) applyTelemetry(remoteCentral *private.ManagedCentral
 func (r *CentralReconciler) restoreCentralSecrets(ctx context.Context, remoteCentral private.ManagedCentral) error {
 	restoreSecrets := []string{}
 	for _, secretName := range remoteCentral.Metadata.SecretsStored { // pragma: allowlist secret
-		exists, err := r.checkSecretExists(ctx, remoteCentral.Metadata.Namespace, secretName)
+		exists, err := checkSecretExists(ctx, r.client, remoteCentral.Metadata.Namespace, secretName)
 		if err != nil {
 			return err
 		}
@@ -511,7 +510,7 @@ func (r *CentralReconciler) reconcileCentralDBConfig(ctx context.Context, remote
 		return nil
 	}
 
-	centralDBConnectionString, err := r.getCentralDBConnectionString(ctx, remoteCentral)
+	centralDBConnectionString, err := r.managedDbReconciler.getCentralDBConnectionString(ctx, remoteCentral)
 	if err != nil {
 		return fmt.Errorf("getting Central DB connection string: %w", err)
 	}
@@ -658,8 +657,9 @@ func (r *CentralReconciler) configureAuthProvider(secret *corev1.Secret, remoteC
 func (r *CentralReconciler) reconcileDeclarativeConfigurationData(ctx context.Context,
 	remoteCentral private.ManagedCentral) error {
 	namespace := remoteCentral.Metadata.Namespace
-	return r.ensureSecretExists(
+	return ensureSecretExists(
 		ctx,
+		r.client,
 		namespace,
 		sensibleDeclarativeConfigSecretName,
 		func(secret *corev1.Secret) error {
@@ -998,51 +998,14 @@ func (r *CentralReconciler) ensureCentralDeleted(ctx context.Context, remoteCent
 	globalDeleted = globalDeleted && podsTerminated
 
 	if r.managedDBEnabled {
-		// skip Snapshot for remoteCentral created by probe
-		skipSnapshot := remoteCentral.Metadata.Internal
-
-		databaseID, err := r.getDatabaseID(ctx, remoteCentral.Metadata.Namespace, remoteCentral.Id)
+		dbDeleted, err := r.managedDbReconciler.ensureDeleted(ctx, *remoteCentral)
 		if err != nil {
-			return false, fmt.Errorf("getting DB ID: %w", err)
+			return false, err
 		}
-
-		err = r.managedDBProvisioningClient.EnsureDBDeprovisioned(databaseID, skipSnapshot)
-		if err != nil {
-			if errors.Is(err, cloudprovider.ErrDBBackupInProgress) {
-				glog.Infof("Can not delete Central DB for: %s, backup in progress", remoteCentral.Metadata.Namespace)
-				return false, nil
-			}
-
-			return false, fmt.Errorf("deprovisioning DB: %v", err)
-		}
-		dbDeleted := true
 		globalDeleted = globalDeleted && dbDeleted
 	}
 
 	return globalDeleted, nil
-}
-
-// getDatabaseID returns the cloud database ID for a central tenant.
-// By default the database ID is equal to the centralID. It can be overridden by a ConfigMap.
-func (r *CentralReconciler) getDatabaseID(ctx context.Context, remoteCentralNamespace, centralID string) (string, error) {
-	configMap := &corev1.ConfigMap{}
-	err := r.client.Get(ctx, ctrlClient.ObjectKey{Namespace: remoteCentralNamespace, Name: centralDbOverrideConfigMap}, configMap)
-	if err != nil {
-		if apiErrors.IsNotFound(err) {
-			return centralID, nil
-		}
-
-		return centralID, fmt.Errorf("getting central DB ID override ConfigMap: %w", err)
-	}
-
-	overrideValue, exists := configMap.Data["databaseID"]
-	if exists {
-		glog.Infof("The database ID for Central %s is overridden with: %s", centralID, overrideValue)
-		return overrideValue, nil
-	}
-
-	glog.Infof("The %s ConfigMap exists but contains no databaseID field, using default: %s", centralDbOverrideConfigMap, centralID)
-	return centralID, nil
 }
 
 // centralChanged compares the given central to the last central reconciled using a hash
@@ -1121,7 +1084,7 @@ func (r *CentralReconciler) ensureImagePullSecretConfigured(ctx context.Context,
 }
 
 func (r *CentralReconciler) ensureEncryptionKeySecretExists(ctx context.Context, remoteCentralNamespace string) error {
-	return r.ensureSecretExists(ctx, remoteCentralNamespace, centralEncryptionKeySecretName, r.populateEncryptionKeySecret)
+	return ensureSecretExists(ctx, r.client, remoteCentralNamespace, centralEncryptionKeySecretName, r.populateEncryptionKeySecret)
 }
 
 func (r *CentralReconciler) populateEncryptionKeySecret(secret *corev1.Secret) error {
@@ -1165,43 +1128,6 @@ func generateNewKeyChainFile(b64Key string) ([]byte, error) {
 	return yamlBytes, nil
 }
 
-func (r *CentralReconciler) getCentralDBConnectionString(ctx context.Context, remoteCentral *private.ManagedCentral) (string, error) {
-	centralDBUserExists, err := r.centralDBUserExists(ctx, remoteCentral.Metadata.Namespace)
-	if err != nil {
-		return "", err
-	}
-
-	// If a Central DB user already exists, it means the managed DB was already
-	// provisioned and successfully created (access to a running Postgres instance is a
-	// precondition to create this user)
-	if !centralDBUserExists {
-		if err := r.ensureManagedCentralDBInitialized(ctx, remoteCentral); err != nil {
-			return "", fmt.Errorf("initializing managed DB: %w", err)
-		}
-	}
-
-	databaseID, err := r.getDatabaseID(ctx, remoteCentral.Metadata.Namespace, remoteCentral.Id)
-	if err != nil {
-		return "", fmt.Errorf("getting DB ID: %w", err)
-	}
-
-	dbConnection, err := r.managedDBProvisioningClient.GetDBConnection(databaseID)
-	if err != nil {
-		if !errors.Is(err, cloudprovider.ErrDBNotFound) {
-			return "", fmt.Errorf("getting RDS DB connection data: %w", err)
-		}
-
-		glog.Infof("expected DB for %s not found, trying to restore...", remoteCentral.Id)
-		// Using no password because we try to restore from backup
-		err := r.managedDBProvisioningClient.EnsureDBProvisioned(ctx, remoteCentral.Id, remoteCentral.Id, "", remoteCentral.Metadata.Internal)
-		if err != nil {
-			return "", fmt.Errorf("trying to restore DB: %w", err)
-		}
-	}
-
-	return dbConnection.GetConnectionForUserAndDB(dbCentralUserName, postgres.CentralDBName).WithSSLRootCert(postgres.DatabaseCACertificatePathCentral).AsConnectionString(), nil
-}
-
 func generateDBPassword() (string, error) {
 	password, err := random.GenerateString(25, random.AlphanumericCharacters)
 	if err != nil {
@@ -1209,126 +1135,6 @@ func generateDBPassword() (string, error) {
 	}
 
 	return password, nil
-}
-
-func (r *CentralReconciler) ensureManagedCentralDBInitialized(ctx context.Context, remoteCentral *private.ManagedCentral) error {
-	remoteCentralNamespace := remoteCentral.Metadata.Namespace
-
-	centralDBSecretExists, err := r.centralDBSecretExists(ctx, remoteCentralNamespace)
-	if err != nil {
-		return err
-	}
-
-	if !centralDBSecretExists {
-		dbMasterPassword, err := generateDBPassword()
-		if err != nil {
-			return fmt.Errorf("generating Central DB master password: %w", err)
-		}
-		if err := r.ensureCentralDBSecretExists(ctx, remoteCentralNamespace, dbUserTypeMaster, dbMasterPassword); err != nil {
-			return fmt.Errorf("ensuring that DB secret exists: %w", err)
-		}
-	}
-
-	dbMasterPassword, err := r.getDBPasswordFromSecret(ctx, remoteCentralNamespace)
-	if err != nil {
-		return fmt.Errorf("getting DB password from secret: %w", err)
-	}
-
-	databaseID, err := r.getDatabaseID(ctx, remoteCentralNamespace, remoteCentral.Id)
-	if err != nil {
-		return fmt.Errorf("getting DB ID: %w", err)
-	}
-
-	err = r.managedDBProvisioningClient.EnsureDBProvisioned(ctx, databaseID, remoteCentral.Id, dbMasterPassword, remoteCentral.Metadata.Internal)
-	if err != nil {
-		return fmt.Errorf("provisioning RDS DB: %w", err)
-	}
-
-	dbConnection, err := r.managedDBProvisioningClient.GetDBConnection(databaseID)
-	if err != nil {
-		return fmt.Errorf("getting RDS DB connection data: %w", err)
-	}
-
-	dbCentralPassword, err := generateDBPassword()
-	if err != nil {
-		return fmt.Errorf("generating Central DB password: %w", err)
-	}
-	err = r.managedDBInitFunc(ctx, dbConnection.WithPassword(dbMasterPassword).WithSSLRootCert(postgres.DatabaseCACertificatePathFleetshard),
-		dbCentralUserName, dbCentralPassword)
-	if err != nil {
-		return fmt.Errorf("initializing managed DB: %w", err)
-	}
-
-	// Replace the password stored in the secret. This replaces the master password (the password of the
-	// rds_superuser account) with the password of the Central user. Note that we don't store
-	// the master password anywhere from this point on.
-	err = r.ensureCentralDBSecretExists(ctx, remoteCentralNamespace, dbUserTypeCentral, dbCentralPassword)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (r *CentralReconciler) ensureCentralDBSecretExists(ctx context.Context, remoteCentralNamespace, userType, password string) error {
-	setPasswordFunc := func(secret *corev1.Secret, userType, password string) {
-		secret.Data = map[string][]byte{"password": []byte(password)}
-		if secret.Annotations == nil {
-			secret.Annotations = make(map[string]string)
-		}
-		secret.Annotations[dbUserTypeAnnotation] = userType
-	}
-	return r.ensureSecretExists(ctx, remoteCentralNamespace, centralDbSecretName, func(secret *corev1.Secret) error {
-		setPasswordFunc(secret, userType, password)
-		return nil
-	})
-}
-
-func (r *CentralReconciler) centralDBSecretExists(ctx context.Context, remoteCentralNamespace string) (bool, error) {
-	return r.checkSecretExists(ctx, remoteCentralNamespace, centralDbSecretName)
-}
-
-func (r *CentralReconciler) centralDBUserExists(ctx context.Context, remoteCentralNamespace string) (bool, error) {
-	secret := &corev1.Secret{}
-	err := r.client.Get(ctx, ctrlClient.ObjectKey{Namespace: remoteCentralNamespace, Name: centralDbSecretName}, secret)
-	if err != nil {
-		if apiErrors.IsNotFound(err) {
-			return false, nil
-		}
-
-		return false, fmt.Errorf("getting central DB secret: %w", err)
-	}
-
-	if secret.Annotations == nil {
-		// if the annotation section is missing, assume it's the master password
-		return false, nil
-	}
-
-	dbUserType, exists := secret.Annotations[dbUserTypeAnnotation]
-	if !exists {
-		// legacy Centrals use the master password and do not have this annotation
-		return false, nil
-	}
-
-	return dbUserType == dbUserTypeCentral, nil
-}
-
-func (r *CentralReconciler) getDBPasswordFromSecret(ctx context.Context, centralNamespace string) (string, error) {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: centralDbSecretName,
-		},
-	}
-	err := r.client.Get(ctx, ctrlClient.ObjectKey{Namespace: centralNamespace, Name: centralDbSecretName}, secret)
-	if err != nil {
-		return "", fmt.Errorf("getting Central DB password from secret: %w", err)
-	}
-
-	if dbPassword, ok := secret.Data["password"]; ok {
-		return string(dbPassword), nil
-	}
-
-	return "", fmt.Errorf("central DB secret does not contain password field: %w", err)
 }
 
 func (r *CentralReconciler) ensureInstancePodsTerminated(ctx context.Context, central *v1alpha1.Central) (bool, error) {
@@ -1496,70 +1302,6 @@ func (r *CentralReconciler) needsReconcile(changed bool, central *v1alpha1.Centr
 	return ok && forceReconcile == "true"
 }
 
-func (r *CentralReconciler) checkSecretExists(
-	ctx context.Context,
-	remoteCentralNamespace string,
-	secretName string,
-) (bool, error) {
-	secret := &corev1.Secret{}
-	err := r.client.Get(ctx, ctrlClient.ObjectKey{Namespace: remoteCentralNamespace, Name: secretName}, secret)
-	if err != nil {
-		if apiErrors.IsNotFound(err) {
-			return false, nil
-		}
-
-		return false, fmt.Errorf("getting secret %s/%s: %w", remoteCentralNamespace, secretName, err)
-	}
-
-	return true, nil
-}
-
-func (r *CentralReconciler) ensureSecretExists(
-	ctx context.Context,
-	namespace string,
-	secretName string,
-	secretModifyFunc func(secret *corev1.Secret) error,
-) error {
-	secret := &corev1.Secret{}
-	secretKey := ctrlClient.ObjectKey{Name: secretName, Namespace: namespace} // pragma: allowlist secret
-
-	err := r.client.Get(ctx, secretKey, secret) // pragma: allowlist secret
-	if err != nil && !apiErrors.IsNotFound(err) {
-		return fmt.Errorf("getting %s/%s secret: %w", namespace, secretName, err)
-	}
-	if err == nil {
-		modificationErr := secretModifyFunc(secret)
-		if modificationErr != nil {
-			return fmt.Errorf("updating %s/%s secret content: %w", namespace, secretName, modificationErr)
-		}
-		if updateErr := r.client.Update(ctx, secret); updateErr != nil { // pragma: allowlist secret
-			return fmt.Errorf("updating %s/%s secret: %w", namespace, secretName, updateErr)
-		}
-
-		return nil
-	}
-
-	// Create secret if it does not exist.
-	secret = &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{ // pragma: allowlist secret
-			Name:      secretName,
-			Namespace: namespace,
-			Labels:    map[string]string{k8s.ManagedByLabelKey: k8s.ManagedByFleetshardValue},
-			Annotations: map[string]string{
-				managedServicesAnnotation: "true",
-			},
-		},
-	}
-
-	if modificationErr := secretModifyFunc(secret); modificationErr != nil {
-		return fmt.Errorf("initializing %s/%s secret payload: %w", namespace, secretName, modificationErr)
-	}
-	if createErr := r.client.Create(ctx, secret); createErr != nil { // pragma: allowlist secret
-		return fmt.Errorf("creating %s/%s secret: %w", namespace, secretName, createErr)
-	}
-	return nil
-}
-
 func (r *CentralReconciler) configureAdditionalAuthProvider(secret *corev1.Secret, central private.ManagedCentral) error {
 	authProviderConfig := findAdditionalAuthProvider(central)
 	if authProviderConfig == nil {
@@ -1634,6 +1376,7 @@ func NewCentralReconciler(k8sClient ctrlClient.Client, fleetmanagerClient *fleet
 	nsReconciler := newNamespaceReconciler(k8sClient)
 	crReconciler := newCentralCrReconciler(k8sClient)
 	argoReconciler := newArgoReconciler(k8sClient, opts.ArgoReconcilerOptions)
+	dbReconciler := newManagedDbReconciler(k8sClient, managedDBProvisioningClient, managedDBInitFunc)
 	r := &CentralReconciler{
 		client:                 k8sClient,
 		fleetmanagerClient:     fleetmanagerClient,
@@ -1654,9 +1397,8 @@ func NewCentralReconciler(k8sClient ctrlClient.Client, fleetmanagerClient *fleet
 		auditLogging:           opts.AuditLogging,
 		encryptionKeyGenerator: encryptionKeyGenerator,
 
-		managedDBEnabled:            opts.ManagedDBEnabled,
-		managedDBProvisioningClient: managedDBProvisioningClient,
-		managedDBInitFunc:           managedDBInitFunc,
+		managedDbReconciler: dbReconciler,
+		managedDBEnabled:    opts.ManagedDBEnabled,
 
 		verifyAuthProviderFunc: hasAuthProvider,
 		tenantImagePullSecret:  []byte(opts.TenantImagePullSecret),

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -1338,12 +1338,7 @@ func compareSecret(t *testing.T, expectedSecret *v1.Secret, secret *v1.Secret, c
 }
 
 func TestEnsureSecretExists(t *testing.T) {
-	fakeClient, _, r := getClientTrackerAndReconciler(
-		t,
-		defaultCentralConfig,
-		nil,
-		defaultReconcilerOptions,
-	)
+	fakeClient, _ := testutils.NewFakeClientWithTracker(t)
 	secretModifyFunc := func(secret *v1.Secret) error {
 		if secret.Data == nil {
 			secret.Data = make(map[string][]byte)
@@ -1404,7 +1399,7 @@ func TestEnsureSecretExists(t *testing.T) {
 			fetchedSecret := &v1.Secret{}
 			initialSecret := getSecret(tc.secretName, centralNamespace, tc.initialData)
 			assert.NoError(t, fakeClient.Create(ctx, initialSecret))
-			assert.NoError(t, r.ensureSecretExists(ctx, centralNamespace, tc.secretName, secretModifyFunc))
+			assert.NoError(t, ensureSecretExists(ctx, fakeClient, centralNamespace, tc.secretName, secretModifyFunc))
 			assert.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Namespace: centralNamespace, Name: tc.secretName}, fetchedSecret))
 			compareSecret(t, getSecret(tc.secretName, centralNamespace, tc.expectedData), fetchedSecret, false)
 		})
@@ -1417,7 +1412,7 @@ func TestEnsureSecretExists(t *testing.T) {
 		}
 		ctx := context.TODO()
 		fetchedSecret := &v1.Secret{}
-		assert.NoError(t, r.ensureSecretExists(ctx, centralNamespace, secretName, secretModifyFunc))
+		assert.NoError(t, ensureSecretExists(ctx, fakeClient, centralNamespace, secretName, secretModifyFunc))
 		assert.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Namespace: centralNamespace, Name: secretName}, fetchedSecret))
 		compareSecret(t, getSecret(secretName, centralNamespace, expectedData), fetchedSecret, true)
 	})


### PR DESCRIPTION
This PR refactors the `CentralReconciler` to introduce a dedicated `ManagedDbReconciler`

It also changes the `ensureSecretExists` and `checkSecretExists` to be methods without a receiver, rendering them able to be used by other parts of the code. In this case, these methods are both used by `CentralReconciler` and `ManagedDbReconciler`