### PR TITLE
ROX-26792: upgrade KMS to use aws-sdk-go-v2

### DIFF
--- a/fleetshard/pkg/cipher/cipher.go
+++ b/fleetshard/pkg/cipher/cipher.go
@@ -4,7 +4,7 @@ package cipher
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
 	"github.com/stackrox/acs-fleet-manager/fleetshard/config"
 )
 
@@ -40,7 +40,7 @@ func NewKeyGenerator(config *config.Config) (KeyGenerator, error) {
 	}
 
 	if encryptionType == "kms" {
-		return NewKMSDataKeyGenerator(config.SecretEncryption.KeyID, kms.DataKeySpecAes256)
+		return NewKMSDataKeyGenerator(config.SecretEncryption.KeyID, types.DataKeySpecAes256)
 	}
 
 	return nil, fmt.Errorf("no KeyGenerator implementation for SecretEncryption.Type: %s", encryptionType)

--- a/fleetshard/pkg/cipher/kms_cipher.go
+++ b/fleetshard/pkg/cipher/kms_cipher.go
@@ -1,15 +1,17 @@
 package cipher
 
 import (
+	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/kms"
+	awsConfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
 )
 
 type kmsCipher struct {
 	keyID      string
-	kms        *kms.KMS
+	kms        *kms.Client
 	dateKeyLen int
 }
 
