### PR TITLE
ROX-34722: Switch to periodic konflux retest

### DIFF
--- a/.github/workflows/konflux-auto-retest.yml
+++ b/.github/workflows/konflux-auto-retest.yml
@@ -1,18 +1,18 @@
-name: Retest Failed Konflux Builds
+name: Periodic Retest Failed Konflux Builds
 
 on:
-  check_run:
-    types: [completed]
-  pull_request:
-    types: [synchronize]
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
 
 jobs:
-  retest-builds:
-    uses: stackrox/actions/.github/workflows/retest-konflux-builds.yml@v1
+  periodic-retest-builds:
+    uses: stackrox/actions/.github/workflows/periodic-retest-konflux-builds.yml@v1
     permissions:
       pull-requests: write
       issues: write
+      checks: read
+      contents: read
     with:
       max_retries: 3
-      check_name_suffix: '-on-push'
       retest_command: '/konflux-retest'


### PR DESCRIPTION
<!-- Describe your changes here or leave empty — CodeRabbit will append a summary, checklist, and test suggestions automatically. -->

Switch to periodic Konflux retest to optimize GH actions invocations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR summary

Updates the Konflux retest process to run periodically, with the goal of optimizing GitHub Actions invocations.

---
*The following was generated by `@coderabbitai` and may be updated automatically.*

## Summary

- Runs Konflux retests hourly through a cron schedule.
- Supports manual runs through `workflow_dispatch`.
- Uses `periodic-retest-konflux-builds.yml`.
- Adds `checks: read` and `contents: read` permissions.
- Uses the `/konflux-retest` command.

## Checklist (Definition of Done)

- [ ] Documentation added if necessary (i.e. changes to dev setup, test execution, ...)
- [ ] CI and all relevant tests are passing

## Test manual

- Confirm that the workflow accepts a manual `workflow_dispatch`.
- Confirm that the scheduled workflow invokes `periodic-retest-konflux-builds.yml`.
- Confirm that the workflow uses the `/konflux-retest` command.
- Confirm that the workflow has the required read permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->