### PR TITLE
ROX-16860: Send aggregated statuses and group the total central metric by status

### DIFF
--- a/fleetshard/pkg/central/reconciler/status.go
+++ b/fleetshard/pkg/central/reconciler/status.go
@@ -1,6 +1,9 @@
 package reconciler
 
-import "github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
+import (
+	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/fleetshardmetrics"
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
+)
 
 func readyStatus() *private.DataPlaneCentralStatus {
 	return &private.DataPlaneCentralStatus{
@@ -35,4 +38,33 @@ func installingStatus() *private.DataPlaneCentralStatus {
 			},
 		},
 	}
+}
+
+// StatusesCount is a container that holds counters grouped by statuses
+type StatusesCount map[string]int32
+
+// Increment increments the counter for a given status
+func (c StatusesCount) Increment(status private.DataPlaneCentralStatus) {
+	c[deriveStatusKey(status)]++
+}
+
+// SubmitMetric sets corresponding prometheus metric of total central instances
+func (c StatusesCount) SubmitMetric() {
+	for key, count := range c {
+		fleetshardmetrics.MetricsInstance().SetTotalCentrals(float64(count), key)
+	}
+}
+
+func deriveStatusKey(status private.DataPlaneCentralStatus) string {
+	if status.Conditions == nil || len(status.Conditions) != 1 {
+		return "Invalid"
+	}
+	condition := status.Conditions[0]
+	if condition.Type != "Ready" {
+		return "Invalid"
+	}
+	if condition.Status == "True" {
+		return "Ready"
+	}
+	return condition.Reason
 }

--- a/fleetshard/pkg/central/reconciler/status.go
+++ b/fleetshard/pkg/central/reconciler/status.go
@@ -1,6 +1,8 @@
 package reconciler
 
 import (
+	"strings"
+
 	"github.com/stackrox/acs-fleet-manager/fleetshard/pkg/fleetshardmetrics"
 	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
 )
@@ -43,9 +45,14 @@ func installingStatus() *private.DataPlaneCentralStatus {
 // StatusesCount is a container that holds counters grouped by statuses
 type StatusesCount map[string]int32
 
-// Increment increments the counter for a given status
-func (c StatusesCount) Increment(status private.DataPlaneCentralStatus) {
-	c[deriveStatusKey(status)]++
+// IncrementWithStatus increments the counter for a given status
+func (c StatusesCount) IncrementWithStatus(status private.DataPlaneCentralStatus) {
+	c.Increment(deriveStatusKey(status))
+}
+
+// Increment increments the counter for a given key
+func (c StatusesCount) Increment(key string) {
+	c[key]++
 }
 
 // SubmitMetric sets corresponding prometheus metric of total central instances
@@ -57,14 +64,14 @@ func (c StatusesCount) SubmitMetric() {
 
 func deriveStatusKey(status private.DataPlaneCentralStatus) string {
 	if status.Conditions == nil || len(status.Conditions) != 1 {
-		return "Invalid"
+		return "invalid"
 	}
 	condition := status.Conditions[0]
 	if condition.Type != "Ready" {
-		return "Invalid"
+		return "invalid"
 	}
 	if condition.Status == "True" {
-		return "Ready"
+		return "ready"
 	}
-	return condition.Reason
+	return strings.ToLower(condition.Reason)
 }

--- a/fleetshard/pkg/central/reconciler/status_test.go
+++ b/fleetshard/pkg/central/reconciler/status_test.go
@@ -105,12 +105,12 @@ func TestStatusesCount(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			counter := StatusesCount{}
 			for _, status := range test.statuses {
-				counter.Increment(status)
+				counter.IncrementWithStatus(status)
 			}
-			require.Equal(t, test.wantInvalid, counter["Invalid"])
-			require.Equal(t, test.wantReady, counter["Ready"])
-			require.Equal(t, test.wantInstalling, counter["Installing"])
-			require.Equal(t, test.wantDeleted, counter["Deleted"])
+			require.Equal(t, test.wantInvalid, counter["invalid"])
+			require.Equal(t, test.wantReady, counter["ready"])
+			require.Equal(t, test.wantInstalling, counter["installing"])
+			require.Equal(t, test.wantDeleted, counter["deleted"])
 		})
 	}
 }

