### PR TITLE
ROX-17156: use clustername in logs

### DIFF
--- a/internal/central/pkg/workers/clusters_mgr_test.go
+++ b/internal/central/pkg/workers/clusters_mgr_test.go
@@ -28,9 +28,11 @@ func TestClusterManager_processReadyClusters_emptyConfig(t *testing.T) {
 	}
 	c := &ClusterManager{
 		ClusterManagerOptions: ClusterManagerOptions{
-			ClusterService:         clusterService,
-			GitOpsConfigProvider:   provider,
-			DataplaneClusterConfig: &config.DataplaneClusterConfig{},
+			ClusterService:       clusterService,
+			GitOpsConfigProvider: provider,
+			DataplaneClusterConfig: &config.DataplaneClusterConfig{
+				ClusterConfig: &config.ClusterConfig{},
+			},
 		},
 	}
 	errs := c.processReadyClusters()


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Changing logs for cluster operations to also include clustername so that it's easier to figure out dataplane issues by just looking at logs.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources
- [ ] (If applicable) Changes to the dp-terraform Helm values have been reflected in the addon on integration environment

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
