### PR TITLE
ROX-34562: Set the declarative config Helm values

### DIFF
--- a/dev/config/gitops-config.yaml
+++ b/dev/config/gitops-config.yaml
@@ -85,4 +85,4 @@ tenantResources:
     centralRdsCidrBlock: "10.1.0.0/16"
 
     declarativeConfig:
-      enabled: false
+      enabled: true

--- a/fleetshard/pkg/central/reconciler/argo_reconciler.go
+++ b/fleetshard/pkg/central/reconciler/argo_reconciler.go
@@ -113,6 +113,22 @@ func (r *argoReconciler) makeDesiredArgoCDApplication(remoteCentral private.Mana
 		delete(values, "additionalCAs")
 	}
 
+	if isArgoDeclarativeConfigReconciliationEnabled(remoteCentral) {
+		dc, _ := values["declarativeConfig"].(map[string]interface{})
+		if dc == nil {
+			dc = map[string]interface{}{}
+			values["declarativeConfig"] = dc
+		}
+		dc["defaultAuthProvider"] = map[string]interface{}{
+			"oidc": map[string]interface{}{
+				"issuer":                  remoteCentral.Spec.Auth.Issuer,
+				"clientCredentialsSecret": authProviderClientCredentialsSecretName,
+			},
+			"ownerUserId":          remoteCentral.Spec.Auth.OwnerUserId,
+			"ownerAlternateUserId": remoteCentral.Spec.Auth.OwnerAlternateUserId,
+		}
+	}
+
 	valuesBytes, err := json.Marshal(values)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling values: %w", err)

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -81,7 +81,8 @@ const (
 
 	centralEncryptionKeySecretName = "central-encryption-key-chain" // pragma: allowlist secret
 
-	sensibleDeclarativeConfigSecretName = "cloud-service-sensible-declarative-configs" // pragma: allowlist secret
+	sensibleDeclarativeConfigSecretName     = "cloud-service-sensible-declarative-configs" // pragma: allowlist secret
+	authProviderClientCredentialsSecretName = "default-auth-provider-client-credentials"   // pragma: allowlist secret
 
 	authProviderDeclarativeConfigKey = "default-sso-auth-provider"
 	additionalAuthProviderConfigKey  = "additional-auth-provider"
@@ -442,7 +443,20 @@ func (r *CentralReconciler) configureAuthProvider(secret *corev1.Secret, remoteC
 func (r *CentralReconciler) reconcileDeclarativeConfigurationData(ctx context.Context,
 	remoteCentral private.ManagedCentral) error {
 	if isArgoDeclarativeConfigReconciliationEnabled(remoteCentral) {
-		return nil
+		return ensureSecretExists(
+			ctx,
+			r.client,
+			remoteCentral.Metadata.Namespace,
+			authProviderClientCredentialsSecretName,
+			func(secret *corev1.Secret) error {
+				if secret.Data == nil {
+					secret.Data = make(map[string][]byte)
+				}
+				secret.Data["clientID"] = []byte(remoteCentral.Spec.Auth.ClientId)
+				secret.Data["clientSecret"] = []byte(remoteCentral.Spec.Auth.ClientSecret) // pragma: allowlist secret
+				return nil
+			},
+		)
 	}
 	namespace := remoteCentral.Metadata.Namespace
 	return ensureSecretExists(


### PR DESCRIPTION
## Description
- Set required values when the declarative config reconciled via Argo
- Create a client credentials secret
- Enable the ArgoCD reconciliation in dev

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.
- [ ] Add secret to app-interface Vault or Secrets Manager if necessary
- [ ] RDS changes were e2e tested [manually](../docs/development/howto-e2e-test-rds.md)
- [ ] Check AWS limits are reasonable for changes provisioning new resources

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
make db/teardown db/setup db/migrate
make ocm/setup
make verify lint binary test test/integration
```
