### PR TITLE
ROX-35945: Fix audit-logs tls hostname mismatch

### DIFF
--- a/fleetshard/config/config.go
+++ b/fleetshard/config/config.go
@@ -72,7 +72,7 @@ type ManagedDBTag struct {
 type AuditLogging struct {
 	Enabled            bool   `env:"AUDIT_LOG_ENABLED" envDefault:"false"`
 	URLScheme          string `env:"AUDIT_LOG_URL_SCHEME" envDefault:"https"`
-	AuditLogTargetHost string `env:"AUDIT_LOG_HOST" envDefault:"audit-logs-aggregator.rhacs-audit-logs"`
+	AuditLogTargetHost string `env:"AUDIT_LOG_HOST" envDefault:"audit-logs-aggregator.rhacs-audit-logs.svc"`
 	AuditLogTargetPort int    `env:"AUDIT_LOG_PORT" envDefault:"8888"`
 	SkipTLSVerify      bool   `env:"AUDIT_LOG_SKIP_TLS_VERIFY" envDefault:"false"`
 }


### PR DESCRIPTION
Fix TLS hostname mismatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR summary

Fixes an audit-logs TLS hostname mismatch.

---
*The following was generated by `@coderabbitai` and may be updated automatically.*

## Summary

Updated the default audit log hostname to include the Kubernetes service namespace, resolving TLS hostname mismatches when connecting to the audit-log aggregator.

## Checklist (Definition of Done)

- [ ] CI and all relevant tests are passing

## Test manual

Verify audit logging connects successfully to the aggregator using the default configuration and that no TLS hostname mismatch occurs.

---

<!-- end of auto-generated comment: release notes by coderabbit.ai -->