### PR TITLE
ROX-13456: return 404 on private cluster if cluster is not found

### DIFF
--- a/internal/central/pkg/handlers/data_plane_central.go
+++ b/internal/central/pkg/handlers/data_plane_central.go
@@ -34,6 +34,7 @@ func NewDataPlaneCentralHandler(
 	return &dataPlaneCentralHandler{
 		service:              service,
 		centralService:       centralService,
+		clusterService:       clusterService,
 		presenter:            presenter,
 		gitopsConfigProvider: gitopsConfigProvider,
 	}

--- a/internal/central/pkg/handlers/data_plane_central.go
+++ b/internal/central/pkg/handlers/data_plane_central.go
@@ -18,6 +18,7 @@ import (
 type dataPlaneCentralHandler struct {
 	service              services.DataPlaneCentralService
 	centralService       services.CentralService
+	clusterService       services.ClusterService
 	presenter            *presenters.ManagedCentralPresenter
 	gitopsConfigProvider gitops.ConfigProvider
 }
@@ -26,6 +27,7 @@ type dataPlaneCentralHandler struct {
 func NewDataPlaneCentralHandler(
 	service services.DataPlaneCentralService,
 	centralService services.CentralService,
+	clusterService services.ClusterService,
 	presenter *presenters.ManagedCentralPresenter,
 	gitopsConfigProvider gitops.ConfigProvider,
 ) *dataPlaneCentralHandler {
@@ -67,6 +69,17 @@ func (h *dataPlaneCentralHandler) GetAll(w http.ResponseWriter, r *http.Request)
 			centralRequests, err := h.service.ListByClusterID(clusterID)
 			if err != nil {
 				return nil, err
+			}
+
+			if len(centralRequests) == 0 {
+				cluster, err := h.clusterService.FindClusterByID(clusterID)
+				if err != nil {
+					return nil, err
+				}
+
+				if cluster == nil {
+					return nil, errors.NotFound("cluster does not exist")
+				}
 			}
 
 			managedCentralList := private.ManagedCentralList{

--- a/internal/central/pkg/routes/route_loader.go
+++ b/internal/central/pkg/routes/route_loader.go
@@ -171,7 +171,7 @@ func (s *options) buildAPIBaseRouter(mainRouter *mux.Router, basePath string) er
 
 	// /agent-clusters/{id}
 	dataPlaneClusterHandler := handlers.NewDataPlaneClusterHandler(s.DataPlaneCluster)
-	dataPlaneCentralHandler := handlers.NewDataPlaneCentralHandler(s.DataPlaneCentralService, s.Central, s.ManagedCentralPresenter, s.GitopsProvider)
+	dataPlaneCentralHandler := handlers.NewDataPlaneCentralHandler(s.DataPlaneCentralService, s.Central, s.ClusterService, s.ManagedCentralPresenter, s.GitopsProvider)
 	apiV1DataPlaneRequestsRouter := apiV1Router.PathPrefix(routes.PrivateAPIPrefix).Subrouter()
 	apiV1DataPlaneRequestsRouter.HandleFunc("/{id}", dataPlaneClusterHandler.GetDataPlaneClusterConfig).
 		Name(logger.NewLogEvent("get-dataplane-cluster-config", "get dataplane cluster config by id").ToString()).


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
This PR changes the private API for data planes, so that it returns 404 if the central requests for a cluster ID are empty and the cluster can't be found in the DB.

We deliberately only check for cluster existence after central requests found is 0 because:
- We still want to be able to get centrals assigned to clusters that have been deleted
- We don't want to send additional DB queries for the default case, which is the cluster exists and has centrals assigned

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
