### PR TITLE
ROX-29638: Do not watch target objects

### DIFF
--- a/fleetshard-operator/pkg/controllers/gitopsinstallation_controller.go
+++ b/fleetshard-operator/pkg/controllers/gitopsinstallation_controller.go
@@ -72,12 +72,6 @@ func (r *GitopsInstallationReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Watches(&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.mapGitopsInstallation),
 			builder.WithPredicates(r.predicateFuncs(r.matchesSourceRepositorySecret))).
-		Watches(&corev1.Secret{},
-			handler.EnqueueRequestsFromMapFunc(r.mapGitopsInstallation),
-			builder.WithPredicates(r.predicateFuncs(r.matchesDestinationRepositorySecret))).
-		Watches(&argoCd.Application{},
-			handler.EnqueueRequestsFromMapFunc(r.mapGitopsInstallation),
-			builder.WithPredicates(r.predicateFuncs(r.matchesBootstrapApp))).
 		Complete(r)
 }
 
@@ -109,15 +103,6 @@ func (r *GitopsInstallationReconciler) predicateFuncs(matchesResource func(names
 
 func (r *GitopsInstallationReconciler) matchesSourceRepositorySecret(namespace, name string) bool {
 	return namespace == r.SourceNamespace && bootstrapAppRepositoryName == name
-}
-
-func (r *GitopsInstallationReconciler) matchesDestinationRepositorySecret(namespace, name string) bool {
-	return namespace == ArgoCdNamespace && bootstrapAppRepositoryName == name
-}
-
-func (r *GitopsInstallationReconciler) matchesBootstrapApp(namespace, name string) bool {
-	return namespace == ArgoCdNamespace && bootstrapAppName == name
-
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to


### PR DESCRIPTION
## Description
This PR solves the following problem: when the reconciler watches `argocd.Application` and the gitops operator is not installed yet on a fresh cluster (CRD is not available), the operator is crashlooping with the following error:
```
E0703 13:02:40.155758 1 kind.go:71] controller-runtime/source/EventHandler: "msg"="if kind is a CRD, it should be installed before calling Start" "error"="failed to get restmapping: no matches for kind \"Application\" in version \"argoproj.io/v1alpha1\"" "kind"="Application.argoproj.io"
```
This PR makes the reconciler stop watching the target objects.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
