### PR TITLE
ROX-34562: Add a switch for the declarative config reconciliation

### DIFF
--- a/dev/config/gitops-config.yaml
+++ b/dev/config/gitops-config.yaml
@@ -83,3 +83,6 @@ tenantResources:
         memory: 100Mi
 
     centralRdsCidrBlock: "10.1.0.0/16"
+
+    declarativeConfig:
+      enabled: false

--- a/fleetshard/pkg/central/reconciler/argo_reconciler.go
+++ b/fleetshard/pkg/central/reconciler/argo_reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -76,7 +77,6 @@ func (r *argoReconciler) makeDesiredArgoCDApplication(remoteCentral private.Mana
 	values["isInternal"] = remoteCentral.Metadata.Internal
 	values["telemetryStorageEndpoint"] = r.argoOpts.Telemetry.StorageEndpoint
 	values["centralAdminPasswordEnabled"] = !r.argoOpts.WantsAuthProvider
-	values["centralEnabled"] = true // TODO: Remove once ROX-27129 fully released
 	values["centralUIHost"] = remoteCentral.Spec.UiHost
 	values["centralDataHost"] = remoteCentral.Spec.DataHost
 
@@ -150,37 +150,58 @@ func (r *argoReconciler) makeDesiredArgoCDApplication(remoteCentral private.Mana
 }
 
 func (r *argoReconciler) getSourceTargetRevision(m private.ManagedCentral) string {
-	return r.getArgoCdTargetParam(m, "sourceTargetRevision", r.argoOpts.TenantDefaultArgoCdAppSourceTargetRevision)
+	return getTenantResourcesValue(m, "argoCd.sourceTargetRevision", r.argoOpts.TenantDefaultArgoCdAppSourceTargetRevision)
 }
 
 func (r *argoReconciler) getSourcePath(m private.ManagedCentral) string {
-	return r.getArgoCdTargetParam(m, "sourcePath", r.argoOpts.TenantDefaultArgoCdAppSourcePath)
+	return getTenantResourcesValue(m, "argoCd.sourcePath", r.argoOpts.TenantDefaultArgoCdAppSourcePath)
 }
 
 func (r *argoReconciler) getSourceRepoURL(m private.ManagedCentral) string {
-	return r.getArgoCdTargetParam(m, "sourceRepoUrl", r.argoOpts.TenantDefaultArgoCdAppSourceRepoURL)
+	return getTenantResourcesValue(m, "argoCd.sourceRepoUrl", r.argoOpts.TenantDefaultArgoCdAppSourceRepoURL)
 }
 
-func (r *argoReconciler) getArgoCdTargetParam(m private.ManagedCentral, key, defaultValue string) string {
-	if m.Spec.TenantResourcesValues == nil {
+func isArgoDeclarativeConfigReconciliationEnabled(m private.ManagedCentral) bool {
+	return getTenantResourcesValue(m, "declarativeConfig.enabled", false)
+}
+
+func isForceReconcile(m private.ManagedCentral) bool {
+	return getTenantResourcesValue(m, "forceReconcile", false)
+}
+
+type valueType interface {
+	string | bool | int | float64
+}
+
+func getTenantResourcesValue[T valueType](remoteCentral private.ManagedCentral, path string, defaultValue T) T {
+	return getHelmValueByPath(remoteCentral.Spec.TenantResourcesValues, path, defaultValue)
+}
+
+func getHelmValueByPath[T valueType](values map[string]interface{}, path string, defaultValue T) T {
+	if values == nil {
 		return defaultValue
 	}
 
-	argoCd, ok := m.Spec.TenantResourcesValues["argoCd"].(map[string]interface{})
+	parts := strings.Split(path, ".")
+	if len(parts) == 0 {
+		return defaultValue
+	}
+
+	current := values
+	for _, part := range parts[:len(parts)-1] {
+		next, ok := current[part].(map[string]interface{})
+		if !ok {
+			return defaultValue
+		}
+		current = next
+	}
+
+	val, ok := current[parts[len(parts)-1]].(T)
 	if !ok {
 		return defaultValue
 	}
 
-	revision, ok := argoCd[key].(string)
-	if !ok {
-		return defaultValue
-	}
-
-	if len(revision) == 0 {
-		return defaultValue
-	}
-
-	return revision
+	return val
 }
 
 func (r *argoReconciler) ensureApplicationDeleted(ctx context.Context, tenantNamespace string) (bool, error) {

--- a/fleetshard/pkg/central/reconciler/argo_reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/argo_reconciler_test.go
@@ -1,9 +1,10 @@
 package reconciler
 
 import (
+	"testing"
+
 	"github.com/stackrox/acs-fleet-manager/internal/central/pkg/api/private"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestSourceGetRepoURL(t *testing.T) {
@@ -49,4 +50,134 @@ func TestGetSourceTargetRevision(t *testing.T) {
 			},
 		},
 	}))
+}
+
+func TestDeclarativeConfigEnabled(t *testing.T) {
+	t.Run("returns false for empty ManagedCentral", func(t *testing.T) {
+		assert.False(t, isArgoDeclarativeConfigReconciliationEnabled(private.ManagedCentral{}))
+	})
+
+	t.Run("returns false for nil TenantResourcesValues", func(t *testing.T) {
+		assert.False(t, isArgoDeclarativeConfigReconciliationEnabled(private.ManagedCentral{
+			Spec: private.ManagedCentralAllOfSpec{
+				TenantResourcesValues: nil,
+			},
+		}))
+	})
+
+	t.Run("returns false when declarativeConfig is missing", func(t *testing.T) {
+		assert.False(t, isArgoDeclarativeConfigReconciliationEnabled(private.ManagedCentral{
+			Spec: private.ManagedCentralAllOfSpec{
+				TenantResourcesValues: map[string]interface{}{
+					"other": "value",
+				},
+			},
+		}))
+	})
+
+	t.Run("returns false when explicitly disabled", func(t *testing.T) {
+		assert.False(t, isArgoDeclarativeConfigReconciliationEnabled(private.ManagedCentral{
+			Spec: private.ManagedCentralAllOfSpec{
+				TenantResourcesValues: map[string]interface{}{
+					"declarativeConfig": map[string]interface{}{
+						"enabled": false,
+					},
+				},
+			},
+		}))
+	})
+
+	t.Run("returns false when enabled is wrong type", func(t *testing.T) {
+		assert.False(t, isArgoDeclarativeConfigReconciliationEnabled(private.ManagedCentral{
+			Spec: private.ManagedCentralAllOfSpec{
+				TenantResourcesValues: map[string]interface{}{
+					"declarativeConfig": map[string]interface{}{
+						"enabled": "true",
+					},
+				},
+			},
+		}))
+	})
+
+	t.Run("returns true when enabled", func(t *testing.T) {
+		assert.True(t, isArgoDeclarativeConfigReconciliationEnabled(private.ManagedCentral{
+			Spec: private.ManagedCentralAllOfSpec{
+				TenantResourcesValues: map[string]interface{}{
+					"declarativeConfig": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+			},
+		}))
+	})
+}
+
+func TestGetHelmValueByPath(t *testing.T) {
+	values := map[string]interface{}{
+		"topLevel": "top-value",
+		"declarativeConfig": map[string]interface{}{
+			"enabled": true,
+			"count":   float64(42),
+			"name":    "my-config",
+			"nested": map[string]interface{}{
+				"deep":      "deep-value",
+				"flag":      false,
+				"threshold": 3.14,
+			},
+		},
+		"wrongType": 123,
+		"intSection": map[string]interface{}{
+			"port":  8080,
+			"count": 3,
+		},
+	}
+
+	t.Run("string values", func(t *testing.T) {
+		assert.Equal(t, "top-value", getHelmValueByPath(values, "topLevel", "default"))
+		assert.Equal(t, "my-config", getHelmValueByPath(values, "declarativeConfig.name", "default"))
+		assert.Equal(t, "deep-value", getHelmValueByPath(values, "declarativeConfig.nested.deep", "default"))
+	})
+
+	t.Run("bool values", func(t *testing.T) {
+		assert.Equal(t, true, getHelmValueByPath(values, "declarativeConfig.enabled", false))
+		assert.Equal(t, false, getHelmValueByPath(values, "declarativeConfig.nested.flag", true))
+	})
+
+	t.Run("int values", func(t *testing.T) {
+		assert.Equal(t, 8080, getHelmValueByPath(values, "intSection.port", 0))
+		assert.Equal(t, 3, getHelmValueByPath(values, "intSection.count", 0))
+		assert.Equal(t, 0, getHelmValueByPath(values, "intSection.missing", 0))
+		// float64 value doesn't match int
+		assert.Equal(t, 0, getHelmValueByPath(values, "declarativeConfig.count", 0))
+	})
+
+	t.Run("float64 values", func(t *testing.T) {
+		assert.Equal(t, float64(42), getHelmValueByPath(values, "declarativeConfig.count", float64(0)))
+		assert.Equal(t, 3.14, getHelmValueByPath(values, "declarativeConfig.nested.threshold", float64(0)))
+	})
+
+	t.Run("returns default for missing key", func(t *testing.T) {
+		assert.Equal(t, "default", getHelmValueByPath(values, "nonexistent", "default"))
+		assert.Equal(t, "default", getHelmValueByPath(values, "declarativeConfig.missing", "default"))
+		assert.Equal(t, "default", getHelmValueByPath(values, "declarativeConfig.nested.missing", "default"))
+	})
+
+	t.Run("returns default for type mismatch", func(t *testing.T) {
+		assert.Equal(t, "default", getHelmValueByPath(values, "declarativeConfig.enabled", "default"))
+		assert.Equal(t, false, getHelmValueByPath(values, "declarativeConfig.name", false))
+	})
+
+	t.Run("returns default when intermediate key is not a map", func(t *testing.T) {
+		assert.Equal(t, "default", getHelmValueByPath(values, "topLevel.child", "default"))
+		assert.Equal(t, "default", getHelmValueByPath(values, "wrongType.child", "default"))
+	})
+
+	t.Run("returns default for nil values map", func(t *testing.T) {
+		assert.Equal(t, "default", getHelmValueByPath[string](nil, "any.path", "default"))
+		assert.Equal(t, true, getHelmValueByPath[bool](nil, "any.path", true))
+	})
+
+	t.Run("returns default for empty path", func(t *testing.T) {
+		assert.Equal(t, "default", getHelmValueByPath(values, "", "default"))
+	})
 }

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -441,6 +441,9 @@ func (r *CentralReconciler) configureAuthProvider(secret *corev1.Secret, remoteC
 
 func (r *CentralReconciler) reconcileDeclarativeConfigurationData(ctx context.Context,
 	remoteCentral private.ManagedCentral) error {
+	if isArgoDeclarativeConfigReconciliationEnabled(remoteCentral) {
+		return nil
+	}
 	namespace := remoteCentral.Metadata.Namespace
 	return ensureSecretExists(
 		ctx,
@@ -961,7 +964,7 @@ func (r *CentralReconciler) needsReconcile(changed bool, remoteCentral private.M
 		return true
 	}
 
-	if force, ok := remoteCentral.Spec.TenantResourcesValues["forceReconcile"].(bool); ok && force {
+	if isForceReconcile(remoteCentral) {
 		return true
 	}
 

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -1232,6 +1232,31 @@ func TestReconcileDeclarativeConfigurationData(t *testing.T) {
 	}
 }
 
+func TestReconcileDeclarativeConfigSkippedWhenArgoManaged(t *testing.T) {
+	centralWithDeclarativeConfig := simpleManagedCentral
+	centralWithDeclarativeConfig.Spec.TenantResourcesValues = map[string]interface{}{
+		"declarativeConfig": map[string]interface{}{
+			"enabled": true,
+		},
+	}
+
+	reconcilerOptions := CentralReconcilerOptions{
+		WantsAuthProvider: true,
+		AuditLogging:      defaultAuditLogConfig,
+	}
+	fakeClient, _, r := getClientTrackerAndReconciler(t, nil, reconcilerOptions)
+
+	err := r.reconcileDeclarativeConfigurationData(context.Background(), centralWithDeclarativeConfig)
+	require.NoError(t, err)
+
+	secret := &v1.Secret{}
+	getErr := fakeClient.Get(context.Background(), client.ObjectKey{
+		Namespace: centralNamespace,
+		Name:      sensibleDeclarativeConfigSecretName,
+	}, secret)
+	assert.True(t, k8sErrors.IsNotFound(getErr), "secret should not be created when declarativeConfig.enabled is true")
+}
+
 func TestRestoreCentralSecrets(t *testing.T) {
 	testCases := []struct {
 		name                     string


### PR DESCRIPTION
## Description
An intermediate PR to move to the ArgoCD reconciliation of the declarative config.
- Switch between fleetshard-sync and ArgoCD reconciliation of the declarative config based on the helm value propagated from Fleet Manager, false by default.
- Refactor the values retrieval func to support generic types and nested paths

Next steps: Rollout tenant-resources and FSS; switch to the ArgoCD reconciliation; Remove FSS reconciliation logic. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
