### PR TITLE
ROX-34456: add central request pruning

### DIFF
--- a/cmd/fleet-manager/main_test.go
+++ b/cmd/fleet-manager/main_test.go
@@ -52,7 +52,7 @@ func TestInjections(t *testing.T) {
 
 	var workerList []workers.Worker
 	env.MustResolve(&workerList)
-	Expect(workerList).To(HaveLen(10))
+	Expect(workerList).To(HaveLen(11))
 }
 
 func createServicesCommand(env *environments.Env) *cobra.Command {

--- a/internal/central/pkg/workers/centralmgrs/central_request_pruning_mgr.go
+++ b/internal/central/pkg/workers/centralmgrs/central_request_pruning_mgr.go
@@ -1,0 +1,112 @@
+package centralmgrs
+
+import (
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/google/uuid"
+	"github.com/stackrox/acs-fleet-manager/internal/central/constants"
+	"github.com/stackrox/acs-fleet-manager/internal/central/pkg/api/dbapi"
+	"github.com/stackrox/acs-fleet-manager/pkg/db"
+	"github.com/stackrox/acs-fleet-manager/pkg/metrics"
+	"github.com/stackrox/acs-fleet-manager/pkg/workers"
+)
+
+const (
+	centralRequestPruningWorkerType = "central_request_pruning"
+
+	standardRetention = 2 * 365 * 24 * time.Hour // 2 years
+	internalRetention = 14 * 24 * time.Hour      // 14 days
+)
+
+// CentralRequestPruningManager permanently deletes soft-deleted central_requests
+// that have exceeded their retention period.
+type CentralRequestPruningManager struct {
+	workers.BaseWorker
+	connectionFactory *db.ConnectionFactory
+}
+
+// NewCentralRequestPruningManager creates a new pruning manager.
+func NewCentralRequestPruningManager(connectionFactory *db.ConnectionFactory) *CentralRequestPruningManager {
+	metrics.InitReconcilerMetricsForType(centralRequestPruningWorkerType)
+	return &CentralRequestPruningManager{
+		BaseWorker: workers.BaseWorker{
+			ID:         uuid.New().String(),
+			WorkerType: centralRequestPruningWorkerType,
+			Reconciler: workers.Reconciler{},
+		},
+		connectionFactory: connectionFactory,
+	}
+}
+
+// GetRepeatInterval returns how often the pruning worker runs.
+func (*CentralRequestPruningManager) GetRepeatInterval() time.Duration {
+	return 6 * time.Hour
+}
+
+// Start initializes the pruning worker.
+func (m *CentralRequestPruningManager) Start() {
+	m.StartWorker(m)
+}
+
+// Stop causes the pruning worker to stop.
+func (m *CentralRequestPruningManager) Stop() {
+	m.StopWorker(m)
+}
+
+// Reconcile permanently deletes soft-deleted central requests past their retention period.
+func (m *CentralRequestPruningManager) Reconcile() []error {
+	glog.Infoln("reconciling central_requests pruning")
+	var errs []error
+
+	if err := m.pruneStandard(); err != nil {
+		errs = append(errs, err)
+	}
+	if err := m.pruneInternal(); err != nil {
+		errs = append(errs, err)
+	}
+
+	return errs
+}
+
+func (m *CentralRequestPruningManager) pruneStandard() error {
+	cutoff := time.Now().Add(-standardRetention)
+	dbConn := m.connectionFactory.New()
+	result := dbConn.Unscoped().
+		Where("deleted_at IS NOT NULL").
+		Where("deleted_at < ?", cutoff).
+		Where("internal = false OR internal IS NULL").
+		Where("status IN ?", terminalStatuses).
+		Delete(&dbapi.CentralRequest{})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected > 0 {
+		glog.Infof("pruned %d standard central requests older than %s", result.RowsAffected, standardRetention)
+	}
+	return nil
+}
+
+func (m *CentralRequestPruningManager) pruneInternal() error {
+	cutoff := time.Now().Add(-internalRetention)
+	dbConn := m.connectionFactory.New()
+	result := dbConn.Unscoped().
+		Where("deleted_at IS NOT NULL").
+		Where("deleted_at < ?", cutoff).
+		Where("internal = true").
+		Where("status IN ?", terminalStatuses).
+		Delete(&dbapi.CentralRequest{})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected > 0 {
+		glog.Infof("pruned %d internal central requests older than %s", result.RowsAffected, internalRetention)
+	}
+	return nil
+}
+
+var terminalStatuses = []string{
+	constants.CentralRequestStatusDeprovision.String(),
+	constants.CentralRequestStatusDeleting.String(),
+	constants.CentralRequestStatusFailed.String(),
+}

--- a/internal/central/providers.go
+++ b/internal/central/providers.go
@@ -72,6 +72,7 @@ func ServiceProviders() di.Option {
 		di.Provide(centralmgrs.NewCentralCNAMEManager, di.As(new(workers.Worker))),
 		di.Provide(centralmgrs.NewCentralAuthConfigManager, di.As(new(workers.Worker))),
 		di.Provide(centralmgrs.NewExpirationDateManager, di.As(new(workers.Worker))),
+		di.Provide(centralmgrs.NewCentralRequestPruningManager, di.As(new(workers.Worker))),
 		di.Provide(gitops.NewEmptyReader),
 		di.Provide(gitops.NewProvider),
 		di.Provide(presenters.NewManagedCentralPresenter),

--- a/internal/central/test/integration/central_request_pruning_test.go
+++ b/internal/central/test/integration/central_request_pruning_test.go
@@ -1,0 +1,97 @@
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stackrox/acs-fleet-manager/internal/central/constants"
+	"github.com/stackrox/acs-fleet-manager/internal/central/pkg/api/dbapi"
+	"github.com/stackrox/acs-fleet-manager/internal/central/pkg/workers/centralmgrs"
+	"github.com/stackrox/acs-fleet-manager/internal/central/test"
+	"github.com/stackrox/acs-fleet-manager/pkg/api"
+	"github.com/stackrox/acs-fleet-manager/test/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestCentralRequestPruning(t *testing.T) {
+	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
+	defer ocmServer.Close()
+
+	_, _, teardown := test.NewCentralHelperWithHooks(t, ocmServer, nil)
+	defer teardown()
+
+	db := test.TestServices.DBFactory.New()
+	mgr := centralmgrs.NewCentralRequestPruningManager(test.TestServices.DBFactory)
+
+	now := time.Now()
+	threeYearsAgo := now.Add(-3 * 365 * 24 * time.Hour)
+	oneYearAgo := now.Add(-365 * 24 * time.Hour)
+	thirtyDaysAgo := now.Add(-30 * 24 * time.Hour)
+	sevenDaysAgo := now.Add(-7 * 24 * time.Hour)
+
+	centralStandardOld := newDeletedCentral("standard-old", false)
+	centralStandardRecent := newDeletedCentral("standard-recent", false)
+	centralInternalOld := newDeletedCentral("internal-old", true)
+	centralInternalRecent := newDeletedCentral("internal-recent", true)
+	centralActive := &dbapi.CentralRequest{
+		Meta:          api.Meta{ID: api.NewID()},
+		Name:          "active",
+		Region:        "us-east-1",
+		CloudProvider: "aws",
+		Owner:         "test-user",
+		Status:        constants.CentralRequestStatusReady.String(),
+	}
+
+	for _, c := range []*dbapi.CentralRequest{centralStandardOld, centralStandardRecent, centralInternalOld, centralInternalRecent, centralActive} {
+		require.NoError(t, db.Create(c).Error)
+	}
+
+	setSoftDeleted(t, db, centralStandardOld.ID, threeYearsAgo)
+	setSoftDeleted(t, db, centralStandardRecent.ID, oneYearAgo)
+	setSoftDeleted(t, db, centralInternalOld.ID, thirtyDaysAgo)
+	setSoftDeleted(t, db, centralInternalRecent.ID, sevenDaysAgo)
+
+	errs := mgr.Reconcile()
+	require.Empty(t, errs)
+
+	assert.True(t, isHardDeleted(t, db, centralStandardOld.ID), "standard central deleted 3y ago should be pruned")
+	assert.False(t, isHardDeleted(t, db, centralStandardRecent.ID), "standard central deleted 1y ago should be kept")
+	assert.True(t, isHardDeleted(t, db, centralInternalOld.ID), "internal central deleted 30d ago should be pruned")
+	assert.False(t, isHardDeleted(t, db, centralInternalRecent.ID), "internal central deleted 7d ago should be kept")
+	assert.False(t, isHardDeleted(t, db, centralActive.ID), "active central should never be pruned")
+
+	// Verify idempotency: running again should produce no errors.
+	errs = mgr.Reconcile()
+	require.Empty(t, errs)
+}
+
+func newDeletedCentral(name string, internal bool) *dbapi.CentralRequest {
+	return &dbapi.CentralRequest{
+		Meta:          api.Meta{ID: api.NewID()},
+		Name:          name,
+		Region:        "us-east-1",
+		CloudProvider: "aws",
+		Owner:         "test-user",
+		Status:        constants.CentralRequestStatusDeleting.String(),
+		Internal:      internal,
+	}
+}
+
+func setSoftDeleted(t *testing.T, db *gorm.DB, id string, deletedAt time.Time) {
+	t.Helper()
+	err := db.Unscoped().
+		Model(&dbapi.CentralRequest{}).
+		Where("id = ?", id).
+		Update("deleted_at", deletedAt).Error
+	require.NoError(t, err)
+}
+
+func isHardDeleted(t *testing.T, db *gorm.DB, id string) bool {
+	t.Helper()
+	var count int64
+	err := db.Unscoped().Model(&dbapi.CentralRequest{}).Where("id = ?", id).Count(&count).Error
+	require.NoError(t, err)
+	return count == 0
+}

--- a/internal/central/test/integration/central_request_pruning_test.go
+++ b/internal/central/test/integration/central_request_pruning_test.go
@@ -26,50 +26,41 @@ func TestCentralRequestPruning(t *testing.T) {
 	mgr := centralmgrs.NewCentralRequestPruningManager(test.TestServices.DBFactory)
 
 	now := time.Now()
-	threeYearsAgo := now.Add(-3 * 365 * 24 * time.Hour)
-	oneYearAgo := now.Add(-365 * 24 * time.Hour)
-	thirtyDaysAgo := now.Add(-30 * 24 * time.Hour)
-	sevenDaysAgo := now.Add(-7 * 24 * time.Hour)
 
-	centralStandardOld := newDeletedCentral("standard-old", false)
-	centralStandardRecent := newDeletedCentral("standard-recent", false)
-	centralInternalOld := newDeletedCentral("internal-old", true)
-	centralInternalRecent := newDeletedCentral("internal-recent", true)
-	centralActive := &dbapi.CentralRequest{
-		Meta:          api.Meta{ID: api.NewID()},
-		Name:          "active",
-		Region:        "us-east-1",
-		CloudProvider: "aws",
-		Owner:         "test-user",
-		Status:        constants.CentralRequestStatusReady.String(),
+	cases := []struct {
+		name       string
+		central    *dbapi.CentralRequest
+		wantPruned bool
+	}{
+		{"standard central deleted 3y ago should be pruned", newDeletedCentral("standard-old", false, now.Add(-3*365*24*time.Hour)), true},
+		{"standard central deleted 1y ago should be kept", newDeletedCentral("standard-recent", false, now.Add(-365*24*time.Hour)), false},
+		{"internal central deleted 30d ago should be pruned", newDeletedCentral("internal-old", true, now.Add(-30*24*time.Hour)), true},
+		{"internal central deleted 7d ago should be kept", newDeletedCentral("internal-recent", true, now.Add(-7*24*time.Hour)), false},
+		{"active central should never be pruned", newActiveCentral(), false},
 	}
 
-	for _, c := range []*dbapi.CentralRequest{centralStandardOld, centralStandardRecent, centralInternalOld, centralInternalRecent, centralActive} {
-		require.NoError(t, db.Create(c).Error)
+	for _, tc := range cases {
+		require.NoError(t, db.Unscoped().Create(tc.central).Error)
 	}
-
-	setSoftDeleted(t, db, centralStandardOld.ID, threeYearsAgo)
-	setSoftDeleted(t, db, centralStandardRecent.ID, oneYearAgo)
-	setSoftDeleted(t, db, centralInternalOld.ID, thirtyDaysAgo)
-	setSoftDeleted(t, db, centralInternalRecent.ID, sevenDaysAgo)
 
 	errs := mgr.Reconcile()
 	require.Empty(t, errs)
 
-	assert.True(t, isHardDeleted(t, db, centralStandardOld.ID), "standard central deleted 3y ago should be pruned")
-	assert.False(t, isHardDeleted(t, db, centralStandardRecent.ID), "standard central deleted 1y ago should be kept")
-	assert.True(t, isHardDeleted(t, db, centralInternalOld.ID), "internal central deleted 30d ago should be pruned")
-	assert.False(t, isHardDeleted(t, db, centralInternalRecent.ID), "internal central deleted 7d ago should be kept")
-	assert.False(t, isHardDeleted(t, db, centralActive.ID), "active central should never be pruned")
+	for _, tc := range cases {
+		assert.Equal(t, tc.wantPruned, isHardDeleted(t, db, tc.central.ID), tc.name)
+	}
 
 	// Verify idempotency: running again should produce no errors.
 	errs = mgr.Reconcile()
 	require.Empty(t, errs)
 }
 
-func newDeletedCentral(name string, internal bool) *dbapi.CentralRequest {
+func newDeletedCentral(name string, internal bool, deletedAt time.Time) *dbapi.CentralRequest {
 	return &dbapi.CentralRequest{
-		Meta:          api.Meta{ID: api.NewID()},
+		Meta: api.Meta{
+			ID:        api.NewID(),
+			DeletedAt: gorm.DeletedAt{Time: deletedAt, Valid: true},
+		},
 		Name:          name,
 		Region:        "us-east-1",
 		CloudProvider: "aws",
@@ -79,13 +70,15 @@ func newDeletedCentral(name string, internal bool) *dbapi.CentralRequest {
 	}
 }
 
-func setSoftDeleted(t *testing.T, db *gorm.DB, id string, deletedAt time.Time) {
-	t.Helper()
-	err := db.Unscoped().
-		Model(&dbapi.CentralRequest{}).
-		Where("id = ?", id).
-		Update("deleted_at", deletedAt).Error
-	require.NoError(t, err)
+func newActiveCentral() *dbapi.CentralRequest {
+	return &dbapi.CentralRequest{
+		Meta:          api.Meta{ID: api.NewID()},
+		Name:          "active",
+		Region:        "us-east-1",
+		CloudProvider: "aws",
+		Owner:         "test-user",
+		Status:        constants.CentralRequestStatusReady.String(),
+	}
 }
 
 func isHardDeleted(t *testing.T, db *gorm.DB, id string) bool {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This PR adds a new background worker to acs-fleet-manager that prunes all soft deleted central_requests after 2 years and all internal/probe soft deleted central_requests after 14d.

Implemented with Claude.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [x] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
