### PR TITLE
ROX-36296: update version selector during delete

### DIFF
--- a/fleetshard/pkg/central/reconciler/argo_reconciler.go
+++ b/fleetshard/pkg/central/reconciler/argo_reconciler.go
@@ -59,20 +59,6 @@ func (r *argoReconciler) ensureApplicationExists(ctx context.Context, remoteCent
 	return nil
 }
 
-// applicationExists reports whether the tenant's ArgoCD Application currently exists. Used to
-// avoid recreating it (via ensureApplicationExists) after it has already been deleted by an
-// earlier pass of the (multi-step, async) deletion flow.
-func (r *argoReconciler) applicationExists(ctx context.Context, tenantNamespace string) (bool, error) {
-	err := r.client.Get(ctx, r.getArgoCdAppObjectKey(tenantNamespace), &argocd.Application{})
-	if err != nil {
-		if apiErrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("getting ArgoCD application: %w", err)
-	}
-	return true, nil
-}
-
 func (r *argoReconciler) makeDesiredArgoCDApplication(remoteCentral private.ManagedCentral, centralDBConnectionString string) (*argocd.Application, error) {
 
 	values := remoteCentral.Spec.TenantResourcesValues

--- a/fleetshard/pkg/central/reconciler/argo_reconciler.go
+++ b/fleetshard/pkg/central/reconciler/argo_reconciler.go
@@ -59,6 +59,20 @@ func (r *argoReconciler) ensureApplicationExists(ctx context.Context, remoteCent
 	return nil
 }
 
+// applicationExists reports whether the tenant's ArgoCD Application currently exists. Used to
+// avoid recreating it (via ensureApplicationExists) after it has already been deleted by an
+// earlier pass of the (multi-step, async) deletion flow.
+func (r *argoReconciler) applicationExists(ctx context.Context, tenantNamespace string) (bool, error) {
+	err := r.client.Get(ctx, r.getArgoCdAppObjectKey(tenantNamespace), &argocd.Application{})
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("getting ArgoCD application: %w", err)
+	}
+	return true, nil
+}
+
 func (r *argoReconciler) makeDesiredArgoCDApplication(remoteCentral private.ManagedCentral, centralDBConnectionString string) (*argocd.Application, error) {
 
 	values := remoteCentral.Spec.TenantResourcesValues

--- a/fleetshard/pkg/central/reconciler/managed_db_reconciler.go
+++ b/fleetshard/pkg/central/reconciler/managed_db_reconciler.go
@@ -73,7 +73,11 @@ func (r *managedDbReconciler) getDatabaseID(ctx context.Context, remoteCentralNa
 	return centralID, nil
 }
 
-func (r *managedDbReconciler) getCentralDBConnectionString(ctx context.Context, remoteCentral private.ManagedCentral) (string, error) {
+// getCentralDBConnectionString returns the tenant's DB connection string. If allowProvisioning is
+// true and no managed DB has been provisioned for the tenant yet (or its record went missing), it
+// provisions/restores one. If allowProvisioning is false, it never provisions anything and simply
+// returns "" when there's nothing to connect to yet.
+func (r *managedDbReconciler) getCentralDBConnectionString(ctx context.Context, remoteCentral private.ManagedCentral, allowProvisioning bool) (string, error) {
 	centralDBUserExists, err := r.centralDBUserExists(ctx, remoteCentral.Metadata.Namespace)
 	if err != nil {
 		return "", err
@@ -83,6 +87,9 @@ func (r *managedDbReconciler) getCentralDBConnectionString(ctx context.Context, 
 	// provisioned and successfully created (access to a running Postgres instance is a
 	// precondition to create this user)
 	if !centralDBUserExists {
+		if !allowProvisioning {
+			return "", nil
+		}
 		if err := r.ensureManagedCentralDBInitialized(ctx, remoteCentral); err != nil {
 			return "", fmt.Errorf("initializing managed DB: %w", err)
 		}
@@ -97,6 +104,9 @@ func (r *managedDbReconciler) getCentralDBConnectionString(ctx context.Context, 
 	if err != nil {
 		if !errors.Is(err, cloudprovider.ErrDBNotFound) {
 			return "", fmt.Errorf("getting RDS DB connection data: %w", err)
+		}
+		if !allowProvisioning {
+			return "", nil
 		}
 
 		glog.Infof("expected DB for %s not found, trying to restore...", remoteCentral.Id)

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -76,6 +76,11 @@ const (
 	centralEncryptionKeySecretName          = "central-encryption-key-chain"             // pragma: allowlist secret
 	authProviderClientCredentialsSecretName = "default-auth-provider-client-credentials" // pragma: allowlist secret
 	tenantImagePullSecretName               = "stackrox"                                 // pragma: allowlist secret
+
+	// rolloutGroupValuesKey is the tenant-resources helm value that controls which
+	// rhacs-operator version reconciles a tenant's Central CR (rendered into the
+	// rhacs.redhat.com/version-selector label by the tenant-resources chart).
+	rolloutGroupValuesKey = "rolloutGroup"
 )
 
 type needsReconcileFunc func(changed bool, central private.ManagedCentral, storedSecrets []string) bool
@@ -293,6 +298,43 @@ func (r *CentralReconciler) reconcileInstanceDeletion(ctx context.Context, remot
 	remoteCentralName := remoteCentral.Metadata.Name
 	remoteCentralNamespace := remoteCentral.Metadata.Namespace
 
+	// Refresh the tenant's rolloutGroup/version-selector before tearing anything down, but only if
+	// the ArgoCD Application still exists: deletion is async and reconcileInstanceDeletion is
+	// called repeatedly until it completes, so once a previous pass has already deleted the
+	// Application there's nothing left to sync -- and calling ensureApplicationExists again would
+	// wrongly recreate it.
+	//
+	// This step matters because, unlike a normal (non-deletion) reconcile, nothing else in this
+	// deletion path ever pushes an updated rolloutGroup to the ArgoCD Application. If a tenant is
+	// deleted while its Central CR is still pinned (via a stale rhacs.redhat.com/version-selector
+	// label) to an operator version that has since been undeployed as part of a canary upgrade, no
+	// operator will ever reconcile the CR again, and its uninstall finalizer (added by the
+	// underlying helm-operator framework) will never be removed -- leaving the Central/namespace
+	// stuck in Terminating indefinitely (ROX-36296).
+	appExists, err := r.argoReconciler.applicationExists(ctx, remoteCentralNamespace)
+	if err != nil {
+		return nil, errors.Wrapf(err, "checking ArgoCD application for central %s/%s", remoteCentralNamespace, remoteCentralName)
+	}
+	if appExists {
+		// The DB connection string is intentionally left empty here: the instance is being
+		// deleted, so there's no live traffic to break, and computing it for real could otherwise
+		// trigger (re-)provisioning a managed DB for an instance that never got that far before
+		// being deleted.
+		if err := r.argoReconciler.ensureApplicationExists(ctx, remoteCentral, ""); err != nil {
+			return nil, errors.Wrapf(err, "syncing rollout group for central %s/%s before deletion", remoteCentralNamespace, remoteCentralName)
+		}
+
+		versionSelectorSynced, err := r.versionSelectorMatchesRolloutGroup(ctx, remoteCentral)
+		if err != nil {
+			return nil, errors.Wrapf(err, "checking version selector for central %s/%s", remoteCentralNamespace, remoteCentralName)
+		}
+		if !versionSelectorSynced {
+			// The Central CR's version-selector label hasn't caught up with the ArgoCD sync yet.
+			// Retry on the next reconcile instead of proceeding with deletion.
+			return nil, ErrDeletionInProgress
+		}
+	}
+
 	deleted, err := r.ensureCentralDeleted(ctx, remoteCentral)
 	if err != nil {
 		return nil, errors.Wrapf(err, "delete central %s/%s", remoteCentralNamespace, remoteCentralName)
@@ -301,6 +343,26 @@ func (r *CentralReconciler) reconcileInstanceDeletion(ctx context.Context, remot
 		return deletedStatus(), nil
 	}
 	return nil, ErrDeletionInProgress
+}
+
+// versionSelectorMatchesRolloutGroup reports whether the live Central CR's
+// rhacs.redhat.com/version-selector label matches the currently configured rolloutGroup value. If
+// the Central CR no longer exists there is nothing left to sync, so this reports true.
+func (r *CentralReconciler) versionSelectorMatchesRolloutGroup(ctx context.Context, remoteCentral private.ManagedCentral) (bool, error) {
+	centralCRList := &unstructured.UnstructuredList{}
+	centralCRList.SetGroupVersionKind(k8s.CentralGVK)
+
+	if err := r.client.List(ctx, centralCRList, &ctrlClient.ListOptions{Namespace: remoteCentral.Metadata.Namespace}); err != nil {
+		return false, fmt.Errorf("getting current central CR from k8s: %w", err)
+	}
+
+	if len(centralCRList.Items) == 0 {
+		return true, nil
+	}
+
+	expected := getTenantResourcesValue(remoteCentral, rolloutGroupValuesKey, "")
+	actual := centralCRList.Items[0].GetLabels()[k8s.VersionSelectorLabelKey]
+	return actual == expected, nil
 }
 
 func (r *CentralReconciler) reconcileDeclarativeConfigurationData(ctx context.Context,

--- a/fleetshard/pkg/central/reconciler/reconciler.go
+++ b/fleetshard/pkg/central/reconciler/reconciler.go
@@ -175,7 +175,11 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 
 	glog.Infof("Start reconcile central %s/%s", remoteCentralNamespace, remoteCentralName)
 
-	if remoteCentral.Metadata.DeletionTimestamp != "" {
+	shouldDelete, err := r.shouldDelete(ctx, remoteCentral)
+	if err != nil {
+		return nil, errors.Wrapf(err, "checking whether central %s/%s should be deleted", remoteCentralNamespace, remoteCentralName)
+	}
+	if shouldDelete {
 		status, err := r.reconcileInstanceDeletion(ctx, remoteCentral)
 		shouldUpdateCentralHash = err == nil
 		return status, err
@@ -205,7 +209,10 @@ func (r *CentralReconciler) Reconcile(ctx context.Context, remoteCentral private
 
 	centralDBConnectionString := ""
 	if r.managedDBEnabled {
-		centralDBConnectionString, err = r.managedDbReconciler.getCentralDBConnectionString(ctx, remoteCentral)
+		// Deletion pending but shouldDelete returned false above (version-selector label hasn't
+		// caught up yet): never provision a DB just to resync the rollout group.
+		allowProvisioning := remoteCentral.Metadata.DeletionTimestamp == ""
+		centralDBConnectionString, err = r.managedDbReconciler.getCentralDBConnectionString(ctx, remoteCentral, allowProvisioning)
 		if err != nil {
 			return nil, fmt.Errorf("getting Central DB connection string: %w", err)
 		}
@@ -298,43 +305,6 @@ func (r *CentralReconciler) reconcileInstanceDeletion(ctx context.Context, remot
 	remoteCentralName := remoteCentral.Metadata.Name
 	remoteCentralNamespace := remoteCentral.Metadata.Namespace
 
-	// Refresh the tenant's rolloutGroup/version-selector before tearing anything down, but only if
-	// the ArgoCD Application still exists: deletion is async and reconcileInstanceDeletion is
-	// called repeatedly until it completes, so once a previous pass has already deleted the
-	// Application there's nothing left to sync -- and calling ensureApplicationExists again would
-	// wrongly recreate it.
-	//
-	// This step matters because, unlike a normal (non-deletion) reconcile, nothing else in this
-	// deletion path ever pushes an updated rolloutGroup to the ArgoCD Application. If a tenant is
-	// deleted while its Central CR is still pinned (via a stale rhacs.redhat.com/version-selector
-	// label) to an operator version that has since been undeployed as part of a canary upgrade, no
-	// operator will ever reconcile the CR again, and its uninstall finalizer (added by the
-	// underlying helm-operator framework) will never be removed -- leaving the Central/namespace
-	// stuck in Terminating indefinitely (ROX-36296).
-	appExists, err := r.argoReconciler.applicationExists(ctx, remoteCentralNamespace)
-	if err != nil {
-		return nil, errors.Wrapf(err, "checking ArgoCD application for central %s/%s", remoteCentralNamespace, remoteCentralName)
-	}
-	if appExists {
-		// The DB connection string is intentionally left empty here: the instance is being
-		// deleted, so there's no live traffic to break, and computing it for real could otherwise
-		// trigger (re-)provisioning a managed DB for an instance that never got that far before
-		// being deleted.
-		if err := r.argoReconciler.ensureApplicationExists(ctx, remoteCentral, ""); err != nil {
-			return nil, errors.Wrapf(err, "syncing rollout group for central %s/%s before deletion", remoteCentralNamespace, remoteCentralName)
-		}
-
-		versionSelectorSynced, err := r.versionSelectorMatchesRolloutGroup(ctx, remoteCentral)
-		if err != nil {
-			return nil, errors.Wrapf(err, "checking version selector for central %s/%s", remoteCentralNamespace, remoteCentralName)
-		}
-		if !versionSelectorSynced {
-			// The Central CR's version-selector label hasn't caught up with the ArgoCD sync yet.
-			// Retry on the next reconcile instead of proceeding with deletion.
-			return nil, ErrDeletionInProgress
-		}
-	}
-
 	deleted, err := r.ensureCentralDeleted(ctx, remoteCentral)
 	if err != nil {
 		return nil, errors.Wrapf(err, "delete central %s/%s", remoteCentralNamespace, remoteCentralName)
@@ -345,23 +315,42 @@ func (r *CentralReconciler) reconcileInstanceDeletion(ctx context.Context, remot
 	return nil, ErrDeletionInProgress
 }
 
+// shouldDelete reports whether it's safe to tear the instance down: deletion must have been
+// requested, and the live Central CR's version-selector label must have caught up with the
+// currently configured rolloutGroup.
+//
+// The label check matters because, unlike a normal (non-deletion) reconcile, reconcileInstanceDeletion
+// never pushes an updated rolloutGroup to the ArgoCD Application. If a tenant is deleted while its
+// Central CR is still pinned (via a stale rhacs.redhat.com/version-selector label) to an operator
+// version that has since been undeployed as part of a canary upgrade, no operator will ever
+// reconcile the CR again, and its uninstall finalizer (added by the underlying helm-operator
+// framework) will never be removed -- leaving the Central/namespace stuck in Terminating
+// indefinitely (ROX-36296). While shouldDelete is false, Reconcile falls through to the normal
+// reconcile path, which resyncs the ArgoCD Application (and thus the label) as usual.
+func (r *CentralReconciler) shouldDelete(ctx context.Context, remoteCentral private.ManagedCentral) (bool, error) {
+	if remoteCentral.Metadata.DeletionTimestamp == "" {
+		return false, nil
+	}
+	return r.versionSelectorMatchesRolloutGroup(ctx, remoteCentral)
+}
+
 // versionSelectorMatchesRolloutGroup reports whether the live Central CR's
 // rhacs.redhat.com/version-selector label matches the currently configured rolloutGroup value. If
 // the Central CR no longer exists there is nothing left to sync, so this reports true.
 func (r *CentralReconciler) versionSelectorMatchesRolloutGroup(ctx context.Context, remoteCentral private.ManagedCentral) (bool, error) {
-	centralCRList := &unstructured.UnstructuredList{}
-	centralCRList.SetGroupVersionKind(k8s.CentralGVK)
+	centralCR := &unstructured.Unstructured{}
+	centralCR.SetGroupVersionKind(k8s.CentralGVK)
 
-	if err := r.client.List(ctx, centralCRList, &ctrlClient.ListOptions{Namespace: remoteCentral.Metadata.Namespace}); err != nil {
+	key := ctrlClient.ObjectKey{Namespace: remoteCentral.Metadata.Namespace, Name: remoteCentral.Metadata.Name}
+	if err := r.client.Get(ctx, key, centralCR); err != nil {
+		if apiErrors.IsNotFound(err) {
+			return true, nil
+		}
 		return false, fmt.Errorf("getting current central CR from k8s: %w", err)
 	}
 
-	if len(centralCRList.Items) == 0 {
-		return true, nil
-	}
-
 	expected := getTenantResourcesValue(remoteCentral, rolloutGroupValuesKey, "")
-	actual := centralCRList.Items[0].GetLabels()[k8s.VersionSelectorLabelKey]
+	actual := centralCR.GetLabels()[k8s.VersionSelectorLabelKey]
 	return actual == expected, nil
 }
 

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager"
 	fmMocks "github.com/stackrox/acs-fleet-manager/pkg/client/fleetmanager/mocks"
 	centralNotifierUtils "github.com/stackrox/rox/central/notifiers/utils"
+	platform "github.com/stackrox/rox/operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
@@ -381,6 +382,81 @@ func TestReconcileDelete(t *testing.T) {
 
 	namespace := &v1.Namespace{}
 	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralNamespace}, namespace)
+	assert.True(t, k8sErrors.IsNotFound(err))
+}
+
+// TestReconcileDeleteWaitsForStaleVersionSelector reproduces ROX-36296: a Central CR whose
+// rhacs.redhat.com/version-selector label is stale (still pointing at an operator version that
+// may already be undeployed as part of a canary upgrade) must not be torn down until the label
+// has been refreshed to match the currently configured rolloutGroup. Otherwise no operator would
+// ever pick up the CR again to remove its uninstall finalizer, orphaning it.
+//
+// The fake test harness (testutils.ReconcileTracker) simulates ArgoCD by synchronously re-syncing
+// the Central CR's labels the moment the ArgoCD Application is created/updated, whereas in a real
+// cluster that sync happens asynchronously. To exercise the "still waiting for the label to catch
+// up" branch of reconcileInstanceDeletion, this test sets the Application's rolloutGroup to its
+// final value up front (so ensureApplicationExists has nothing left to update) and then manually
+// drives the live Central CR's label out of sync, mimicking the real-world window where ArgoCD
+// hasn't reconciled the new label yet.
+func TestReconcileDeleteWaitsForStaleVersionSelector(t *testing.T) {
+	managedCentral := simpleManagedCentral
+	managedCentral.Spec.TenantResourcesValues = map[string]interface{}{
+		rolloutGroupValuesKey: "v2",
+	}
+
+	fakeClient, _, r := getClientTrackerAndReconciler(t, nil, defaultReconcilerOptions)
+
+	_, err := r.Reconcile(context.TODO(), managedCentral)
+	require.NoError(t, err)
+
+	// Simulate the real-world window where the tenant's ArgoCD Application already targets the
+	// new rollout group, but the live Central CR hasn't been synced to the new
+	// version-selector label yet (e.g. operator v1 was undeployed before ArgoCD got around to
+	// re-syncing this particular tenant).
+	centralCR := &platform.Central{}
+	require.NoError(t, fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralName, Namespace: centralNamespace}, centralCR))
+	centralCR.Labels[k8s.VersionSelectorLabelKey] = "v1"
+	require.NoError(t, fakeClient.Update(context.TODO(), centralCR))
+
+	deletedCentral := managedCentral
+	deletedCentral.Metadata.DeletionTimestamp = "2006-01-02T15:04:05Z07:00"
+
+	status, err := r.Reconcile(context.TODO(), deletedCentral)
+	require.ErrorIs(t, err, ErrDeletionInProgress)
+	require.Nil(t, status)
+
+	// Nothing should have been torn down while the label is still stale.
+	namespace := &v1.Namespace{}
+	assert.NoError(t, fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralNamespace}, namespace))
+	assert.NoError(t, fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralArgoCDAppName, Namespace: openshiftGitopsNamespace}, &argocd.Application{}))
+
+	// Reconciling again without anything changing must keep waiting.
+	status, err = r.Reconcile(context.TODO(), deletedCentral)
+	require.ErrorIs(t, err, ErrDeletionInProgress)
+	require.Nil(t, status)
+
+	// ArgoCD finally syncs the new label onto the live Central CR.
+	require.NoError(t, fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralName, Namespace: centralNamespace}, centralCR))
+	centralCR.Labels[k8s.VersionSelectorLabelKey] = "v2"
+	require.NoError(t, fakeClient.Update(context.TODO(), centralCR))
+
+	// Deletion can now proceed (mirroring the two-call async deletion pattern used elsewhere).
+	status, err = r.Reconcile(context.TODO(), deletedCentral)
+	require.ErrorIs(t, err, ErrDeletionInProgress)
+	require.Nil(t, status)
+
+	status, err = r.Reconcile(context.TODO(), deletedCentral)
+	require.NoError(t, err)
+	require.NotNil(t, status)
+
+	readyCondition, ok := conditionForType(status.Conditions, conditionTypeReady)
+	require.True(t, ok, "Ready condition not found in conditions", status.Conditions)
+	assert.Equal(t, "False", readyCondition.Status)
+	assert.Equal(t, "Deleted", readyCondition.Reason)
+
+	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralArgoCDAppName, Namespace: openshiftGitopsNamespace}, &argocd.Application{})
+	assert.True(t, k8sErrors.IsNotFound(err))
+	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralNamespace}, &v1.Namespace{})
 	assert.True(t, k8sErrors.IsNotFound(err))
 }
 

--- a/fleetshard/pkg/central/reconciler/reconciler_test.go
+++ b/fleetshard/pkg/central/reconciler/reconciler_test.go
@@ -421,9 +421,11 @@ func TestReconcileDeleteWaitsForStaleVersionSelector(t *testing.T) {
 	deletedCentral := managedCentral
 	deletedCentral.Metadata.DeletionTimestamp = "2006-01-02T15:04:05Z07:00"
 
-	status, err := r.Reconcile(context.TODO(), deletedCentral)
-	require.ErrorIs(t, err, ErrDeletionInProgress)
-	require.Nil(t, status)
+	// shouldDelete reports false while the label is stale, so Reconcile falls through to a normal
+	// reconcile pass instead of tearing anything down (fleet-manager ignores status updates for
+	// centrals it has already marked as deprovisioning, so this is safe).
+	_, err = r.Reconcile(context.TODO(), deletedCentral)
+	require.NoError(t, err)
 
 	// Nothing should have been torn down while the label is still stale.
 	namespace := &v1.Namespace{}
@@ -431,9 +433,8 @@ func TestReconcileDeleteWaitsForStaleVersionSelector(t *testing.T) {
 	assert.NoError(t, fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralArgoCDAppName, Namespace: openshiftGitopsNamespace}, &argocd.Application{}))
 
 	// Reconciling again without anything changing must keep waiting.
-	status, err = r.Reconcile(context.TODO(), deletedCentral)
-	require.ErrorIs(t, err, ErrDeletionInProgress)
-	require.Nil(t, status)
+	_, err = r.Reconcile(context.TODO(), deletedCentral)
+	require.NoError(t, err)
 
 	// ArgoCD finally syncs the new label onto the live Central CR.
 	require.NoError(t, fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralName, Namespace: centralNamespace}, centralCR))
@@ -441,7 +442,7 @@ func TestReconcileDeleteWaitsForStaleVersionSelector(t *testing.T) {
 	require.NoError(t, fakeClient.Update(context.TODO(), centralCR))
 
 	// Deletion can now proceed (mirroring the two-call async deletion pattern used elsewhere).
-	status, err = r.Reconcile(context.TODO(), deletedCentral)
+	status, err := r.Reconcile(context.TODO(), deletedCentral)
 	require.ErrorIs(t, err, ErrDeletionInProgress)
 	require.Nil(t, status)
 
@@ -458,6 +459,162 @@ func TestReconcileDeleteWaitsForStaleVersionSelector(t *testing.T) {
 	assert.True(t, k8sErrors.IsNotFound(err))
 	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralNamespace}, &v1.Namespace{})
 	assert.True(t, k8sErrors.IsNotFound(err))
+}
+
+// TestVersionSelectorMatchesRolloutGroup covers the Get-based lookup used by
+// versionSelectorMatchesRolloutGroup, including the case where the Central CR doesn't exist.
+func TestVersionSelectorMatchesRolloutGroup(t *testing.T) {
+	managedCentral := simpleManagedCentral
+	managedCentral.Spec.TenantResourcesValues = map[string]interface{}{
+		rolloutGroupValuesKey: "v2",
+	}
+
+	t.Run("Central CR not found", func(t *testing.T) {
+		_, _, r := getClientTrackerAndReconciler(t, nil, defaultReconcilerOptions)
+
+		synced, err := r.versionSelectorMatchesRolloutGroup(context.TODO(), managedCentral)
+		require.NoError(t, err)
+		assert.True(t, synced)
+	})
+
+	t.Run("label matches rollout group", func(t *testing.T) {
+		centralCR := &platform.Central{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      centralName,
+				Namespace: centralNamespace,
+				Labels:    map[string]string{k8s.VersionSelectorLabelKey: "v2"},
+			},
+		}
+		_, _, r := getClientTrackerAndReconciler(t, nil, defaultReconcilerOptions, centralCR)
+
+		synced, err := r.versionSelectorMatchesRolloutGroup(context.TODO(), managedCentral)
+		require.NoError(t, err)
+		assert.True(t, synced)
+	})
+
+	t.Run("label is stale", func(t *testing.T) {
+		centralCR := &platform.Central{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      centralName,
+				Namespace: centralNamespace,
+				Labels:    map[string]string{k8s.VersionSelectorLabelKey: "v1"},
+			},
+		}
+		_, _, r := getClientTrackerAndReconciler(t, nil, defaultReconcilerOptions, centralCR)
+
+		synced, err := r.versionSelectorMatchesRolloutGroup(context.TODO(), managedCentral)
+		require.NoError(t, err)
+		assert.False(t, synced)
+	})
+}
+
+// TestReconcileDeleteWithProvisionedDBPreservesConnectionStringWhileWaiting reproduces ROX-36296
+// for tenants with an already-provisioned managed DB: while shouldDelete is false (stale label),
+// Reconcile falls through to the normal path, which must keep passing the real connection string
+// instead of blanking it out.
+//
+// This primes the process-wide DB CA cert cache up front to work around an unrelated pre-existing
+// quirk: postgres.GetDatabaseCACertificates caches its result via sync.Once but ignores the cached
+// error on subsequent calls, so two Reconcile calls in the same test can otherwise render two
+// different Application payloads for reasons unrelated to what's being tested here.
+func TestReconcileDeleteWithProvisionedDBPreservesConnectionStringWhileWaiting(t *testing.T) {
+	_, _ = postgres.GetDatabaseCACertificates()
+
+	managedCentral := simpleManagedCentral
+	managedCentral.Spec.TenantResourcesValues = map[string]interface{}{
+		rolloutGroupValuesKey: "v2",
+	}
+
+	connection, err := postgres.NewDBConnection("localhost", 5432, "rhacs", "postgres")
+	require.NoError(t, err)
+	expectedConnectionString := connection.GetConnectionForUserAndDB(dbCentralUserName, postgres.CentralDBName).
+		WithSSLRootCert(postgres.DatabaseCACertificatePathCentral).AsConnectionString()
+
+	managedDBProvisioningClient := &cloudprovider.DBClientMock{}
+	managedDBProvisioningClient.EnsureDBProvisionedFunc = func(_ context.Context, _, _, _ string, _ bool) error {
+		return nil
+	}
+	managedDBProvisioningClient.GetDBConnectionFunc = func(_ string) (postgres.DBConnection, error) {
+		return connection, nil
+	}
+
+	reconcilerOptions := defaultReconcilerOptions
+	reconcilerOptions.ManagedDBEnabled = true
+	reconcilerOptions.ArgoReconcilerOptions.ManagedDBEnabled = true
+	fakeClient, _, r := getClientTrackerAndReconciler(t, managedDBProvisioningClient, reconcilerOptions)
+
+	// Provision the DB via a normal reconcile first.
+	_, err = r.Reconcile(context.TODO(), managedCentral)
+	require.NoError(t, err)
+	require.Len(t, managedDBProvisioningClient.EnsureDBProvisionedCalls(), 1)
+
+	// Stale the live Central CR's version-selector label, as in TestReconcileDeleteWaitsForStaleVersionSelector.
+	centralCR := &platform.Central{}
+	require.NoError(t, fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralName, Namespace: centralNamespace}, centralCR))
+	centralCR.Labels[k8s.VersionSelectorLabelKey] = "v1"
+	require.NoError(t, fakeClient.Update(context.TODO(), centralCR))
+
+	deletedCentral := managedCentral
+	deletedCentral.Metadata.DeletionTimestamp = "2006-01-02T15:04:05Z07:00"
+
+	_, err = r.Reconcile(context.TODO(), deletedCentral)
+	require.NoError(t, err)
+
+	// The wait for the label must not trigger any new DB provisioning.
+	assert.Len(t, managedDBProvisioningClient.EnsureDBProvisionedCalls(), 1)
+
+	// The resynced Application must still carry the real connection string.
+	app := &argocd.Application{}
+	require.NoError(t, fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralArgoCDAppName, Namespace: openshiftGitopsNamespace}, app))
+	values := map[string]interface{}{}
+	require.NoError(t, json.Unmarshal(app.Spec.Source.Helm.ValuesObject.Raw, &values))
+	assert.Equal(t, expectedConnectionString, values["centralDbConnectionString"])
+}
+
+// TestReconcileDeleteWithoutProvisionedDBSkipsProvisioningWhileWaiting ensures that falling
+// through to the normal reconcile path while shouldDelete is false never provisions a managed DB
+// for a tenant that never had one, mirroring the original "" workaround.
+func TestReconcileDeleteWithoutProvisionedDBSkipsProvisioningWhileWaiting(t *testing.T) {
+	_, _ = postgres.GetDatabaseCACertificates()
+
+	managedCentral := simpleManagedCentral
+	managedCentral.Spec.TenantResourcesValues = map[string]interface{}{
+		rolloutGroupValuesKey: "v2",
+	}
+
+	managedDBProvisioningClient := &cloudprovider.DBClientMock{}
+	managedDBProvisioningClient.EnsureDBProvisionedFunc = func(_ context.Context, _, _, _ string, _ bool) error {
+		return nil
+	}
+
+	reconcilerOptions := defaultReconcilerOptions
+	reconcilerOptions.ManagedDBEnabled = true
+	reconcilerOptions.ArgoReconcilerOptions.ManagedDBEnabled = true
+	fakeClient, _, r := getClientTrackerAndReconciler(t, managedDBProvisioningClient, reconcilerOptions)
+
+	// Bootstrap the namespace/Application/Central CR directly, without ever provisioning a
+	// managed DB (a normal Reconcile call with ManagedDBEnabled would provision one).
+	require.NoError(t, r.namespaceReconciler.reconcile(context.TODO(), r.getDesiredNamespace(managedCentral)))
+	require.NoError(t, r.argoReconciler.ensureApplicationExists(context.TODO(), managedCentral, ""))
+
+	centralCR := &platform.Central{}
+	require.NoError(t, fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralName, Namespace: centralNamespace}, centralCR))
+	centralCR.Labels[k8s.VersionSelectorLabelKey] = "v1"
+	require.NoError(t, fakeClient.Update(context.TODO(), centralCR))
+
+	deletedCentral := managedCentral
+	deletedCentral.Metadata.DeletionTimestamp = "2006-01-02T15:04:05Z07:00"
+
+	_, err := r.Reconcile(context.TODO(), deletedCentral)
+	require.NoError(t, err)
+
+	assert.Empty(t, managedDBProvisioningClient.EnsureDBProvisionedCalls(), "must never provision a DB while waiting for the version-selector label")
+
+	app := &argocd.Application{}
+	require.NoError(t, fakeClient.Get(context.TODO(), client.ObjectKey{Name: centralArgoCDAppName, Namespace: openshiftGitopsNamespace}, app))
+	values := map[string]interface{}{}
+	require.NoError(t, json.Unmarshal(app.Spec.Source.Helm.ValuesObject.Raw, &values))
+	assert.Empty(t, values["centralDbConnectionString"])
 }
 
 func TestReconcileDeleteWithManagedDB(t *testing.T) {

--- a/fleetshard/pkg/k8s/constants.go
+++ b/fleetshard/pkg/k8s/constants.go
@@ -6,4 +6,9 @@ const (
 	ManagedByLabelKey = "app.kubernetes.io/managed-by"
 	// ManagedByFleetshardValue used for indication that the resource is managed by the fleetshard sync
 	ManagedByFleetshardValue = "rhacs-fleetshard"
+	// VersionSelectorLabelKey is the label the rhacs-operator uses (via its CENTRAL_LABEL_SELECTOR
+	// setting) to decide which Central CRs it reconciles. It is stamped onto the Central CR by the
+	// tenant-resources Helm chart from the tenant's rolloutGroup value, allowing multiple operator
+	// versions to coexist during a canary upgrade.
+	VersionSelectorLabelKey = "rhacs.redhat.com/version-selector"
 )

--- a/fleetshard/pkg/testutils/k8s.go
+++ b/fleetshard/pkg/testutils/k8s.go
@@ -65,6 +65,12 @@ var centralLabels = map[string]string{
 	"app.kubernetes.io/component": "central",
 }
 
+// versionSelectorLabelKey mirrors the rhacs.redhat.com/version-selector label the real
+// tenant-resources Helm chart stamps onto the Central CR from the rolloutGroup helm value
+// (see fleetshard/pkg/k8s.VersionSelectorLabelKey; duplicated here as a literal to avoid an
+// import cycle between fleetshard/pkg/k8s tests and this package).
+const versionSelectorLabelKey = "rhacs.redhat.com/version-selector"
+
 var (
 	_ k8sTesting.ObjectTracker = (*ReconcileTracker)(nil)
 )
@@ -236,6 +242,9 @@ func centralCrFromArgoCdApp(app *argoCDApplication) *platform.Central {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      app.instanceName(),
 			Namespace: app.destinationNamespace,
+			Labels: map[string]string{
+				versionSelectorLabelKey: app.rolloutGroup(),
+			},
 		},
 	}
 }
