### PR TITLE
ROX-28579: use vector-rhel9 image for audit logs

### DIFF
--- a/dp-terraform/helm/rhacs-terraform/charts/audit-logs/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/audit-logs/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 # Vector image used for audit-logs aggregator.
-image: 'registry.redhat.io/openshift-logging/vector-rhel8:v0.28'
+image: 'registry.redhat.io/openshift-logging/vector-rhel9@sha256:ded523b690006817d7e826eaec49fc62fe94362ec28b66dbd2c3dc4f79384970'
 
 # General annotations for all deployed resources.
 annotations: {}


### PR DESCRIPTION
## Description
registry.redhat.io/openshift-logging/vector-rhel8 is deprecated and needs to be replaced.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