--- a/fleetshard/pkg/central/reconciler/status_test.go
+++ b/fleetshard/pkg/central/reconciler/status_test.go
@@ -1,0 +1,116 @@
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/stackrox/acs-fleet-manager/internal/dinosaur/pkg/api/private"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatusesCount(t *testing.T) {
+	tests := []struct {
+		name           string
+		statuses       []private.DataPlaneCentralStatus
+		wantInvalid    int32
+		wantReady      int32
+		wantInstalling int32
+		wantDeleted    int32
+	}{
+		{
+			name: "should contain invalid when status is empty",
+			statuses: []private.DataPlaneCentralStatus{
+				{},
+			},
+			wantInvalid: 1,
+		},
+		{
+			name: "should contain invalid when conditions is nil",
+			statuses: []private.DataPlaneCentralStatus{
+				{
+					Conditions: nil,
+				},
+			},
+			wantInvalid: 1,
+		},
+		{
+			name: "should contain invalid when conditions is empty",
+			statuses: []private.DataPlaneCentralStatus{
+				{
+					Conditions: []private.DataPlaneCentralStatusConditions{},
+				},
+			},
+			wantInvalid: 1,
+		},
+		{
+			name: "should contain invalid when conditions length more than one",
+			statuses: []private.DataPlaneCentralStatus{
+				{
+					Conditions: []private.DataPlaneCentralStatusConditions{
+						{Type: "Ready", Status: "True"},
+						{Type: "Ready", Status: "True"},
+					},
+				},
+			},
+			wantInvalid: 1,
+		},
+		{
+			name: "should contain invalid when conditions type is not ready",
+			statuses: []private.DataPlaneCentralStatus{
+				{
+					Conditions: []private.DataPlaneCentralStatusConditions{
+						{Type: "NotReady", Status: "True"},
+					},
+				},
+			},
+			wantInvalid: 1,
+		},
+		{
+			name: "should contain ready when conditions status is ready",
+			statuses: []private.DataPlaneCentralStatus{
+				*readyStatus(),
+			},
+			wantReady: 1,
+		},
+		{
+			name: "should contain installing when condition is ready and reason is installing",
+			statuses: []private.DataPlaneCentralStatus{
+				*installingStatus(),
+			},
+			wantInstalling: 1,
+		},
+		{
+			name: "should contain installing when condition is ready and reason is installing",
+			statuses: []private.DataPlaneCentralStatus{
+				*deletedStatus(),
+			},
+			wantDeleted: 1,
+		},
+		{
+			name: "should combine multiple statuses",
+			statuses: []private.DataPlaneCentralStatus{
+				*readyStatus(),
+				*readyStatus(),
+				*readyStatus(),
+				*installingStatus(),
+				*installingStatus(),
+				*deletedStatus(),
+			},
+			wantReady:      3,
+			wantInstalling: 2,
+			wantDeleted:    1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			counter := StatusesCount{}
+			for _, status := range test.statuses {
+				counter.Increment(status)
+			}
+			require.Equal(t, test.wantInvalid, counter["Invalid"])
+			require.Equal(t, test.wantReady, counter["Ready"])
+			require.Equal(t, test.wantInstalling, counter["Installing"])
+			require.Equal(t, test.wantDeleted, counter["Deleted"])
+		})
+	}
+}

--- a/fleetshard/pkg/fleetshardmetrics/metrics.go
+++ b/fleetshard/pkg/fleetshardmetrics/metrics.go
@@ -24,7 +24,7 @@ type Metrics struct {
 	centralReconcilations       prometheus.Counter
 	centralReconcilationErrors  prometheus.Counter
 	activeCentralReconcilations prometheus.Gauge
-	totalCentrals               prometheus.Gauge
+	totalCentrals               *prometheus.GaugeVec
 	centralDBClustersUsed       prometheus.Gauge
 	centralDBClustersMax        prometheus.Gauge
 	centralDBInstancesUsed      prometheus.Gauge
@@ -64,8 +64,8 @@ func (m *Metrics) IncCentralReconcilationErrors() {
 }
 
 // SetTotalCentrals sets the metric for total centrals to the given value
-func (m *Metrics) SetTotalCentrals(v float64) {
-	m.totalCentrals.Set(v)
+func (m *Metrics) SetTotalCentrals(v float64, status string) {
+	m.totalCentrals.With(prometheus.Labels{"status": status}).Set(v)
 }
 
 // IncActiveCentralReconcilations increments the metric gauge for active central reconcilations
@@ -152,10 +152,13 @@ func newMetrics() *Metrics {
 			Name: metricsPrefix + "active_central_reconcilations",
 			Help: "The number of currently running central reconcilations",
 		}),
-		totalCentrals: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: metricsPrefix + "total_centrals",
-			Help: "The total number of centrals monitored by fleetshard-sync",
-		}),
+		totalCentrals: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: metricsPrefix + "total_centrals",
+				Help: "The total number of centrals monitored by fleetshard-sync",
+			},
+			[]string{"status"},
+		),
 		centralDBClustersUsed: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: metricsPrefix + "central_db_clusters_used",
 			Help: "The current number of Central DB clusters in the cloud region of fleetshard-sync",

