### PR TITLE
chores: Bump snyk-check task

### DIFF
--- a/.tekton/base-acscs-pipeline.yaml
+++ b/.tekton/base-acscs-pipeline.yaml
@@ -390,7 +390,7 @@ spec:
       - name: name
         value: sast-snyk-check
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check:0.5@sha256:2a61c29aacfb9dfe68c114eb17caa2714af2f734c94ee3ad0c236f198b54809b
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check:0.5@sha256:a7ea295dec280b3ac9783df7c085b6792e718097537de03be09f5a7eef5a7bee
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/base-acscs-pipeline.yaml
+++ b/.tekton/base-acscs-pipeline.yaml
@@ -390,7 +390,7 @@ spec:
       - name: name
         value: sast-snyk-check
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check:0.5@sha256:a7ea295dec280b3ac9783df7c085b6792e718097537de03be09f5a7eef5a7bee
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check:0.5-0@sha256:2a61c29aacfb9dfe68c114eb17caa2714af2f734c94ee3ad0c236f198b54809b
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
Bump snyk-check Konflux task

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request updates the `task-sast-snyk-check` Tekton task bundle reference in the `.tekton/base-acscs-pipeline.yaml` file. The task reference bundle was updated from `quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check:0.5@sha256:2a61c29aacfb9dfe68c114eb17caa2714af2f734c94ee3ad0c236f198b54809b` to `quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check:0.5-0@sha256:2a61c29aacfb9dfe68c114eb17caa2714af2f734c94ee3ad0c236f198b54809b`. All task parameters, conditions (`when`), and workspace references remain unchanged.

## Checklist (Definition of Done)

- [ ] CI and all relevant tests are passing

## Test manual

N/A

---
*The following was generated by `@coderabbitai` and may be updated automatically.*

## Summary
This PR bumps the Konflux `task-sast-snyk-check` Tekton task bundle reference used by the `sast-snyk-check` pipeline task. Specifically, the `taskRef` `bundle` for `task-sast-snyk-check` was updated from `:0.5@sha256:2a61c29aacfb9dfe68c114eb17caa2714af2f734c94ee3ad0c236f198b54809b` to `:0.5-0@sha256:2a61c29aacfb9dfe68c114eb17caa2714af2f734c94ee3ad0c236f198b54809b`, with no other Tekton configuration changes.

## Checklist (Definition of Done)
- [ ] CI and all relevant tests are passing

## Test manual
N/A
<!-- end of auto-generated comment: release notes by coderabbit.ai -->