### PR TITLE
ROX-27980: Support argocd reconciliation for routes 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -705,6 +705,8 @@ deploy/db:
 .PHONY: deploy/db
 
 # deploys the secrets required by the service to an OpenShift cluster
+# TLS cert and key are base64 encoded because make translates newlines in the shell command output into spaces which makes
+# pem certificates invalid
 deploy/secrets:
 	@oc process -f ./templates/secrets-template.yml --local \
 		-p DATABASE_HOST="fleet-manager-db" \
@@ -723,8 +725,8 @@ deploy/secrets:
 		-p SSO_CLIENT_ID="$(shell ([ -s './secrets/redhatsso-service.clientId' ] && [ -z '${SSO_CLIENT_ID}' ]) && cat ./secrets/redhatsso-service.clientId || echo '${SSO_CLIENT_ID}')" \
 		-p SSO_CLIENT_SECRET="$(shell ([ -s './secrets/redhatsso-service.clientSecret' ] && [ -z '${SSO_CLIENT_SECRET}' ]) && cat ./secrets/redhatsso-service.clientSecret || echo '${SSO_CLIENT_SECRET}')" \
 		-p CENTRAL_IDP_CLIENT_SECRET="$(shell ([ -s './secrets/central.idp-client-secret' ] && [ -z '${CENTRAL_IDP_CLIENT_SECRET}' ]) && cat ./secrets/central.idp-client-secret || echo '${CENTRAL_IDP_CLIENT_SECRET}')" \
-		-p CENTRAL_TLS_CERT="$(shell ([ -s './secrets/central-tls.crt' ] && [ -z '${CENTRAL_TLS_CERT}' ]) && cat ./secrets/central-tls.crt || echo '${CENTRAL_TLS_CERT}')" \
-		-p CENTRAL_TLS_KEY="$(shell ([ -s './secrets/central-tls.key' ] && [ -z '${CENTRAL_TLS_KEY}' ]) && cat ./secrets/central-tls.key || echo '${CENTRAL_TLS_KEY}')" \
+		-p CENTRAL_TLS_CERT="$(shell ([ -s './secrets/central-tls.crt' ] && [ -z '${CENTRAL_TLS_CERT}' ]) && (cat ./secrets/central-tls.crt || echo '${CENTRAL_TLS_CERT}') | base64)" \
+		-p CENTRAL_TLS_KEY="$(shell ([ -s './secrets/central-tls.key' ] && [ -z '${CENTRAL_TLS_KEY}' ]) && (cat ./secrets/central-tls.key || echo '${CENTRAL_TLS_KEY}') | base64)" \
 		| oc apply -f - -n $(NAMESPACE)
 .PHONY: deploy/secrets
 

--- a/dev/config/gitops-config.yaml
+++ b/dev/config/gitops-config.yaml
@@ -42,7 +42,6 @@ tenantResources:
         memory: 100Mi
 
     centralRdsCidrBlock: "10.1.0.0/16"
-    centralIngressEnabled: true
 
     verticalPodAutoscalers:
       central:

--- a/dev/config/gitops-config.yaml
+++ b/dev/config/gitops-config.yaml
@@ -42,6 +42,7 @@ tenantResources:
         memory: 100Mi
 
     centralRdsCidrBlock: "10.1.0.0/16"
