### PR TITLE
chore(dev): bump ACS operator to 4.11.3

### DIFF
--- a/dev/config/gitops-config.yaml
+++ b/dev/config/gitops-config.yaml
@@ -13,7 +13,7 @@ applications:
           include: '{platform.stackrox.io_centrals.yaml,platform.stackrox.io_securedclusters.yaml}'
         path: operator/bundle/manifests
         repoURL: https://github.com/stackrox/stackrox
-        targetRevision: 4.10.0
+        targetRevision: 4.11.3
       syncPolicy:
         automated:
           prune: true
@@ -45,8 +45,8 @@ applications:
           valuesObject:
             operator:
               images:
-                - deploymentName: "rhacs-operator-4.10.0"
-                  image: "registry.redhat.io/advanced-cluster-security/rhacs-rhel8-operator@sha256:2205a04f297fa92b157e36ff3e6994dc88c041b291193bd7d03b3f033910b2fe"
+                - deploymentName: "rhacs-operator-4.11.3"
+                  image: "registry.redhat.io/advanced-cluster-security/rhacs-rhel9-operator@sha256:79b2148d133e88cc538dca567dc51b3536b14edc0d059a2e332dae3919725a29"
                   centralLabelSelector: "rhacs.redhat.com/version-selector=dev"
                   securedClusterLabelSelector: "rhacs.redhat.com/selector=dev"
 


### PR DESCRIPTION
## Summary
- Bump RHACS operator from 4.10.0 to 4.11.3 in dev gitops config
- Update CRDs targetRevision, operator deployment name, and image reference

## Test plan
- [x] Verify dev environment deploys successfully with the updated operator version

🤖 Generated with [Claude Code](https://claude.com/claude-code)