### PR TITLE
fix(CI): Enable server-side apply in dev scripts

### DIFF
--- a/dev/env/scripts/apply
+++ b/dev/env/scripts/apply
@@ -13,7 +13,7 @@ apply_res() {
     short_path=${path/#${GITROOT}/}
     res=$(envsubst <"$path")
     log "Applying resource from '${short_path}'"
-    echo "$res" | $KUBECTL apply -f -
+    echo "$res" | $KUBECTL apply --server-side -f -
 }
 
 for path in "$@"; do

--- a/scripts/ci/multicluster_tests/entrypoint.sh
+++ b/scripts/ci/multicluster_tests/entrypoint.sh
@@ -48,6 +48,8 @@ eval "$secrets"
 
 KUBECTL="$(which kubectl)"
 export KUBECTL
+log "kubectl version:"
+kubectl version --client
 
 bash "$SOURCE_DIR/deploy.sh"
 EXIT_CODE="$?"

--- a/scripts/ci/multicluster_tests/entrypoint.sh
+++ b/scripts/ci/multicluster_tests/entrypoint.sh
@@ -48,8 +48,6 @@ eval "$secrets"
 
 KUBECTL="$(which kubectl)"
 export KUBECTL
-log "kubectl version:"
-kubectl version --client
 
 bash "$SOURCE_DIR/deploy.sh"
 EXIT_CODE="$?"


### PR DESCRIPTION
## Description 
Fleetshard-sync deployment fails on CI with recent `kubectl` versions.
Caused by: https://github.com/kubernetes/kubernetes/pull/125646. We set null values for `nodeSelector` and `tolerations` in the Fleetshard CR in order to delete the default values in the helm chart.
Fix: Enable server-side apply in dev/CI scripts.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
