### PR TITLE
ROX-28157: emailsender return 429 status on rate limit hit

### DIFF
--- a/emailsender/pkg/api/emailhandler.go
+++ b/emailsender/pkg/api/emailhandler.go
@@ -60,7 +60,7 @@ func (eh *EmailHandler) SendEmail(w http.ResponseWriter, r *http.Request) {
 	if err := eh.emailSender.Send(r.Context(), request.To, request.RawMessage, tenantID); err != nil {
 		var returnErr *apiErrors.ServiceError
 		if errors.As(err, &email.RateLimitError{}) {
-			returnErr = apiErrors.NewWithCause(apiErrors.ErrorTooManyRequests, err, "rate limitted")
+			returnErr = apiErrors.NewWithCause(apiErrors.ErrorTooManyRequests, err, "rate limited")
 		} else {
 			returnErr = apiErrors.GeneralError("cannot send email")
 		}

--- a/emailsender/pkg/api/emailhandler.go
+++ b/emailsender/pkg/api/emailhandler.go
@@ -2,16 +2,18 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/golang/glog"
 	"github.com/stackrox/acs-fleet-manager/emailsender/pkg/email"
 	"github.com/stackrox/acs-fleet-manager/pkg/auth"
-	"github.com/stackrox/acs-fleet-manager/pkg/errors"
+	apiErrors "github.com/stackrox/acs-fleet-manager/pkg/errors"
 	"github.com/stackrox/acs-fleet-manager/pkg/shared"
 )
 
+// EmailHandler defines HTTP handlers for emailsender
 type EmailHandler struct {
 	emailSender email.Sender
 }
@@ -24,12 +26,14 @@ type SendEmailRequest struct {
 
 type Envelope map[string]interface{}
 
+// NewEmailHandler ...
 func NewEmailHandler(emailSender email.Sender) *EmailHandler {
 	return &EmailHandler{
 		emailSender: emailSender,
 	}
 }
 
+// SendEmail is the HTTP handler function to send emails via emailsender
 func (eh *EmailHandler) SendEmail(w http.ResponseWriter, r *http.Request) {
 	var request SendEmailRequest
 
@@ -37,24 +41,30 @@ func (eh *EmailHandler) SendEmail(w http.ResponseWriter, r *http.Request) {
 	jsonDecoder.DisallowUnknownFields()
 
 	if err := jsonDecoder.Decode(&request); err != nil {
-		shared.HandleError(r, w, errors.MalformedRequest("failed to decode send email request payload"))
+		shared.HandleError(r, w, apiErrors.MalformedRequest("failed to decode send email request payload"))
 		return
 	}
 
 	claims, err := auth.GetClaimsFromContext(r.Context())
 	if err != nil {
-		shared.HandleError(r, w, errors.Unauthenticated("failed to get token claims"))
+		shared.HandleError(r, w, apiErrors.Unauthenticated("failed to get token claims"))
 		return
 	}
 
 	tenantID, err := claims.GetTenantID()
 	if err != nil {
-		shared.HandleError(r, w, errors.Unauthenticated("failed to get tenantID"))
+		shared.HandleError(r, w, apiErrors.Unauthenticated("failed to get tenantID"))
 		return
 	}
 
 	if err := eh.emailSender.Send(r.Context(), request.To, request.RawMessage, tenantID); err != nil {
-		shared.HandleError(r, w, errors.GeneralError("cannot send email"))
+		var returnErr *apiErrors.ServiceError
+		if errors.As(err, &email.RateLimitError{}) {
+			returnErr = apiErrors.NewWithCause(apiErrors.ErrorTooManyRequests, err, "rate limitted")
+		} else {
+			returnErr = apiErrors.GeneralError("cannot send email")
+		}
+		shared.HandleError(r, w, returnErr)
 		return
 	}
 

--- a/emailsender/pkg/api/emailhandler_test.go
+++ b/emailsender/pkg/api/emailhandler_test.go
@@ -97,7 +97,7 @@ func TestEmailHandler_SendEmail(t *testing.T) {
 			},
 			req:             httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(jsonReq)),
 			wantCode:        http.StatusTooManyRequests,
-			wantErrorReason: "rate limitted",
+			wantErrorReason: "rate limited",
 		},
 	}
 	for _, tt := range tests {

--- a/emailsender/pkg/api/emailhandler_test.go
+++ b/emailsender/pkg/api/emailhandler_test.go
@@ -88,6 +88,17 @@ func TestEmailHandler_SendEmail(t *testing.T) {
 			wantCode:        http.StatusInternalServerError,
 			wantErrorReason: "cannot send email",
 		},
+		{
+			name: "should return 429 status when SendFunc returns RateLimitError",
+			emailSender: &MockEmailSender{
+				SendFunc: func(ctx context.Context, to []string, rawMessage []byte) error {
+					return email.RateLimitError{TenantID: "test-sub"}
+				},
+			},
+			req:             httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(jsonReq)),
+			wantCode:        http.StatusTooManyRequests,
+			wantErrorReason: "rate limitted",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -114,7 +125,7 @@ func TestEmailHandler_SendEmail(t *testing.T) {
 					t.Errorf("response error body does not have reason key")
 				}
 				if errorReason != tt.wantErrorReason {
-					t.Errorf("expected error reason %s, got %s", tt.wantBody, resp.Body.String())
+					t.Errorf("expected error reason %s, got %s", tt.wantBody, errorReason)
 				}
 			}
 

--- a/emailsender/pkg/client/openapi/api/openapi.yaml
+++ b/emailsender/pkg/client/openapi/api/openapi.yaml
@@ -96,12 +96,21 @@ paths:
               examples:
                 "403Example":
                   $ref: '#/components/examples/403Example'
-                "403TUnauthorizedExample":
-                  $ref: '#/components/examples/403TUnauthorizedExample'
+                "403UnauthorizedExample":
+                  $ref: '#/components/examples/403UnauthorizedExample'
               schema:
                 $ref: '#/components/schemas/Error'
           description: User forbidden either because the user is not authorized to
             access the service
+        "429":
+          content:
+            application/json:
+              examples:
+                "429Example":
+                  $ref: '#/components/examples/429Example'
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Rate limit for the tenant exceeded
         "500":
           content:
             application/json:
@@ -158,7 +167,7 @@ components:
         code: ACSCS-EMAIL-4
         reason: User 'foo-bar' is not authorized to access the service
         operation_id: 1lY3UiEhznXBpWPfI2lNejpd4YC
-    "403TUnauthorizedExample":
+    "403UnauthorizedExample":
       value:
         id: "11"
         kind: Error
@@ -166,6 +175,14 @@ components:
         code: ACSCS-EMAIL-11
         reason: Account is unauthorized to perform this action
         operation_id: kXCzWPeI2oXBpVPeI2LvF9jMQY
+    "429Example":
+      value:
+        id: "429"
+        kind: Error
+        href: /api/v1/acscsemail/errors/429
+        code: ACSCS-EMAIL-429
+        reason: rate limitted
+        operation_id: 1ieELvF9jMQY6YghfM9gGRsHvEW
     "500Example":
       value:
         id: "9"

--- a/emailsender/pkg/client/openapi/api/openapi.yaml
+++ b/emailsender/pkg/client/openapi/api/openapi.yaml
@@ -181,7 +181,7 @@ components:
         kind: Error
         href: /api/v1/acscsemail/errors/429
         code: ACSCS-EMAIL-429
-        reason: rate limitted
+        reason: rate limited
         operation_id: 1ieELvF9jMQY6YghfM9gGRsHvEW
     "500Example":
       value:

--- a/emailsender/pkg/client/openapi/api_default.go
+++ b/emailsender/pkg/client/openapi/api_default.go
@@ -119,6 +119,16 @@ func (a *DefaultApiService) SendEmail(ctx _context.Context, sendEmailPayload Sen
 			newErr.model = v
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
+		if localVarHTTPResponse.StatusCode == 429 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))

