### PR TITLE
fix(e2e): Change TLS termination to passthrough

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -253,15 +253,6 @@
         "line_number": 7
       }
     ],
-    "e2e/e2e_test.go": [
-      {
-        "type": "Secret Keyword",
-        "filename": "e2e/e2e_test.go",
-        "hashed_secret": "7f38822bc2b03e97325ff310099f457f6f788daf",
-        "is_verified": false,
-        "line_number": 289
-      }
-    ],
     "internal/central/pkg/api/public/api/openapi.yaml": [
       {
         "type": "Base64 High Entropy String",
@@ -400,5 +391,5 @@
       }
     ]
   },
-  "generated_at": "2025-04-28T14:33:13Z"
+  "generated_at": "2025-05-12T10:17:39Z"
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -184,7 +184,8 @@ var _ = Describe("Central", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(centralUIURL.Scheme).To(Equal("https"))
 
-			Eventually(assertRouteExists(ctx, namespaceName, openshiftRouteV1.TLSTerminationReencrypt, centralUIURL.Host)).
+			// TODO change the route name
+			Eventually(assertRouteExists(ctx, namespaceName, openshiftRouteV1.TLSTerminationPassthrough, centralUIURL.Host)).
 				WithTimeout(waitTimeout).
 				WithPolling(defaultPolling).
 				Should(Succeed())
@@ -286,7 +287,7 @@ var _ = Describe("Central", Ordered, func() {
 			Expect(oldSecrets).ToNot(BeEmpty())
 
 			// modify secrets to later test that the backup was updated succesfully
-			for _, secret := range oldSecrets {
+			for _, secret := range oldSecrets { // pragma: allowlist secret
 				secret.Data["test"] = []byte("modified")
 				err := k8sClient.Update(ctx, secret)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
