### PR TITLE
fix: reset EnteredProvisioningAt for restore operation

### DIFF
--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -859,6 +859,7 @@ func (k *dinosaurService) Restore(ctx context.Context, id string) *errors.Servic
 		// of the expiration manager. If there is still no quota, the grace
 		// period will start over.
 		"ExpiredAt",
+		"EnteredProvisioningAt",
 	}
 
 	// use a new central request, so that unset field for columnsToReset will automatically be set to the zero value
@@ -866,7 +867,9 @@ func (k *dinosaurService) Restore(ctx context.Context, id string) *errors.Servic
 	resetRequest := &dbapi.CentralRequest{}
 	resetRequest.ID = centralRequest.ID
 	resetRequest.Status = dinosaurConstants.CentralRequestStatusPreparing.String()
-	resetRequest.CreatedAt = time.Now()
+	now := time.Now()
+	resetRequest.CreatedAt = now
+	resetRequest.EnteredProvisioningAt = dbapi.TimePtrToNullTime(&now)
 
 	logStateChange("restore", resetRequest.ID, resetRequest)
 

--- a/internal/dinosaur/pkg/services/dinosaur_test.go
+++ b/internal/dinosaur/pkg/services/dinosaur_test.go
@@ -238,7 +238,7 @@ func Test_dinosaurService_RestoreExpiredDinosaurs(t *testing.T) {
 		func(s string, nv []driver.NamedValue) {
 			expiredAt, _ := (nv[11].Value).(*time.Time)
 			assert.Nil(t, expiredAt)
-			assert.Equal(t, "test-id", nv[12].Value)
+			assert.Equal(t, "test-id", nv[13].Value)
 			expiredChecked = true
 		})
 	svcErr := centralService.Restore(context.Background(), "test-id")


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
There's a bug that the restore API for deleted tenants does not reset EnteredProvisioningAt which causes restore to fail.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
