### PR TITLE
ROX-29122: remove service account token from cloudwatch exporter

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/templates/01-operator-04-deployment.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/cloudwatch/templates/01-operator-04-deployment.yaml
@@ -27,6 +27,7 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: false
       containers:
         - name: cloudwatch-exporter
           image: {{ .Values.image | quote }}


### PR DESCRIPTION
## Description
As discussed in acs-cs bi-weekly review

