### PR TITLE
ROX-23278: Allow specifying custom argoCD application source per tenant

### DIFF
--- a/fleetshard/pkg/central/reconciler/argo_reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/argo_reconciler_test.go
@@ -1,0 +1,52 @@
+package reconciler
+
+import (
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSourceGetRepoURL(t *testing.T) {
+	options := ArgoReconcilerOptions{TenantDefaultArgoCdAppSourceRepoURL: "default-repo-url"}
+	r := argoReconciler{argoOpts: options}
+	assert.Equal(t, "default-repo-url", r.getSourceRepoURL(private.ManagedCentral{}))
+	assert.Equal(t, "custom-repo-url", r.getSourceRepoURL(private.ManagedCentral{
+		Spec: private.ManagedCentralAllOfSpec{
+			TenantResourcesValues: map[string]interface{}{
+				"argoCd": map[string]interface{}{
+					"sourceRepoUrl": "custom-repo-url",
+				},
+			},
+		},
+	}))
+}
+
+func TestGetSourcePath(t *testing.T) {
+	options := ArgoReconcilerOptions{TenantDefaultArgoCdAppSourcePath: "default-source-path"}
+	r := argoReconciler{argoOpts: options}
+	assert.Equal(t, "default-source-path", r.getSourcePath(private.ManagedCentral{}))
+	assert.Equal(t, "custom-source-path", r.getSourcePath(private.ManagedCentral{
+		Spec: private.ManagedCentralAllOfSpec{
+			TenantResourcesValues: map[string]interface{}{
+				"argoCd": map[string]interface{}{
+					"sourcePath": "custom-source-path",
+				},
+			},
+		},
+	}))
+}
+
+func TestGetSourceTargetRevision(t *testing.T) {
+	options := ArgoReconcilerOptions{TenantDefaultArgoCdAppSourceTargetRevision: "default-revision"}
+	r := argoReconciler{argoOpts: options}
+	assert.Equal(t, "default-revision", r.getSourceTargetRevision(private.ManagedCentral{}))
+	assert.Equal(t, "custom-revision", r.getSourceTargetRevision(private.ManagedCentral{
+		Spec: private.ManagedCentralAllOfSpec{
+			TenantResourcesValues: map[string]interface{}{
+				"argoCd": map[string]interface{}{
+					"sourceTargetRevision": "custom-revision",
+				},
+			},
+		},
+	}))
+}


### PR DESCRIPTION
This PR adds the capability to specify, through `tenantResourcesValues`, a custom ArgoCD source (path/revision/repo).
This is useful because this allows overriding a single tenant, so that it uses a different set of manifests from the `acscs-manifests` repository.

Example:
```
# gitops config
tenantResources:
  overrides:
    - instanceIds: [...]
      values: |
        argoCd:
          sourceTargetRevision: "abc"
          sourcePath: "/custom-manifests"
          sourceRepoUrl: "github.com/my-custom-repo"
```