+    centralIngressEnabled: true
 
     verticalPodAutoscalers:
       central:

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -237,9 +237,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 
 	centralTLSSecretFound := true // pragma: allowlist secret
 	if r.useRoutes {
-		centralIngressEnabled, ok := remoteCentral.Spec.TenantResourcesValues["centralIngressEnabled"].(bool)
-		if ok && centralIngressEnabled {
-			// Routes / Ingress resources are managed by ArgoCD
+		if routesManagedByArgoCD(remoteCentral) {
 			if err := r.ensureRoutesDeleted(ctx, remoteCentral); err != nil {
 				return nil, err
 			}
@@ -296,6 +294,11 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 	glog.Infof("Returning central status %+v", logStatus)
 
 	return status, nil
+}
+
+func routesManagedByArgoCD(remoteCentral private.ManagedCentral) bool {
+	centralIngressEnabledValue, ok := remoteCentral.Spec.TenantResourcesValues["centralIngressEnabled"].(bool)
+	return ok && centralIngressEnabledValue
 }
 
 func (r *CentralReconciler) reconcileIngressSecrets(ctx context.Context, remoteCentral private.ManagedCentral) (centralTLSSecretFound bool, err error) {

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -235,7 +235,8 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		return nil, err
 	}
 
-	centralTLSSecretFound := true // pragma: allowlist secret
+	// central-tls secret provisioned by the ACS operator.
+	centralTLSSecretProvisioned := true // pragma: allowlist secret
 	if r.useRoutes {
 		if routesManagedByArgoCD(remoteCentral) {
 			if err := r.ensureRoutesDeleted(ctx, remoteCentral); err != nil {
@@ -247,7 +248,8 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		}
 		if err != nil {
 			if k8s.IsCentralTLSNotFound(err) {
-				centralTLSSecretFound = false // pragma: allowlist secret
+				// Not considered as an error, waiting for the ACS operator to create it.
+				centralTLSSecretProvisioned = false // pragma: allowlist secret
 			} else {
 				return nil, errors.Wrap(err, "updating routes")
 			}
@@ -264,7 +266,7 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 		return nil, err
 	}
 
-	if !centralDeploymentReady || !centralTLSSecretFound {
+	if !centralDeploymentReady || !centralTLSSecretProvisioned {
 		if isRemoteCentralProvisioning(remoteCentral) && !needsReconcile { // no changes detected, wait until central become ready
 			return nil, ErrCentralNotChanged
 		}

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -748,7 +748,7 @@ func (r *CentralReconciler) getRoutesStatuses(ctx context.Context, central *priv
 
 	ingresses, err := r.routeService.FindAdmittedIngresses(ctx, central.Metadata.Namespace)
 	if err != nil {
-		return nil, fmt.Errorf("get routes statues: %w", err)
+		return nil, fmt.Errorf("obtaining ingresses for routes statuses: %w", err)
 	}
 	var routesStatuses []private.DataPlaneCentralStatusRoutes
 	for _, ingress := range ingresses {

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -737,21 +737,18 @@ func isRemoteCentralReady(remoteCentral *private.ManagedCentral) bool {
 }
 
 func (r *CentralReconciler) getRoutesStatuses(ctx context.Context, namespace string) ([]private.DataPlaneCentralStatusRoutes, error) {
-	reencryptIngress, err := r.routeService.FindReencryptIngress(ctx, namespace)
+	ingresses, err := r.routeService.FindAdmittedCloudServiceIngresses(ctx, namespace)
 	if err != nil {
-		return nil, fmt.Errorf("obtaining ingress for reencrypt route: %w", err)
+		return nil, fmt.Errorf("get routes statues: %w", err)
 	}
-	passthroughIngress, err := r.routeService.FindPassthroughIngress(ctx, namespace)
-	if err != nil {
-		return nil, fmt.Errorf("obtaining ingress for passthrough route: %w", err)
+	var routesStatuses []private.DataPlaneCentralStatusRoutes
+	for _, ingress := range ingresses {
+		routesStatuses = append(routesStatuses, getRouteStatus(ingress))
 	}
-	return []private.DataPlaneCentralStatusRoutes{
-		getRouteStatus(reencryptIngress),
-		getRouteStatus(passthroughIngress),
-	}, nil
+	return routesStatuses, nil
 }
 
-func getRouteStatus(ingress *openshiftRouteV1.RouteIngress) private.DataPlaneCentralStatusRoutes {
+func getRouteStatus(ingress openshiftRouteV1.RouteIngress) private.DataPlaneCentralStatusRoutes {
 	return private.DataPlaneCentralStatusRoutes{
 		Domain: ingress.Host,
 		Router: ingress.RouterCanonicalHostname,

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -1046,7 +1046,8 @@ func (r *CentralReconciler) ensureCentralCASecretExists(ctx context.Context, cen
 	return centralTLSSecretFound, ensureSecretExists(ctx, r.client, centralNamespace, centralCaTLSSecretName, func(secret *corev1.Secret) error {
 		secret.Type = corev1.SecretTypeTLS
 		secret.Data = map[string][]byte{
-			corev1.TLSCertKey: centralTLSSecret.Data["ca.pem"],
+			corev1.TLSPrivateKeyKey: {},
+			corev1.TLSCertKey:       centralTLSSecret.Data["ca.pem"],
 		}
 		return nil
 	})

--- a/fleetshard/pkg/central/reconciler/util.go
+++ b/fleetshard/pkg/central/reconciler/util.go
@@ -3,9 +3,10 @@ package reconciler
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/k8s"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 
 	centralClientPkg "github.com/stackrox/acs-fleet-manager/fleetshard/pkg/central/client"
 	"github.com/stackrox/rox/pkg/urlfmt"

--- a/templates/secrets-template.yml
+++ b/templates/secrets-template.yml
@@ -75,10 +75,10 @@ parameters:
   description: Client secret used to interact with mas sso
 
 - name: CENTRAL_TLS_CERT
-  description: Central TLS certificate
+  description: Base64 encoded Central TLS certificate
 
 - name: CENTRAL_TLS_KEY
-  description: Central TLS certificate private key
+  description: Base64 encoded Central TLS certificate private key
 
 objects:
 
@@ -119,6 +119,6 @@ objects:
   kind: Secret
   metadata:
     name: fleet-manager-dataplane-certificate
-  stringData:
+  data:
     tls.crt: ${CENTRAL_TLS_CERT}
     tls.key: ${CENTRAL_TLS_KEY}


### PR DESCRIPTION
## Description
Add support for the routes reconciliation on ArgoCD. 
The feature can be now enabled by setting the value `centralIngressEnabled` to `true` in the gitops config.
If disabled (default), reconciliation should be performed in fleetshard-sync mode as before.
If enabled, the routes created by fleetshard-sync are deleted and the reconciliation will be performed by tenant-resources (ArgoCD).

Next steps:
1. Enable the feature on dev environment to make E2E tests pass with the new setup.
2. Enable the feature on the rest environments and effectively delete the routes reconciled by fleetshard-sync.
3. Set `centralIngressEnabled` to true by default in `tenant-resources`
4. Cleanup the fleetshard-sync source code by removing the switch and code which is responsible for the routes reconciliation. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
