### PR TITLE
allow configuring node selector for VPA deployment

### DIFF
--- a/dev/env/manifests/fleetshard-operator/51-fleetshard-cr.yaml
+++ b/dev/env/manifests/fleetshard-operator/51-fleetshard-cr.yaml
@@ -48,4 +48,6 @@ spec:
   scc:
     enabled: false
   verticalPodAutoscaler:
-    enabled: $INSTALL_VERTICAL_POD_AUTOSCALER_OLM
+    enabled: $
+    nodeSelector:
+      node-role.kubernetes.io/worker: ""

--- a/dp-terraform/helm/rhacs-terraform/charts/vertical-pod-autoscaler/templates/02-subscription.yaml
+++ b/dp-terraform/helm/rhacs-terraform/charts/vertical-pod-autoscaler/templates/02-subscription.yaml
@@ -9,3 +9,8 @@ spec:
   name: vertical-pod-autoscaler
   source: redhat-operators
   sourceNamespace: openshift-marketplace
+  {{- if .Values.verticalPodAutoscaler.nodeSelector }}
+  config:
+    nodeSelector:
+      {{- toYaml .Values.verticalPodAutoscaler.nodeSelector | nindent 6 }}
+  {{- end }}

--- a/dp-terraform/helm/rhacs-terraform/values.yaml
+++ b/dp-terraform/helm/rhacs-terraform/values.yaml
@@ -186,6 +186,9 @@ secured-cluster:
 
 verticalPodAutoscaler:
   enabled: true
+  # For HCP clusters, master nodes are hosted so VPA cannot use master node selectors
+  # because of that we need a way to overwrite initial selectors
+  nodeSelector: {}
 
 scc:
   enabled: true


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

On ROSA HCP the default node selector for the VPA is not working because there are no master nodes. To fix that this PR adds an option nodeSelector value for the subscription.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