@@ -371,6 +380,14 @@ func (a *argoCDApplication) centralDataHost() string {
 
 func (a *argoCDApplication) instanceName() string {
 	return a.helmValues["instanceName"].(string)
+}
+
+func (a *argoCDApplication) rolloutGroup() string {
+	value, ok := a.helmValues["rolloutGroup"]
+	if !ok {
+		return ""
+	}
+	return value.(string)
 }
 
 func newArgoCDApplicationFromCustomResource(app *argoCd.Application) (*argoCDApplication, error) {


### PR DESCRIPTION
<!-- Describe your changes here or leave empty — CodeRabbit will append a summary, checklist, and test suggestions automatically. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
---
*The following was generated by `@coderabbitai` and may be updated automatically.*

## Summary

Deletion now waits until the Central CR has the configured rollout-group version-selector label. Pending deletions continue normal reconciliation and resync ArgoCD. The reconciler does not provision a new managed database while deletion is pending.

Tests cover stale labels, label synchronization, managed database preservation, and missing database provisioning.

[JIRA: [ROX-36296](https://redhat.atlassian.net/browse/ROX-36296)](https://issues.redhat.com/browse/ROX-36296)

## Checklist (Definition of Done)

- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] CI and all relevant tests are passing

## Test manual

1. Start deletion of a Central CR with a stale version-selector label.
2. Confirm that deletion remains pending without a deletion error.
3. Confirm that reconciliation resyncs the ArgoCD application.
4. Restore the expected rollout-group label.
5. Confirm that deletion proceeds.
6. Verify that an existing managed database connection remains available.
7. Verify that the reconciler does not provision a database when no database exists.

---
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ROX-36296]: https://redhat.atlassian.net/browse/ROX-36296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