### PR TITLE
fix: have probe ignore disabled regions

### DIFF
--- a/probe/pkg/central/service.go
+++ b/probe/pkg/central/service.go
@@ -113,6 +113,9 @@ func (s *serviceImpl) appendRegions(ctx context.Context, cloudProvider public.Cl
 		return specs
 	}
 	for _, region := range regions.Items {
+		if !region.Enabled {
+			continue
+		}
 		specs = append(specs, Spec{CloudProvider: cloudProvider.Id, Region: region.Id})
 	}
 	return specs


### PR DESCRIPTION
## Description

Fixing an alert where probe tries to deploy to a disabled region

Context: https://redhat-internal.slack.com/archives/C043EBGTKMJ/p1746614278185969

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