@@ -17,17 +19,17 @@ type kmsCipher struct {
 // The implementation uses the KMS keyID to generate KMS data keys and encrypt data using
 // those data keys. This is necessary because encrypting via KMS API caps plaintext length to 4096 bytes
 func NewKMSCipher(keyID string) (Cipher, error) {
-	sess, err := session.NewSession()
+	cfg, err := awsConfig.LoadDefaultConfig(context.TODO())
 	if err != nil {
-		return nil, fmt.Errorf("unable to create session for KMS client %w", err)
+		return nil, fmt.Errorf("unable to load AWS config for KMS client %w", err)
 	}
 
 	kmsCipher := kmsCipher{
 		keyID: keyID,
-		kms:   kms.New(sess),
+		kms:   kms.NewFromConfig(cfg),
 	}
 
-	dataKeyOut, err := kmsCipher.kms.GenerateDataKey(kmsCipher.dateKeyInput())
+	dataKeyOut, err := kmsCipher.kms.GenerateDataKey(context.TODO(), kmsCipher.dateKeyInput())
 	if err != nil {
 		return nil, fmt.Errorf("intializing KMS data key length: %w", err)
 	}
@@ -38,13 +40,13 @@ func NewKMSCipher(keyID string) (Cipher, error) {
 }
 
 func (k kmsCipher) dateKeyInput() *kms.GenerateDataKeyInput {
-	keySpec := kms.DataKeySpecAes256
-	return &kms.GenerateDataKeyInput{KeyId: &k.keyID, KeySpec: &keySpec}
+	keySpec := types.DataKeySpecAes256
+	return &kms.GenerateDataKeyInput{KeyId: &k.keyID, KeySpec: keySpec}
 }
 
 func (k kmsCipher) Encrypt(plaintext []byte) ([]byte, error) {
 
-	dataKeyOut, err := k.kms.GenerateDataKey(k.dateKeyInput())
+	dataKeyOut, err := k.kms.GenerateDataKey(context.TODO(), k.dateKeyInput())
 	if err != nil {
 		return nil, fmt.Errorf("creating KMS data key")
 	}
@@ -68,7 +70,7 @@ func (k kmsCipher) Decrypt(ciphertext []byte) ([]byte, error) {
 	keyIndex := len(ciphertext) - k.dateKeyLen
 	cipher, encryptedKey := ciphertext[:keyIndex], ciphertext[keyIndex:]
 
-	decryptOut, err := k.kms.Decrypt(&kms.DecryptInput{
+	decryptOut, err := k.kms.Decrypt(context.TODO(), &kms.DecryptInput{
 		KeyId:          &k.keyID,
 		CiphertextBlob: encryptedKey,
 	})
@@ -92,28 +94,28 @@ func (k kmsCipher) Decrypt(ciphertext []byte) ([]byte, error) {
 // KMSDataKeyGenerator implements KeyGenerator using AWS KMS
 type KMSDataKeyGenerator struct {
 	keyID          string
-	kms            *kms.KMS
-	kmsDataKeySpec string
+	kms            *kms.Client
+	kmsDataKeySpec types.DataKeySpec
 }
 
 // NewKMSDataKeyGenerator initiates a AWS KMS session and
 // returns a new instance of KMSDataKeyGenerator
-func NewKMSDataKeyGenerator(keyID, keySpec string) (*KMSDataKeyGenerator, error) {
-	sess, err := session.NewSession()
+func NewKMSDataKeyGenerator(keyID string, keySpec types.DataKeySpec) (*KMSDataKeyGenerator, error) {
+	cfg, err := awsConfig.LoadDefaultConfig(context.TODO())
 	if err != nil {
-		return nil, fmt.Errorf("unable to create session for KMS client %w", err)
+		return nil, fmt.Errorf("unable to load AWS config for KMS client %w", err)
 	}
 
 	return &KMSDataKeyGenerator{
 		keyID:          keyID,
-		kms:            kms.New(sess),
+		kms:            kms.NewFromConfig(cfg),
 		kmsDataKeySpec: keySpec,
 	}, nil
 }
 
 // Generate generates a KMS data key with the KMSDataKeyGenerator configuration
 func (g KMSDataKeyGenerator) Generate() ([]byte, error) {
-	dateKeyOut, err := g.kms.GenerateDataKey(&kms.GenerateDataKeyInput{KeyId: &g.keyID, KeySpec: &g.kmsDataKeySpec})
+	dateKeyOut, err := g.kms.GenerateDataKey(context.TODO(), &kms.GenerateDataKeyInput{KeyId: &g.keyID, KeySpec: g.kmsDataKeySpec})
 	if err != nil {
 		return nil, fmt.Errorf("generating kms data key: %w", err)
 	}

--- a/fleetshard/pkg/cipher/kms_cipher_test.go
+++ b/fleetshard/pkg/cipher/kms_cipher_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,7 +38,7 @@ func TestKMSDataKeyGenerator(t *testing.T) {
 
 	keyID := os.Getenv("SECRET_ENCRYPTION_KEY_ID")
 	require.NotEmpty(t, keyID, "SECRET_ENCRYPTION_KEY_ID not set")
-	generator, err := NewKMSDataKeyGenerator(keyID, kms.DataKeySpecAes256)
+	generator, err := NewKMSDataKeyGenerator(keyID, types.DataKeySpecAes256)
 	require.NoError(t, err)
 
 	key, err := generator.Generate()

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go v1.55.7
 	github.com/aws/aws-sdk-go-v2 v1.36.5
 	github.com/aws/aws-sdk-go-v2/config v1.29.17
+	github.com/aws/aws-sdk-go-v2/service/kms v1.41.2
 	github.com/aws/aws-sdk-go-v2/service/rds v1.99.1
 	github.com/aws/aws-sdk-go-v2/service/ses v1.29.9
 	github.com/aws/smithy-go v1.22.4

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4 h1:CXV68E2
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4/go.mod h1:/xFi9KtvBXP97ppCz1TAEvU1Uf66qvid89rbem3wCzQ=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.17 h1:t0E6FzREdtCsiLIoLCWsYliNsRBgyGD/MCK571qk4MI=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.17/go.mod h1:ygpklyoaypuyDvOM5ujWGrYWpAK3h7ugnmKCU/76Ys4=
+github.com/aws/aws-sdk-go-v2/service/kms v1.41.2 h1:zJeUxFP7+XP52u23vrp4zMcVhShTWbNO8dHV6xCSvFo=
+github.com/aws/aws-sdk-go-v2/service/kms v1.41.2/go.mod h1:Pqd9k4TuespkireN206cK2QBsaBTL6X+VPAez5Qcijk=
 github.com/aws/aws-sdk-go-v2/service/rds v1.99.1 h1:eiDDf+cf2fAxOF5XaGLlrdCZPsnr5BTcPW55UK92sY4=
 github.com/aws/aws-sdk-go-v2/service/rds v1.99.1/go.mod h1:Xe+NMlf/DY/XTXSevASAjGRika9Qt2LnuCDLtos03ms=
 github.com/aws/aws-sdk-go-v2/service/ses v1.29.9 h1:MIiyk/qQEBO+AI1WHRQDSZft9w2XGAenB58lhzVrByg=


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Upgrade the kms package to use `aws-sdk-go-v2` instead of the V1 `aws-sdk-go`

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

CI is sufficient

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
