### PR TITLE
Revert "ROX-27835: upgrade external secret operator in dp-terraform"

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/Chart.lock
+++ b/dp-terraform/helm/rhacs-terraform/Chart.lock
@@ -13,9 +13,9 @@ dependencies:
   version: 0.1.0
 - name: external-secrets
   repository: https://charts.external-secrets.io/
-  version: 0.14.4
+  version: 0.9.5
 - name: vertical-pod-autoscaler
   repository: ""
   version: 0.1.0
-digest: sha256:e488ffdb97f3aac4951308985ebd1711023ae8de774237583178ef83063b1181
-generated: "2025-03-17T15:01:48.18316+01:00"
+digest: sha256:0be6aed6c8e38f2703f02e1e70979987839ab27ac7b4b44689025c0283ba67ab
+generated: "2024-11-26T16:20:45.541627+01:00"

--- a/dp-terraform/helm/rhacs-terraform/Chart.yaml
+++ b/dp-terraform/helm/rhacs-terraform/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
     version: "0.1.0"
     condition: secured-cluster.enabled
   - name: external-secrets
-    version: "0.14.4"
+    version: "0.9.5"
     repository: https://charts.external-secrets.io/
     condition: external-secrets.enabled
   - name: vertical-pod-autoscaler

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -202,7 +202,7 @@ external-secrets:
   installCRDs: false
   image:
     repository: quay.io/app-sre/external-secrets
-    tag: v0.14.4
+    tag: v0.9.18
   securityContext:
     runAsUser: null
   webhook:


### PR DESCRIPTION
Reverts stackrox/acs-fleet-manager#2238

It's causing issues because we're overriding some helm chart values that are not compatible with the newer chart.