### PR TITLE
Fix missing quota-internal-organisation-ids mapping

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -305,63 +305,63 @@
         "filename": "templates/service-template.yml",
         "hashed_secret": "13032f402fed753c2248419ea4f69f99931f6dbc",
         "is_verified": false,
-        "line_number": 471
+        "line_number": 476
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "30025f80f6e22cdafb85db387d50f90ea884576a",
         "is_verified": false,
-        "line_number": 471
+        "line_number": 476
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "355f24fd038bcaf85617abdcaa64af51ed19bbcf",
         "is_verified": false,
-        "line_number": 471
+        "line_number": 476
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "3d8a1dcd2c3c765ce35c9a9552d23273cc4ddace",
         "is_verified": false,
-        "line_number": 471
+        "line_number": 476
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "4ac7b0522761eba972467942cd5cd7499dd2c361",
         "is_verified": false,
-        "line_number": 471
+        "line_number": 476
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "7639ab2a6bcf2ea30a055a99468c9cd844d4c22a",
         "is_verified": false,
-        "line_number": 471
+        "line_number": 476
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "b56360daf4793d2a74991a972b34d95bc00fb2da",
         "is_verified": false,
-        "line_number": 471
+        "line_number": 476
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "templates/service-template.yml",
         "hashed_secret": "c9a73ef9ee8ce9f38437227801c70bcc6740d1a1",
         "is_verified": false,
-        "line_number": 471
+        "line_number": 476
       },
       {
         "type": "Secret Keyword",
         "filename": "templates/service-template.yml",
         "hashed_secret": "4e199b4a1c40b497a95fcd1cd896351733849949",
         "is_verified": false,
-        "line_number": 654,
+        "line_number": 659,
         "is_secret": false
       }
     ],
@@ -391,5 +391,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-10T08:35:01Z"
+  "generated_at": "2025-09-04T08:53:01Z"
 }

--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -294,6 +294,11 @@ parameters:
   description: The domain name to use for Central instances
   value: acs-stage.rhcloud.com
 
+- name: QUOTA_INTERNAL_ORG_IDS
+  displayName: Quota internal organisation ids
+  description: A Comma separated list of organisation IDs that should be ignored for quota checks and for the expiration worker
+  value: ""
+
 - name: ENABLE_READY_DATA_PLANE_CLUSTERS_RECONCILE
   description: Enables reconciliation for data plane clusters in the 'Ready' state
   value: "true"
@@ -958,6 +963,7 @@ objects:
             - --public-host-url=${SERVICE_PUBLIC_HOST_URL}
             - --dataplane-cluster-scaling-type=${DATAPLANE_CLUSTER_SCALING_TYPE}
             - --central-domain-name=${CENTRAL_DOMAIN_NAME}
+            - --quota-internal-organisation-ids=${QUOTA_INTERNAL_ORG_IDS}
             - --alsologtostderr
             - --central-request-expiration-timeout=${CENTRAL_REQUEST_EXPIRATION_TIMEOUT}
             - --central-request-internal-user-agents=${CENTRAL_REQUEST_INTERNAL_USER_AGENTS}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Fix missing service-template mapping for the `quota-internal-organisation-ids` parameter

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

N/A
