### PR TITLE
ROX-29863: do not block deletion if deleting quota fails with 404

### DIFF
--- a/internal/central/pkg/services/quota/ams_quota_service.go
+++ b/internal/central/pkg/services/quota/ams_quota_service.go
@@ -4,6 +4,7 @@ package quota
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/golang/glog"
@@ -235,8 +236,12 @@ func (q amsQuotaService) DeleteQuota(subscriptionID string) *errors.ServiceError
 		return nil
 	}
 
-	_, err := q.amsClient.DeleteSubscription(subscriptionID)
+	status, err := q.amsClient.DeleteSubscription(subscriptionID)
 	if err != nil {
+		if status == http.StatusNotFound {
+			glog.Infof("quota for subscription: %v not found, asuming it's already deleted", subscriptionID)
+			return nil
+		}
 		return errors.GeneralError("failed to delete the quota: %v", err)
 	}
 	return nil

--- a/internal/central/pkg/services/quota/ams_quota_service_test.go
+++ b/internal/central/pkg/services/quota/ams_quota_service_test.go
@@ -741,6 +741,20 @@ func Test_Delete_Quota(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "failed to delete a quota by id with 404 status",
+			args: args{
+				subscriptionID: "1223",
+			},
+			fields: fields{
+				ocmClient: &ocmClientMock.ClientMock{
+					DeleteSubscriptionFunc: func(id string) (int, error) {
+						return 404, serviceErrors.GeneralError("failed to delete subscription")
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Sometimes in the integration env of AMS subscription may disappear. Which is why sometimes tenants in ACSCS are stuck in a deleting state.

This PR changes the deletion logic to don't cause deletion to fail, but print a info message if a 404 was received when trying to delete the Subscription. It's reasonable to assume the Sub doesn't exists if we receive a 404.


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [x] Added test description under `Test manual`
- [x] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

e2e tests and added unit test are sufficient

