### PR TITLE
ROX-16860: rollback the status label to total_centrals

### DIFF
--- a/fleetshard/pkg/fleetshardmetrics/metrics_test.go
+++ b/fleetshard/pkg/fleetshardmetrics/metrics_test.go
@@ -25,7 +25,7 @@ func TestCounterIncrements(t *testing.T) {
 		{
 			metricName: "total_central_reconcilation_errors",
 			callIncrementFunc: func(m *Metrics) {
-				m.IncCentralReconcilationErrors()
+				m.AddCentralReconcilationErrors(1)
 			},
 		},
 	}
@@ -48,10 +48,22 @@ func TestCounterIncrements(t *testing.T) {
 func TestTotalCentrals(t *testing.T) {
 	m := newMetrics()
 	metricName := metricsPrefix + "total_centrals"
-	expectedValue := 37.0
-	expectedStatus := "Ready"
+	expectedValue := 37
 
-	m.SetTotalCentrals(expectedValue, expectedStatus)
+	m.SetTotalCentrals(expectedValue)
+	metrics := serveMetrics(t, m)
+
+	targetMetric := requireMetric(t, metrics, metricName)
+	value := targetMetric.Metric[0].Gauge.Value
+	assert.Equalf(t, 37.0, *value, "expected metric: %s to have value: %v", metricName, expectedValue)
+}
+
+func TestReadyCentrals(t *testing.T) {
+	m := newMetrics()
+	metricName := metricsPrefix + "ready_centrals"
+	expectedValue := 37
+
+	m.SetReadyCentrals(expectedValue)
 	metrics := serveMetrics(t, m)
 
 	targetMetric := requireMetric(t, metrics, metricName)

--- a/fleetshard/pkg/fleetshardmetrics/server_test.go
+++ b/fleetshard/pkg/fleetshardmetrics/server_test.go
@@ -33,31 +33,13 @@ func TestMetricsServerServesCustomMetrics(t *testing.T) {
 		"total_central_reconcilations",
 		"total_central_reconcilation_errors",
 		"active_central_reconcilations",
+		"total_centrals",
+		"ready_centrals",
 	}
 
 	for _, key := range expectedKeys {
 		assert.Containsf(t, metrics, metricsPrefix+key, "expected metrics to contain %s but it did not: %v", key, metrics)
 	}
-}
-
-func TestMetricsServerServesTotalCentralsMetric(t *testing.T) {
-	server := NewMetricsServer(":8081")
-
-	MetricsInstance().SetTotalCentrals(1, "ready")
-
-	rec := httptest.NewRecorder()
-	req, err := http.NewRequest(http.MethodGet, "/metrics", nil)
-	require.NoError(t, err, "failed creating metrics requests")
-
-	server.Handler.ServeHTTP(rec, req)
-	require.Equal(t, http.StatusOK, rec.Code, "status code should be OK")
-
-	promParser := expfmt.TextParser{}
-	metrics, err := promParser.TextToMetricFamilies(rec.Body)
-	require.NoError(t, err, "failed parsing metrics file")
-
-	key := metricsPrefix + "total_centrals"
-	assert.Containsf(t, metrics, key, "expected metrics to contain %s but it did not: %v", key, metrics)
 }
 
 func serveMetrics(t *testing.T, customMetrics *Metrics) metricResponse {

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -283,9 +283,8 @@ func (r *Runtime) handleReconcileResults(results <-chan reconcileResult) {
 				glog.V(10).Infof("Skip sending the status for central %s/%s: %v", central.Metadata.Namespace, central.Metadata.Name, err)
 				statusesCount.Increment(central.RequestStatus) // get previous status
 			} else {
-				fleetshardmetrics.MetricsInstance().IncCentralReconcilationErrors()
 				glog.Errorf("Unexpected error occurred %s/%s: %s", central.Metadata.Namespace, central.Metadata.Name, err.Error())
-				statusesCount.Increment("error")
+				statusesCount.IncrementError()
 			}
 		} else {
 			statusesCount.IncrementWithStatus(result.status)


### PR DESCRIPTION
Instead introduce a metric for ready centrals.

This fixes a problem when the sum(total_count) is shown incorrectly after central transitioned from one status to another.

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
