### PR TITLE
ROX-33948: upgrade dev and test psql version for fleet-manager to 18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
       TEST_TIMEOUT: 30m
     services:
       postgres:
-        image: postgres:11
+        image: postgres:18
         env:
           POSTGRES_PASSWORD: foobar-bizz-buzz # pragma: allowlist secret - dummy value
           POSTGRES_USER: fleet_manager

--- a/dev/env/manifests/emailsender-db/emailsender-db.yaml
+++ b/dev/env/manifests/emailsender-db/emailsender-db.yaml
@@ -16,7 +16,7 @@ spec:
         app: emailsender-db
     spec:
       containers:
-        - image: postgres:13
+        - image: postgres:15
           name: postgres
           ports:
             - containerPort: 5432

--- a/scripts/local_db_setup.sh
+++ b/scripts/local_db_setup.sh
@@ -17,4 +17,4 @@ docker run \
   -e POSTGRES_USER="$(cat secrets/db.user)" \
   -e POSTGRES_DB="$(cat secrets/db.name)" \
   -p "$(cat secrets/db.port)":5432 \
-  -d postgres:13
+  -d postgres:18

--- a/templates/db-template.yml
+++ b/templates/db-template.yml
@@ -49,7 +49,7 @@ parameters:
     description: Version of PostgreSQL image to be used (10 or latest).
     displayName: Version of PostgreSQL Image
     required: true
-    value: "13"
+    value: "18"
 
 objects:
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->
This PR is in preparation to a major version upgrade to PSQL 18 for the fleet-manager RDS databases.
- Changes all dev/local/test instances of PSQL for the fleet-manager DB to major version 18
- Additionally changes emailsender test db to PSQL 15, since that is what is used in our current environments

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

CI is sufficient.

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
