### PR TITLE
external-dns reconciliation logic

### DIFF
--- a/internal/central/pkg/externaldns/externaldns.go
+++ b/internal/central/pkg/externaldns/externaldns.go
@@ -2,6 +2,7 @@ package externaldns
 
 import "github.com/stackrox/acs-fleet-manager/internal/central/pkg/api/private"
 
+// IsEnabled checks if the external DNS feature is enabled for the given managed central.
 func IsEnabled(managedCentral private.ManagedCentral) bool {
 	isEnabled, ok := managedCentral.Spec.TenantResourcesValues["externalDnsEnabled"].(bool)
 	return ok && isEnabled

--- a/internal/central/pkg/externaldns/externaldns.go
+++ b/internal/central/pkg/externaldns/externaldns.go
@@ -1,0 +1,8 @@
+package externaldns
+
+import "github.com/stackrox/acs-fleet-manager/internal/central/pkg/api/private"
+
+func IsEnabled(managedCentral private.ManagedCentral) bool {
+	isEnabled, ok := managedCentral.Spec.TenantResourcesValues["externalDnsEnabled"].(bool)
+	return ok && isEnabled
+}

--- a/internal/central/pkg/workers/centralmgrs/centrals_routes_cname_mgr.go
+++ b/internal/central/pkg/workers/centralmgrs/centrals_routes_cname_mgr.go
@@ -4,8 +4,8 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	"github.com/stackrox/acs-fleet-manager/internal/central/pkg/api/private"
 	"github.com/stackrox/acs-fleet-manager/internal/central/pkg/config"
+	"github.com/stackrox/acs-fleet-manager/internal/central/pkg/externaldns"
 	"github.com/stackrox/acs-fleet-manager/internal/central/pkg/presenters"
 	"github.com/stackrox/acs-fleet-manager/internal/central/pkg/services"
 	"github.com/stackrox/acs-fleet-manager/pkg/metrics"
@@ -67,7 +67,7 @@ func (k *CentralRoutesCNAMEManager) Reconcile() []error {
 			errs = append(errs, errors.Wrapf(err, "failed to present managed central for central %s", central.ID))
 			continue
 		}
-		if k.centralConfig.EnableCentralExternalDomain && !isExternalDnsEnabled(managedCentral) {
+		if k.centralConfig.EnableCentralExternalDomain && !externaldns.IsEnabled(managedCentral) {
 			if central.RoutesCreationID == "" {
 				glog.Infof("creating CNAME records for central %s", central.ID)
 
@@ -109,9 +109,4 @@ func (k *CentralRoutesCNAMEManager) Reconcile() []error {
 	}
 
 	return errs
-}
-
-func isExternalDnsEnabled(managedCentral private.ManagedCentral) bool {
-	isEnabled, ok := managedCentral.Spec.TenantResourcesValues["externalDnsEnabled"].(bool)
-	return ok && isEnabled
 }

--- a/internal/central/pkg/workers/centralmgrs/centrals_routes_cname_mgr.go
+++ b/internal/central/pkg/workers/centralmgrs/centrals_routes_cname_mgr.go
@@ -67,11 +67,7 @@ func (k *CentralRoutesCNAMEManager) Reconcile() []error {
 			errs = append(errs, errors.Wrapf(err, "failed to present managed central for central %s", central.ID))
 			continue
 		}
-		if isExternalDnsEnabled(managedCentral) {
-			// If external-dns is enabled, we do not need to create CNAME records here. ExternalDNS will take care of it.
-			// Also, assume routes created by ExternalDNS (set RoutesCreated=true). Otherwise the Central will not read the Ready state.
-			central.RoutesCreated = true
-		} else if k.centralConfig.EnableCentralExternalDomain {
+		if k.centralConfig.EnableCentralExternalDomain && !isExternalDnsEnabled(managedCentral) {
 			if central.RoutesCreationID == "" {
 				glog.Infof("creating CNAME records for central %s", central.ID)
 


### PR DESCRIPTION
## Description
Skips creation of CNAME records when ExternalDNS is enabled.


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
