### PR TITLE
Migrate from deprecated oc-installer to openshift-tools-installer

### DIFF
--- a/.github/workflows/multicluster-e2e.yaml
+++ b/.github/workflows/multicluster-e2e.yaml
@@ -81,7 +81,9 @@ jobs:
       - name: Install infractl
         uses: stackrox/actions/infra/install-infractl@v1
       - name: Install oc
-        uses: redhat-actions/oc-installer@v1
+        uses: redhat-actions/openshift-tools-installer@v2
+        with:
+          oc: "latest"
       - name: Check out code
         uses: actions/checkout@v6
       - name: Set cluster credentials


### PR DESCRIPTION
## Summary

- Replace `redhat-actions/oc-installer@v1` with `redhat-actions/openshift-tools-installer@v2` in the multicluster e2e workflow

## Why

`redhat-actions/oc-installer` is deprecated:
- The download mirror it points to has not been updated since December 2020
- The action now emits a deprecation warning at runtime ([redhat-actions/oc-installer#32](https://github.com/redhat-actions/oc-installer/pull/32))

`openshift-tools-installer` is the actively maintained successor, supporting semver ranges, arm64, cross-workflow caching, and 18+ tools.

## Test plan

- [ ] Verify the multicluster e2e workflow installs `oc` successfully with the new action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR summary

This PR replaces `redhat-actions/oc-installer@v1` with `redhat-actions/openshift-tools-installer@v2` in the multicluster end-to-end workflow. The change addresses the deprecation of `oc-installer`, whose download mirror has not been updated since December 2020. The replacement action is actively maintained and supports semver ranges, arm64, cross-workflow caching, and more than 18 tools.

## Test plan

Verify that the multicluster end-to-end workflow successfully installs `oc` with the new action.

---

*The following was generated by `@coderabbitai` and may be updated automatically.*

## Summary

Updated the multicluster end-to-end workflow to install the latest `oc` release using the actively maintained `redhat-actions/openshift-tools-installer@v2`.

## Checklist (Definition of Done)

- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing

## Test manual

1. Trigger the multicluster end-to-end workflow.
2. Confirm the “Install oc” step completes successfully.
3. Confirm subsequent end-to-end tests run successfully using the installed `oc` tool.

---

<!-- end of auto-generated comment: release notes by coderabbit.ai -->