### PR TITLE
fix(e2e): Improve retry logic after the cluster provisioning

### DIFF
--- a/.openshift-ci/tests/e2e-test.sh
+++ b/.openshift-ci/tests/e2e-test.sh
@@ -5,7 +5,8 @@ export GITROOT
 # shellcheck source=/dev/null
 source "${GITROOT}/dev/env/scripts/lib.sh"
 
-bootstrap.sh
+# Add retries to fix the transient DNS errors immediately after cluster provisioning.
+retry 10 60 bootstrap.sh
 
 log "Setting up e2e test environment"
 

--- a/dev/env/scripts/bootstrap.sh
+++ b/dev/env/scripts/bootstrap.sh
@@ -22,32 +22,6 @@ fi
 log "** Preparing ACSCS Environment **"
 print_env
 
-# Retry for up to 30 minutes to contact the Kubernetes cluster
-MAX_RETRIES=180  # 30 minutes with 10 second intervals
-RETRY_COUNT=0
-RETRY_DELAY=10
-
-log "Attempting to contact Kubernetes cluster..."
-while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-    if kc_output=$($KUBECTL api-versions 2>&1); then
-        log "Successfully contacted Kubernetes cluster"
-        break
-    fi
-
-    RETRY_COUNT=$((RETRY_COUNT + 1))
-    ELAPSED=$((RETRY_COUNT * RETRY_DELAY))
-    log "Failed to contact cluster (attempt $RETRY_COUNT/$MAX_RETRIES, elapsed: ${ELAPSED}s). Retrying in ${RETRY_DELAY}s..."
-    sleep $RETRY_DELAY
-done
-
-if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
-    die "Error: Sanity check for contacting Kubernetes cluster failed after $((MAX_RETRIES * RETRY_DELAY)) seconds:
-
-Command tried: '$KUBECTL api-versions'
-Last output:
-${kc_output:-(no output)}"
-fi
-
 # Create Namespaces.
 apply "${MANIFESTS_DIR}/shared"
 create-imagepullsecrets

--- a/dev/env/scripts/lib.sh
+++ b/dev/env/scripts/lib.sh
@@ -11,6 +11,26 @@ if ! command -v bootstrap.sh >/dev/null 2>&1; then
     export PATH="$GITROOT/dev/env/scripts:${PATH}"
 fi
 
+retry() {
+    local max_attempts="$1"
+    local delay="$2"
+    shift 2
+
+    local attempt=1
+    while true; do
+        if "$@"; then
+            return 0
+        fi
+        if [[ $attempt -ge $max_attempts ]]; then
+            log "Command failed after $max_attempts attempts: $*"
+            return 1
+        fi
+        log "Command failed (attempt $attempt/$max_attempts), retrying in ${delay}s..."
+        sleep "$delay"
+        attempt=$((attempt + 1))
+    done
+}
+
 try_kubectl() {
     local kubectl
     if command -v kubectl >/dev/null 2>&1; then


### PR DESCRIPTION
<!-- Describe your changes here or leave empty — CodeRabbit will append a summary, checklist, and test suggestions automatically. -->
## Description
Prior to this change, there was only a single retry check during cluster bootstrap. This does not fully protect against the cluster DNS issues we are currently experiencing on OSCI, as subsequent calls to the Kubernetes API can still result in a DNS error. Therefore, I have extended the retry logic to the entire bootstrap script during E2E test runs, since the bootstap script is idempotent by design. Adding retries to every `kubectl apply` command is cumbersome and easy to miss.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR summary

Updates end-to-end test retry logic after cluster provisioning.

---
*The following was generated by `@coderabbitai` and may be updated automatically.*

## Summary

`@coderabbitai` summary

- Added a reusable `retry` helper to `dev/env/scripts/lib.sh`.
- Updated `.openshift-ci/tests/e2e-test.sh` to retry `bootstrap.sh` up to 10 times with 60-second delays.
- Removed the duplicate cluster-connectivity retry loop from `bootstrap.sh`.

## Checklist (Definition of Done)

- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing

## Test manual

- Run the end-to-end test workflow.
- Confirm that `bootstrap.sh` retries up to 10 times after provisioning failures.
- Confirm that retries wait 60 seconds between attempts.
- Confirm that the command reports failure after all attempts are exhausted.

---

<!-- end of auto-generated comment: release notes by coderabbit.ai -->