### PR TITLE
ROX-28980: add tenant restore operation to e2e tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -259,7 +259,7 @@
         "filename": "e2e/e2e_test.go",
         "hashed_secret": "7f38822bc2b03e97325ff310099f457f6f788daf",
         "is_verified": false,
-        "line_number": 293
+        "line_number": 289
       }
     ],
     "internal/dinosaur/pkg/api/public/api/openapi.yaml": [
@@ -312,7 +312,7 @@
         "filename": "pkg/client/fleetmanager/mocks/client_moq.go",
         "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
         "is_verified": false,
-        "line_number": 746
+        "line_number": 760
       }
     ],
     "pkg/client/redhatsso/api/api/openapi.yaml": [
@@ -416,5 +416,5 @@
       }
     ]
   },
-  "generated_at": "2025-04-14T16:46:27Z"
+  "generated_at": "2025-04-15T08:25:28Z"
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -444,12 +444,13 @@ var _ = Describe("Central", Ordered, func() {
 				res, err := adminAPI.RestoreCentral(ctx, centralRequestID)
 				Expect(err).To(Not(HaveOccurred()))
 				Expect(res.StatusCode).To(Equal(200))
-				It("should reach ready state", func() {
-					Eventually(testutil.AssertCentralRequestReady(ctx, client, centralRequestID)).
-						WithTimeout(waitTimeout).
-						WithPolling(defaultPolling).
-						Should(Succeed())
-				})
+			})
+
+			It("should reach ready state", func() {
+				Eventually(testutil.AssertCentralRequestReady(ctx, client, centralRequestID)).
+					WithTimeout(waitTimeout).
+					WithPolling(defaultPolling).
+					Should(Succeed())
 			})
 
 			It("should delete all resources after deleting again", func() {
@@ -460,7 +461,7 @@ var _ = Describe("Central", Ordered, func() {
 						Should(Succeed())
 				})
 
-				It("by deleting external DNS entries", func() {
+				By("by deleting external DNS entries", func() {
 					testutil.SkipIf(!dnsEnabled, testutil.SkipDNSMsg)
 					var centralRequest public.CentralRequest
 					Expect(testutil.GetCentralRequest(ctx, client, centralRequestID, &centralRequest)).

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -446,7 +446,7 @@ var _ = Describe("Central", Ordered, func() {
 				Expect(res.StatusCode).To(Equal(200))
 			})
 
-			It("should reach ready state", func() {
+			By("reaching ready state", func() {
 				Eventually(testutil.AssertCentralRequestReady(ctx, client, centralRequestID)).
 					WithTimeout(waitTimeout).
 					WithPolling(defaultPolling).

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -240,10 +240,6 @@ var _ = Describe("Central", Ordered, func() {
 			Expect(putGitopsConfig(ctx, cfg)).To(Succeed())
 		})
 
-		// TODO(ROX-11368): Add test to eventually reach ready state
-		// TODO(ROX-11368): create test to check that Central and Scanner are healthy
-		// TODO(ROX-11368): Create test to check Central is correctly exposed
-
 		It("should restore secrets and deployment on namespace delete", func() {
 			// Using managedDB false here because e2e don't run with managed postgresql
 			secretBackup := k8s.NewSecretBackup(k8sClient, false)
@@ -442,6 +438,43 @@ var _ = Describe("Central", Ordered, func() {
 				WithPolling(defaultPolling).
 				Should(BeEmpty(), "Started at %s", time.Now())
 		})
+
+		It("should be restorable", func() {
+			By("calling the admin restore API", func() {
+				res, err := adminAPI.RestoreCentral(ctx, centralRequestID)
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(res.StatusCode).To(Equal(200))
+				It("should reach ready state", func() {
+					Eventually(testutil.AssertCentralRequestReady(ctx, client, centralRequestID)).
+						WithTimeout(waitTimeout).
+						WithPolling(defaultPolling).
+						Should(Succeed())
+				})
+			})
+
+			It("should delete all resources after deleting again", func() {
+				By("removing central namespace", func() {
+					Eventually(assertNamespaceDeleted(ctx, namespaceName)).
+						WithTimeout(waitTimeout).
+						WithPolling(defaultPolling).
+						Should(Succeed())
+				})
+
+				It("by deleting external DNS entries", func() {
+					testutil.SkipIf(!dnsEnabled, testutil.SkipDNSMsg)
+					var centralRequest public.CentralRequest
+					Expect(testutil.GetCentralRequest(ctx, client, centralRequestID, &centralRequest)).
+						To(Succeed())
+					dnsRecordsLoader := dns.NewRecordsLoader(route53Client, centralRequest)
+					Eventually(dnsRecordsLoader.LoadDNSRecords).
+						WithTimeout(waitTimeout).
+						WithPolling(defaultPolling).
+						Should(BeEmpty(), "Started at %s", time.Now())
+				})
+			})
+
+		})
+
 	})
 
 	Describe("should be deployed and can be force-deleted", Ordered, func() {

--- a/internal/dinosaur/pkg/api/admin/private/api/openapi.yaml
+++ b/internal/dinosaur/pkg/api/admin/private/api/openapi.yaml
@@ -478,6 +478,7 @@ paths:
       summary: Rotate RHSSO client or Secret Backup of a central tenant
   /api/rhacs/v1/admin/centrals/{id}/restore:
     post:
+      operationId: restoreCentral
       parameters:
       - description: The ID of record
         in: path

--- a/internal/dinosaur/pkg/api/admin/private/api_default.go
+++ b/internal/dinosaur/pkg/api/admin/private/api_default.go
@@ -29,121 +29,6 @@ var (
 type DefaultApiService service
 
 /*
-ApiRhacsV1AdminCentralsIdRestorePost Restore a central tenant that was already deleted
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param id The ID of record
-*/
-func (a *DefaultApiService) ApiRhacsV1AdminCentralsIdRestorePost(ctx _context.Context, id string) (*_nethttp.Response, error) {
-	var (
-		localVarHTTPMethod   = _nethttp.MethodPost
-		localVarPostBody     interface{}
-		localVarFormFileName string
-		localVarFileName     string
-		localVarFileBytes    []byte
-	)
-
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/api/rhacs/v1/admin/centrals/{id}/restore"
-	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", _neturl.QueryEscape(parameterToString(id, "")), -1)
-
-	localVarHeaderParams := make(map[string]string)
-	localVarQueryParams := _neturl.Values{}
-	localVarFormParams := _neturl.Values{}
-
-	// to determine the Content-Type header
-	localVarHTTPContentTypes := []string{}
-
-	// set Content-Type header
-	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
-	if localVarHTTPContentType != "" {
-		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
-	}
-
-	// to determine the Accept header
-	localVarHTTPHeaderAccepts := []string{"application/json"}
-
-	// set Accept header
-	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
-	if localVarHTTPHeaderAccept != "" {
-		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	localVarHTTPResponse, err := a.client.callAPI(r)
-	if err != nil || localVarHTTPResponse == nil {
-		return localVarHTTPResponse, err
-	}
-
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	if err != nil {
-		return localVarHTTPResponse, err
-	}
-
-	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHTTPResponse.Status,
-		}
-		if localVarHTTPResponse.StatusCode == 400 {
-			var v Error
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarHTTPResponse, newErr
-			}
-			newErr.model = v
-			return localVarHTTPResponse, newErr
-		}
-		if localVarHTTPResponse.StatusCode == 401 {
-			var v Error
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarHTTPResponse, newErr
-			}
-			newErr.model = v
-			return localVarHTTPResponse, newErr
-		}
-		if localVarHTTPResponse.StatusCode == 403 {
-			var v Error
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarHTTPResponse, newErr
-			}
-			newErr.model = v
-			return localVarHTTPResponse, newErr
-		}
-		if localVarHTTPResponse.StatusCode == 404 {
-			var v Error
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarHTTPResponse, newErr
-			}
-			newErr.model = v
-			return localVarHTTPResponse, newErr
-		}
-		if localVarHTTPResponse.StatusCode == 500 {
-			var v Error
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarHTTPResponse, newErr
-			}
-			newErr.model = v
-		}
-		return localVarHTTPResponse, newErr
-	}
-
-	return localVarHTTPResponse, nil
-}
-
-/*
 AssignCentralCluster Reassign the cluster a central tenant should be scheduled to
   - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
   - @param id The ID of record
@@ -1482,6 +1367,121 @@ func (a *DefaultApiService) PutCentralTrait(ctx _context.Context, id string, tra
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 401 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 403 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 404 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 500 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
+
+/*
+RestoreCentral Restore a central tenant that was already deleted
+  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+  - @param id The ID of record
+*/
+func (a *DefaultApiService) RestoreCentral(ctx _context.Context, id string) (*_nethttp.Response, error) {
+	var (
+		localVarHTTPMethod   = _nethttp.MethodPost
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/api/rhacs/v1/admin/centrals/{id}/restore"
+	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", _neturl.QueryEscape(parameterToString(id, "")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v Error

--- a/openapi/fleet-manager-private-admin.yaml
+++ b/openapi/fleet-manager-private-admin.yaml
@@ -346,6 +346,7 @@ paths:
                 $ref: 'fleet-manager.yaml#/components/schemas/Error'
   '/api/rhacs/v1/admin/centrals/{id}/restore':
     post:
+      operationId: restoreCentral
       summary: Restore a central tenant that was already deleted
       parameters:
         - $ref: "fleet-manager.yaml#/components/parameters/id"

--- a/pkg/client/fleetmanager/client.go
+++ b/pkg/client/fleetmanager/client.go
@@ -37,6 +37,7 @@ type AdminAPI interface {
 	CentralRotateSecrets(ctx context.Context, id string, centralRotateSecretsRequest admin.CentralRotateSecretsRequest) (*http.Response, error)
 	UpdateCentralNameById(ctx context.Context, id string, centralUpdateNameRequest admin.CentralUpdateNameRequest) (admin.Central, *http.Response, error)
 	AssignCentralCluster(ctx context.Context, id string, centralAssignClusterRequest admin.CentralAssignClusterRequest) (*http.Response, error)
+	RestoreCentral(ctx context.Context, id string) (*http.Response, error)
 }
 
 // Client is a helper struct that wraps around the API clients generated from

--- a/pkg/client/fleetmanager/mocks/client_moq.go
+++ b/pkg/client/fleetmanager/mocks/client_moq.go
@@ -612,6 +612,9 @@ var _ fleetmanager.AdminAPI = &AdminAPIMock{}
 //			GetCentralsFunc: func(ctx context.Context, localVarOptionals *admin.GetCentralsOpts) (admin.CentralList, *http.Response, error) {
 //				panic("mock out the GetCentrals method")
 //			},
+//			RestoreCentralFunc: func(ctx context.Context, id string) (*http.Response, error) {
+//				panic("mock out the RestoreCentral method")
+//			},
 //			UpdateCentralNameByIdFunc: func(ctx context.Context, id string, centralUpdateNameRequest admin.CentralUpdateNameRequest) (admin.Central, *http.Response, error) {
 //				panic("mock out the UpdateCentralNameById method")
 //			},
@@ -636,6 +639,9 @@ type AdminAPIMock struct {
 
 	// GetCentralsFunc mocks the GetCentrals method.
 	GetCentralsFunc func(ctx context.Context, localVarOptionals *admin.GetCentralsOpts) (admin.CentralList, *http.Response, error)
+
+	// RestoreCentralFunc mocks the RestoreCentral method.
+	RestoreCentralFunc func(ctx context.Context, id string) (*http.Response, error)
 
 	// UpdateCentralNameByIdFunc mocks the UpdateCentralNameById method.
 	UpdateCentralNameByIdFunc func(ctx context.Context, id string, centralUpdateNameRequest admin.CentralUpdateNameRequest) (admin.Central, *http.Response, error)
@@ -683,6 +689,13 @@ type AdminAPIMock struct {
 			// LocalVarOptionals is the localVarOptionals argument value.
 			LocalVarOptionals *admin.GetCentralsOpts
 		}
+		// RestoreCentral holds details about calls to the RestoreCentral method.
+		RestoreCentral []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ID is the id argument value.
+			ID string
+		}
 		// UpdateCentralNameById holds details about calls to the UpdateCentralNameById method.
 		UpdateCentralNameById []struct {
 			// Ctx is the ctx argument value.
@@ -698,6 +711,7 @@ type AdminAPIMock struct {
 	lockCreateCentral         sync.RWMutex
 	lockDeleteDbCentralById   sync.RWMutex
 	lockGetCentrals           sync.RWMutex
+	lockRestoreCentral        sync.RWMutex
 	lockUpdateCentralNameById sync.RWMutex
 }
 
@@ -890,6 +904,42 @@ func (mock *AdminAPIMock) GetCentralsCalls() []struct {
 	mock.lockGetCentrals.RLock()
 	calls = mock.calls.GetCentrals
 	mock.lockGetCentrals.RUnlock()
+	return calls
+}
+
+// RestoreCentral calls RestoreCentralFunc.
+func (mock *AdminAPIMock) RestoreCentral(ctx context.Context, id string) (*http.Response, error) {
+	if mock.RestoreCentralFunc == nil {
+		panic("AdminAPIMock.RestoreCentralFunc: method is nil but AdminAPI.RestoreCentral was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		ID  string
+	}{
+		Ctx: ctx,
+		ID:  id,
+	}
+	mock.lockRestoreCentral.Lock()
+	mock.calls.RestoreCentral = append(mock.calls.RestoreCentral, callInfo)
+	mock.lockRestoreCentral.Unlock()
+	return mock.RestoreCentralFunc(ctx, id)
+}
+
+// RestoreCentralCalls gets all the calls that were made to RestoreCentral.
+// Check the length with:
+//
+//	len(mockedAdminAPI.RestoreCentralCalls())
+func (mock *AdminAPIMock) RestoreCentralCalls() []struct {
+	Ctx context.Context
+	ID  string
+} {
+	var calls []struct {
+		Ctx context.Context
+		ID  string
+	}
+	mock.lockRestoreCentral.RLock()
+	calls = mock.calls.RestoreCentral
+	mock.lockRestoreCentral.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This PR adds the testing of restore operation to the admin API e2e tests.

Together with #2289 this change will ensure appropriate regression testing of the restore logic for ACSCS tenants.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

CI is sufficient
