### PR TITLE
fix: update subscription id in the database when changing billing parameters

### DIFF
--- a/internal/dinosaur/pkg/services/dinosaur.go
+++ b/internal/dinosaur/pkg/services/dinosaur.go
@@ -1126,6 +1126,7 @@ func (k *dinosaurService) ChangeBillingParameters(ctx context.Context, centralID
 		return svcErr
 	}
 	updated.subscriptionID = newSubscriptionID
+	centralRequest.SubscriptionID = newSubscriptionID
 
 	if !reflect.DeepEqual(original, updated) {
 		if svcErr = k.UpdateIgnoreNils(centralRequest); svcErr != nil {


### PR DESCRIPTION
## Description
A new subscription is created, but the subscription ID value in the database remains old.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
