### PR TITLE
fix(fleet-manager): auth_test flake

### DIFF
--- a/pkg/server/api_server.go
+++ b/pkg/server/api_server.go
@@ -24,39 +24,29 @@ import (
 	"github.com/stackrox/acs-fleet-manager/pkg/logger"
 )
 
-// APIServerReadyCondition ...
-type APIServerReadyCondition interface {
-	Wait()
-}
-
 // APIServer ...
 type APIServer struct {
-	httpServer      *http.Server
-	serverConfig    *ServerConfig
-	sentryTimeout   time.Duration
-	readyConditions []APIServerReadyCondition
+	httpServer    *http.Server
+	serverConfig  *ServerConfig
+	sentryTimeout time.Duration
 }
-
-var _ Server = &APIServer{}
 
 // ServerOptions ...
 type ServerOptions struct {
 	di.Inject
-	ServerConfig    *ServerConfig
-	IAMConfig       *iam.IAMConfig
-	SentryConfig    *sentry.Config
-	RouteLoaders    []environments.RouteLoader
-	Env             *environments.Env
-	ReadyConditions []APIServerReadyCondition `di:"optional"`
+	ServerConfig *ServerConfig
+	IAMConfig    *iam.IAMConfig
+	SentryConfig *sentry.Config
+	RouteLoaders []environments.RouteLoader
+	Env          *environments.Env
 }
 
 // NewAPIServer ...
 func NewAPIServer(options ServerOptions) *APIServer {
 	s := &APIServer{
-		httpServer:      nil,
-		serverConfig:    options.ServerConfig,
-		sentryTimeout:   options.SentryConfig.Timeout,
-		readyConditions: options.ReadyConditions,
+		httpServer:    nil,
+		serverConfig:  options.ServerConfig,
+		sentryTimeout: options.SentryConfig.Timeout,
 	}
 
 	// mainRouter is top level "/"
@@ -125,7 +115,7 @@ func NewAPIServer(options ServerOptions) *APIServer {
 func (s *APIServer) Serve(listener net.Listener) {
 	var err error
 	if s.serverConfig.EnableHTTPS {
-		// Check https cert and key path path
+		// Check https cert and key path
 		if s.serverConfig.HTTPSCertFile == "" || s.serverConfig.HTTPSKeyFile == "" {
 			check(
 				fmt.Errorf("Unspecified required --https-cert-file, --https-key-file"),
@@ -149,7 +139,7 @@ func (s *APIServer) Serve(listener net.Listener) {
 
 // Listen only starts the listener, not the server.
 // Useful for breaking up ListenAndServer (Start) when you require the server to be listening before continuing
-func (s *APIServer) Listen() (listener net.Listener, err error) {
+func (s *APIServer) listen() (listener net.Listener, err error) {
 	l, err := net.Listen("tcp", s.serverConfig.BindAddress)
 	if err != nil {
 		return l, fmt.Errorf("starting the listener: %w", err)
@@ -157,28 +147,17 @@ func (s *APIServer) Listen() (listener net.Listener, err error) {
 	return l, nil
 }
 
-// Start ...
+// Start starts listening on the configured port and start the server.
 func (s *APIServer) Start() {
-	go s.Run()
-}
-
-// Run Start listening on the configured port and start the server. This is a convenience wrapper for Listen() and Serve(listener Listener)
-func (s *APIServer) Run() {
-	listener, err := s.Listen()
+	listener, err := s.listen()
 	if err != nil {
 		glog.Fatalf("Unable to start API server: %s", err)
-	}
-
-	// Before we start processing requests, wait
-	// for the server to be ready to run.
-	for _, condition := range s.readyConditions {
-		condition.Wait()
 	}
 
 	s.Serve(listener)
 }
 
-// Stop ...
+// Stop stops the service
 func (s *APIServer) Stop() {
 	err := s.httpServer.Shutdown(context.Background())
 	if err != nil {

--- a/pkg/server/healthcheck_server.go
+++ b/pkg/server/healthcheck_server.go
@@ -3,12 +3,12 @@ package server
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"time"
 
 	"github.com/stackrox/acs-fleet-manager/pkg/api"
 	"github.com/stackrox/acs-fleet-manager/pkg/db"
+	"github.com/stackrox/acs-fleet-manager/pkg/environments"
 	"github.com/stackrox/acs-fleet-manager/pkg/services/sentry"
 
 	health "github.com/docker/go-healthcheck"
@@ -19,6 +19,8 @@ import (
 var (
 	updater = health.NewStatusUpdater()
 )
+
+var _ environments.BootService = &HealthCheckServer{}
 
 // HealthCheckServer ...
 type HealthCheckServer struct {
@@ -58,11 +60,10 @@ func NewHealthCheckServer(healthCheckConfig *HealthCheckConfig, serverConfig *Se
 
 // Start ...
 func (s HealthCheckServer) Start() {
-	go s.Run()
+	go s.run()
 }
 
-// Run ...
-func (s HealthCheckServer) Run() {
+func (s HealthCheckServer) run() {
 	var err error
 	if s.healthCheckConfig.EnableHTTPS {
 		if s.serverConfig.HTTPSCertFile == "" || s.serverConfig.HTTPSKeyFile == "" {
@@ -89,15 +90,6 @@ func (s HealthCheckServer) Stop() {
 	if err != nil {
 		glog.Warningf("Unable to stop health check server: %s", err)
 	}
-}
-
-// Listen Unimplemented
-func (s HealthCheckServer) Listen() (listener net.Listener, err error) {
-	return nil, nil
-}
-
-// Serve Unimplemented
-func (s HealthCheckServer) Serve(listener net.Listener) {
 }
 
 func upHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/healthcheck_server.go
+++ b/pkg/server/healthcheck_server.go
@@ -20,8 +20,6 @@ var (
 	updater = health.NewStatusUpdater()
 )
 
-var _ Server = &HealthCheckServer{}
-
 // HealthCheckServer ...
 type HealthCheckServer struct {
 	httpServer          *http.Server

--- a/pkg/server/metrics_server.go
+++ b/pkg/server/metrics_server.go
@@ -47,8 +47,6 @@ type MetricsServer struct {
 	sentryTimeout time.Duration
 }
 
-var _ Server = &MetricsServer{}
-
 // Listen ...
 func (s MetricsServer) Listen() (listener net.Listener, err error) {
 	return nil, nil

--- a/pkg/server/metrics_server.go
+++ b/pkg/server/metrics_server.go
@@ -3,11 +3,11 @@ package server
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/stackrox/acs-fleet-manager/pkg/environments"
 	"github.com/stackrox/acs-fleet-manager/pkg/services/sentry"
 
 	"github.com/gorilla/mux"
@@ -15,6 +15,8 @@ import (
 	"github.com/stackrox/acs-fleet-manager/pkg/api"
 	"github.com/stackrox/acs-fleet-manager/pkg/handlers"
 )
+
+var _ environments.BootService = &MetricsServer{}
 
 // NewMetricsServer ...
 func NewMetricsServer(metricsConfig *MetricsConfig, serverConfig *ServerConfig, sentryConfig *sentry.Config) *MetricsServer {
@@ -47,22 +49,12 @@ type MetricsServer struct {
 	sentryTimeout time.Duration
 }
 
-// Listen ...
-func (s MetricsServer) Listen() (listener net.Listener, err error) {
-	return nil, nil
-}
-
-// Serve ...
-func (s MetricsServer) Serve(listener net.Listener) {
-}
-
 // Start ...
 func (s MetricsServer) Start() {
-	go s.Run()
+	go s.run()
 }
 
-// Run ...
-func (s MetricsServer) Run() {
+func (s MetricsServer) run() {
 	glog.Infof("start metrics server")
 	var err error
 	if s.metricsConfig.EnableHTTPS {

--- a/pkg/server/profiler/profiler_server.go
+++ b/pkg/server/profiler/profiler_server.go
@@ -15,10 +15,8 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/stackrox/acs-fleet-manager/pkg/environments"
-	"github.com/stackrox/acs-fleet-manager/pkg/server"
 )
 
-var _ server.Server = &PprofServer{}
 var _ environments.BootService = &PprofServer{}
 
 // PprofServer ...

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -10,14 +9,6 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/golang/glog"
 )
-
-// Server ...
-type Server interface {
-	Run()
-	Stop()
-	Listen() (net.Listener, error)
-	Serve(net.Listener)
-}
 
 func removeTrailingSlash(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Description
Integration tests sometimes fail because they call the api server when it's not yet started. 
Reason: `APIServer.Start()` runs server in a separate goroutine. 
Fix: bind address in the same goroutine, then start the http service asynchronously (as before).

\+ refactor: remove redundant `Service` interface  

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