--- a/fleetshard/pkg/fleetshardmetrics/metrics_test.go
+++ b/fleetshard/pkg/fleetshardmetrics/metrics_test.go
@@ -49,8 +49,9 @@ func TestTotalCentrals(t *testing.T) {
 	m := newMetrics()
 	metricName := metricsPrefix + "total_centrals"
 	expectedValue := 37.0
+	expectedStatus := "Ready"
 
-	m.SetTotalCentrals(expectedValue)
+	m.SetTotalCentrals(expectedValue, expectedStatus)
 	metrics := serveMetrics(t, m)
 
 	targetMetric := requireMetric(t, metrics, metricName)

--- a/fleetshard/pkg/fleetshardmetrics/server_test.go
+++ b/fleetshard/pkg/fleetshardmetrics/server_test.go
@@ -33,12 +33,31 @@ func TestMetricsServerServesCustomMetrics(t *testing.T) {
 		"total_central_reconcilations",
 		"total_central_reconcilation_errors",
 		"active_central_reconcilations",
-		"total_centrals",
 	}
 
 	for _, key := range expectedKeys {
 		assert.Containsf(t, metrics, metricsPrefix+key, "expected metrics to contain %s but it did not: %v", key, metrics)
 	}
+}
+
+func TestMetricsServerServesTotalCentralsMetric(t *testing.T) {
+	server := NewMetricsServer(":8081")
+
+	MetricsInstance().SetTotalCentrals(1, "ready")
+
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodGet, "/metrics", nil)
+	require.NoError(t, err, "failed creating metrics requests")
+
+	server.Handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, "status code should be OK")
+
+	promParser := expfmt.TextParser{}
+	metrics, err := promParser.TextToMetricFamilies(rec.Body)
+	require.NoError(t, err, "failed parsing metrics file")
+
+	key := metricsPrefix + "total_centrals"
+	assert.Containsf(t, metrics, key, "expected metrics to contain %s but it did not: %v", key, metrics)
 }
 
 func serveMetrics(t *testing.T, customMetrics *Metrics) metricResponse {

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -278,8 +278,7 @@ func (r *Runtime) handleReconcileResults(results <-chan reconcileResult) {
 
 	for result := range results {
 		central := result.central
-		err := result.err
-		if err != nil {
+		if err := result.err; err != nil {
 			if centralReconciler.IsSkippable(err) {
 				glog.V(10).Infof("Skip sending the status for central %s/%s: %v", central.Metadata.Namespace, central.Metadata.Name, err)
 				statusesCount.Increment(central.RequestStatus) // get previous status
@@ -290,9 +289,8 @@ func (r *Runtime) handleReconcileResults(results <-chan reconcileResult) {
 			}
 		} else {
 			statusesCount.IncrementWithStatus(result.status)
+			statuses[central.Id] = result.status
 		}
-
-		statuses[central.Id] = result.status
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)


### PR DESCRIPTION
## Description
1. Instead of sending a single status for every central in the same reconcile gouroutine, introduce a new goroutine that waits for all the central reconciliation and sends the aggregated status report to fleet-manager. This keeps the main runtime function nonblocking and reduces the number of HTTP requests sent to fleet-manager
2. Added `status` label to `acs_fleetshard_total_centrals` metric that allows to group total centrals by status. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual
- Unit tests
- Manual tests
