### PR TITLE
ROX-16860: Remove misleading central error status from the status counter

### DIFF
--- a/fleetshard/pkg/central/reconciler/status_test.go
+++ b/fleetshard/pkg/central/reconciler/status_test.go
@@ -110,11 +110,10 @@ func TestStatusesCount(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			counter := StatusesCount{}
 			for _, status := range test.statuses {
-				counter.IncrementWithStatus(status)
+				counter.IncrementCurrent(status)
 			}
 			require.Equal(t, test.wantTotal, counter.totalCentrals)
 			require.Equal(t, test.wantReady, counter.readyCentrals)
-			require.Equal(t, test.wantError, counter.errorCentrals)
 		})
 	}
 }

--- a/fleetshard/pkg/fleetshardmetrics/metrics.go
+++ b/fleetshard/pkg/fleetshardmetrics/metrics.go
@@ -60,9 +60,9 @@ func (m *Metrics) IncCentralReconcilations() {
 	m.centralReconcilations.Inc()
 }
 
-// AddCentralReconcilationErrors increments the metric counter for central reconcilation errors
-func (m *Metrics) AddCentralReconcilationErrors(v int) {
-	m.centralReconcilationErrors.Add(float64(v))
+// IncCentralReconcilationErrors increments the metric counter for central reconcilation errors
+func (m *Metrics) IncCentralReconcilationErrors() {
+	m.centralReconcilationErrors.Inc()
 }
 
 // SetTotalCentrals sets the metric for total centrals to the given value

--- a/fleetshard/pkg/fleetshardmetrics/metrics_test.go
+++ b/fleetshard/pkg/fleetshardmetrics/metrics_test.go
@@ -25,7 +25,7 @@ func TestCounterIncrements(t *testing.T) {
 		{
 			metricName: "total_central_reconcilation_errors",
 			callIncrementFunc: func(m *Metrics) {
-				m.AddCentralReconcilationErrors(1)
+				m.IncCentralReconcilationErrors()
 			},
 		},
 	}

--- a/fleetshard/pkg/runtime/runtime.go
+++ b/fleetshard/pkg/runtime/runtime.go
@@ -281,13 +281,13 @@ func (r *Runtime) handleReconcileResults(results <-chan reconcileResult) {
 		if err := result.err; err != nil {
 			if centralReconciler.IsSkippable(err) {
 				glog.V(10).Infof("Skip sending the status for central %s/%s: %v", central.Metadata.Namespace, central.Metadata.Name, err)
-				statusesCount.Increment(central.RequestStatus) // get previous status
+				statusesCount.IncrementRemote(central.RequestStatus) // get remote status
 			} else {
+				fleetshardmetrics.MetricsInstance().IncCentralReconcilationErrors()
 				glog.Errorf("Unexpected error occurred %s/%s: %s", central.Metadata.Namespace, central.Metadata.Name, err.Error())
-				statusesCount.IncrementError()
 			}
 		} else {
-			statusesCount.IncrementWithStatus(result.status)
+			statusesCount.IncrementCurrent(result.status)
 			statuses[central.Id] = result.status
 		}
 	}


### PR DESCRIPTION
## Description
- Returned back the error counter metric
- Removed misleading central error status (the reconciliation error != central error status)
- Renamed increment methods for better readability

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