--- a/emailsender/pkg/email/ratelimiter_test.go
+++ b/emailsender/pkg/email/ratelimiter_test.go
@@ -23,9 +23,10 @@ func TestAllowTrue_Success(t *testing.T) {
 		dbConnection:   mockDatabaseClient,
 	}
 
-	allowed := service.IsAllowed(testTenantID)
+	allowed, err := service.IsAllowed(testTenantID)
 
 	assert.True(t, allowed)
+	assert.Nil(t, err)
 	assert.True(t, mockDatabaseClient.CalledCountEmailSentByTenantFrom)
 }
 
@@ -41,9 +42,10 @@ func TestAllowFalse_LimitReached(t *testing.T) {
 		dbConnection:   mockDatabaseClient,
 	}
 
-	allowed := service.IsAllowed(testTenantID)
+	allowed, err := service.IsAllowed(testTenantID)
 
 	assert.False(t, allowed)
+	assert.Nil(t, err)
 	assert.True(t, mockDatabaseClient.CalledCountEmailSentByTenantFrom)
 }
 

--- a/openapi/emailsender.yaml
+++ b/openapi/emailsender.yaml
@@ -275,7 +275,7 @@ components:
         kind: "Error"
         href: "/api/v1/acscsemail/errors/429"
         code: "ACSCS-EMAIL-429"
-        reason: "rate limitted"
+        reason: "rate limited"
         operation_id: "1ieELvF9jMQY6YghfM9gGRsHvEW"
     500Example:
       value:

--- a/openapi/emailsender.yaml
+++ b/openapi/emailsender.yaml
@@ -92,9 +92,18 @@ paths:
               examples:
                 403Example:
                   $ref: "#/components/examples/403Example"
-                403TUnauthorizedExample:
-                  $ref: "#/components/examples/403TUnauthorizedExample"
+                403UnauthorizedExample:
+                  $ref: "#/components/examples/403UnauthorizedExample"
           description: User forbidden either because the user is not authorized to access the service
+        "429":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                429Example:
+                  $ref: "#/components/examples/429Example"
+          description: Rate limit for the tenant exceeded
         "500":
           content:
             application/json:
@@ -252,7 +261,7 @@ components:
         code: "ACSCS-EMAIL-4"
         reason: "User 'foo-bar' is not authorized to access the service"
         operation_id: "1lY3UiEhznXBpWPfI2lNejpd4YC"
-    403TUnauthorizedExample:
+    403UnauthorizedExample:
       value:
         id: "11"
         kind: "Error"
@@ -260,6 +269,14 @@ components:
         code: "ACSCS-EMAIL-11"
         reason: "Account is unauthorized to perform this action"
         operation_id: "kXCzWPeI2oXBpVPeI2LvF9jMQY"
+    429Example:
+      value:
+        id: "429"
+        kind: "Error"
+        href: "/api/v1/acscsemail/errors/429"
+        code: "ACSCS-EMAIL-429"
+        reason: "rate limitted"
+        operation_id: "1ieELvF9jMQY6YghfM9gGRsHvEW"
     500Example:
       value:
         id: "9"


### PR DESCRIPTION
## Description

Adds some logic and tests to return 429 rate limited instead if 500 cannot send mail for emailsender.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

CI and local test unit test execution.

