### PR TITLE
ROX-27835: update external secret operator and remove special handling of user

### DIFF
--- a/dp-terraform/helm/Dockerfile
+++ b/dp-terraform/helm/Dockerfile
@@ -19,8 +19,6 @@ RUN microdnf install gzip tar && \
         chmod +x /usr/local/bin/yq && \
         rm /tmp/yq_linux_amd64.tar.gz
 
-RUN cd rhacs-terraform/charts && for filename in *.tgz; do tar -xf "$filename" && rm -f "$filename"; done
-
 ARG IMAGE_TAG=latest
 RUN yq -i ".global.image.tag = strenv(IMAGE_TAG)" rhacs-terraform/values.yaml
 

--- a/dp-terraform/helm/Dockerfile
+++ b/dp-terraform/helm/Dockerfile
@@ -19,12 +19,7 @@ RUN microdnf install gzip tar && \
         chmod +x /usr/local/bin/yq && \
         rm /tmp/yq_linux_amd64.tar.gz
 
-# Fix ignored securityContext.runAsUser set to null in values.yaml file.
-# Manually dropping  securityContext.runAsUser value from the external secret subchart.
-# This could be fixed with ose-helm-operator version bump.
-# See: https://github.com/operator-framework/operator-sdk/issues/6635
-RUN cd rhacs-terraform/charts && for filename in *.tgz; do tar -xf "$filename" && rm -f "$filename"; done && \
-        yq -i 'del(.securityContext.runAsUser) | del(.webhook.securityContext.runAsUser) | del(.certController.securityContext.runAsUser)' external-secrets/values.yaml
+RUN cd rhacs-terraform/charts && for filename in *.tgz; do tar -xf "$filename" && rm -f "$filename"; done
 
 ARG IMAGE_TAG=latest
 RUN yq -i ".global.image.tag = strenv(IMAGE_TAG)" rhacs-terraform/values.yaml

--- a/dp-terraform/helm/rhacs-terraform/Chart.lock
+++ b/dp-terraform/helm/rhacs-terraform/Chart.lock
@@ -13,9 +13,9 @@ dependencies:
   version: 0.1.0
 - name: external-secrets
   repository: https://charts.external-secrets.io/
-  version: 0.9.5
+  version: 0.14.4
 - name: vertical-pod-autoscaler
   repository: ""
   version: 0.1.0
-digest: sha256:0be6aed6c8e38f2703f02e1e70979987839ab27ac7b4b44689025c0283ba67ab
-generated: "2024-11-26T16:20:45.541627+01:00"
+digest: sha256:e488ffdb97f3aac4951308985ebd1711023ae8de774237583178ef83063b1181
+generated: "2025-03-19T11:11:28.086874+01:00"

--- a/dp-terraform/helm/rhacs-terraform/Chart.yaml
+++ b/dp-terraform/helm/rhacs-terraform/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
     version: "0.1.0"
     condition: secured-cluster.enabled
   - name: external-secrets
-    version: "0.9.5"
+    version: "0.14.4"
     repository: https://charts.external-secrets.io/
     condition: external-secrets.enabled
   - name: vertical-pod-autoscaler

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -202,9 +202,7 @@ external-secrets:
   installCRDs: false
   image:
     repository: quay.io/app-sre/external-secrets
-    tag: v0.9.18
-  securityContext:
-    runAsUser: null
+    tag: v0.14.4
   webhook:
     create: false
   certController:


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
- Upgrades the external secret helm chart and image to 0.14.4
- Removes our special handling of `securityContext.runAsUser` because the helm chart implemented openshift specific logic with https://github.com/external-secrets/external-secrets/pull/3420

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

Manually tested installing the helm chart against infra OCP cluster and made sure there are no conflicts with SCCs