### PR TITLE
Revert "ROX-27835: update external secret operator and remove special handling of user"

### DIFF
--- a/dp-terraform/helm/Dockerfile
+++ b/dp-terraform/helm/Dockerfile
@@ -19,6 +19,13 @@ RUN microdnf install gzip tar && \
         chmod +x /usr/local/bin/yq && \
         rm /tmp/yq_linux_amd64.tar.gz
 
+# Fix ignored securityContext.runAsUser set to null in values.yaml file.
+# Manually dropping  securityContext.runAsUser value from the external secret subchart.
+# This could be fixed with ose-helm-operator version bump.
+# See: https://github.com/operator-framework/operator-sdk/issues/6635
+RUN cd rhacs-terraform/charts && for filename in *.tgz; do tar -xf "$filename" && rm -f "$filename"; done && \
+        yq -i 'del(.securityContext.runAsUser) | del(.webhook.securityContext.runAsUser) | del(.certController.securityContext.runAsUser)' external-secrets/values.yaml
+
 ARG IMAGE_TAG=latest
 RUN yq -i ".global.image.tag = strenv(IMAGE_TAG)" rhacs-terraform/values.yaml
 

--- a/dp-terraform/helm/rhacs-terraform/Chart.lock
+++ b/dp-terraform/helm/rhacs-terraform/Chart.lock
@@ -13,9 +13,9 @@ dependencies:
   version: 0.1.0
 - name: external-secrets
   repository: https://charts.external-secrets.io/
-  version: 0.14.4
+  version: 0.9.5
 - name: vertical-pod-autoscaler
   repository: ""
   version: 0.1.0
-digest: sha256:e488ffdb97f3aac4951308985ebd1711023ae8de774237583178ef83063b1181
-generated: "2025-03-19T11:11:28.086874+01:00"
+digest: sha256:0be6aed6c8e38f2703f02e1e70979987839ab27ac7b4b44689025c0283ba67ab
+generated: "2024-11-26T16:20:45.541627+01:00"

--- a/dp-terraform/helm/rhacs-terraform/Chart.yaml
+++ b/dp-terraform/helm/rhacs-terraform/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
     version: "0.1.0"
     condition: secured-cluster.enabled
   - name: external-secrets
-    version: "0.14.4"
+    version: "0.9.5"
     repository: https://charts.external-secrets.io/
     condition: external-secrets.enabled
   - name: vertical-pod-autoscaler

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -202,7 +202,9 @@ external-secrets:
   installCRDs: false
   image:
     repository: quay.io/app-sre/external-secrets
-    tag: v0.14.4
+    tag: v0.9.18
+  securityContext:
+    runAsUser: null
   webhook:
     create: false
   certController:


### PR DESCRIPTION
We need to rollback again due to the lack of a upgrade path for external secret operator CRDs.

The missing CRDs are leading to crash of the operator pod.

Reverts stackrox/acs-fleet-manager#2249